### PR TITLE
Fix detector energy resolution and Altarelli-Parisi FSR normalization

### DIFF
--- a/hazma/parameters.py
+++ b/hazma/parameters.py
@@ -396,20 +396,61 @@ def load_interp(rf_name, bounds_error=False, fill_value=0.0):
 
 
 def spec_res_fn(ep, e, energy_res):
-    """Get the spectral resolution function."""
-    sigma = e * energy_res(e)
+    r"""Get the spectral resolution function.
 
-    if sigma == 0:
-        if hasattr(ep, "__len__"):
-            return np.zeros(ep.shape)
-        else:
-            return 0.0
-    else:
-        return (
+    This is the probability density for a photon of *true* energy ``e`` to be
+    reconstructed at energy ``ep``. The two arguments are not interchangeable:
+    the width of the response is set by the true energy, :math:`\sigma = e
+    \times \Delta E/E(e)`. Evaluating the width at the reconstructed energy
+    instead lets a sharp spectral feature leak to arbitrarily high
+    reconstructed energies wherever the detector's resolution is poor.
+
+    Parameters
+    ----------
+    ep : float or array-like
+        Reconstructed (measured) photon energy.
+    e : float or array-like
+        True photon energy. Sets the width of the response.
+    energy_res : float -> float
+        The detector's energy resolution (Delta E / E) as a function of photon
+        energy in MeV.
+    """
+    sigma = np.asarray(e, dtype=float) * energy_res(e)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        res = (
             1.0
             / np.sqrt(2.0 * np.pi * sigma**2)
             * np.exp(-((ep - e) ** 2) / (2.0 * sigma**2))
         )
+
+    # A vanishing width carries no photons, matching the historical behavior.
+    return np.where(sigma == 0.0, 0.0, res)
+
+
+#: Hard cap on the number of true-energy points used by the convolution
+#: integral, to bound its runtime for very fine energy resolutions.
+_MAX_CONV_PTS = 200_000
+
+
+def _true_energy_grid(lo, hi, energy_res, n_pts):
+    r"""Build the grid of true photon energies used by the convolution integral.
+
+    The detector response has a width of :math:`\sigma(E) = E \times \Delta
+    E/E(E)`, so a logarithmic grid resolves it uniformly when its spacing
+    ``dlog`` satisfies ``dlog << min(Delta E / E)``. We target four points per
+    :math:`\sigma`; a grid that is too coarse silently under-integrates the
+    response.
+    """
+    grid = np.geomspace(lo, hi, n_pts)
+    res = np.asarray(energy_res(grid), dtype=float)
+    res = res[res > 0.0]
+
+    if res.size == 0:
+        return grid
+
+    n_needed = int(np.ceil(4.0 * np.log(hi / lo) / np.min(res)))
+    return np.geomspace(lo, hi, int(np.clip(n_needed, n_pts, _MAX_CONV_PTS)))
 
 
 def convolved_spectrum_fn(
@@ -446,7 +487,7 @@ def convolved_spectrum_fn(
     dnde_conv = np.zeros(es.shape)
 
     # Pad energy grid to avoid edge effects
-    es_padded = np.geomspace(0.1 * e_min, 10 * e_max, n_pts)
+    es_padded = _true_energy_grid(0.1 * e_min, 10 * e_max, energy_res, n_pts)
     if spec_fn is not None:
         dnde_src = spec_fn(es_padded)
         if not np.all(dnde_src == 0):
@@ -455,12 +496,13 @@ def convolved_spectrum_fn(
                 """
                 Performs the integration at given photon energy.
                 """
-                spec_res_fn_vals = spec_res_fn(es_padded, e, energy_res)
-                integrand_vals = (
-                    dnde_src * spec_res_fn_vals / trapz(spec_res_fn_vals, es_padded)
-                )
-
-                return trapz(integrand_vals, es_padded)
+                # Integrate the source spectrum against the detector response
+                # R(e | e'), whose width is set by the *true* energy e'. The
+                # response is normalized over the reconstructed energy, so no
+                # further normalization is applied here; doing so would not
+                # conserve the total number of photons.
+                response = spec_res_fn(e, es_padded, energy_res)
+                return trapz(dnde_src * response, es_padded)
 
             dnde_conv += np.vectorize(integral)(es)
 

--- a/hazma/parameters.py
+++ b/hazma/parameters.py
@@ -395,6 +395,28 @@ def load_interp(rf_name, bounds_error=False, fill_value=0.0):
     return interp1d(xs, ys, bounds_error=bounds_error, fill_value=fill_value)
 
 
+def _eval_energy_res(energy_res, e):
+    r"""Evaluate an energy-resolution callback over one or many energies.
+
+    ``energy_res`` is documented as ``float -> float``. Interpolators and other
+    vectorized callbacks accept arrays directly, but a plain Python callback
+    such as ``lambda e: 0.1 if e < 10 else 0.2`` raises on array input, so fall
+    back to evaluating it element-wise. A callback returning a single value for
+    an array of energies is treated as a constant resolution.
+    """
+    e = np.asarray(e, dtype=float)
+
+    try:
+        res = np.asarray(energy_res(e), dtype=float)
+    except (ValueError, TypeError):
+        return np.vectorize(energy_res, otypes=[float])(e)
+
+    if res.shape != e.shape:
+        return np.broadcast_to(res, e.shape)
+
+    return res
+
+
 def spec_res_fn(ep, e, energy_res):
     r"""Get the spectral resolution function.
 
@@ -415,7 +437,8 @@ def spec_res_fn(ep, e, energy_res):
         The detector's energy resolution (Delta E / E) as a function of photon
         energy in MeV.
     """
-    sigma = np.asarray(e, dtype=float) * energy_res(e)
+    e = np.asarray(e, dtype=float)
+    sigma = e * _eval_energy_res(energy_res, e)
 
     with np.errstate(divide="ignore", invalid="ignore"):
         res = (
@@ -443,7 +466,7 @@ def _true_energy_grid(lo, hi, energy_res, n_pts):
     response.
     """
     grid = np.geomspace(lo, hi, n_pts)
-    res = np.asarray(energy_res(grid), dtype=float)
+    res = _eval_energy_res(energy_res, grid)
     res = res[res > 0.0]
 
     if res.size == 0:
@@ -486,9 +509,9 @@ def convolved_spectrum_fn(
     es = np.geomspace(e_min, e_max, n_pts)
     dnde_conv = np.zeros(es.shape)
 
-    # Pad energy grid to avoid edge effects
-    es_padded = _true_energy_grid(0.1 * e_min, 10 * e_max, energy_res, n_pts)
     if spec_fn is not None:
+        # Pad energy grid to avoid edge effects
+        es_padded = _true_energy_grid(0.1 * e_min, 10 * e_max, energy_res, n_pts)
         dnde_src = spec_fn(es_padded)
         if not np.all(dnde_src == 0):
 

--- a/hazma/spectra/altarelli_parisi.py
+++ b/hazma/spectra/altarelli_parisi.py
@@ -1,3 +1,16 @@
+r"""Approximate final-state radiation in the Altarelli-Parisi approximation.
+
+.. note::
+
+    The functions in this module give the FSR from a **single** radiating
+    particle, and so carry a prefactor of :math:`\alpha_{\mathrm{em}}/2\pi`.
+    Eq. (4.6) of the hazma paper (arXiv:1907.11846), and the deprecated
+    ``hazma.utils.dnde_altarelli_parisi_*`` functions, instead give the result
+    summed over a **pair** of oppositely-charged particles and carry
+    :math:`\alpha_{\mathrm{em}}/\pi`. To reproduce Eq. (4.6), add the spectrum
+    once per charged final-state particle, as ``hazma.spectra`` does.
+"""
+
 from typing import Any, Callable
 
 import numpy as np

--- a/hazma/vector_mediator/_gev/spectra.py
+++ b/hazma/vector_mediator/_gev/spectra.py
@@ -119,7 +119,9 @@ def dnde_photon_e_e(_, photon_energies, cme: float):
     if cme < 2 * me:
         return np.zeros_like(photon_energies)
 
-    return dnde_photon_ap_fermion(photon_energies, cme**2, me, charge=-1.0)
+    # Factor of 2: the AP functions give the FSR off a single radiating
+    # particle, and both leptons radiate.
+    return 2.0 * dnde_photon_ap_fermion(photon_energies, cme**2, me, charge=-1.0)
 
 
 def dnde_photon_mu_mu(_, photon_energies, cme: float):
@@ -140,7 +142,9 @@ def dnde_photon_mu_mu(_, photon_energies, cme: float):
     if cme < 2 * mmu:
         return np.zeros_like(photon_energies)
 
-    fsr = dnde_photon_ap_fermion(photon_energies, cme**2, mmu, charge=-1.0)
+    # Factor of 2: the AP functions give the FSR off a single radiating
+    # particle, and both muons radiate.
+    fsr = 2.0 * dnde_photon_ap_fermion(photon_energies, cme**2, mmu, charge=-1.0)
     dec = 2 * spectra.dnde_photon_muon(photon_energies, cme / 2.0)
     return fsr + dec
 
@@ -168,7 +172,9 @@ def dnde_photon_pi_pi(_, photon_energies, cme: float):
     if cme < 2 * mpi:
         return np.zeros_like(photon_energies)
 
-    fsr = dnde_photon_ap_scalar(photon_energies, cme**2, mpi, charge=-1.0)
+    # Factor of 2: the AP functions give the FSR off a single radiating
+    # particle, and both pions radiate.
+    fsr = 2.0 * dnde_photon_ap_scalar(photon_energies, cme**2, mpi, charge=-1.0)
     dec = 2 * spectra.dnde_photon_charged_pion(photon_energies, cme / 2.0)
     return fsr + dec
 
@@ -214,8 +220,10 @@ def dnde_photon_k_k(_, photon_energies, cme: float):
     if cme < 2 * mk:
         return np.zeros_like(photon_energies)
 
-    fsr = dnde_photon_ap_scalar(photon_energies, cme**2, mk, charge=-1.0)
-    dec = spectra.dnde_photon_charged_kaon(photon_energies, cme / 2.0)
+    # Factor of 2: the AP functions give the FSR off a single radiating
+    # particle, and both kaons radiate.
+    fsr = 2.0 * dnde_photon_ap_scalar(photon_energies, cme**2, mk, charge=-1.0)
+    dec = 2 * spectra.dnde_photon_charged_kaon(photon_energies, cme / 2.0)
     return fsr + dec
 
 
@@ -712,8 +720,8 @@ def dnde_photon_pi_pi_pi0_pi0(
     ff: VectorFormFactorPiPiPi0Pi0 = self._ff_pi_pi_pi0_pi0
 
     dnde_decays = [
-        spectra.dnde_photon_charged_kaon,
-        spectra.dnde_photon_charged_kaon,
+        spectra.dnde_photon_charged_pion,
+        spectra.dnde_photon_charged_pion,
         spectra.dnde_photon_neutral_pion,
         spectra.dnde_photon_neutral_pion,
     ]
@@ -735,7 +743,11 @@ def dnde_photon_pi_pi_pi0_pi0(
     dpdm = inv_mass_dist[(0, 1)]
     ps = dpdm.probabilities
     ms = dpdm.bin_centers
-    fsr = np.array([dnde_photon_ap_scalar(photon_energies, m**2, mpi) for m in ms])
+    # Factor of 2: the AP functions give the FSR off a single radiating
+    # particle, and both charged pions radiate.
+    fsr = np.array(
+        [2.0 * dnde_photon_ap_scalar(photon_energies, m**2, mpi) for m in ms]
+    )
     dnde += np.trapz(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
 
     return dnde

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -1,0 +1,134 @@
+"""Tests for the detector energy-resolution convolution."""
+
+import numpy as np
+import pytest
+from scipy.integrate import trapz
+
+from hazma.parameters import convolved_spectrum_fn, spec_res_fn
+
+
+def scalar_only_energy_res(energy):
+    """Resolution callback that only accepts scalars, per the documented API.
+
+    Passing an array raises ``ValueError: truth value of an array is
+    ambiguous``, so anything consuming this must evaluate it element-wise.
+    """
+    return 0.1 if energy < 10.0 else 0.2
+
+
+def constant_energy_res(energy):
+    """Resolution callback returning a single value regardless of input shape."""
+    return 0.05
+
+
+def vectorized_energy_res(energy):
+    """Resolution callback that handles arrays natively."""
+    return np.where(np.asarray(energy) < 10.0, 0.1, 0.2)
+
+
+def gaussian_line_source(energies):
+    """A narrow source spectrum centered at 5 MeV, normalized to one photon."""
+    width = 0.5
+    energies = np.asarray(energies, dtype=float)
+    return np.exp(-((energies - 5.0) ** 2) / (2 * width**2)) / np.sqrt(
+        2 * np.pi * width**2
+    )
+
+
+ENERGY_RES_CALLBACKS = [
+    scalar_only_energy_res,
+    constant_energy_res,
+    vectorized_energy_res,
+]
+
+
+@pytest.mark.parametrize("energy_res", ENERGY_RES_CALLBACKS)
+def test_convolution_accepts_scalar_and_vector_callbacks(energy_res):
+    """`energy_res` is documented as `float -> float` and must stay supported."""
+    dnde = convolved_spectrum_fn(
+        1e-1, 1e2, energy_res, spec_fn=gaussian_line_source, n_pts=200
+    )
+
+    energies = np.geomspace(1e-1, 1e2, 300)
+    assert np.all(np.isfinite(dnde(energies)))
+
+
+@pytest.mark.parametrize("energy_res", ENERGY_RES_CALLBACKS)
+def test_line_only_convolution_accepts_scalar_callbacks(energy_res):
+    """A line-only convolution must not require a vectorized callback."""
+    dnde = convolved_spectrum_fn(
+        1e-1, 1e2, energy_res, lines={"g g": {"bf": 1.0, "energy": 5.0}}, n_pts=200
+    )
+
+    energies = np.geomspace(1e-1, 1e2, 300)
+    assert np.all(np.isfinite(dnde(energies)))
+
+
+def test_scalar_callback_matches_vectorized_equivalent():
+    """Element-wise fallback must give the same answer as a native array call."""
+    energies = np.geomspace(1e-1, 1e2, 300)
+
+    scalar = convolved_spectrum_fn(
+        1e-1, 1e2, scalar_only_energy_res, spec_fn=gaussian_line_source, n_pts=200
+    )
+    vector = convolved_spectrum_fn(
+        1e-1, 1e2, vectorized_energy_res, spec_fn=gaussian_line_source, n_pts=200
+    )
+
+    assert np.allclose(scalar(energies), vector(energies), rtol=1e-12, atol=0.0)
+
+
+def test_response_width_is_set_by_the_true_energy():
+    """The response must not smear photons past where the source spectrum ends.
+
+    The width of the response is `sigma = E * (Delta E / E)` evaluated at the
+    *true* energy. Using the reconstructed energy instead lets a sharp feature
+    leak to arbitrarily high energies wherever the resolution is poor: a
+    Gaussian centered at 100 MeV with a 20% resolution has `sigma = 20` MeV, and
+    so reaches back down to a source that cuts off at 6 MeV.
+    """
+    dnde = convolved_spectrum_fn(
+        1e-1, 1e3, scalar_only_energy_res, spec_fn=gaussian_line_source, n_pts=200
+    )
+
+    # The source is dead by 8 MeV (6 sigma), and the fine resolution there
+    # cannot push photons out to 50 MeV and beyond.
+    assert np.all(dnde(np.geomspace(50.0, 1e3, 50)) < 1e-20)
+
+
+def test_convolution_conserves_photon_number():
+    """Smearing redistributes photons in energy; it must not create or lose them."""
+    energies = np.geomspace(1e-1, 1e2, 2000)
+
+    dnde = convolved_spectrum_fn(
+        1e-1, 1e2, vectorized_energy_res, spec_fn=gaussian_line_source, n_pts=500
+    )
+
+    assert trapz(dnde(energies), energies) == pytest.approx(1.0, rel=1e-3)
+
+
+def test_spec_res_fn_arguments_are_not_interchangeable():
+    """The width comes from the true energy, so the response is asymmetric."""
+    # 4 MeV true -> 10% width; 20 MeV true -> 20% width. Swapping the arguments
+    # changes which width is used and therefore the value.
+    forward = spec_res_fn(20.0, 4.0, scalar_only_energy_res)
+    backward = spec_res_fn(4.0, 20.0, scalar_only_energy_res)
+
+    assert not np.isclose(forward, backward)
+
+
+def test_spec_res_fn_accepts_an_array_of_true_energies():
+    """The convolution integral evaluates the response over a grid of true energies."""
+    true_energies = np.array([4.0, 5.0, 20.0])
+
+    response = spec_res_fn(5.0, true_energies, scalar_only_energy_res)
+
+    assert response.shape == true_energies.shape
+    assert np.all(np.isfinite(response))
+    # The response peaks where the true energy matches the reconstructed one.
+    assert np.argmax(response) == 1
+
+
+def test_zero_width_response_carries_no_photons():
+    """A vanishing resolution yields a zero response, matching historical behavior."""
+    assert spec_res_fn(5.0, 5.0, lambda energy: 0.0) == 0.0


### PR DESCRIPTION
Both issues here were reported by Chris Cappiello, who ran into them modelling
a 10 MeV scalar decaying to `e+e-`.

## 1. Energy resolution leaked photons to high energies

`convolved_spectrum_fn` built the Gaussian detector response with a width set by
the **reconstructed** photon energy while normalizing over the **true** energy.
The two call sites of `spec_res_fn` disagreed about which argument was which —
the line contribution passed the true line energy (correct), the continuum
contribution passed the reconstructed energy (wrong).

Where a detector's resolution is poor, this let sharp spectral features leak to
arbitrarily high reconstructed energies. e-ASTROGAM's tabulated resolution jumps
from 0.5% at 10 MeV to 20% at 30 MeV (the pair-production regime), so the
response used at 30 MeV was a Gaussian of σ = 6 MeV — wide enough to pick up real
photons at 1–5 MeV. A spectrum that cuts off at ~4.95 MeV acquired a spurious
1e-7 tail from 25 MeV out to 1 GeV.

The response is now `R(e | e')` with the width set by the true energy `e'`,
normalized over the reconstructed energy and **not** renormalized afterwards —
renormalizing over `e'` loses ~5% of the photons, because the width varies with
`e'`.

Verified on the reported configuration (10 MeV → `e+e-`, e-ASTROGAM):

| E [MeV] | raw | before | after |
|---|---|---|---|
| 1.0 | 1.8e-2 | 1.8e-2 | 1.8e-2 |
| 4.5 | 1.4e-3 | 1.4e-3 | 1.4e-3 |
| 30 | 0 | **7.8e-8** | 0 |
| 300 | 0 | **1.6e-8** | 0 |
| 1000 | 0 | **3.8e-8** | 0 |

The spectrum below the endpoint is unchanged and total photon number is conserved
to 3e-5.

**Performance note.** The old ad-hoc renormalization was incidentally cancelling
grid undersampling error, so removing it exposed an 8% pointwise error at
`n_pts=1000`. The convolution integral now runs on its own grid, sized from the
finest ΔE/E in range and capped at 200k points (15k for e-ASTROGAM). This costs
about 6x runtime per call — 0.03s → 0.20s — and converges to better than 0.05%.
Worth a look if anyone calls this in a tight loop.

## 2. Altarelli-Parisi normalization convention

`hazma/spectra/altarelli_parisi.py` gives the FSR off a **single** radiating
particle (α/2π). Eq. 4.6 of arXiv:1907.11846, and the deprecated
`hazma.utils.dnde_altarelli_parisi_*`, give the **pair-summed** result (α/π). The
ratio is exactly 2. This tripped up the reporter and wasn't documented anywhere;
it now is, at the top of the module.

The `hazma.spectra.dnde_photon` path was already correct — `_dnde_two_body` adds
the per-leg spectrum once per charged final-state particle, reproducing Eq. 4.6.

But five call sites in `_gev/spectra.py` applied it once for a charged *pair*
(`e e`, `mu mu`, `pi pi`, `k k`, `pi pi pi0 pi0`), making them a factor of 2 low
relative to the equivalent `hazma.spectra` path. Two other sites in the same file
already had the explicit `2.0 *`. All seven are now consistent.

## 3. Two adjacent bugs in the same file

Found while fixing the above:

- `dnde_photon_k_k` counted the decay spectrum once, though both K⁺ and K⁻ decay.
  Every sibling (`mu mu`, `pi pi`) uses `2 *`.
- `dnde_photon_pi_pi_pi0_pi0` listed `dnde_photon_charged_kaon` twice in
  `dnde_decays` for a π⁺π⁻π⁰π⁰ final state — copy-pasted from a neighboring
  function. The index convention is confirmed by the same function's FSR block,
  which uses `inv_mass_dist[(0, 1)]` with `mpi`.

## Not changed

- `rh_neutrino` uses the pair convention consistently (it has an explicit `0.5`
  when averaging over two lepton species).
- `hazma/vector_mediator/_gev_spectra.py` has the same one-per-pair issue but has
  no importers anywhere — it looks like a dead copy of `_gev/spectra.py`. Left
  alone; probably wants deleting separately.

## Testing

No existing tests cover the convolution or these spectra. Validation was done
against a standalone reimplementation, checking photon-number conservation, grid
convergence, and agreement with the unconvolved spectrum where resolution is
fine. Worth adding regression tests for the resolution response — happy to do
that here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
