### PR TITLE
docs(agents): add project workflow and agent skills

### DIFF
--- a/.claude/skills/begin-phase/SKILL.md
+++ b/.claude/skills/begin-phase/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: begin-phase
+description: Prepare a guarded, ready-to-paste kickoff prompt for the next eligible phase of a phased project, verifying strict prerequisite closeout first and refusing blocked or ambiguous phase starts.
+---
+
+**Role:** Prepare a safe, ready-to-paste prompt for the next phase of a
+**phased** project without letting an agent start a blocked or ambiguous
+phase.
+
+**When to use this skill**
+
+- The user asks to begin the next phase of a phased project.
+- The user asks which phase is actually ready to start next.
+- The user asks to prepare a specific phase safely.
+
+This skill **prepares a handoff prompt only**. It does not start
+implementation or edit project files. First-task selection inside the
+chosen phase is delegated to `/execute-single-task`.
+
+**When NOT to use**
+
+- Flat (non-phased) projects — refuse and point at
+  `/execute-single-task` (see Step 2).
+- Actually implementing a task — that is `/execute-single-task`.
+
+## Inputs
+
+Required:
+
+- **project slug** — explicit `--project <slug>`, or inferred from the
+  current branch (see Step 1).
+
+Optional:
+
+- **completed phase** — the phase that just wrapped up (e.g. `2`, `3.1`),
+  passed as `--completed-phase`. When set, the helper prefers phases this
+  one directly unlocks.
+- **target phase** — a specific phase to prepare, via `--target-phase`.
+
+## Workflow
+
+### Step 1: Resolve the project slug
+
+1. **Explicit argument** (`--project <slug>`) wins.
+2. **Branch-name inference.** A project branch is
+   `<agent>/<project-slug>/<task-slug>`, `<agent>` ∈ `{claude, codex}` —
+   **parse both prefixes**. The first segment after the prefix is the
+   slug. Ad-hoc branches have no second `/` and name no project.
+3. **Stop and ask** if neither resolves a slug.
+
+### Step 2: Confirm the project is phased
+
+Read `projects/<slug>/PLAN.md`'s frontmatter.
+
+- `phased: true` → continue.
+- `phased: false` (or missing) → **refuse.** `begin-phase` exists only
+  for phased projects. Point the user at `/execute-single-task` with
+  their target task number.
+
+The helper enforces this too (it returns `status: error` for a non-phased
+project), so this read is belt-and-suspenders, not the sole gate.
+
+### Step 3: Determine the request shape
+
+Map the user's request to helper arguments:
+
+- "What phase is ready next?" → no phase arguments.
+- "Prepare the next phase after Phase X" → `--completed-phase X`.
+- "Prepare Phase Y" → `--target-phase Y`.
+- Both supplied → pass both.
+
+### Step 4: Run the shared helper
+
+The helper is at `.claude/skills/begin-phase/scripts/resolve_phase.py`.
+**Run it from the repo root** — the Bash-tool cwd can reset between
+calls, so pass an absolute path or `cd` in the same command.
+
+```sh
+# Current frontier:
+python3 .claude/skills/begin-phase/scripts/resolve_phase.py \
+  --project <slug>
+
+# After a just-completed phase:
+python3 .claude/skills/begin-phase/scripts/resolve_phase.py \
+  --project <slug> --completed-phase 4
+
+# Explicit target:
+python3 .claude/skills/begin-phase/scripts/resolve_phase.py \
+  --project <slug> --target-phase 6
+```
+
+The helper emits JSON on stdout with `status`:
+
+- `ready` — exactly one phase is eligible; a kickoff prompt is included
+  under `prompt`.
+- `choose` — multiple phases are eligible; `choices[]` lists them with
+  reasons.
+- `blocked` — the requested or frontier phase has unmet prerequisites or
+  its prereq prose can't be machine-resolved; `blockers[]` lists them.
+- `error` — bad input or project not found; stop and report the message.
+
+It also carries a `notes[]` array — surface anything listed there.
+
+### Step 5: Follow the helper output strictly
+
+- **`ready`:**
+  - Tell the user which phase is eligible, why (the helper's `reason`),
+    and whether any notes were emitted.
+  - Paste the `prompt` inside a fenced block. **Paste it verbatim; do not
+    rewrite, trim, or "clean up" the prompt** — it already carries the
+    guardrails (phase scope, a re-run-and-refuse-unless-`ready` check for
+    the next agent, worktree setup per `/execute-single-task` Step 3).
+- **`choose`:**
+  - List the numbered `choices` with their `reason`s. Stop. Do not
+    auto-select — the user must choose before a kickoff prompt is
+    generated.
+- **`blocked`:**
+  - Explain each blocker clearly (which phase, which issue). A phase is
+    only eligible when every prerequisite is **both** `status: Complete`
+    **and** has a matching learnings document
+    (`learnings/phase-XX-*.md`). So `blocked: missing learnings document`
+    means the prereq phase is marked done but its write-up is absent —
+    say that, don't just echo the string.
+  - Synthetic `(none)` blocker: when the helper reports
+    `phase_id: "(none)"`, no phase is in a Not-started state. Tell the
+    user the project may be complete or needs a new phase file authored.
+  - Do not draft a kickoff prompt for any blocked phase.
+- **`error`:** report it. Ask for the correct project slug or phase id if
+  it's an input problem.
+
+## Guardrails
+
+- **Do not auto-start phases for flat projects.** Refuse with a pointer
+  to `/execute-single-task` when `phased: false`.
+- **Do not bypass the helper.** Never eyeball the phase files and decide
+  a phase is ready without running `resolve_phase.py`.
+- **Do not prepare a kickoff prompt for a blocked phase.** The helper's
+  blockers list is the source of truth.
+- **Do not auto-pick between parallel phases.** On `choose`, surface the
+  options and stop.
+- **Do not start implementation work yourself.** This skill only
+  generates a handoff prompt.
+- **Do not flag `_template.md` files as project state.** The helper
+  ignores phase-file names starting with `_`; you should too.

--- a/.claude/skills/begin-phase/scripts/resolve_phase.py
+++ b/.claude/skills/begin-phase/scripts/resolve_phase.py
@@ -1,0 +1,931 @@
+#!/usr/bin/env python3
+"""
+Resolve which phase of a phased project is eligible to start next and build a
+kickoff prompt for the next agent.
+
+This script is the readiness oracle for the ``begin-phase`` skill. It inspects
+the frontmatter of each ``projects/<slug>/phases/phase-XX-*.md`` file plus the
+project's ``PLAN.md`` frontmatter, then emits JSON with one of three states:
+
+- ``ready`` -- exactly one phase is eligible and a kickoff prompt is included
+- ``choose`` -- multiple phases are eligible; the caller must pick one
+- ``blocked`` -- the requested (or next) phase has unmet prerequisites
+
+Prerequisite handling is intentionally conservative. Each phase file's
+``## Prerequisites`` section is prose (human-readable). This script scans it
+for machine-readable patterns like ``Phase 0 complete`` or ``Phase 3.1
+complete`` and maps them to phase IDs. Phases whose prerequisites do not match
+any such pattern are flagged as ``prereqs unknown (manual check required)``
+rather than being optimistically marked eligible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# ---------------------------------------------------------------------------
+# Phase-id helpers
+
+
+def normalize_phase_id(value: str) -> str:
+    """Normalize a user-provided phase id like ``phase-03``, ``3.1``, or
+    ``8A`` into the canonical form used internally.
+
+    Canonical forms:
+      - ``"3"`` for major-only phases
+      - ``"3.1"`` for decimal sub-phases
+      - ``"8A"`` for letter-suffixed parallel phases
+    """
+
+    token = value.strip().lower()
+    token = re.sub(r"^phase[\s_-]*", "", token)
+    token = token.replace("_", ".").replace(" ", "")
+    if not token:
+        raise ValueError("phase id cannot be empty")
+
+    letter_match = re.fullmatch(r"0*(\d+)([a-z])", token)
+    if letter_match:
+        return f"{int(letter_match.group(1))}{letter_match.group(2).upper()}"
+
+    numeric_match = re.fullmatch(r"0*(\d+)(?:\.0*(\d+))?", token)
+    if numeric_match:
+        major = str(int(numeric_match.group(1)))
+        minor = numeric_match.group(2)
+        if minor is None:
+            return major
+        return f"{major}.{int(minor)}"
+
+    raise ValueError(f"unsupported phase id: {value!r}")
+
+
+def phase_id_from_prefix(prefix: str) -> str:
+    """Turn the ``XX`` (or ``XX_Y``, or ``XXa``) prefix of a phase filename
+    into the canonical id."""
+
+    lower = prefix.lower()
+    if lower and lower[-1].isalpha():
+        return f"{int(lower[:-1])}{lower[-1].upper()}"
+    if "_" in lower:
+        major, minor = lower.split("_", 1)
+        return f"{int(major)}.{int(minor)}"
+    return str(int(lower))
+
+
+def phase_sort_key(phase_id: str) -> tuple[int, int, int, str]:
+    """Sort canonical phase ids deterministically.
+
+    Order: major phases < decimal sub-phases within a major < lettered
+    parallel phases within a major.
+    """
+
+    if phase_id and phase_id[-1].isalpha():
+        return (int(phase_id[:-1]), 2, 0, phase_id[-1])
+    if "." in phase_id:
+        major, minor = phase_id.split(".", 1)
+        return (int(major), 1, int(minor), "")
+    return (int(phase_id), 0, 0, "")
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter + prerequisite parsing
+
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n?", re.S)
+_KEY_VALUE_RE = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$"
+)
+_PHASE_NUMBER_RE = re.compile(
+    r"Phase\s+(?P<id>[0-9]+(?:\.[0-9]+)?|[0-9]+[A-Za-z])",
+    re.I,
+)
+_COMPLETE_MENTION_RE = re.compile(
+    r"Phase\s+(?P<id>[0-9]+(?:\.[0-9]+)?|[0-9]+[A-Za-z])"
+    r"\s+(?:is\s+)?complete",
+    re.I,
+)
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Parse the YAML-ish frontmatter block at the top of a Markdown file.
+
+    We do not depend on a YAML library -- frontmatter in this repo is always
+    simple ``key: value`` lines. Quoted values are unquoted.
+    """
+
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+
+    data: dict[str, str] = {}
+    for line in match.group("body").splitlines():
+        kv = _KEY_VALUE_RE.match(line)
+        if not kv:
+            continue
+        value = kv.group(2).strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        data[kv.group(1)] = value
+    return data
+
+
+def status_is_complete(status: str | None) -> bool:
+    return status is not None and status.strip().lower().startswith("complete")
+
+
+def status_is_not_started(status: str | None) -> bool:
+    if status is None:
+        return False
+    return status.strip().lower().startswith("not started")
+
+
+def extract_phase_title(text: str, default: str) -> str:
+    match = re.search(r"^#\s+Phase\s+[^\n:]+:\s+(?P<title>.+)$", text, re.M)
+    if match:
+        return match.group("title").strip()
+    return default
+
+
+def extract_prerequisite_section(text: str) -> str:
+    """Return the body of the ``## Prerequisites`` block, or ``""`` if the
+    section is missing."""
+
+    match = re.search(
+        r"^## Prerequisites\s*\n(?P<body>.*?)(?=^## |\Z)",
+        text,
+        re.M | re.S,
+    )
+    if not match:
+        return ""
+    return match.group("body")
+
+
+def extract_prereq_phase_ids(prereq_text: str) -> tuple[tuple[str, ...], bool]:
+    """Extract machine-resolvable phase-id prerequisites from free-form
+    prose.
+
+    Returns ``(ids, machine_resolvable)`` where ``machine_resolvable`` is:
+      - ``True`` if the section is empty, or mentions no phases, or mentions
+        phases with explicit ``complete`` wording for every reference.
+      - ``False`` if the prose references phases but does not use the
+        ``Phase N complete`` phrasing we understand, so a human should check.
+
+    We're intentionally strict: ambiguous prose is flagged rather than
+    optimistically resolved.
+    """
+
+    stripped = prereq_text.strip()
+    if not stripped:
+        return (tuple(), True)
+
+    raw_mentions = list(_PHASE_NUMBER_RE.finditer(stripped))
+    complete_mentions = list(_COMPLETE_MENTION_RE.finditer(stripped))
+
+    if not raw_mentions:
+        # Prose has no phase references -- treat as no phase-level prereqs.
+        return (tuple(), True)
+
+    if len(complete_mentions) < len(raw_mentions):
+        # Some phase references don't have matching "complete" wording.
+        # Return what we found but flag as not machine-resolvable.
+        ids = tuple(
+            sorted(
+                {
+                    normalize_phase_id(m.group("id"))
+                    for m in complete_mentions
+                }
+            )
+        )
+        return (ids, False)
+
+    ids = tuple(
+        sorted(
+            {normalize_phase_id(m.group("id")) for m in complete_mentions},
+            key=phase_sort_key,
+        )
+    )
+    return (ids, True)
+
+
+# ---------------------------------------------------------------------------
+# Phase records
+
+
+@dataclass(frozen=True)
+class PhaseRecord:
+    """A single phase file, parsed and normalized."""
+
+    phase_id: str
+    title: str
+    prefix: str
+    phase_file: Path
+    status: str | None
+    prerequisite_ids: tuple[str, ...]
+    prereqs_machine_resolvable: bool
+    learnings_paths: tuple[Path, ...] = field(default_factory=tuple)
+
+
+def load_phase_records(project_dir: Path) -> dict[str, PhaseRecord]:
+    phases_dir = project_dir / "phases"
+    if not phases_dir.is_dir():
+        return {}
+
+    learnings_dir = project_dir / "learnings"
+
+    records: dict[str, PhaseRecord] = {}
+    for phase_file in sorted(phases_dir.glob("phase-*.md")):
+        # Skip the template file used as a reference artifact.
+        if phase_file.name.startswith("_"):
+            continue
+        prefix_match = re.match(r"phase-(?P<prefix>[^-]+)-", phase_file.name)
+        if not prefix_match:
+            continue
+        prefix = prefix_match.group("prefix")
+
+        text = phase_file.read_text()
+        frontmatter = parse_frontmatter(text)
+        try:
+            phase_id = phase_id_from_prefix(prefix)
+        except ValueError:
+            continue
+        # Frontmatter `phase:` wins if present and consistent.
+        if frontmatter.get("phase"):
+            try:
+                phase_id = normalize_phase_id(frontmatter["phase"])
+            except ValueError:
+                pass
+        title = frontmatter.get("title") or extract_phase_title(text, phase_id)
+        status = frontmatter.get("status")
+
+        prereq_section = extract_prerequisite_section(text)
+        prereq_ids, machine_resolvable = extract_prereq_phase_ids(
+            prereq_section
+        )
+
+        learnings_paths: tuple[Path, ...] = tuple()
+        if learnings_dir.is_dir():
+            pattern = f"phase-{prefix.lower()}-*.md"
+            learnings_paths = tuple(
+                sorted(
+                    p
+                    for p in learnings_dir.glob(pattern)
+                    if not p.name.startswith("_")
+                )
+            )
+
+        records[phase_id] = PhaseRecord(
+            phase_id=phase_id,
+            title=title,
+            prefix=prefix,
+            phase_file=phase_file,
+            status=status,
+            prerequisite_ids=prereq_ids,
+            prereqs_machine_resolvable=machine_resolvable,
+            learnings_paths=learnings_paths,
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Eligibility resolution
+
+
+def relpath(repo_root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+def phase_closeout_issues(
+    repo_root: Path, record: PhaseRecord
+) -> list[str]:
+    """Reasons a phase is not considered fully closed out. Empty list means
+    the phase is closed out and its downstream dependents may proceed."""
+
+    issues: list[str] = []
+    if not status_is_complete(record.status):
+        issues.append(
+            f"{relpath(repo_root, record.phase_file)} frontmatter "
+            f"status is {record.status or 'unknown'}, not Complete"
+        )
+    if not record.learnings_paths:
+        issues.append(
+            f"missing learnings document matching "
+            f"{relpath(repo_root, record.phase_file.parent.parent)}/"
+            f"learnings/phase-{record.prefix.lower()}-*.md"
+        )
+    return issues
+
+
+def prerequisite_blockers(
+    repo_root: Path,
+    phases: dict[str, PhaseRecord],
+    phase_id: str,
+) -> tuple[list[dict[str, object]], list[str]]:
+    """Return ``(blockers, unknown_prereqs)`` for the given phase.
+
+    - ``blockers`` -- prereq phases that are known and not yet closed out.
+    - ``unknown_prereqs`` -- raw prereq ids referenced but not present as
+      phase files in the project.
+    """
+
+    record = phases[phase_id]
+    blockers: list[dict[str, object]] = []
+    unknown: list[str] = []
+    for prereq_id in sorted(record.prerequisite_ids, key=phase_sort_key):
+        prereq = phases.get(prereq_id)
+        if prereq is None:
+            unknown.append(prereq_id)
+            continue
+        issues = phase_closeout_issues(repo_root, prereq)
+        if issues:
+            blockers.append(
+                {
+                    "phase_id": prereq.phase_id,
+                    "title": prereq.title,
+                    "issues": issues,
+                }
+            )
+    return blockers, unknown
+
+
+def eligible_frontier(
+    repo_root: Path, phases: dict[str, PhaseRecord]
+) -> list[str]:
+    """Phases whose ``status: Not started`` and whose prerequisites are all
+    closed out and machine-resolvable."""
+
+    frontier: list[str] = []
+    for phase_id, record in sorted(
+        phases.items(), key=lambda item: phase_sort_key(item[0])
+    ):
+        if not status_is_not_started(record.status):
+            continue
+        if not record.prereqs_machine_resolvable:
+            # Don't silently promote prereqs-unknown phases to the frontier.
+            continue
+        blockers, unknown = prerequisite_blockers(
+            repo_root, phases, phase_id
+        )
+        if blockers or unknown:
+            continue
+        frontier.append(phase_id)
+    return frontier
+
+
+def blocked_frontier_candidates(
+    repo_root: Path, phases: dict[str, PhaseRecord]
+) -> list[dict[str, object]]:
+    """Phases that look like the next candidates to start but are currently
+    blocked.
+
+    A phase makes the blocked-candidate list when its own status is
+    ``Not started`` but one or more of the following is true:
+      - its prerequisites are not machine-resolvable (prose doesn't match
+        the ``Phase N complete`` pattern); or
+      - at least one prerequisite is incomplete; or
+      - at least one prerequisite references a phase that has no file in
+        the project.
+    """
+    candidates: list[dict[str, object]] = []
+    for phase_id, record in sorted(
+        phases.items(), key=lambda item: phase_sort_key(item[0])
+    ):
+        if not status_is_not_started(record.status):
+            continue
+
+        issues: list[str] = []
+        if not record.prereqs_machine_resolvable:
+            issues.append(
+                "prose in `## Prerequisites` does not match the "
+                "`Phase N complete` pattern; manual check required"
+            )
+            # Continue to also list any prereqs we *did* recognize so
+            # the operator sees concrete context.
+
+        blockers, unknown = prerequisite_blockers(
+            repo_root, phases, phase_id
+        )
+        for prereq_id in unknown:
+            issues.append(
+                f"Phase {prereq_id} referenced as a prerequisite but "
+                "no matching phase file exists in the project"
+            )
+        for blocker in blockers:
+            prereq_label = f"Phase {blocker['phase_id']}"
+            for issue in blocker["issues"]:  # type: ignore[index]
+                issues.append(f"{prereq_label}: {issue}")
+
+        if not issues:
+            # No machine-visible blockers. It should have been on the
+            # eligible frontier; skip.
+            continue
+
+        candidates.append(
+            {
+                "phase_id": record.phase_id,
+                "title": record.title,
+                "phase_file": relpath(repo_root, record.phase_file),
+                "issues": issues,
+            }
+        )
+    return candidates
+
+
+def phase_summary(
+    repo_root: Path,
+    phases: dict[str, PhaseRecord],
+    phase_id: str,
+) -> dict[str, object]:
+    record = phases[phase_id]
+    payload: dict[str, object] = {
+        "phase_id": record.phase_id,
+        "title": record.title,
+        "status": record.status,
+        "phase_file": relpath(repo_root, record.phase_file),
+        "prerequisites": list(record.prerequisite_ids),
+        "prereqs_machine_resolvable": record.prereqs_machine_resolvable,
+    }
+    prereqs = list(record.prerequisite_ids)
+    if not prereqs:
+        payload["reason"] = "No phase-level prerequisites."
+    else:
+        labels = [f"Phase {p}" for p in prereqs]
+        payload["reason"] = (
+            f"Prerequisites satisfied: {', '.join(labels)}."
+        )
+    return payload
+
+
+def build_prompt(
+    project_slug: str,
+    project_dir: Path,
+    repo_root: Path,
+    phases: dict[str, PhaseRecord],
+    phase_id: str,
+) -> str:
+    record = phases[phase_id]
+
+    prereq_learnings: list[str] = []
+    for prereq_id in sorted(record.prerequisite_ids, key=phase_sort_key):
+        prereq = phases.get(prereq_id)
+        if prereq is None:
+            continue
+        for learning_path in prereq.learnings_paths:
+            prereq_learnings.append(relpath(repo_root, learning_path))
+    learning_block = "\n".join(f"- `{p}`" for p in prereq_learnings)
+    if not learning_block:
+        learning_block = "- None yet."
+
+    plan_path = relpath(repo_root, project_dir / "PLAN.md")
+    rules_path = relpath(repo_root, project_dir / "rules.md")
+    phase_path = relpath(repo_root, record.phase_file)
+    recheck = (
+        f"python3 .claude/skills/begin-phase/scripts/resolve_phase.py "
+        f"--project {project_slug} --target-phase {phase_id}"
+    )
+
+    return (
+        f"Use the `/execute-single-task` skill.\n\n"
+        f"You are starting Phase {phase_id}: {record.title} for project "
+        f"`{project_slug}` (root `{repo_root}`).\n\n"
+        "Before editing:\n"
+        f"1. Re-run `{recheck}` and refuse to proceed unless the result "
+        f"is still `ready`.\n"
+        "2. Create your worktree as Step 3 of `/execute-single-task` "
+        "instructs -- path `.claude/worktrees/"
+        f"{project_slug}/<task-slug>/`, branch "
+        f"`claude/{project_slug}/<task-slug>`.\n\n"
+        "Scope:\n"
+        f"- Work only within Phase {phase_id}.\n"
+        "- Do not start sibling or downstream phases.\n"
+        f"- Start with the next lowest-numbered unfinished task in "
+        f"Phase {phase_id} -- read it from the live Tasks table in "
+        f"`projects/{project_slug}/task-notes/phase-"
+        f"{phase_id}/README.md` (not `PLAN.md` or the phase file).\n\n"
+        "Read only:\n"
+        f"1. `{plan_path}`\n"
+        f"2. `projects/{project_slug}/task-notes/README.md` "
+        "(project-level working memory)\n"
+        f"3. `{rules_path}` (optional -- skip if missing)\n"
+        f"4. `{phase_path}`\n"
+        f"5. `projects/{project_slug}/task-notes/phase-"
+        f"{phase_id}/README.md` (per-phase working memory -- the live "
+        f"Tasks status table for Phase {phase_id})\n"
+        f"6. The files listed under `## Prerequisites` in `{phase_path}`\n"
+        "7. Relevant upstream learnings already closed out:\n"
+        f"{learning_block}\n"
+        "8. Active ADRs touching the same subsystem (project-scoped "
+        f"under `projects/{project_slug}/adrs/` and repo-wide under "
+        "`docs/adrs/`)\n"
+        f"9. The existing task note for the first unfinished Phase "
+        f"{phase_id} task, if one exists\n\n"
+        "Guardrails:\n"
+        "- Avoid reading unrelated phase files.\n"
+        "- Follow `/execute-single-task` to keep scope to one task or "
+        "tightly related task cluster.\n"
+        "- If prerequisite closeout or repo state has drifted since this "
+        "prompt was generated, stop and report it instead of beginning "
+        "the phase.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level resolution
+
+
+def resolve_project_dir(
+    repo_root: Path, project_arg: str | None, project_dir_arg: Path | None
+) -> Path:
+    if project_dir_arg is not None:
+        return project_dir_arg.resolve()
+    if project_arg is not None:
+        return (repo_root / "projects" / project_arg).resolve()
+    raise ValueError(
+        "one of --project <slug> or --project-dir <path> is required"
+    )
+
+
+def resolve_phase(
+    repo_root: Path,
+    project_slug: str,
+    project_dir: Path,
+    completed_phase: str | None = None,
+    target_phase: str | None = None,
+) -> dict[str, object]:
+    plan_path = project_dir / "PLAN.md"
+    if not plan_path.exists():
+        raise ValueError(
+            f"project PLAN not found at "
+            f"{relpath(repo_root, plan_path)}"
+        )
+    plan_frontmatter = parse_frontmatter(plan_path.read_text())
+    phased_flag = plan_frontmatter.get("phased", "").strip().lower()
+    if phased_flag != "true":
+        raise ValueError(
+            f"project `{project_slug}` is not phased "
+            f"(PLAN.md frontmatter `phased: {plan_frontmatter.get('phased') or 'missing'}`). "
+            "begin-phase only works on phased projects."
+        )
+
+    phases = load_phase_records(project_dir)
+    if not phases:
+        raise ValueError(
+            f"project `{project_slug}` has no phase files under "
+            f"{relpath(repo_root, project_dir / 'phases')}"
+        )
+
+    notes: list[str] = []
+
+    # Flag any phases whose prereqs couldn't be machine-resolved so the
+    # operator sees them in the output.
+    prereq_unknown = [
+        phase_id
+        for phase_id, record in phases.items()
+        if not record.prereqs_machine_resolvable
+    ]
+    for phase_id in sorted(prereq_unknown, key=phase_sort_key):
+        notes.append(
+            f"Phase {phase_id} prerequisites are not machine-resolvable "
+            "(prose did not match `Phase N complete`). Manual check "
+            "required before starting that phase."
+        )
+
+    frontier = eligible_frontier(repo_root, phases)
+    frontier_payload = [
+        phase_summary(repo_root, phases, phase_id) for phase_id in frontier
+    ]
+
+    normalized_completed = (
+        normalize_phase_id(completed_phase) if completed_phase else None
+    )
+    normalized_target = (
+        normalize_phase_id(target_phase) if target_phase else None
+    )
+    if normalized_completed and normalized_completed not in phases:
+        raise ValueError(f"unknown completed phase: {completed_phase}")
+    if normalized_target and normalized_target not in phases:
+        raise ValueError(f"unknown target phase: {target_phase}")
+
+    # --- Explicit target -----------------------------------------------------
+    if normalized_target:
+        record = phases[normalized_target]
+        if status_is_complete(record.status):
+            return {
+                "status": "blocked",
+                "project": project_slug,
+                "message": f"Phase {normalized_target} is already complete.",
+                "eligible_frontier": frontier_payload,
+                "blockers": [
+                    {
+                        "phase_id": normalized_target,
+                        "title": record.title,
+                        "issues": [
+                            f"{relpath(repo_root, record.phase_file)} "
+                            "frontmatter status is Complete"
+                        ],
+                    }
+                ],
+                "notes": notes,
+                "prompt": None,
+            }
+        if not status_is_not_started(record.status):
+            return {
+                "status": "blocked",
+                "project": project_slug,
+                "message": (
+                    f"Phase {normalized_target} is not in the "
+                    "`Not started` state."
+                ),
+                "eligible_frontier": frontier_payload,
+                "blockers": [
+                    {
+                        "phase_id": normalized_target,
+                        "title": record.title,
+                        "issues": [
+                            f"{relpath(repo_root, record.phase_file)} "
+                            f"frontmatter status is "
+                            f"{record.status or 'unknown'}"
+                        ],
+                    }
+                ],
+                "notes": notes,
+                "prompt": None,
+            }
+        if not record.prereqs_machine_resolvable:
+            return {
+                "status": "blocked",
+                "project": project_slug,
+                "message": (
+                    f"Phase {normalized_target} prerequisites are not "
+                    "machine-resolvable; cannot verify readiness."
+                ),
+                "eligible_frontier": frontier_payload,
+                "blockers": [
+                    {
+                        "phase_id": normalized_target,
+                        "title": record.title,
+                        "issues": [
+                            "prose in `## Prerequisites` does not match the "
+                            "`Phase N complete` pattern; manual check "
+                            "required"
+                        ],
+                    }
+                ],
+                "notes": notes,
+                "prompt": None,
+            }
+
+        blockers, unknown = prerequisite_blockers(
+            repo_root, phases, normalized_target
+        )
+        for prereq_id in unknown:
+            blockers.append(
+                {
+                    "phase_id": prereq_id,
+                    "title": "(unknown -- no phase file found)",
+                    "issues": [
+                        f"Phase {prereq_id} referenced as a prerequisite "
+                        "but no matching phase file exists in the project"
+                    ],
+                }
+            )
+        if blockers:
+            return {
+                "status": "blocked",
+                "project": project_slug,
+                "message": (
+                    f"Phase {normalized_target} is blocked by incomplete "
+                    "prerequisite closeout."
+                ),
+                "eligible_frontier": frontier_payload,
+                "blockers": blockers,
+                "notes": notes,
+                "prompt": None,
+            }
+
+        return {
+            "status": "ready",
+            "project": project_slug,
+            "message": f"Phase {normalized_target} is eligible to begin.",
+            "eligible_frontier": frontier_payload,
+            "phase": phase_summary(repo_root, phases, normalized_target),
+            "notes": notes,
+            "prompt": build_prompt(
+                project_slug,
+                project_dir,
+                repo_root,
+                phases,
+                normalized_target,
+            ),
+        }
+
+    # --- No explicit target; inspect the current frontier --------------------
+    candidates = frontier[:]
+    if normalized_completed:
+        # Prefer phases this newly-completed phase unlocks.
+        direct_unlocks = [
+            phase_id
+            for phase_id in frontier
+            if normalized_completed in phases[phase_id].prerequisite_ids
+        ]
+        if direct_unlocks:
+            candidates = direct_unlocks
+        else:
+            notes.append(
+                f"Phase {normalized_completed} does not directly unlock a "
+                "new phase by itself. Showing the current eligible "
+                "frontier instead."
+            )
+
+    if not candidates:
+        blockers = blocked_frontier_candidates(repo_root, phases)
+        if not blockers:
+            # No "Not started" phase at all -- every phase is either
+            # complete or in progress. Surface that explicitly so the
+            # caller doesn't get an empty list with no context.
+            in_progress_or_complete = [
+                {
+                    "phase_id": record.phase_id,
+                    "title": record.title,
+                    "issues": [
+                        f"{relpath(repo_root, record.phase_file)} "
+                        f"frontmatter status is "
+                        f"{record.status or 'unknown'}; no phase is in "
+                        "the `Not started` state"
+                    ],
+                }
+                for _, record in sorted(
+                    phases.items(),
+                    key=lambda item: phase_sort_key(item[0]),
+                )
+            ]
+            blockers = [
+                {
+                    "phase_id": "(none)",
+                    "title": "No phase is `Not started`",
+                    "issues": [
+                        "Every phase file is either Complete or In "
+                        "Progress; there is no next phase to begin. "
+                        "Manual check required to confirm the project "
+                        "status or whether a new phase file is needed.",
+                    ],
+                    "phases": in_progress_or_complete,
+                }
+            ]
+        return {
+            "status": "blocked",
+            "project": project_slug,
+            "message": "No project phase is currently eligible to begin.",
+            "eligible_frontier": frontier_payload,
+            "blockers": blockers,
+            "notes": notes,
+            "prompt": None,
+        }
+
+    if len(candidates) > 1:
+        return {
+            "status": "choose",
+            "project": project_slug,
+            "message": (
+                "Multiple phases are eligible. Ask the user to choose one "
+                "before generating a kickoff prompt."
+            ),
+            "eligible_frontier": frontier_payload,
+            "choices": [
+                phase_summary(repo_root, phases, phase_id)
+                for phase_id in candidates
+            ],
+            "notes": notes,
+            "prompt": None,
+        }
+
+    phase_id = candidates[0]
+    return {
+        "status": "ready",
+        "project": project_slug,
+        "message": f"Phase {phase_id} is eligible to begin.",
+        "eligible_frontier": frontier_payload,
+        "phase": phase_summary(repo_root, phases, phase_id),
+        "notes": notes,
+        "prompt": build_prompt(
+            project_slug, project_dir, repo_root, phases, phase_id
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def default_repo_root() -> Path:
+    """Walk up from the script looking for a checkout root.
+
+    This script lives at
+    ``<repo>/.claude/skills/begin-phase/scripts/resolve_phase.py``, so the
+    repo root is four ``parents`` up. If that doesn't look like a checkout
+    (no ``projects/`` and no ``.git``), fall back to CWD.
+    """
+
+    here = Path(__file__).resolve()
+    candidate = here.parents[4] if len(here.parents) > 4 else here.parent
+    if (candidate / "projects").is_dir() or (candidate / ".git").exists():
+        return candidate
+    return Path.cwd()
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resolve which phase of a phased project is eligible to "
+            "start next, and emit a kickoff-prompt payload as JSON."
+        )
+    )
+    parser.add_argument(
+        "--project",
+        help=(
+            "Project slug under `projects/`. Example: "
+            "--project overhaul-test-infra. Either --project or "
+            "--project-dir is required."
+        ),
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        help=(
+            "Absolute or repo-relative path to the project directory. "
+            "Overrides --project."
+        ),
+    )
+    parser.add_argument(
+        "--completed-phase",
+        help=(
+            "Phase that just completed. Example: --completed-phase 2. "
+            "When set, the helper prefers downstream phases this one "
+            "unlocks if any are now eligible."
+        ),
+    )
+    parser.add_argument(
+        "--target-phase",
+        help=(
+            "Ask about a specific phase. Example: --target-phase 3.1. "
+            "The helper returns `ready`, `blocked`, or an error."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root. Defaults to the containing checkout.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    if args.project is None and args.project_dir is None:
+        sys.stderr.write(
+            "error: one of --project or --project-dir is required\n"
+        )
+        return 2
+
+    repo_root = (args.repo_root or default_repo_root()).resolve()
+
+    try:
+        project_dir = resolve_project_dir(
+            repo_root, args.project, args.project_dir
+        )
+        # Infer the slug if only --project-dir was supplied.
+        project_slug = args.project or project_dir.name
+        result = resolve_phase(
+            repo_root=repo_root,
+            project_slug=project_slug,
+            project_dir=project_dir,
+            completed_phase=args.completed_phase,
+            target_phase=args.target_phase,
+        )
+    except Exception as exc:  # CLI error path
+        payload = {
+            "status": "error",
+            "project": args.project,
+            "message": str(exc),
+        }
+        json.dump(payload, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 1
+
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/begin-phase/scripts/resolve_phase.py
+++ b/.claude/skills/begin-phase/scripts/resolve_phase.py
@@ -473,6 +473,16 @@ def build_prompt(
 ) -> str:
     record = phases[phase_id]
 
+    # `phase_id` is the *canonical display* id ("2"); `record.prefix` is the
+    # filename prefix ("02"). Working-memory directories are named after the
+    # filename prefix -- `projects/<slug>/task-notes/phase-02/` -- matching
+    # both the template and `scripts/agents/resolve_task.py`, which derives
+    # the directory from the phase filename. Interpolating `phase_id` into a
+    # path yields `phase-2/` and sends the next agent to a directory that
+    # does not exist, so every filesystem path below MUST use `dir_prefix`.
+    # Display text keeps `phase_id`.
+    dir_prefix = record.prefix.lower()
+
     prereq_learnings: list[str] = []
     for prereq_id in sorted(record.prerequisite_ids, key=phase_sort_key):
         prereq = phases.get(prereq_id)
@@ -509,7 +519,7 @@ def build_prompt(
         f"- Start with the next lowest-numbered unfinished task in "
         f"Phase {phase_id} -- read it from the live Tasks table in "
         f"`projects/{project_slug}/task-notes/phase-"
-        f"{phase_id}/README.md` (not `PLAN.md` or the phase file).\n\n"
+        f"{dir_prefix}/README.md` (not `PLAN.md` or the phase file).\n\n"
         "Read only:\n"
         f"1. `{plan_path}`\n"
         f"2. `projects/{project_slug}/task-notes/README.md` "
@@ -517,7 +527,7 @@ def build_prompt(
         f"3. `{rules_path}` (optional -- skip if missing)\n"
         f"4. `{phase_path}`\n"
         f"5. `projects/{project_slug}/task-notes/phase-"
-        f"{phase_id}/README.md` (per-phase working memory -- the live "
+        f"{dir_prefix}/README.md` (per-phase working memory -- the live "
         f"Tasks status table for Phase {phase_id})\n"
         f"6. The files listed under `## Prerequisites` in `{phase_path}`\n"
         "7. Relevant upstream learnings already closed out:\n"

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: commit-and-pr
+description: Branch, run the preflight gate, commit with Conventional Commits, push, and open a PR that follows the repo's PR guidelines and passes CI.
+---
+
+**Role:** Ship the current working-tree changes as a well-formed branch,
+commit, and pull request conforming to
+[`docs/PR_GUIDELINES.md`](../../../docs/PR_GUIDELINES.md). This skill is
+the **sole commit authority** — when a review skill lands fixes, it
+follows the same preflight gate and title rules, not a hand-rolled
+`git commit`.
+
+## When to use this skill
+
+- The user asks to commit and open a PR, or says "ship it".
+- A standalone `/execute-single-task` run finished and its working-tree
+  changes need to become a branch, commit, and PR.
+
+## When NOT to use this skill
+
+- You are already inside a `/task-pipeline` or `/review-cycle` run that
+  owns the branch and PR — commit to the branch the caller established;
+  do not mint a second one.
+- The changes span two unrelated concerns that should be two PRs — split
+  them first, then run this once per PR.
+
+## Workflow
+
+### Step 1: Read the PR guidelines
+
+Read [`docs/PR_GUIDELINES.md`](../../../docs/PR_GUIDELINES.md) **before**
+composing any commit message or PR title. It is authoritative; the rules
+below are a reminder.
+
+- Header: `type(scope): subject`, max **69 characters total**.
+- `type` ∈ `feat fix chore ci docs test refactor perf style build revert`.
+- `scope` is **required**, `^[a-z0-9-]+$`, max 10 chars, not a type name.
+  (`phase-space` is 11 chars → rejected; use `phase`.)
+- `subject` starts alphanumeric, no trailing `.` or space, lowercase
+  first word by convention.
+
+The scope table lives in the guidelines file — read it there rather than
+inventing a one-off scope.
+
+### Step 2: Assess the working tree
+
+- `git status` and `git diff` to see what will be committed.
+- `git log --oneline -n 10` for recent commit style.
+- If there are no changes, stop and tell the user.
+- **Numerical-change check.** If the diff can reach a public code path,
+  confirm the task note (or your own measurement) records whether any
+  returned value moved. A PR that silently shifts a published spectrum is
+  the failure mode this repo cares most about — it belongs in the Summary
+  and, on a closing PR, in `CHANGELOG.md`.
+- **Version-bump check (project-closing PRs only).** If the diff flips a
+  `projects/<slug>/PLAN.md` `status:` to `Complete`, the PR must carry
+  the `VERSION` bump in `hazma/__init__.py` and a `CHANGELOG.md` entry.
+  `/execute-single-task` Step 8 is the canonical place to do it; if you
+  arrive here with a closing diff that lacks it, stop and add it.
+
+### Step 3: Create a branch (if needed)
+
+- If already on the caller-established feature branch for **this** task,
+  stay on it. Do not pile a commit onto an unrelated stale feature
+  branch — if the current branch is not this task's branch, branch fresh.
+- If the current branch is `master`, create a new branch. **Never commit
+  directly to `master`.** The trunk here is `master`, not `main`.
+
+Branch naming (parse both agent prefixes; create with `claude/`):
+
+- **Project work:** `claude/<project-slug>/<task-slug>`. The slash
+  separator is load-bearing — `review-pr` and `task-pipeline` parse it.
+- **Ad-hoc work:** `claude/<short-description>`.
+
+### Step 4: Run the preflight gate
+
+Run it **before** you stage anything:
+
+```sh
+scripts/agents/preflight.sh --paths "<touched paths>" \
+    --tests "<test targets>" [--md "<changed .md files>"] [--closing]
+```
+
+See [`preflight.md`](../../../docs/agents/preflight.md) for the
+rationale, the zero-collection trap, and the manual fallback. There are
+no pre-commit hooks in this repo, and CI's flake8 pass is advisory —
+this gate is the only thing standing between you and a red PR. A non-zero
+exit is a blocked commit; a `WARN` row is an unrun gate, not a pass.
+
+If the diff touched `.pyx` / `.pxd` / `_build.py`, rebuild
+(`pip install -e .`) **before** the gate, not after.
+
+### Step 5: Stage and commit
+
+- Stage only the files relevant to the change. Do **not** `git add -A`
+  blindly — it sweeps in scratch files, build artifacts, editor configs,
+  or secrets. Compiled `.c` / `.so` output is never committed.
+- Compose the header and **validate it before committing**:
+
+  ```sh
+  scripts/agents/check_pr_title.py "type(scope): subject"
+  ```
+
+  Deterministic — do not eyeball the 69-char count. For complex changes,
+  add a body (blank-line-separated) explaining the "why".
+- **Branch/worktree assertion, immediately before `git commit`:** confirm
+  `git rev-parse --abbrev-ref HEAD` is the intended branch (**never
+  `master`**) and `git rev-parse --show-toplevel` is the intended
+  worktree. The Bash-tool cwd can reset between calls, so prefer
+  `git -C <worktree>` with an absolute path.
+- The critical path is sequential: edit → rebuild → gate → read → stage →
+  commit → push → verify. Never batch these in one parallel tool block.
+
+### Step 6: Push and open the PR
+
+- `git push -u origin HEAD`, then verify: `git rev-parse HEAD` must equal
+  `git rev-parse origin/<branch>`.
+- Open with `gh pr create --base master`. The **title** is the validated
+  header from Step 5.
+- **PR body:**
+
+  ````markdown
+  ## Summary
+  <1-3 bullets describing what changed and why>
+
+  ## Test plan
+  - [ ] <command(s) you ran, with the real output pasted>
+  ````
+
+- The Test plan quotes **real command output** (the pytest summary line,
+  a REPL evaluation) or cites the task note's `## Verification` section —
+  never invented counts.
+- Reconcile the `## Summary` bullets against `git diff --stat`: every
+  claim must map to a change in the diff.
+- **If any returned value moved,** say so explicitly in the Summary, with
+  the function, the magnitude, and which value is right. Do this even
+  when the tests stayed green because a tolerance absorbed the shift.
+
+For **project work**, add a `## Project` section between Summary and Test
+plan:
+
+````markdown
+## Project
+`projects/<slug>/` — Task N: <title>.
+
+See `projects/<slug>/task-notes/task-N-<slug>.md` for detail.
+````
+
+(Phased: `task-notes/phase-XX/task-X.Y-<slug>.md`.) Put task IDs, issue
+links, and extra context in the body, never in the title. For reverts,
+add a `Refs:` trailer linking the original PR.
+
+### Step 7: Watch CI
+
+```sh
+gh pr checks <N> --watch --fail-fast
+```
+
+If a check fails, read the failure and either fix it (new commit → push,
+back through Steps 4–6) or, if the fix is out of scope, report the
+failing check to the caller. Do not declare done on a red PR.
+
+### Step 8: Validate before finishing
+
+Title passed `check_pr_title.py`; body has `## Summary` + `## Test plan`
+(+ `## Project` for project work); branch matches the naming policy; the
+push verified; CI green or its failure reported.
+
+## Error recovery
+
+- **`git push` rejected (diverged).** `git fetch origin`, rebase onto
+  `origin/<branch>`, re-run the preflight gate, re-push. **Never
+  `--force`.** If the divergence is not clearly yours, stop and report.
+- **A landed commit needs redoing.** `git reset --soft origin/<branch>`
+  then create a fresh commit — do not `--amend` a pushed commit.
+- **`gh pr create` says a PR already exists.** Use `gh pr edit` /
+  `gh pr view` on the existing PR.
+
+## Structured report
+
+```text
+STATUS: Pushed | PR opened | Committed-only | Failed
+BRANCH: <branch name>
+COMMIT_SHA: <short sha>
+PR_URL: <url or n/a>
+TITLE: <final PR title>
+```
+
+`Committed-only` = the commit landed but the push or PR did not;
+`Failed` = the gate or commit itself blocked. Report the reason in prose
+above the block.
+
+## Guardrails
+
+- Never force-push; never push to `master` directly; never `--no-verify`.
+- Never commit files that look like secrets (`.env`, credentials,
+  tokens, `*.pem`) or build output (`*.c`, `*.cpp`, `*.so`, `build/`).
+- Do not blindly `git add -A`; stage the specific files you intended.
+- Do not include unrelated changes. Pull drive-by cleanup in deliberately
+  (and note it in Summary) or stash it for a follow-up.
+- Do not fabricate Test-plan output or Summary claims — both reconcile
+  against real command output and `git diff --stat`.

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -83,9 +83,10 @@ scripts/agents/preflight.sh --paths "<touched paths>" \
 
 See [`preflight.md`](../../../docs/agents/preflight.md) for the
 rationale, the zero-collection trap, and the manual fallback. There are
-no pre-commit hooks in this repo, and CI's flake8 pass is advisory —
-this gate is the only thing standing between you and a red PR. A non-zero
-exit is a blocked commit; a `WARN` row is an unrun gate, not a pass.
+no pre-commit hooks in this repo, and CI's lint pass is narrow
+(`ruff check --isolated --select E9,F63,F7,F82`, with no formatting check
+at all) — so this gate catches far more than CI will. A non-zero exit is
+a blocked commit; a `WARN` row is an unrun gate, not a pass.
 
 If the diff touched `.pyx` / `.pxd` / `_build.py`, rebuild
 (`pip install -e .`) **before** the gate, not after.

--- a/.claude/skills/execute-single-task/SKILL.md
+++ b/.claude/skills/execute-single-task/SKILL.md
@@ -1,0 +1,441 @@
+---
+name: execute-single-task
+description: Execute exactly one task (or tightly related task cluster) from a project's PLAN, keep scope narrow, update the task note, run the preflight gate, and escalate only canonical plan changes into ADRs and plan files. Stops before commit — the caller (or /commit-and-pr) owns the commit.
+---
+
+**Role:** Act as the engineer responsible for completing exactly one task
+from a project's plan with minimal scope drift and durable project
+memory.
+
+## When to use this skill
+
+- The user asks to work on one task from a project, or to take the next
+  task in a project.
+- The user wants a bounded execution pass with a clean handoff.
+
+## When NOT to use this skill
+
+- **Full task lifecycle (implement → review → ship)** → `/task-pipeline`,
+  which wraps this skill in a context-isolated subagent and owns the
+  review loop and PR.
+- **Ad-hoc, non-project work** (a one-off fix, dep bump, or a branch that
+  is not `<agent>/<project-slug>/<task-slug>`) → this skill errors out in
+  Step 1. Do it directly and use `/commit-and-pr`.
+- **Committing / opening the PR** → out of scope. This skill runs the
+  preflight gate and leaves the tree ready.
+
+## Inputs
+
+- **project slug** (optional) — explicit `--project <slug>`, or inferred
+  from the current branch.
+- **task identifier** (optional) — `Task 3` (flat) or `Task 2.4`
+  (phased). If omitted, resolve the next unfinished task (Step 2).
+
+## The one status invariant (stated once)
+
+`PLAN.md` holds canonical task **shape** — objectives, scope, ordering,
+Exit Criteria. It is **never** a live status log. Live task **state**
+lives in the working-memory README under
+`projects/<slug>/task-notes/`. Every step below assumes this split; never
+edit a `Status` column inside `PLAN.md`. You touch `PLAN.md` only when
+canonical shape, ordering, or task definition changes (Step 7).
+
+## Workflow
+
+### Step 1: Resolve the project slug
+
+Project branches are `<agent>/<project-slug>/<task-slug>`, where
+`<agent>` is `claude` or `codex`; ad-hoc branches are
+`<agent>/<short-description>`. **Parse both prefixes.** The slug is the
+first segment after the prefix.
+
+Precedence: explicit `--project` → branch-name inference → stop and ask.
+A branch that does not match the three-segment project pattern is ad-hoc
+— error out and ask the user for the intended project.
+
+Confirm `projects/<slug>/PLAN.md` exists. If not, stop and report the
+missing scaffold.
+
+### Step 2: Determine the task boundary
+
+Work on one numbered task, or one tightly coupled cluster. A unit sized
+for one task touches ≲1 subsystem and carries ≲2 architectural
+decisions. If the requested task is broader, split it to the smallest
+meaningful testable unit and record the split in the task note. Do not
+cross phase boundaries in one pass.
+
+If the user did not specify a task, resolve it deterministically:
+
+```sh
+scripts/agents/resolve_task.py --project <slug>
+```
+
+It reads the live Tasks table (flat → `task-notes/README.md`; phased →
+the current phase's `phase-XX/README.md`), skips `_template.md`, and
+emits single-line JSON: `{status, task_id, task_title, task_slug, phase,
+reason}`. Pass `--task <id>` to pin a specific row. Trust `task_slug`.
+
+**Fallback (script unavailable):** read the table by hand — the lowest-
+numbered row whose `Status` is not `Complete`/`Superseded`.
+
+### Step 3: Enter a worktree (branch off origin/master)
+
+Create an isolated git worktree **before** any code change. Never modify
+the main checkout directly, and never branch from ambient `HEAD` — Step 9's
+`git diff origin/master --` is only sound if the branch was cut from a
+freshly-fetched trunk.
+
+```sh
+scripts/agents/setup_task_worktree.sh \
+  --project <slug> --task-slug <task-slug> --agent claude
+```
+
+It fetches origin, resolves the trunk from `origin/HEAD` (falling back to
+`master`), picks a collision-free name, verifies `HEAD == origin/<trunk>`,
+and prints `{"branch":…,"wt_path":<absolute>,"head_sha":…}`. If the
+`EnterWorktree` tool is available, prefer it.
+
+All edits and gates happen inside the worktree. The Bash-tool cwd can
+reset between calls — use `git -C <worktree>` with absolute paths (see
+[`environment.md`](../../../docs/agents/environment.md)).
+
+**If the task touches Cython** (`.pyx`, `.pxd`, `_build.py`), rebuild in
+the worktree before running anything: `pip install -e .`, then confirm
+`python -c "import hazma; print(hazma.__file__)"` points inside the
+worktree. A stale extension makes every later result meaningless.
+
+### Step 4: Read only the required context
+
+In this order; skip what does not apply:
+
+1. `projects/<slug>/PLAN.md` — always. Frontmatter `phased:` picks the
+   branch below. Read the **Numerical impact** section; it constrains
+   what you are allowed to change.
+2. `projects/<slug>/task-notes/README.md` — **always.** The live Tasks
+   table (flat) or Phases table (phased), cumulative findings, the
+   Numerical-impact-so-far log, open questions, and the rolling
+   `## Handoff to Next Task`. Read *before* individual task notes.
+3. `projects/<slug>/rules.md` — cross-cutting project rules (optional).
+4. `projects/<slug>/phases/phase-XX-<slug>.md` — **phased only**, and
+   **only the target phase**. Find the exact `### Task X.Y`, its Exit
+   Criteria, and Prerequisites.
+5. `projects/<slug>/task-notes/phase-XX/README.md` — **phased only.**
+   Per-phase working memory; authoritative for "next unfinished task".
+6. Files named in that phase file's Prerequisites block.
+7. `projects/<slug>/learnings/phase-XX-*.md` for completed upstream
+   phases (phased only).
+8. Active ADRs touching the same area: `projects/<slug>/adrs/ADR-*.md`
+   and `docs/adrs/ADR-*.md`.
+9. The existing task note if this task is already in progress.
+10. [`lessons.md`](../../../docs/agents/lessons.md) — check your plan
+    against each recurring class before writing code.
+11. [`environment.md`](../../../docs/agents/environment.md) — skim; it is
+    load-bearing for every command you will run.
+
+**Do NOT** read other phase files unless a Prerequisites link pulls you
+there, and do not read the whole `projects/` tree "to get oriented". When
+you genuinely need to survey the codebase, delegate the sweep to an
+`Explore` subagent rather than pulling every file into this context.
+
+**Template-file awareness:** files named `_template.md` are references,
+not artifacts. Glob for artifact patterns explicitly:
+
+| Directory     | Artifact glob                                             |
+|---------------|-----------------------------------------------------------|
+| `adrs/`       | `ADR-[0-9][0-9][0-9][0-9]-*.md`                           |
+| `task-notes/` | `task-[0-9]*-*.md` (flat) or `phase-*/task-*.md` (phased) |
+| `phases/`     | `phase-[0-9][0-9]-*.md`                                   |
+| `learnings/`  | `phase-[0-9][0-9]-*.md` or `project-retrospective.md`     |
+
+### Step 5: Create or update the task note
+
+- **Template:** `projects/_template/task-notes/_template.md`.
+- **Path:** flat → `projects/<slug>/task-notes/task-N-<slug>.md`;
+  phased → `projects/<slug>/task-notes/phase-XX/task-X.Y-<slug>.md`.
+- Keep it current **while working**, not only at the end.
+
+**Fill in Exit Criteria first**, before you implement — copy the concrete
+bullets from the phase file's `**Exit criteria:**` block (phased) or the
+task row and PLAN prose (flat). That is what "done" means.
+
+`## Verification` is the retrospective record of what you ran, and must
+contain the exact `pytest` command(s) and their real summary lines
+(`23 passed, 1 skipped`), a categorized list of what the tests cover (not
+just a count), and anything intentionally deferred with a reason.
+
+### Step 6: Execute the task
+
+Keep changes scoped to the chosen task. Verify against the Exit Criteria
+you wrote in Step 5. If blocked, record the blocker and current state in
+the task note before stopping.
+
+#### 6a: Testing discipline
+
+Every public function and every non-trivial path needs at least one test
+that would fail if the implementation were wrong.
+
+- **Pin a number, not a shape.** For any physics change, assert against
+  an analytic limit, a published value (cite the source in the test), an
+  independent implementation, or a stored regression array. A test that
+  only checks `shape`, `> 0`, or `np.isfinite` pins nothing.
+- **State the tolerance and why.** An unexplained `rtol` invites silent
+  loosening later. Choose it from the expected numerical error, not from
+  what makes the test pass.
+- **Boundaries:** threshold energy, the spectrum endpoint, zero mass,
+  equal masses, the massless limit, an empty array, a scalar where an
+  array is expected and vice versa, negative and NaN input.
+- **Broadcasting:** a spectrum-shaped function gets a scalar test *and*
+  an array test.
+- **Error paths:** every raise and documented failure mode has a test
+  that triggers it.
+- **Test validity (stash-proof):** for every new/modified test asserting
+  a behavior change, prove it fails without your fix — `git stash` the
+  production change, run, confirm failure, `git stash pop`. A test that
+  still passes with the fix reverted is not testing what its name
+  implies.
+- **Symmetry with prior tasks:** if a prior task covered one channel or
+  one direction, the symmetric variant should exist unless the spec
+  defers it.
+
+Do not count tests by hand:
+
+```sh
+pytest test/spectra --collect-only -q | tail -n 1
+```
+
+Guard against a false green: `pytest` exits **5** on zero collected, and
+a `-k` filter matching nothing exits 0 with `no tests ran`. Also note
+`test/conftest.py` excludes `test/decay/` and `test_gamma_ray.py` from a
+bare run — if your change touches those areas, run them explicitly.
+Record the real count in the task note.
+
+**Correctness shapes to defend:** adding an entry to a dispatch table (a
+final-state → spectrum-function map, a channel list) requires sweeping
+every sibling lookup, `__all__`, and test; a constant becoming a
+user-supplied argument needs a validity guard; an invariant must hold at
+every public entry point, not just the one the happy-path test hits;
+validate before writing to any module-level cache or table.
+
+#### 6b: Measure the numerical impact
+
+**Mandatory whenever the diff can reach a public code path.** Before and
+after your change, evaluate every public function the diff can reach on a
+representative grid and diff the arrays. Record in the task note:
+
+- the functions checked and the grid used,
+- whether any value moved, and by how much,
+- whether that is intended.
+
+`No public value changes (verified: <command>)` is a valid result.
+Silence is not. If a value moved, say so in the task note, append a line
+to the working-memory README's **Numerical impact so far** section, and
+re-check the project's `version_bump:` level against
+[`versioning.md`](../../../docs/versioning.md) — a moved published number
+is `minor`, not `patch`.
+
+#### 6c: Verify your claims
+
+Every factual claim in comments, docstrings, the task note, and any PR
+description needs a citation or a command + output — never an estimate.
+Run [`doc-consistency.md`](../../../docs/agents/doc-consistency.md) §1,
+§2, and §7 against your diff. Three implementer-only checks:
+
+- **Docstring parameters** match the actual signature, and **every
+  physical quantity states its units**.
+- **Performance claims** ("vectorized", "2x faster") are backed by a
+  measurement with a stated grid size — never by intent.
+- **External-behavior assertions need a primary source in the same
+  paragraph.** "Matches PPPC4DMID", "reproduces Eq. 14 of
+  arXiv:1907.11846" must carry a DOI, arXiv id + equation number,
+  permalink, or command + output. Confident prose without a citation is a
+  fabrication risk — if you cannot cite, soften or remove the claim. A
+  self-citing "23 passed via `pytest test/spectra`" already satisfies
+  this.
+
+#### 6d: Durable-doc sweep (implementer pass)
+
+Before staging, run
+[`doc-consistency.md`](../../../docs/agents/doc-consistency.md) over
+every durable doc your change touches or references — you run it
+shift-left; Reviewer D re-runs it at review. Load-bearing points:
+re-derive every numeric claim from the live tree and replace **every**
+occurrence via the §11 stale-sibling sweep; treat the task note's
+`## Verification` as regenerated, not curated; reconcile ADR §Body ↔
+§Consequences, phase-file gate text, phase README row, and the `PLAN.md`
+summary line; grep `docs/source/` for any renamed public object; and
+sweep **new** files too (§12).
+
+### Step 7: Handle plan changes correctly
+
+- **Local implementation detail** → task note only.
+- **Durable context later tasks need** → task note now; fold into phase
+  learnings or the project retrospective at closure.
+- **Out-of-scope deferred work this task surfaced in its touched area**:
+  1. `rg` [`docs/followups/`](../../../docs/followups/) for the
+     identifier. If an entry covers it, link that file in the task note's
+     `## Open Questions` and stop.
+  2. Dedup against open PRs — `gh pr list --state open`, then
+     `gh pr diff <n> --name-only | grep followups`.
+  3. Otherwise drop a stub in `docs/followups/todo/<slug>.md` (from
+     `_template.md`), add a row under "Open" in
+     `docs/followups/README.md`, and note it in `## Open Questions`.
+
+  Trivial cleanups you could do in the same PR need no follow-up file —
+  just do them. Drive-by `TODO`s outside your touched area are out.
+  **Wrong-premise guard:** a followup can prescribe a mechanism that no
+  longer matches the code — before building on one, `rg` its cited
+  symbols and run its cited command against current code.
+- **Canonical change to architecture, invariants, interfaces, task
+  ordering, units, or normalization conventions** → write an ADR, patch
+  the affected phase file or `rules.md`, and update the one-line summary
+  in `PLAN.md` only if it is now wrong.
+
+**ADR placement:** could someone read this ADR without knowing which
+project produced it and still find it useful? Yes → `docs/adrs/`; No →
+`projects/<slug>/adrs/`. Default bias: start project-scoped.
+
+**Canonical-contract diff.** Before reporting `PLAN_IMPACT: None`, open
+the canonical phase file and every active ADR, read each gate sentence
+and exit-criterion bullet, and check it against what you shipped. If any
+is now factually wrong, patch it in this same task — do not defer a
+canonical-contract patch to a follow-up.
+
+### Step 8: Finish with a handoff
+
+Re-run the 6c/6d checks, then grep for `TODO`, `FIXME`, `breakpoint()`,
+`pdb`, and stray `print()` you introduced — resolve, document, or file a
+follow-up.
+
+**Run the preflight gate:**
+
+```sh
+scripts/agents/preflight.sh --paths "<touched paths>" --tests "<test targets>"
+```
+
+Rationale and manual fallback:
+[`preflight.md`](../../../docs/agents/preflight.md). A `WARN` row means a
+tool is missing and its gate did not run — that is a hole, not a pass.
+Non-zero exit is a blocked handoff.
+
+Then **record task status in two places**:
+
+1. **Per-task note:** set `**Status:**` to `Complete` / `Blocked` /
+   `Superseded`. Record files changed, verification performed, the
+   numerical-impact result, `## Plan Impact`, and
+   `## Handoff to Next Task`.
+2. **Working memory:** flat → `task-notes/README.md`; phased → this
+   task's `Status` cell in `task-notes/phase-XX/README.md` (touch the
+   project-level README only for cross-phase material and the Phases
+   table). Every status change updates: the Tasks-table cell;
+   **Findings** (only what outlives this task); **Numerical impact so
+   far**; **Decisions** (one-liners with rationale, linking an ADR if
+   written); **Open Questions**; **Files Changed** (a `### Task N`
+   roll-up); and a rewritten `## Handoff to Next Task`.
+
+Then handle closure:
+
+- **Phased, last task in the phase:** synthesize
+  `learnings/phase-XX-<slug>.md`, set the phase file frontmatter
+  `status: Complete`, update its cell in `PLAN.md`'s `## Phases` table.
+- **Last task overall:** synthesize `learnings/project-retrospective.md`.
+  For every substantive §5 follow-on seed, file a
+  `docs/followups/todo/<slug>.md` stub with an index row, and
+  cross-check **all** of `docs/followups/todo/` for entries sourced from
+  this project. Set `PLAN.md` `status: Complete` and move the row from
+  Active to Completed in `projects/README.md` with the Shipped date.
+
+  **Then bump the version (mandatory closure step).** Read
+  `version_bump:` from `PLAN.md`, re-confirm the level against the
+  project's realized **Numerical impact** and
+  [`versioning.md`](../../../docs/versioning.md), set `VERSION` in
+  `hazma/__init__.py`, and add a `## [X.Y.Z] — YYYY-MM-DD` section to
+  `CHANGELOG.md` naming the slug and stating any numerical change and its
+  magnitude. Verify with `scripts/agents/preflight.sh --closing`.
+
+### Step 9: Self-review before the commit boundary
+
+**Commit boundary:** this skill does **not** commit or push unless its
+caller instructs it. Either way the preflight gate and the
+branch/worktree assertion in
+[`preflight.md`](../../../docs/agents/preflight.md) MUST run immediately
+before that commit — confirm `git rev-parse --abbrev-ref HEAD` is the
+intended branch (**never `master`**) and `--show-toplevel` is the
+worktree. Never batch edit→gate→commit→push into one parallel tool block.
+
+After Step 8 and before staging, do a fresh-eyes pass on your **full**
+diff. Step 8's bookkeeping is part of the deliverable and gets the same
+scrutiny.
+
+1. **Re-read the task spec end-to-end** and capture every deliverable,
+   gate sentence, and constraint as an explicit checklist.
+2. **Inventory the full change** with `git status --short` and
+   `git diff origin/master --` (single-arg: self-review runs before the
+   commit). That does not show untracked files — for each `??`,
+   `git add -N <path>` or walk it as a fresh creation.
+3. **Walk each checklist item against the change.** Flag anything
+   uncovered, scope creep, or divergence from a stated approach.
+4. **Sanity-check correctness** on the changed surfaces: branches, error
+   paths, empty/NaN inputs, and whether the new tests would actually fail
+   without the production change.
+5. **Re-confirm the doc sweep and bookkeeping are internally
+   consistent.** The Tasks-table cell, the `**Status:**` header, any
+   phase `status:` flip, the `projects/README.md` row on closure, and the
+   synthesized learnings must agree with each other and the diff. On
+   closing PRs re-run `scripts/agents/preflight.sh --closing`.
+6. **Produce a `## Stale-state sweep` block in the task note.** This is
+   the forcing function for items 1–5 — describing what to check is not
+   enough; paste actual command output. The canonical block shape is in
+   [`doc-consistency.md`](../../../docs/agents/doc-consistency.md) under
+   "The sweep block". Append it above `## Handoff to Next Task`, running
+   each command against the current branch, and include the
+   **Numerical-impact statement** row. For a zero-touch sweep rows may
+   read "no occurrences" — but still produce the block to prove each
+   command ran.
+
+If self-review surfaces a real gap, fix it in the same working tree now.
+Do not record "noted for later"; either fix it or set the task-note
+status to `Blocked` with a concrete blocker description.
+
+## Output checklist
+
+- Code, tests, or docs changes for exactly one task.
+- Updated per-task note with Exit Criteria, Verification, the numerical-
+  impact result, Plan Impact, and the `## Stale-state sweep` block.
+- Updated working-memory README: Tasks Status cell, Findings, Numerical
+  impact so far, Decisions, Open Questions, Files Changed roll-up, and a
+  rewritten `## Handoff to Next Task`.
+- ADR (project-scoped or repo-wide) if the decision is canonical.
+- `PLAN.md` / phase file updated only if canonical scope, ordering, or
+  task *shape* changed — never for live status.
+- Phase learnings / project retrospective synthesized on closure.
+- On project closure: `PLAN.md` `status: Complete`, working-memory
+  `**Status:**` set, `projects/README.md` row moved, **and** the version
+  bump + CHANGELOG entry (verify with `preflight.sh --closing`).
+- Preflight gate green.
+
+## Structured report
+
+End with a block the caller can scrape:
+
+```text
+STATUS: Complete | Blocked | Superseded
+PROJECT: <slug>
+TASK_ID: <e.g., Task 3 or Task 2.4>
+TASK_NOTE: <path>
+FILES_CHANGED: <count and/or short list>
+TESTS: <command> — <literal pytest summary line>
+NUMERICAL_IMPACT: <none (verified: <command>) | <function>: <magnitude>>
+PLAN_IMPACT: None | Task note only | Phase file patched | ADR-XXXX | Both
+NEXT: <what the next agent should read first>
+```
+
+## Guardrails
+
+- Do not silently broaden scope.
+- Do not start the next task in the same pass unless asked.
+- Do not commit or push unless the caller instructs it.
+- Do not bury durable findings only in PR text or chat.
+- Do not report a numerical result from a tree you did not rebuild after
+  a Cython edit, or from an installed hazma rather than the worktree.
+- Never hand-edit generated `.c` / `.cpp` — edit the `.pyx` and rebuild.
+- Prefer files and tests over long explanations.

--- a/.claude/skills/review-cycle/SKILL.md
+++ b/.claude/skills/review-cycle/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: review-cycle
+description: Orchestrate the full PR review loop — select reviewers, spawn them in parallel, commit and push fixes, verify, post a round comment, and iterate to convergence or a cap. The single review-loop implementation; task-pipeline Phase D delegates here.
+---
+
+**Role:** Orchestrate a multi-agent review loop for a pushed PR. You
+select reviewers, spawn them in parallel, drive a review-respond agent
+that **commits and pushes** fixes to the PR branch, verify the push
+landed, run verification reviewers, post a durable round comment, and
+iterate until reviewers approve or a cap is reached. This is THE
+review-loop implementation in the repo — `/task-pipeline` Phase D
+delegates to it rather than re-implementing it.
+
+## When to use this skill
+
+- The user wants a full automated review cycle for an open PR.
+- `/task-pipeline` reaches its review phase.
+
+## When NOT to use
+
+- **Uncommitted local work.** Reviewer agents run in isolated contexts
+  and fetch the PR by number; they cannot see your working tree. Push the
+  branch or open a draft PR first.
+- **A single advisory review** → `/review-pr`; **a plan** →
+  `/review-plan`.
+- **Never recurse.** A review-respond or reviewer subagent must not
+  invoke `review-cycle` or `task-pipeline`. There is exactly one
+  orchestration level.
+
+## Inputs
+
+Required:
+
+- A **PR number**, **PR URL**, or **pushed branch name**.
+
+Optional:
+
+- **`WT_PATH` / `BRANCH`** — when a caller already owns the shared
+  worktree, pass them so review-respond's fixes land there. When absent,
+  Phase A sets up a worktree on the PR branch.
+- **External reviews** — file paths or pasted text from reviewers outside
+  Claude Code. **Advisory only:** they never gate convergence, receive no
+  verification pass, do not participate in the all-APPROVE shortcut, and
+  are surfaced verbatim in the round comment.
+- **Max iterations** — cap on review rounds (default `3`).
+- **Reviewer override** — a caller may pin `SELECTED_REVIEWERS`.
+
+## Shared references (do not restate — point)
+
+- [`review-lenses.md`](../../../docs/agents/review-lenses.md) — roster,
+  models, effort, `--lens` flags, selection rules, verdict rule, baseline
+  duties, per-lens FOCUS rubrics.
+- [`preflight.md`](../../../docs/agents/preflight.md) — the pre-commit /
+  pre-push gate.
+- [`doc-consistency.md`](../../../docs/agents/doc-consistency.md) — the
+  checklist Reviewer D runs and review-respond sweeps.
+- [`lessons.md`](../../../docs/agents/lessons.md) — recurring
+  review-defect classes every reviewer checks first.
+
+---
+
+## Workflow
+
+### Phase A: Setup
+
+1. **Normalize to a PR number.** A number is used directly; a URL yields
+   its trailing number; a branch resolves via
+   `gh pr list --head <branch> --json number --jq '.[0].number'` (if
+   none, ask the user to open one, even a draft). Fetch the
+   orchestrator's view (`gh pr view <N>`, `gh pr diff <N>`) and record
+   the head branch and SHA (`--json headRefName,headRefOid`).
+2. **Resolve the project slug** from the head branch, parsing **both**
+   agent prefixes. `<agent>/<slug>/<task-slug>` → project work;
+   `<agent>/<short-description>` → ad-hoc; skip the project-spec reads.
+3. **Read the task spec** (project work only), for judging reviews and
+   detecting scope creep: `PLAN.md` (frontmatter, `version_bump`, the
+   **Numerical impact** section, the task row), `rules.md` if present,
+   the phase file (phased), the task note, and active ADRs.
+4. **Ensure a worktree for fixes.** If `WT_PATH` / `BRANCH` were passed,
+   use them. Otherwise `git fetch origin` and add a worktree on the PR
+   head branch. Record `WT_PATH` and `BRANCH`.
+
+### Phase B: Review round (repeat up to max iterations)
+
+#### B.0: Select reviewers
+
+Select once, at the start of the loop, per the **selection rules** in
+[`review-lenses.md`](../../../docs/agents/review-lenses.md) —
+default-include A and D; add B for explicit Exit Criteria, C for
+runtime-behavior changes, **E whenever the diff can move a number**
+(any change under `hazma/` that is not purely a rename, docstring, or
+annotation); always include D on project-closing PRs. Or use the caller's
+`reviewer override`.
+
+Record `SELECTED_REVIEWERS` (e.g. `{A, C, D, E}`) with a one-sentence
+justification per chosen and per omitted reviewer. The set is **fixed for
+every round** (convergence assumes a stable set); surface it in the Round
+1 PR comment only.
+
+#### B.1: Spawn selected reviewers in parallel
+
+Use the **Agent tool** to spawn one `general-purpose` agent per ID in
+`SELECTED_REVIEWERS`, **in a single message** (parallel tool calls).
+Substitute `<ID>`, `<Role>`, `<MODEL>`, `<EFFORT>`, `<LENS>` from the
+review-lenses roster row; when `--lens` is `(none)`, omit the
+`with lens:` clause.
+
+```text
+Agent(
+  subagent_type: "general-purpose",
+  model: "<MODEL>",       # from the roster: sonnet for A–D, opus for E
+  description: "Reviewer <ID> (<Role>)",
+  prompt: <template body below>
+)
+```
+
+**Template body:**
+
+> You are Reviewer `<ID>` (`<Role>`). Use the `/review-pr` skill[ with
+> lens: `<LENS>`] to review PR #`<PR_NUMBER>`.
+>
+> Apply your lens's FOCUS rubric and the baseline duties (fresh-eyes
+> PR-head recipe, zero-collection guard, empirical execution, rebuild
+> awareness, lessons.md read, verdict rule, new-code correctness shapes)
+> from `docs/agents/review-lenses.md` — read your section there. Reviewer
+> D runs `docs/agents/doc-consistency.md`.
+>
+> **Pipeline-managed placeholders — do NOT flag.** A draft placeholder
+> title (`chore(pipe): pipeline draft …`) and stub body (`"Draft —
+> pipeline in progress."`) are rewritten before the PR leaves draft. Skip
+> them; if `gh pr view` shows a real title/body, evaluate it against
+> `docs/PR_GUIDELINES.md` as normal.
+>
+> Your verdict MUST be APPROVE or REQUEST CHANGES — never COMMENT inside
+> this loop. Non-blocking-only ⇒ APPROVE and list them. Return your full
+> structured review.
+
+Collect all reviewer results (external reviews stay alongside as advisory
+context). One branch fires:
+
+- **Shortcut — every selected internal reviewer APPROVES with zero
+  comments:** converged; no fix round needed. Post a brief round comment
+  (B.5 shortcut form, carrying the Round 1 selection block) and go to
+  Phase C. Do **not** run a pointless verification round.
+- **Otherwise** (any REQUEST CHANGES, or all APPROVE with at least one
+  non-blocking suggestion): proceed to **B.2**.
+
+#### B.2: Review-respond — implement, commit, and push
+
+Spawn a fresh **opus** subagent. Open its prompt with the worktree
+directive (`cd <WT_PATH>`; do not create a worktree; branch `<BRANCH>`).
+
+```text
+Agent(
+  subagent_type: "general-purpose",
+  model: "opus",
+  description: "Review respond",
+  prompt: <review-respond prompt below>
+)
+```
+
+> Use the `/review-respond` skill to process these reviews for PR
+> #`<PR_NUMBER>` (Project `<slug>`, Task `<TASK_ID>` — `<TASK_TITLE>`,
+> task note `<TASK_NOTE_PATH>`):
+>
+> <paste each selected internal reviewer's result, tagged with its ID>
+>
+> <!-- Only if external reviews were provided: advisory only, no
+>      verification pass, do not gate convergence. -->
+> <paste any external reviews here>
+>
+> Follow `/review-respond`: the categorization table, the scope-of-fix
+> sweep (`docs/agents/doc-consistency.md` §11), the class-fix rule
+> (re-run the CLASS of check across the whole touched artifact set —
+> never point-fix the cited line), the measurement rule (reject a
+> numerics comment only with pasted numbers), and the lessons-ledger
+> append when a finding is class-shaped.
+>
+> **You MUST commit and push.** Stage only files you intentionally
+> changed. Rebuild first if you touched `.pyx` / `.pxd` / `_build.py`.
+> Run the preflight gate (`docs/agents/preflight.md`) before staging;
+> assert a real `N passed` count. Commit with a Conventional Commits
+> message (validate with `scripts/agents/check_pr_title.py`) and
+> `git push`; report `FINAL_COMMIT_SHA` from `git rev-parse HEAD` after
+> the push. Quote the literal pytest summary line — a bare "tests pass"
+> is insufficient.
+>
+> Emit one `## Response to Reviewer <ID>` block per selected reviewer (a
+> decisions table: `# | Comment | Category | Action | Rationale`), a
+> block per external reviewer using an `Ext-<Label>` tag, then a
+> `## Pipeline Report` with STATUS
+> (`FIXES_APPLIED | NO_FIXES_NEEDED | BLOCKED`), COMMENTS_FIXED,
+> COMMENTS_REJECTED, COMMENTS_ACKNOWLEDGED, NUMERICAL_IMPACT,
+> FINAL_COMMIT_SHA.
+
+**Verify the push landed** before spawning verifiers — the whole loop
+reviews stale code otherwise.
+`gh pr view "${PR_NUMBER}" --json headRefOid --jq .headRefOid` must equal
+the agent's `FINAL_COMMIT_SHA` and differ from the pre-round head. If it
+did not advance and the agent claimed fixes, stop and report. If the push
+was rejected (branch behind), the review-respond agent fetches and
+rebases onto `origin/<BRANCH>` and re-pushes; never force-push a shared
+branch.
+
+#### B.3: Verification reviewers in parallel
+
+Spawn one verification agent per **selected** reviewer, same model and
+lens as Round 1, in a single parallel message. Each fetches the PR head
+fresh (not the worktree).
+
+```text
+Agent(
+  subagent_type: "general-purpose",
+  model: "<same model as the original reviewer>",
+  description: "Verification — Reviewer <ID>",
+  prompt: "You are Reviewer <ID> (<Role>). You previously reviewed
+           PR #<PR_NUMBER> and raised these comments:
+
+  <your Round N review, verbatim>
+
+  The implementer responded:
+
+  <that reviewer's ## Response to Reviewer <ID> block from B.2>
+
+  Fetch the PR head fresh (baseline fresh-ref recipe in
+  docs/agents/review-lenses.md): delete any stale ref, then
+  `git fetch origin pull/<PR_NUMBER>/head:refs/remotes/origin/pr/<PR_NUMBER>`,
+  verify the SHA against `gh pr view`, never verify the ambient checkout.
+
+  **Live-tree verification (not snapshot).** Before REQUEST CHANGES on a
+  volume claim ('N stale refs survive', 'M criteria uncovered'), re-run
+  the command against the freshly-fetched diff and quote the output —
+  review-respond may have committed since your first read. Such a verdict
+  with no pasted command output is not blocking.
+
+  **Numerics claims need numbers.** If you asserted a value was wrong and
+  the implementer pasted a measurement, re-run it yourself before holding
+  the comment UNRESOLVED.
+
+  **Stale-state sweep** (per docs/agents/doc-consistency.md §11): for any
+  count / command / identifier / unit / qualitative claim you raised, `rg`
+  it across the rest of the touched docs; the original value surviving
+  anywhere — even in an untouched section — is a NEW blocking issue.
+
+  Mark each original comment RESOLVED / PARTIALLY RESOLVED / UNRESOLVED,
+  then list NEW issues in your area. Verdict MUST be APPROVE or
+  REQUEST CHANGES.
+
+  ## Verification — Reviewer <ID> (<Role>)
+  | # | Original Comment | Status | Notes |
+  |---|-----------------|--------|-------|
+
+  ## New Issues
+  ### Blocking
+  <numbered list, or 'None'>
+  ### Non-blocking
+  <numbered list, or 'None'>
+
+  ## Verdict: <APPROVE | REQUEST CHANGES>"
+)
+```
+
+If review-respond returned `NO_FIXES_NEEDED`, verification still runs —
+verifiers independently judge whether each rejection was justified, so
+the responder cannot unilaterally overrule blocking feedback.
+
+#### B.4: Convergence
+
+| Condition | Action |
+|-----------|--------|
+| Every selected verifier APPROVES, no new blocking issues | **Converged** → B.5, then Phase C |
+| Any UNRESOLVED blocking comment or new blocking issue | Loop to B.2 with verification results as the new input |
+| Same blocking comment persists two consecutive rounds | **Escalate** to the user — needs human judgment |
+| `max-review-iterations` reached | **Stop**, not converged; carry the unresolved list forward |
+
+Each round must resolve at least one blocking issue; a round with zero
+progress on blocking items escalates rather than looping.
+
+#### B.5: Post the round comment to the PR
+
+Only after B.4 has decided the round outcome, post one durable comment so
+the PR timeline records why the code ended up as it did. This runs
+**every** round — looping, cap-reached, escalated, and the shortcut path
+(brief form). Use `<details>` blocks so the verdicts table stays visible.
+
+```markdown
+## Automated Review — Round <N>
+
+<!-- Round 1 only: the B.0 reviewer-selection block (chosen + omitted,
+     one reason each). -->
+
+### Verdicts
+| Reviewer | Role | Model | Initial | Verification |
+|----------|------|-------|---------|--------------|
+<!-- One row per SELECTED reviewer, A→E order. -->
+
+**Round outcome:** <Converged | Not converged — looping to Round <N+1>
+| Not converged — iteration cap reached | Escalated — blocking comment
+persisted two rounds>
+
+<!-- One <details> block per selected reviewer (A→E): initial key
+     comments, then the verification status table + New Issues. -->
+
+<!-- External Reviews section only when provided — advisory, no
+     verification column, not counted toward convergence. -->
+
+### Decisions
+| # | Source | Comment | Decision | Rationale |
+|---|--------|---------|----------|-----------|
+<!-- Built from review-respond's per-reviewer tables; Source = <ID>.<n>
+     or Ext-<Label>.<n>. -->
+
+### Numerical impact
+<review-respond's NUMERICAL_IMPACT for this round, or "no public code
+path touched">
+
+### Fix commit
+<short SHA + one-line message from B.2, or "NO_FIXES_NEEDED — <reason>">
+```
+
+Post via `gh pr comment "${PR_NUMBER}" --body-file <file>` from the
+worktree, then remove the temp file. Increment `<N>` each round.
+
+### Phase C: Final summary
+
+Report to the user; do not clean up the worktree or branch. When called
+by `/task-pipeline`, these fields are the review phase's return value.
+
+```text
+## Review Cycle Summary
+
+**Target:** PR #<N> / branch `<name>`
+**Project / Task:** <slug> — <TASK_ID> / "<title>"
+**Selected reviewers:** <SELECTED_REVIEWERS + models>
+
+### Per round
+- Round N — <per-reviewer verdicts, resolved/new-issue counts, changes>.
+
+### Final state
+- **STATUS:** CONVERGED | NOT_CONVERGED (iteration cap) | ESCALATE
+- **ITERATIONS_USED:** <N>
+- **UNRESOLVED:** <list with reviewer attribution, or "none">
+- **FILES_MODIFIED:** <list>
+- **TESTS:** <literal pytest summary line from the final round>
+- **NUMERICAL_IMPACT:** <none (verified: <command>) | <function>:
+  <magnitude>>
+- **FINAL_COMMIT_SHA:** <sha; MUST equal
+  `gh pr view <N> --json headRefOid` — verify against origin>
+- **REVIEW_SUMMARY:** <one-paragraph synthesis, e.g. "Converged in 2
+  rounds. Round 1: 3 REQUEST CHANGES, 7 fixes applied. Round 2: all
+  APPROVE.">
+- **External review re-verification needed:** yes / no
+
+Callers (`/task-pipeline` Phase D.2) parse the literal `STATUS`,
+`ITERATIONS_USED`, `UNRESOLVED`, `FINAL_COMMIT_SHA`, and
+`REVIEW_SUMMARY` keys — keep the tokens exact.
+```
+
+Handoff: this skill does not finalize the PR title/body. Standalone, the
+user (or `/commit-and-pr`) finalizes; under `/task-pipeline`, Phase E
+does — report `STATUS` so the caller routes accordingly.
+
+---
+
+## Guardrails
+
+- **Iteration cap / progress required:** default 3 rounds; never loop
+  indefinitely. Each round must resolve at least one blocking issue —
+  zero progress ⇒ stop and escalate.
+- **Fixes must be pushed before verification.** B.2 commits and pushes;
+  the orchestrator verifies the PR head advanced before spawning
+  verifiers.
+- **Preflight gate before every commit.** review-respond runs
+  [`preflight.md`](../../../docs/agents/preflight.md), including a
+  rebuild when Cython sources changed. There are no pre-commit hooks
+  here.
+- **No fabricated test claims.** Every TESTS line quotes the literal
+  pytest summary; a zero-collection run is a false green.
+- **No unmeasured numerics verdicts.** Neither a reviewer nor the
+  responder settles "did the number change?" by argument. Numbers or it
+  did not happen.
+- **Scope discipline:** reviewer suggestions do not expand the task
+  beyond its boundary. Acknowledge out-of-scope suggestions (or file a
+  followup); do not implement them here.
+- **Test gate / no silent retries:** never proceed to verification with
+  failing tests, and never revert a fix just to make tests green.
+- **Reviewer identity is stable across rounds** so verification maps back
+  to the original comments; the selected set is fixed once in B.0.
+- **Roster and models live in review-lenses.md** — this skill selects a
+  subset and never re-defines identities or rubrics inline.
+- **External reviews are advisory only** — synthesized, never
+  auto-verified; the summary flags when re-verification is needed.
+- **Template files are not artifacts:** never flag `_template.md` as
+  missing content.
+- **No recursion:** no subagent may invoke `review-cycle`,
+  `task-pipeline`, or another orchestration skill.

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: review-plan
+description: Stress-test a project plan under projects/<slug>/ before implementation starts, producing a findings-first review across feasibility, numerics, correctness, architecture, and idiomatic Python — read-only, no plan edits.
+---
+
+**Role:** Act as a rigorous plan reviewer for a Hazma project plan. The
+plan is still being authored or iterated — your job is to surface
+problems now, before an implementer starts coding against it. The plan
+author wants the plan to fail here, not in PR review. This skill is
+read-only: it reviews plans and emits a report; it never edits the plan.
+
+**When to use this skill**
+
+- The user asks to review a project plan (by slug, directory, or
+  `PLAN.md` path).
+- The user asks whether a plan is ready to hand off to an implementation
+  agent.
+- A plan is being iterated and the author wants a checkpoint review.
+
+**When NOT to use this skill**
+
+- Reviewing an implementation **PR diff** against a task spec →
+  `/review-pr`.
+- Reviewing uncommitted **working-tree** changes → `/code-review`.
+- Orchestrating a **multi-reviewer loop** on a PR → `/review-cycle`.
+
+"Review the plan for this PR" is ambiguous: a `projects/<slug>/PLAN.md`
+is a plan (this skill); a code diff is a PR (`/review-pr`).
+
+## Inputs
+
+Required:
+
+- **project** — a slug, a project directory, or a `PLAN.md` path.
+  Normalize to the project directory.
+
+Optional:
+
+- **focus** — a comma-separated subset of review categories
+  (`feasibility`, `numerics`, `correctness`, `architecture`,
+  `idiomatic-python`, `other`). If omitted, review all categories.
+
+## Workflow
+
+### Step 1: Locate the plan
+
+Verify `projects/<slug>/` exists and `projects/<slug>/PLAN.md` exists and
+is non-empty. If either fails, stop and ask the user to point at a real
+plan. This skill reviews plans, not empty scaffolds.
+
+Decide the ambiguous cases here:
+
+- **`focus` names an unknown category** — stop and ask; do not silently
+  drop it.
+- **A plan-cited context file is missing** (a `references/*.md`, a linked
+  ADR) — note-and-proceed: record it as a finding, do not abort.
+- **`phased:` frontmatter disagrees with the filesystem** — the
+  filesystem wins for the reading order in Step 2; flag the mismatch as a
+  finding.
+
+### Step 2: Load the plan and its context
+
+Read, in this order:
+
+1. `projects/<slug>/PLAN.md` — frontmatter (`status`, `phased`,
+   `version_bump`), goal, scope, **Numerical impact**, task details, exit
+   criteria, anticipated ADRs.
+2. `projects/<slug>/rules.md` if present.
+3. `projects/<slug>/phases/*.md` if phased.
+4. `projects/<slug>/references/*.md` if present.
+5. `projects/<slug>/adrs/*.md` if present.
+6. `projects/<slug>/task-notes/README.md` for live-state context (but do
+   not review this file — it is working memory, not the plan).
+7. [`AGENTS.md`](../../../AGENTS.md),
+   [`docs/workflow.md`](../../../docs/workflow.md),
+   [`docs/versioning.md`](../../../docs/versioning.md),
+   [`docs/PR_GUIDELINES.md`](../../../docs/PR_GUIDELINES.md), and any
+   specific files the plan cites.
+8. [`docs/agents/lessons.md`](../../../docs/agents/lessons.md) — the
+   recurring review-defect classes. A plan can bake in a class before
+   code exists.
+
+Ignore `_template.md` files. They are reference artifacts, never missing
+content.
+
+### Step 3: Verify grounded facts
+
+**Verify the file paths, line numbers, function names, and module
+references the plan makes** with `Grep` / `Read` / `Glob` — a plan that
+names `hazma/spectra/_photon/_muon.py:42` claims something relevant lives
+there; don't take its word. Two disciplines make this sound rather than
+performative:
+
+- **Distinguish should-exist-now from will-be-created.** A plan
+  legitimately names files it will *create*; those SHOULD fail `Glob`,
+  and emitting a Blocker for them is a false positive. For a
+  to-be-created path, verify instead that the **parent package exists**
+  and the **naming matches conventions** (snake_case module, right
+  subpackage, leading underscore if private). Only a path the plan treats
+  as pre-existing evidence blocks when absent.
+- **Premise-check rule.** When the plan (or a followup it builds on)
+  asserts "X exists / is used / returns Y", `rg` the *exact* symbol and
+  run the *exact* command — do not paraphrase or trust the claim. A plan
+  built on a function that was renamed two releases ago wastes an entire
+  implementation pass.
+
+**Bound the effort.** In a large plan with a broken-out `references/`
+tree, verify the **load-bearing** facts first (paths/APIs a task's
+correctness depends on, premises other tasks depend on), then sample the
+rest — mark sampled rows as `Sampled` in the audit.
+
+**Run the commands the plan tells implementers to run.** For every
+command cited as an exit criterion or a "run this to verify" step,
+actually execute it. A command that exits **green while doing nothing** is
+a **Blocker**: `pytest` exits 5 on zero collected, a `-k` filter matching
+nothing exits 0 with `no tests ran`, and `test/conftest.py` silently
+excludes `test/decay/` and `test_gamma_ray.py` from a bare run. A plan
+gating a decay-spectra task on a bare `pytest` has a green-but-noop gate.
+
+Every fact you check becomes a Grounded-facts audit row — and every
+**Verified: Yes** must cite its evidence (the matching `file:line`, grep
+hit, or command + output). A "Yes" with no evidence is indistinguishable
+from a fabricated one.
+
+### Step 4: Evaluate each review category
+
+For each category, produce a verdict (**Pass**, **Needs work**, or
+**Blocker**) plus specific, cited findings. Every finding names the file,
+section, and (where applicable) line.
+
+If the user supplied a `focus` list, evaluate only those categories — but
+still verify grounded facts (Step 3) for the whole plan.
+
+#### 1. Feasibility — can an agent actually implement this?
+
+- **One-PR sizing heuristic.** A task sized for a single PR touches ≲1
+  subsystem and carries ≲2 architectural decisions. More than that ⇒ the
+  task must be split; flag an oversized task as Needs work, or a Blocker
+  if it also blocks downstream tasks.
+- **No open TBDs with dependents.** Any unresolved "TBD" / "pick one" /
+  "decide at implementation time" on a task a downstream task depends on
+  is a **Blocker** — it will stall the dependent. A TBD on a leaf task is
+  at most Needs work.
+- Are concrete file paths, function names, and API sketches provided
+  where non-obvious?
+- Is each exit criterion testable — a command to run, a value to pin, a
+  measurement to record — and does it actually run work (Step 3)?
+- Are task dependencies explicit and acyclic?
+- Are there handwaves ("fix the normalization", "integrate properly")?
+  They become rework vectors — call them out.
+- Is anything ambiguous enough that two competent implementers would
+  produce materially different diffs?
+
+#### 2. Numerics — this is a physics library
+
+The highest-value category. A plan that is silent about numbers will
+produce a PR that moves them silently.
+
+- **Does the plan state its numerical impact?** `PLAN.md` has a
+  **Numerical impact** section. `Unknown — Task 1 measures it` is a valid
+  plan-time answer; an *absent* section, or one that says "none" for a
+  plan that clearly touches a spectrum, is a **Blocker**.
+- **Does `version_bump:` match?** A plan that corrects a published number
+  is `minor`, not `patch`, per
+  [`versioning.md`](../../../docs/versioning.md). A mismatch is Needs
+  work at minimum.
+- **Are units and normalization pinned?** "Returns the spectrum" is not a
+  spec. Which spectrum — `dN/dE` or `E dN/dE`? Per annihilation or per
+  decay? Which frame? Which energy units? If the plan does not say, two
+  implementers will disagree and only one will be right.
+- **Is there an oracle for each new number?** Every task that produces a
+  physical quantity should name what it will be checked against: an
+  analytic limit, a published value (with a citation), an independent
+  implementation, or a stored regression array. "Add tests" is not an
+  oracle.
+- **Are the numerically dangerous spots identified?** Threshold and
+  endpoint behavior, catastrophic cancellation, integrable singularities,
+  interpolation outside the tabulated range, `sqrt` of a
+  rounding-negative quantity. A plan touching these without naming them
+  is Needs work.
+- **Are tolerances discussed?** A plan whose only stated gate is
+  "tests pass" gives the implementer license to pick whatever `rtol`
+  makes it green.
+
+#### 3. Correctness — beyond the numbers
+
+- For each task, enumerate failure modes. Does the plan close them?
+- Edge cases: empty arrays, scalar-vs-array input, zero and equal masses,
+  the massless limit, negative or NaN input, arrays with a single
+  element.
+- Ambiguity in "correct": "return the spectrum for the final state" —
+  including or excluding FSR? Summed over charge states or per state?
+  The plan must pin this down.
+- How does the change interact with `hazma/theory/`, the model packages,
+  and the limit-setting machinery downstream?
+- New-code correctness shapes the plan should already defend: adding to a
+  dispatch table requires fanning out to every sibling lookup, `__all__`,
+  and test; a constant becoming a user argument needs a validity guard;
+  an invariant must hold at every public entry point.
+
+#### 4. Architecture — does it fit the repo?
+
+- **Layering.** The dependency direction in
+  [`AGENTS.md`](../../../AGENTS.md) must hold: Cython kernels import
+  nothing from pure-Python layers; models depend on `theory`, not the
+  reverse; analysis consumes models. Flag any task that inverts it.
+- **Public vs private.** Does the plan put new code in the right place —
+  a leading-underscore package for implementation, the public package for
+  the user-facing entry point — and export it where users will look?
+- Does the plan reuse existing abstractions (the `Theory` interface, the
+  spectra dispatch, `phase_space`, the boost machinery) or reinvent them?
+- **Cython vs NumPy.** If the plan proposes a new `.pyx` kernel, does it
+  justify why vectorized NumPy is insufficient? A new compiled extension
+  adds build surface, a rebuild step for every contributor, and a
+  platform-specific failure mode — it needs a reason.
+- **Data files.** New `*.dat` / `*.csv` under `hazma/` must be registered
+  in `[tool.setuptools.package-data]` or they vanish from the wheel. Does
+  the plan say so, and does it record the data's provenance?
+- ADR placement: project-scoped vs repo-wide per
+  [`workflow.md`](../../../docs/workflow.md). Unit and normalization
+  conventions are the classic repo-wide tier here.
+- Anything load-bearing (an invariant, a convention, a data provenance)
+  that should be documented in the plan but isn't?
+
+#### 5. Idiomatic Python — a Python dev should feel at home
+
+Apply the `10x-standards:python-standards` skill and the
+[`AGENTS.md`](../../../AGENTS.md) conventions rather than re-deriving
+them. The hazma-specific points:
+
+- Naming: modules/functions `snake_case`, classes `UpperCamel`,
+  constants `SCREAMING_SNAKE`. Physics symbols stay in docstrings, not
+  identifiers.
+- Type annotations on public functions; NumPy-style docstrings with
+  `Parameters` / `Returns` and **units for every physical quantity**.
+- Arrays in, arrays out — the broadcasting contract.
+- Error handling: which errors from `hazma/hazma_errors.py`, raised when?
+  No bare `except`.
+- Does the plan smuggle in `print()`, `breakpoint()`, a mutable default
+  argument, or a module-level side effect?
+- Formatting is black + isort; the plan should not propose fighting them.
+
+#### 6. Additional dimensions (the "Other" row)
+
+- **Test strategy.** Every task has a test plan naming real pytest
+  targets, and it accounts for `conftest.py`'s exclusions.
+- **Scope discipline.** "In scope" and "Out of scope" don't overlap.
+  Nothing implicit is smuggled in. The out-of-scope list is honest about
+  what the author *was* tempted to include.
+- **Regression risk.** Does the change risk moving an existing spectrum,
+  limit, or relic-density result? Is there a battery that would catch it?
+- **Performance.** Python loops over arrays, repeated recomputation, or
+  per-element crossings of the Cython boundary — does the plan know where
+  its cost is, and does it commit to a measurement rather than a claim?
+- **Dep hygiene.** New third-party dependencies justified? They land in
+  `pyproject.toml` and every downstream user pays for them.
+- **Docs surface.** Does a new public object need a `docs/source/*.rst`
+  entry? Does a rename break an existing `automodule` directive?
+- **Commit / PR plan.** Each task maps cleanly to one PR with a
+  Conventional Commits title and a valid ≤10-char scope.
+- **Task-notes hygiene.** Live state lives in `task-notes/README.md`, not
+  `PLAN.md`.
+
+### Step 5: Emit the report — findings first, verdict last
+
+```md
+# Plan Review: <project slug>
+
+## Findings
+
+<Severity-ordered numbered list. Each entry is tagged [P1] (Blocker),
+[P2] (Needs work), or [P3] (Suggestion); cites the exact plan location
+(e.g. `PLAN.md §Task 2 "Scope / implementation notes"` or
+`references/foo.md:18`); states the problem in one sentence; and
+proposes a concrete fix or the decision that must be made. Order P1s
+first.>
+
+## Summary
+
+| Category         | Verdict                     | Top finding (one line, cited) |
+|------------------|-----------------------------|-------------------------------|
+| Feasibility      | Pass / Needs work / Blocker | ...                           |
+| Numerics         | Pass / Needs work / Blocker | ...                           |
+| Correctness      | Pass / Needs work / Blocker | ...                           |
+| Architecture     | Pass / Needs work / Blocker | ...                           |
+| Idiomatic Python | Pass / Needs work / Blocker | ...                           |
+| Other            | Pass / Needs work / Blocker | ...                           |
+
+## Grounded-facts audit
+
+| Claim (plan location) | Verified? | Evidence |
+|-----------------------|-----------|----------|
+| ...                   | Yes / No / Partial / Sampled | grep hit, file:line, or command output |
+
+## What the plan does well
+
+<2–5 bullets. Not filler — concrete strengths (good scoping, clean exit
+criteria, a real oracle for each number, right ADR placement), each
+cited.>
+
+## Verdict
+
+<APPROVE | APPROVE WITH CHANGES | REQUEST MAJOR REVISION>
+<Then 2–3 sentences of why. Keep it brief — the findings are the
+primary output.>
+```
+
+Severity maps to the verdict: any **[P1]** ⇒ REQUEST MAJOR REVISION;
+[P2]s but no [P1] ⇒ APPROVE WITH CHANGES; only [P3]s ⇒ APPROVE. The
+blocking anchors are those in
+[`review-lenses.md`](../../../docs/agents/review-lenses.md), plus three
+plan-specific blockers: green-but-noop verification commands (Step 3),
+open TBDs with dependents, and a missing or obviously-wrong **Numerical
+impact** section.
+
+**No-findings shape.** If nothing rises above a nit, drop the Summary and
+Grounded-facts tables: emit `## Findings` with `No blocking or needs-work
+findings.`, replace the two tables with a `## Residual Risks` list of
+load-bearing assumptions you could not fully verify (one line each), and
+close with `## Verdict` / `APPROVE` and a sentence.
+
+## Review posture
+
+- **Cite everything.** A finding without a file and section is noise;
+  re-verify your own line citations are current before shipping.
+- **Be specific.** "Task 3 is vague" is useless; "Task 3 says 'boost the
+  rest-frame spectrum' but does not say whether the boost integral is
+  taken over the lab-frame or rest-frame energy grid;
+  `spectra/boost.py:88` assumes the former" is useful.
+- **Propose fixes.** A good finding tells the author what text would
+  resolve it, or what decision is missing.
+- **Don't pad.** If a category is clean, say "Pass" and move on.
+- **Flag dead weight** — empty `rules.md`, stale references files,
+  anticipated ADRs that should already be written. Never flag
+  `_template.md` files.
+- **Don't re-write the plan.** Review it; point at missing decisions;
+  don't ghostwrite them.
+- **Don't ratify handwaves.** "Decide at implementation time" for
+  something that blocks downstream work is a blocker, not a deferred
+  detail. This applies double to units and normalization.
+
+## Output
+
+Emit only the report. This skill is read-only: do not modify the plan,
+task notes, or any file in the project — the author drives revisions.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: review-pr
+description: Review a PR that implements one plan task against its spec in projects/<slug>/, as a single lens-focused reviewer. Distinct from generic /code-review (working-tree diffs), /review-plan (pre-implementation plans), and /review-cycle (multi-reviewer orchestration).
+---
+
+**Role:** Act as a rigorous code reviewer for a PR that implements one
+task from a project's plan (or an ad-hoc change). You are **one**
+reviewer running **one** lens and producing **one** structured verdict.
+Synthesis across lenses and iteration to convergence is `/review-cycle`'s
+job. Your job is to determine whether the task was completed correctly,
+with depth dictated by your assigned lens.
+
+## When to use this skill
+
+- The user asks to review a PR (by number or URL) against its plan task.
+- Called by `/review-cycle` for each reviewer agent (one lens per
+  invocation).
+
+## When NOT to use this skill
+
+- **Working-tree diffs / uncommitted changes** → `/code-review`. This
+  skill reviews PRs; push the branch or open a draft PR first.
+- **A project plan not yet implemented** → `/review-plan`.
+- **Driving multiple reviewers to convergence** → `/review-cycle`.
+
+## Inputs
+
+Required:
+
+- **PR** — a number, URL, or pushed branch name.
+
+Optional:
+
+- **lens** — `default`, `completeness`, `logic`, `doc-consistency`, or
+  `numerics`. Default is `default` (the generalist pass). Each lens maps
+  to one reviewer in the roster; see
+  [`review-lenses.md`](../../../docs/agents/review-lenses.md).
+
+## Workflow
+
+### Step 1: Gather PR context
+
+Normalize the input to a PR number: a number is used directly; a URL
+yields its trailing number (`/pull/(\d+)`); a branch resolves via
+`gh pr list --head <branch> --json number --jq '.[0].number'` (if none,
+ask the user to open one, even a draft).
+
+Fetch metadata:
+`gh pr view <N> --json title,body,state,baseRefName,headRefName,files,additions,deletions,commits`
+
+**Fetch the PR head fresh (baseline duty).** Do not review against the
+ambient checkout. Delete any stale ref, then
+`git fetch origin pull/<N>/head:refs/remotes/origin/pr/<N>`, and verify
+the fetched SHA against `gh pr view`. Treat `gh pr diff <N>` as possibly
+**truncated** — if the diff is large or looks clipped, read the changed
+files from the fetched ref. Full recipe in
+[`review-lenses.md`](../../../docs/agents/review-lenses.md) under
+Baseline duties.
+
+### Step 2: Resolve the project slug
+
+Parse the head branch. `<agent>` is `claude` or `codex` — **parse both**:
+
+- `<agent>/<slug>/<task-slug>` → project work; the first segment after
+  the prefix is the slug.
+- `<agent>/<desc>` (no second `/`) → ad-hoc. Skip project-spec reading;
+  review against `AGENTS.md`, `docs/PR_GUIDELINES.md`, and the diff.
+
+A branch starting with neither prefix is treated as ad-hoc — note it.
+
+### Step 3: Read the task specification (project work only)
+
+1. [`lessons.md`](../../../docs/agents/lessons.md) — read first and check
+   the diff against each listed class (baseline duty).
+2. `projects/<slug>/PLAN.md` — scope, frontmatter (`phased`,
+   `version_bump`), the **Numerical impact** section, the task row.
+3. `projects/<slug>/rules.md` if present.
+4. **Phased only:** the target phase file, for the exact task definition,
+   Exit Criteria, and Prerequisites.
+5. The task note (`task-notes/task-N-<slug>.md` or
+   `task-notes/phase-XX/task-X.Y-<slug>.md`). `_template.md` files are
+   reference material — skip them.
+6. ADRs referenced by the task or touching the same area:
+   `projects/<slug>/adrs/` and `docs/adrs/`.
+7. Upstream phase learnings or prior task notes where they help judge
+   this implementation.
+
+For ad-hoc PRs, skip 2–7.
+
+### Step 4: Read the changed files in full
+
+Do **not** review only the diff. For every file with non-trivial changes,
+read the full file (or at minimum the surrounding module) so you can
+judge integration, breakage, and omissions.
+
+Common "diff omits" patterns in this repo:
+
+- A new public object not exported from the package `__init__.py` (or
+  missing from `__all__`) — users cannot reach it.
+- A new final state / channel added to one dispatch table but not its
+  siblings (photon but not positron; the function map but not the
+  documented channel list).
+- A `.pyx` / `.pxd` change with no evidence of a rebuild, so the cited
+  test results came from the old extension.
+- A renamed or removed public object still referenced by `docs/source/`
+  — the published Sphinx build breaks without any test failing.
+- Package data (`*.dat`, `*.csv`) added under `hazma/` but not registered
+  in `[tool.setuptools.package-data]` in `pyproject.toml`, so it is
+  missing from the installed wheel.
+- A new test file that `test/conftest.py`'s `collect_ignore` silently
+  excludes.
+
+### Step 5: Evaluate based on your assigned lens
+
+Spend ~90% of your effort on your assigned lens. If you notice a clearly
+blocking issue outside it, note it briefly under "Cross-cutting", but do
+not hunt outside your area — that is another reviewer's job.
+
+**Baseline duties for EVERY lens** (before your lens-specific work):
+
+- **PR-body claims reproduce.** Cross-check every count, file name, and
+  identifier in the body against today's diff.
+- **Zero-collection guard.** `pytest` exits 5 on zero tests collected;
+  a `-k` filter matching nothing exits 0 with `no tests ran`. Read the
+  `N passed` line before trusting any cited green. `test/conftest.py`
+  excludes `test/decay/` and `test_gamma_ray.py` from a bare run.
+- **Empirical execution.** When the diff edits a docstring example, a
+  README snippet, or claims a user-visible behavior, RUN it and paste the
+  output. Static review does not catch a wrong number.
+- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` /
+  `_build.py`, confirm the cited results came from a rebuilt tree.
+
+The full baseline duties and the **per-lens FOCUS rubric** for your lens
+live in [`review-lenses.md`](../../../docs/agents/review-lenses.md) —
+read your section there; it carries the load-bearing detail. Summaries:
+
+- **`default` (A — Generalist):** all dimensions with equal weight, plus
+  public-surface hygiene (exports, NumPy docstrings, **units stated**),
+  layering per `AGENTS.md`, the scalar/array broadcasting contract, no
+  stray debug, and PR title/body per `docs/PR_GUIDELINES.md`.
+- **`completeness` (B):** does the diff satisfy each Exit Criterion, with
+  a pinning test per bullet, and stay within scope? A test that would
+  still pass under a plausible regression is *not* a pinning test.
+- **`logic` (C):** adversarial correctness, edge cases, error handling,
+  and test validity. Single-symbol mutation test; one adversarial
+  boundary case the PR's tests miss (threshold, endpoint, zero/equal
+  masses, empty array, scalar-vs-array, NaN, integration across a
+  singularity).
+- **`doc-consistency` (D):** run
+  [`doc-consistency.md`](../../../docs/agents/doc-consistency.md) as your
+  review pass and report each check with line-numbered evidence; any
+  contradiction is blocking. Includes units-in-docstrings, the Sphinx
+  surface, and version-bump + CHANGELOG on closing PRs.
+- **`numerics` (E):** **did any published value move?** Run the affected
+  public functions before and after on a representative grid and diff.
+  A value that moved without acknowledgement in the PR body or CHANGELOG
+  is blocking regardless of test status. Then: dimensional analysis
+  against `hazma/parameters.py`, limiting cases, floating-point
+  stability, integration/interpolation ranges, tolerance justification,
+  and performance (vectorization, the Cython boundary, measured claims).
+
+### Step 6: Produce the review
+
+**Verdict rule (apply deterministically):**
+
+- **Any Blocking finding ⇒ REQUEST CHANGES.**
+- **Zero Blocking findings ⇒ APPROVE** (list non-blocking suggestions).
+- **COMMENT** only for a standalone advisory review — never inside
+  `/review-cycle` or `/task-pipeline`.
+
+Severity anchors: **Blocking** = correctness bug, a number that moves
+without being acknowledged, CI-breaking change, spec/Exit-Criterion
+violation, durable-doc contradiction, or a missing mandated gate.
+**Non-blocking** = style, optional improvement, deferred-scope
+suggestion. On verification rounds mark each original comment
+**RESOLVED**, **PARTIALLY RESOLVED**, or **UNRESOLVED**.
+
+**Focused lens template** (`completeness`, `logic`, `doc-consistency`,
+`numerics`):
+
+```text
+## Verdict
+
+<APPROVE | REQUEST CHANGES | COMMENT>
+
+One-sentence summary of the overall assessment.
+
+## Issues (<lens> Focus)
+
+### Blocking
+
+<Numbered. File path, line number, what's wrong, what should change.
+Empty if none.>
+
+### Non-blocking
+
+<Numbered. Empty if none.>
+
+## Cross-cutting
+
+<Clearly blocking issues outside your lens. Omit the section entirely if
+there are none. Keep entries brief.>
+
+## Lens-Specific Observations
+
+<completeness: Exit-Criterion → test map (pass/fail per bullet) + scope.
+logic: test-validity and edge-case assessment, naming the regression each
+key test would catch. doc-consistency: per-check results with
+line-numbered evidence. numerics: the before/after comparison you ran —
+function, grid, command, and result — plus stability and performance
+assessment.>
+```
+
+**Default / generalist template** (`default`):
+
+```text
+## Verdict
+
+<APPROVE | REQUEST CHANGES | COMMENT>
+
+One-sentence summary.
+
+## Task Completeness
+
+<Exit Criteria checklist with pass/fail. Verify required artifacts exist
+(task note filled in, ADR if needed, phase file / rules.md / PLAN.md
+updated if canonical behavior changed). Ad-hoc PRs: assess against the
+PR's own Summary.>
+
+## Issues
+
+### Blocking
+### Non-blocking
+
+## Numerics
+
+<Did anything the library returns change? What did you check, and how?
+"No public code path touched" is a valid answer; silence is not.>
+
+## Scope
+
+<Did the PR stay within task boundaries? Any drift?>
+
+## Testing
+
+<Test quality and coverage relative to the task requirements — including
+whether the tests pin values or only shapes.>
+
+## Conventions
+
+<Code style, `projects/<slug>/rules.md` compliance, ADR alignment, and
+PR title/body format per `docs/PR_GUIDELINES.md`.>
+```
+
+## When a step can't complete
+
+Degrade gracefully — review what you can, surface the gap, never
+fabricate the missing piece.
+
+- **Diff too large to read in one pass.** Do not silently skim. Read the
+  highest-risk files first (behavior-changing code, then tests, then
+  docs), then list the unread surfaces under a **Residual Risks**
+  heading.
+- **Task spec missing.** Do not hallucinate a spec. Review as ad-hoc and
+  flag the missing spec as a finding.
+- **A re-run command fails** (no compiler, no built extensions, missing
+  dependency). Report it as a finding stating what you could not verify —
+  do not invent a result and do not treat reviewer-env noise as a code
+  defect.
+
+## Guardrails
+
+- Do not skim. Read every line of the diff (or degrade explicitly).
+- Do not approve by default. Start skeptical and let the code convince
+  you. Apply the verdict rule mechanically — the same findings must yield
+  the same verdict across fan-out reviewers.
+- Do not conflate "tests pass" with "correct." In a physics library a
+  green suite with a loose tolerance is the most common way a wrong
+  number ships.
+- Do not request stylistic changes that contradict existing patterns —
+  and do not cite `hazma/experimental/` as a pattern; it is outside the
+  lint gate and outside the public surface.
+- Do not suggest scope expansion beyond the task spec.
+- Be specific: file, line, what's wrong, what should change.
+- If you are uncertain whether something is a bug, say so explicitly
+  rather than silently passing it.
+- `_template.md` files are reference material. Do not flag their absence
+  from listings or their placeholders as missing content.

--- a/.claude/skills/review-respond/SKILL.md
+++ b/.claude/skills/review-respond/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: review-respond
+description: As the implementer, synthesize existing PR review feedback from one or more reviewers, implement the justified fixes behind the preflight gate, and produce per-reviewer, verification-ready response summaries. Use when reviews already exist and you need to address them — not to collect reviews.
+---
+
+**Role:** Act as the engineer who implemented the changes under review.
+You critically evaluate feedback from multiple independent reviewers,
+implement the justified fixes, and produce a structured response each
+reviewer can verify.
+
+## When to use this skill
+
+- The user (or an orchestrator) provides review feedback and asks you to
+  process, address, or respond to it.
+- Called by `/review-cycle` (its B.2 step) after collecting a round.
+
+## When NOT to use this skill
+
+- No reviews exist yet and you need to *spawn* reviewers and loop →
+  `/review-cycle`.
+- You are the reviewer, not the implementer → `/review-pr`.
+- You have only a working-tree diff to critique with no feedback →
+  `/code-review`.
+
+## Inputs
+
+Reviews may arrive as pasted text, file paths, or subagent results. You
+also need a handle for the changes under review:
+
+- **PR number** or **URL** (extract the trailing number), or
+- **Branch name** — resolve via
+  `gh pr list --head <branch> --json number --jq '.[0].number'`,
+  otherwise fall back to the local branch diff.
+
+When a caller (`/review-cycle`, `/task-pipeline`) hands you `WT_PATH` /
+`BRANCH`, work in that shared worktree; fixes must land there. Use
+`git -C <WT_PATH>` for every git command.
+
+## Workflow
+
+### Step 1: Gather context
+
+- Obtain the diff: `gh pr diff <N>`, or `git diff <base>...HEAD`. Confirm
+  `<base>` is the true merge-base —
+  `git merge-base --fork-point origin/master HEAD` — so a stacked branch
+  does not pull unrelated commits into the diff.
+- Parse the head branch for the project slug. Project branches are
+  `<agent>/<project-slug>/<task-slug>`; ad-hoc are
+  `<agent>/<short-description>`, `<agent>` ∈ `{claude, codex}` — **parse
+  both prefixes**.
+- For **project work**, read in order: `projects/<slug>/PLAN.md` (check
+  `phased`, `version_bump`, and the **Numerical impact** section);
+  `rules.md` if present; the phase file (phased); the task note; any
+  referenced ADRs.
+- Read [`lessons.md`](../../../docs/agents/lessons.md), then every review
+  input provided.
+
+### Step 2: Evaluate every comment
+
+Assess each comment on technical merit:
+
+- **Correctness:** does the claim hold against the code, spec, and tests?
+- **Scope:** is the fix within the task boundary, or scope creep?
+- **Severity:** would ignoring it cause a bug, a wrong number, a spec
+  violation, a test failure, or a canonical-rule violation? Use the
+  severity anchors in
+  [`review-lenses.md`](../../../docs/agents/review-lenses.md).
+- **Conflicts:** if reviewers disagree, choose the path aligned with
+  `rules.md`, active ADRs, and the repo conventions in `AGENTS.md`; cite
+  which source resolved the conflict.
+
+A **numerics finding gets a measurement, not an argument.** If a reviewer
+claims a value moved or is wrong, evaluate the function and paste the
+numbers. Rejecting a numerics comment without running the comparison is
+not a rejection you can defend in verification.
+
+Categorize each comment:
+
+| Category      | Meaning                                      | Action                           |
+|---------------|----------------------------------------------|----------------------------------|
+| `fix`         | Valid, in-scope issue                        | Implement the fix                |
+| `fix-partial` | Valid concern, suggested fix wrong/overkill  | Fix differently, explain how     |
+| `acknowledge` | Valid but out of scope for this task         | Defer to a follow-up (see below) |
+| `reject`      | Incorrect, already handled, or out of scope  | Explain why, with evidence       |
+
+For `acknowledge`, follow the follow-up lifecycle in
+[`workflow.md#follow-ups`](../../../docs/workflow.md#follow-ups): grep
+`docs/followups/` for an existing entry and link it; else copy
+`_template.md` into `docs/followups/todo/<slug>.md` and add a README row.
+**Dedup against open PRs too** (`gh pr list --state open`, then
+`gh pr diff <n> --name-only | grep followups`). Cite the follow-up file
+in the response.
+
+### Step 3: Implement accepted changes
+
+- Apply all `fix` and `fix-partial` changes. Stay scoped — do **not**
+  drift into adjacent cleanup a reviewer did not flag.
+- **Class-fix, not point-fix.** Every fix re-runs the *class* of check
+  across the whole touched artifact set, not just the cited line. A
+  correctness fix that guards one entry point re-checks every sibling
+  entry point; a fixed count re-derives every sibling count; a corrected
+  unit or contract phrase is swept across all durable docs. A point fix
+  that leaves an adjacent stale sibling is what drives extra rounds.
+- **Stale-sibling sweep.** Before fixing any factual claim (count,
+  identifier, command, line number, unit, or qualitative prose claim),
+  run the class-wide sweep in
+  [`doc-consistency.md`](../../../docs/agents/doc-consistency.md) §11:
+  `rg -n '<old-value>' projects/ docs/ hazma/ test/ README.md
+  CHANGELOG.md`, paste under `### Pre-fix occurrences`; fix every
+  occurrence or justify each skip; re-run and paste under
+  `### Post-fix occurrences`. Numeric fixes sweep the bare digit
+  (`\b<old>\b`). Re-derive a corrected fact from first principles rather
+  than confirming it against an adjacent copy.
+- **Re-measure after any behavior fix.** If your fixes changed a code
+  path a public function reaches, re-run the numerical comparison and
+  update the task note and (on a closing PR) `CHANGELOG.md`. Then
+  re-check the PR body against the post-fix diff — a stale body is a
+  blocking finding.
+- **Rebuild before gating** if you touched `.pyx` / `.pxd` /
+  `_build.py`: `pip install -e .`.
+- **Run the preflight gate.** `scripts/agents/preflight.sh --paths
+  "<touched>" --tests "<targets>"` (or the manual list in
+  [`preflight.md`](../../../docs/agents/preflight.md)). Read the pytest
+  summary line — exit 5 is zero collected, a FAIL not a pass. Never
+  silently revert a fix to make a gate pass; diagnose it.
+- Update the task note to reflect the review fixes — a brief bullet under
+  its decisions/implementation-notes section is enough.
+
+### Step 4: Produce per-reviewer response summaries
+
+One block per reviewer (downstream verification parses these — keep the
+shape). If the caller specifies a condensed shape (e.g. `/review-cycle`'s
+single decisions table), use the caller's shape; the invariants are one
+block per reviewer, a category per comment, and a verdict line.
+
+```text
+## Response to <Reviewer ID>
+
+### Accepted
+
+| # | Comment Summary | Category | Action Taken |
+|---|-----------------|----------|--------------|
+| 1 | ... | fix | Changed X in `spectra/_muon.py:42` |
+| 2 | ... | fix-partial | Addressed by Y instead of Z because ... |
+
+### Acknowledged (deferred)
+
+| # | Comment Summary | Reason | Follow-up file |
+|---|-----------------|--------|----------------|
+| 3 | ... | Out of scope for this task | `docs/followups/todo/<slug>.md` |
+
+### Rejected
+
+| # | Comment Summary | Reason (with evidence) |
+|---|-----------------|------------------------|
+| 4 | ... | Value is unchanged: `<command>` → `<output>` |
+
+### Verdict Requested: <ACCEPT | ITERATE>
+```
+
+`ACCEPT` = every blocking concern from this reviewer is addressed;
+`ITERATE` = open questions remain. If you were stuck mid-fix, say
+`ITERATE` and state which fixes landed and which did not — never report a
+clean verdict over a half-applied round.
+
+### Step 5: Produce the combined summary
+
+```text
+## Combined Summary
+
+- **Reviews processed:** N reviewers, M total comments
+- **Breakdown:** X fixed, Y partially fixed, Z acknowledged, W rejected
+- **Files modified:** [list]
+- **Tests:** <literal pytest summary line, e.g. "43 passed, 2 skipped">
+  — quote it verbatim from the run, never paraphrase
+- **Numerical impact:** <none (verified: <command>) | <function>:
+  <magnitude and direction>>
+- **Open questions:** [tradeoffs or ambiguities needing user input]
+```
+
+### Step 6: Append to the lessons ledger
+
+If any addressed finding is **class-shaped** — it could recur on
+unrelated tasks, not a one-off typo — append a one-line entry to
+[`lessons.md`](../../../docs/agents/lessons.md) in the *same commit* as
+the fix: `- [class] one-line rule (PR #N)`. If an existing entry covers
+the class, add this PR to its citation list rather than duplicating.
+Cite a real PR; an uncited lesson is a guess.
+
+### Commit boundary
+
+- **Inside `/review-cycle` or `/task-pipeline`** (you were given
+  `WT_PATH` / `BRANCH`): commit and push the fixes to the PR branch per
+  the caller's instructions, but only **after** the Step 3 preflight gate
+  passes and the branch/worktree assertion in
+  [`preflight.md`](../../../docs/agents/preflight.md) holds (intended
+  branch, never `master`; `git -C <WT_PATH>`). The orchestrator then
+  verifies the push landed.
+- **Standalone:** leave the changes uncommitted and **say so** in the
+  combined summary — hand off to `/commit-and-pr`. Do not improvise a
+  commit.
+
+## Guardrails
+
+- Do not accept comments uncritically — reviewers can be wrong. Do not
+  reject defensively — if the code has a bug, fix it.
+- Reject a numerics comment only with a pasted measurement.
+- Do not expand scope beyond the task boundary even if a reviewer
+  suggests it; acknowledge as deferred and file/link a follow-up.
+- Be specific: file path, line number, what changed and why.
+- If two reviewers flag the same issue, credit both, implement once.
+- If a comment is ambiguous, note the ambiguity rather than guessing.
+- Do not "fix" things reviewers did not mention — it muddies
+  verification; out-of-scope cleanup is a separate follow-up.
+- If a fix conflicts with another or introduces a regression, document
+  the tradeoff and choose the safer path.
+- If a gate starts failing after applying fixes, diagnose it before
+  proceeding; never silently revert a fix to make it pass.

--- a/.claude/skills/task-pipeline/SKILL.md
+++ b/.claude/skills/task-pipeline/SKILL.md
@@ -1,0 +1,498 @@
+---
+name: task-pipeline
+description: Orchestrate one project task end-to-end — resolve, implement, review, ship — delegating each phase to a context-isolated subagent over a shared worktree.
+---
+
+**Role:** Act as the lightweight orchestrator that drives one task from
+implementation through review to a shipped PR, delegating each phase to a
+fresh subagent with full context isolation. The orchestrator stays slim:
+it reads structured `## Pipeline Report` blocks, makes go/no-go
+decisions, and points at the shared agent layer
+([`docs/agents/`](../../../docs/agents/README.md)) rather than restating
+its rules.
+
+**When to use this skill**
+
+- The user asks to "run the pipeline", "implement and ship", or "do one
+  task end-to-end".
+- The user wants automated implement → review → PR without manual
+  `/clear` steps.
+
+**When NOT to use this skill**
+
+- **Ad-hoc work with no project** — the pipeline hard-requires a
+  `projects/<slug>/PLAN.md` (Phase A stalls without one). Route these to
+  a plain commit + PR via `/commit-and-pr`.
+- **A review loop with no implementation** — reviewing an already-pushed
+  PR is `/review-cycle`; reviewing a working-tree diff is
+  `/code-review`.
+- **Stress-testing a plan before implementation** — `/review-plan`.
+
+## Inputs
+
+Required:
+
+- A **task identifier** (`Task 5.2` phased, `Task 3` flat), or the
+  literal string `next`. Phase A resolves it with
+  [`resolve_task.py`](../../../scripts/agents/resolve_task.py).
+- A **project slug**, via `--project <slug>` or parsed from the current
+  branch (both `claude/` and `codex/` prefixes; the slug is the first
+  segment after the prefix). If neither resolves, stop and ask.
+
+Optional:
+
+- **skip-review** — skip Phase D. Default `false`.
+- **skip-pr** — skip PR creation and finalization (Phases C and E). If
+  review is not skipped, a draft PR is still created for the review phase
+  but not finalized. Default `false`.
+- **external-reviews** — file paths or pasted text from reviewers outside
+  Claude Code. Passed through to `/review-cycle` as **advisory context
+  only**. The full contract lives there.
+- **max-review-iterations** — cap on review rounds (default `3`).
+
+---
+
+## Workflow
+
+### Subagent preamble
+
+Every subagent prompt that operates inside the worktree (Phase B
+implementer, Phase E finalizer, and the review subagents spawned by
+`/review-cycle`) opens with the preamble below. Substitute `<WT_PATH>`
+and `<BRANCH>` from Phase A.
+
+> Your working directory is `<WT_PATH>`. Change to it immediately with
+> `cd <WT_PATH>` before doing anything else. All file operations, git
+> commands, and Python commands must run inside this directory.
+>
+> **CRITICAL: Do NOT create your own worktree or call any
+> worktree-creation tool.** You are already in an isolated git worktree
+> on branch `<BRANCH>`, branched from the trunk. This worktree is managed
+> by the pipeline orchestrator.
+>
+> Hazma ships Cython extensions. If your work touches `.pyx`, `.pxd`, or
+> `_build.py`, run `pip install -e .` inside this worktree before running
+> tests, and confirm `python -c "import hazma; print(hazma.__file__)"`
+> resolves inside `<WT_PATH>` — otherwise every result you report comes
+> from a different tree.
+
+### Phase A: Setup (orchestrator — no subagent)
+
+#### A.1: Resolve the project slug and task
+
+Resolve the **project slug** (precedence: explicit `--project` → branch
+parse → error). Confirm `projects/<slug>/PLAN.md` exists and read its
+frontmatter for `phased: true|false`. `PLAN.md` is **not** the source of
+live task status — the Tasks tables under `task-notes/` are.
+
+Resolve the task **before** creating the worktree:
+
+```sh
+scripts/agents/resolve_task.py --project <slug> [--task <id>]
+```
+
+It reads the live Tasks status table (flat → `task-notes/README.md`;
+phased → the current phase's `task-notes/phase-XX/README.md`), skips
+`_template.md`, and prints JSON: `{status, task_id, task_title,
+task_slug, phase, reason}`. Omit `--task` for the lowest-numbered
+non-Complete row. On `status: done` the project has no open task — stop
+and report. On `status: error` fall back to reading the table by hand.
+
+Record `TASK_ID`, `TASK_TITLE`, and `TASK_SLUG`.
+
+#### A.2: Create the shared worktree
+
+```sh
+scripts/agents/setup_task_worktree.sh \
+  --project <slug> --task-slug <TASK_SLUG> --agent claude
+```
+
+It fetches origin, resolves the trunk from `origin/HEAD` (falling back to
+`master`), always branches from it (never ambient HEAD), picks a
+collision-free name, and verifies HEAD before reporting success.
+
+**Branch policy (canonical).** Project branches are
+`<agent>/<project-slug>/<task-slug>`. This skill runs under Claude Code,
+so it **creates** with `--agent claude` and a matching
+`.claude/worktrees/<slug>/<task-slug>/` base. Always *parse* both
+prefixes (A.1); *create* with the running agent's.
+
+The script prints one line of JSON:
+`{"branch":…,"wt_path":<absolute>,"head_sha":…}`. Record `BRANCH` and the
+absolute `WT_PATH`.
+
+#### A.3: Verify the worktree
+
+```sh
+git -C "${WT_PATH}" rev-parse HEAD
+git -C "${WT_PATH}" status --short
+```
+
+Confirm HEAD matches the trunk SHA the script reported and the worktree
+is clean.
+
+---
+
+### Phase B: Implementation (fresh subagent)
+
+```text
+Agent(
+  subagent_type: "general-purpose",
+  model: "opus",
+  description: "Pipeline — implement",
+  prompt: <implementation prompt below>
+)
+```
+
+**Implementation agent prompt:** open with the
+[Subagent preamble](#subagent-preamble), then continue with:
+
+> You are the implementation engineer. Use the `/execute-single-task`
+> skill exactly as written, with these pipeline-specific overrides:
+>
+> - **Skip Step 3** (entering a worktree) — already done.
+> - **Project slug:** `<project-slug>`.
+> - **Task:** `<TASK_ID>` — `<TASK_TITLE>`.
+> - Execute every other step. `/execute-single-task` carries the full
+>   gate itself — the numerical-impact measurement, the durable-doc
+>   sweep, test-validity preflight, canonical-contract diff, Step 9
+>   self-review, the `scripts/agents/preflight.sh` gate, and the
+>   project-closure version bump are all defined there. Do not
+>   re-implement or second-guess them here.
+> - **Commit and push.** Stage only files you intentionally changed
+>   (never `git add -A` blindly; never commit build output). Immediately
+>   before committing, run the preflight gate and the branch/worktree
+>   assertion from `docs/agents/preflight.md` (`git rev-parse
+>   --abbrev-ref HEAD` is `<BRANCH>`, never `master`; cwd is
+>   `<WT_PATH>`). Write a Conventional Commits message — validate the
+>   header with `scripts/agents/check_pr_title.py "<header>"` before
+>   committing. Then `git push -u origin HEAD`.
+> - **Record the exact commit SHA** via `git rev-parse HEAD` after push;
+>   report it as `COMMIT_SHA`.
+>
+> **Output format — you MUST end your response with this exact section:**
+>
+> ```text
+> ## Pipeline Report
+>
+> STATUS: <COMPLETE | BLOCKED>
+> PROJECT: <project slug>
+> TASK_ID: <e.g. Task 5.2 or Task 3>
+> TASK_TITLE: <short title>
+> TASK_NOTE_PATH: <projects/<slug>/task-notes/... path>
+> BRANCH: <branch name>
+> COMMIT_SHA: <output of git rev-parse HEAD after push>
+> FILES_CHANGED: <comma-separated list of changed files>
+> SUMMARY: <one-paragraph summary of what was implemented>
+> NUMERICAL_IMPACT: <none (verified: <command>) | <function>: <magnitude>>
+> BLOCKER: <description if BLOCKED, "none" if COMPLETE>
+> PLAN_IMPACT: <None | Task note only | Phase file patched | ADR-XXXX | Project closure>
+> ```
+
+#### B.2: Extract implementation results
+
+Parse **only** the `## Pipeline Report`. Do not read the full narrative —
+the orchestrator stays slim.
+
+- `STATUS == BLOCKED`: stop the pipeline. Report the blocker. The
+  worktree remains for inspection.
+- `Pipeline Report` missing: treat as failed. Report the raw output
+  (first and last ~60 lines).
+
+#### B.3: Verify the branch and commit landed
+
+Do not trust the self-reported SHA:
+
+```sh
+git -C "${WT_PATH}" fetch origin "${BRANCH}"
+git -C "${WT_PATH}" rev-parse "origin/${BRANCH}"
+```
+
+The `origin/<BRANCH>` HEAD must equal `COMMIT_SHA`. If the branch is
+absent from origin, or the SHAs disagree, report failure and stop.
+
+#### B.4: Check skip flags
+
+If both `skip-review` and `skip-pr` are `true`, skip to Phase F.
+
+---
+
+### Phase C: Draft PR (orchestrator — no subagent)
+
+The orchestrator opens the draft PR **inline**. The draft lets Phase D
+reviewers use native PR tooling (`gh pr view`, `gh pr diff`).
+
+Safe placeholder title (scope `pipe`):
+
+```sh
+DRAFT_TITLE="chore(pipe): pipeline draft <TASK_SLUG>"
+```
+
+Shorten the slug if the header would exceed 69 characters (validate with
+`scripts/agents/check_pr_title.py "${DRAFT_TITLE}"`). Phase E rewrites
+the title with a real scope before marking the PR ready.
+
+Write a temporary body file inside the worktree:
+
+```markdown
+## Task
+<TASK_ID>: <TASK_TITLE>
+Task note: `<TASK_NOTE_PATH>`
+
+## Summary
+- Draft — pipeline in progress. Title and body finalized after review.
+```
+
+Open the draft and capture its number:
+
+```sh
+cd "${WT_PATH}" && \
+  gh pr create --draft --base master --head "${BRANCH}" \
+    --title "${DRAFT_TITLE}" --body-file pr_draft_body.md && \
+  rm pr_draft_body.md
+PR_NUMBER="$(gh pr view --json number --jq .number)"
+```
+
+Record `PR_NUMBER`. If `skip-review` is `true`, skip to Phase E.
+
+---
+
+### Phase D: Review (delegate to `/review-cycle`)
+
+`/review-cycle` is the single review-loop implementation. The
+orchestrator runs its workflow **itself** — it does not spawn a level-2
+orchestration subagent — passing the shared worktree so fixes land in
+`WT_PATH`. Reviewer, review-respond, and verification subagents are
+spawned by `/review-cycle`'s own phases; that keeps subagent nesting at
+one level.
+
+Run the [`/review-cycle`](../review-cycle/SKILL.md) workflow with
+`PR_NUMBER`, `WT_PATH`, `BRANCH`, `external-reviews`, and
+`max-review-iterations`.
+
+`/review-cycle` owns reviewer selection (per
+[`review-lenses.md`](../../../docs/agents/review-lenses.md)), the
+per-round PR comment, the commit-and-push of review fixes, the
+verification rounds, and the convergence shortcut. Do not restate the
+roster here.
+
+#### D.2: Capture the review outcome
+
+From `/review-cycle`'s final summary, capture: `STATUS`
+(`CONVERGED | NOT_CONVERGED | ESCALATE`), `ITERATIONS_USED`,
+`UNRESOLVED`, `NUMERICAL_IMPACT`, `FINAL_COMMIT_SHA` (already verified
+against origin; falls back to Phase B `COMMIT_SHA` when the all-APPROVE
+shortcut fired), and `REVIEW_SUMMARY`.
+
+Route on `STATUS`:
+
+- `CONVERGED` → Phase E.
+- `NOT_CONVERGED` → Phase E, but Phase E leaves the PR a draft and lists
+  the unresolved items in the body.
+- `ESCALATE` → stop the pipeline. Report the stuck items. The worktree
+  and draft PR remain for manual resolution.
+
+If `skip-pr` is `true`, skip to Phase F.
+
+---
+
+### Phase E: PR finalization (fresh subagent)
+
+```text
+Agent(
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "Pipeline — finalize PR",
+  prompt: <finalization prompt below>
+)
+```
+
+**PR finalization agent prompt:** open with the
+[Subagent preamble](#subagent-preamble), then continue with:
+
+> You are finalizing draft PR #`<PR_NUMBER>`. Do NOT use
+> `/commit-and-pr` — the PR already exists and the code is already
+> committed.
+>
+> **Context:**
+> - Project: `<project-slug>` — Task `<TASK_ID>`: `<TASK_TITLE>`.
+> - Branch: `<BRANCH>`; task note: `<TASK_NOTE_PATH>`.
+> - Implementation summary: `<SUMMARY from Phase B>`.
+> - Numerical impact: `<NUMERICAL_IMPACT>`.
+> - Review: `<CONVERGED | NOT_CONVERGED | skipped>`; unresolved:
+>   `<UNRESOLVED or "none">`; summary: `<REVIEW_SUMMARY or "skipped">`.
+> - Plan impact: `<PLAN_IMPACT from Phase B>`.
+>
+> **Steps:**
+>
+> 1. Read `docs/PR_GUIDELINES.md` and the task note.
+> 2. Run `git diff --stat origin/master...<BRANCH>` and reconcile the
+>    Summary bullets you write against it.
+> 3. Compose a Conventional Commits title (`type(scope): subject`) using
+>    the guidelines' scope table. Do NOT include task IDs. **Validate
+>    before setting it:** `scripts/agents/check_pr_title.py "<title>"`.
+>    Rewrite until it passes; do not hand-count.
+> 4. Compose the body to `pr_body.md`:
+>    ```markdown
+>    ## Summary
+>    - <bullets from implementation and review outcomes>
+>
+>    ## Project
+>    `projects/<project-slug>/` — <TASK_ID>: <TASK_TITLE>.
+>    See `<TASK_NOTE_PATH>` for detail, decisions, and verification.
+>
+>    ## Numerical impact
+>    <NUMERICAL_IMPACT — name the functions and the magnitude, or state
+>    "no public code path touched". Never omit this section.>
+>
+>    ## Review
+>    - Internal review: <converged in N rounds | not converged — N
+>      unresolved items | skipped>
+>    - <list unresolved items if any>
+>
+>    ## Test plan
+>    - <verification commands + real output, or cite the task note's
+>      ## Verification section — do not invent green results>
+>    ```
+>    **If `<PLAN_IMPACT>` is `Project closure`,** insert a `## Versioning`
+>    section between `## Project` and `## Numerical impact`. Read the new
+>    version from `hazma/__init__.py`; the prior is in
+>    `git show origin/master:hazma/__init__.py`:
+>    ```markdown
+>    ## Versioning
+>    Closing project — version bumps `<OLD>` → `<NEW>`
+>    (`<patch | minor | major>` per `PLAN.md` `version_bump:`). New
+>    `CHANGELOG.md` entry under `## [<NEW>]`. See `docs/versioning.md`.
+>    ```
+> 5. Update the PR: `gh pr edit <PR_NUMBER> --title "<title>"
+>    --body-file pr_body.md`, then `rm pr_body.md`.
+> 6. If review is `CONVERGED` (or skipped): `gh pr ready <PR_NUMBER>`,
+>    then watch CI to a bounded conclusion:
+>    `gh pr checks <PR_NUMBER> --watch --fail-fast`. Report the outcome;
+>    **fixing a CI failure is out of scope** — surface it, do not loop on
+>    it. If review is `NOT_CONVERGED`, leave the PR a draft and ensure the
+>    body's `## Review` section lists the unresolved items.
+>
+> **Output format — you MUST end your response with this exact section:**
+>
+> ```text
+> ## Pipeline Report
+>
+> STATUS: <PR_READY | PR_DRAFT | PR_FAILED>
+> PR_URL: <URL or "none">
+> PR_TITLE: <the title used>
+> CI_STATUS: <passing | failing | pending | not-watched>
+> ERROR: <description if PR_FAILED, "none" otherwise>
+> ```
+
+Parse the report: `PR_READY` → record URL and `CI_STATUS` (report a
+failing CI to the user; the pipeline does not fix CI). `PR_DRAFT` →
+record the URL and the unresolved items. `PR_FAILED` → report the error;
+the worktree and draft PR remain for manual recovery.
+
+Before Phase F, verify `gh pr view <PR_NUMBER> --json headRefOid` equals
+`FINAL_COMMIT_SHA`.
+
+---
+
+### Phase F: Summary (orchestrator — no subagent)
+
+Report the final pipeline state. Do **not** clean up the worktree or
+branch — the user decides when to delete them.
+
+```text
+## Pipeline Summary
+
+**Project:** <project-slug>
+**Task:** <TASK_ID> — <TASK_TITLE>
+**Branch:** <BRANCH>
+**Worktree:** <WT_PATH>
+
+### Implementation
+- Status: <COMPLETE | BLOCKED>
+- Commit: <COMMIT_SHA>
+- Files changed: <FILES_CHANGED>
+- Summary: <SUMMARY>
+
+### Numerical impact
+<NUMERICAL_IMPACT>
+
+### Review
+- Status: <CONVERGED | NOT_CONVERGED | ESCALATE | skipped>
+- Iterations: <ITERATIONS_USED>
+- Unresolved: <UNRESOLVED or "none">
+- Final commit: <FINAL_COMMIT_SHA>
+
+### PR
+- Status: <PR_READY | PR_DRAFT | PR_FAILED | skipped>
+- URL: <PR_URL>
+- Title: <PR_TITLE>
+- CI: <CI_STATUS>
+
+### Plan Impact
+<PLAN_IMPACT from Phase B; note if a phase file or PLAN frontmatter was
+flipped to Complete, or a project moved from Active to Completed in
+projects/README.md.>
+
+### Versioning (only when PLAN_IMPACT is `Project closure`)
+- Package version: <OLD> → <NEW> (<patch | minor | major>)
+- CHANGELOG entry: `## [<NEW>]` added to `CHANGELOG.md`
+```
+
+---
+
+## Guardrails
+
+- **Orchestrator stays slim.** For Phases A, B, C, E, and F, read only
+  `## Pipeline Report` sections and make go/no-go decisions. Phase D runs
+  the `/review-cycle` workflow, which does its own reading. The
+  orchestrator never reads source code or implements fixes.
+- **Never commit to `master`.** The pipeline always branches in Phase A
+  and every write uses `git -C <worktree>`. The branch/worktree assertion
+  runs immediately before every commit. Note the trunk is `master`, not
+  `main` — an assertion written against `main` protects nothing here.
+- **Trust no self-reported SHA.** B.3 verifies `COMMIT_SHA` against
+  `origin/<BRANCH>`; Phase E verifies the final HEAD against
+  `FINAL_COMMIT_SHA`.
+- **No nested worktrees.** The orchestrator creates the one worktree in
+  Phase A. Every subagent prompt tells the agent to `cd` into `WT_PATH`
+  and **not** call any worktree-creation tool.
+- **Rebuild discipline is stated in every worktree prompt.** A subagent
+  reporting green tests against a stale Cython extension is a failed
+  phase, not a pass.
+- **Bounded subagent nesting (one level).** The orchestrator spawns the
+  Phase B implementer and the Phase E finalizer directly; Phase D's
+  subagents come from the inline `/review-cycle` workflow. No subagent
+  may spawn another orchestration skill.
+- **The preflight gate is mandatory before every commit** —
+  implementation and review-fix alike. There are no pre-commit hooks in
+  this repo and CI's lint pass is advisory.
+- **Numerical impact is a required field**, not an optional one. A Phase
+  B report with `NUMERICAL_IMPACT` missing or hand-waved is a failed
+  phase — the whole point of the pipeline in a physics library is that no
+  number moves silently.
+- **Draft PR before review** so Phase D reviewers can use `gh pr view` /
+  `gh pr diff`.
+- **Review rounds are posted to the PR** by `/review-cycle`, every round
+  — including rounds that loop, hit the cap, or escalate. The PR timeline
+  is the durable record.
+- **Do not invoke `/commit-and-pr` for finalization.** That skill assumes
+  uncommitted changes and a non-existent PR; Phase E uses `gh pr edit`.
+- **Phase boundaries are go/no-go gates.** A missing or failed Pipeline
+  Report stops the pipeline. Never silently skip a failed phase.
+- **One task per pipeline run.** Do not batch tasks.
+- **Subagent prompts are self-contained** — worktree path, branch,
+  project slug, task context, explicit skill instructions. Subagents do
+  not rely on orchestrator session state.
+- **No worktree cleanup; reclaim failed runs.** The orchestrator leaves
+  `WT_PATH` and the branch in place. When a run ends BLOCKED / ESCALATE /
+  PR_FAILED and the user is done inspecting, reclaim the stale worktree
+  with `git worktree remove <WT_PATH>` (and delete the unused branch)
+  before re-running, so collision suffixes do not pile up.
+- **Project lifecycle bookkeeping belongs to the implementation agent.**
+  If the closed task ends a phase or the project,
+  `/execute-single-task` handles the frontmatter flips, learnings
+  synthesis, the `projects/README.md` move, **and** the version bump +
+  CHANGELOG entry. Phase E only surfaces it in the PR body.
+- **Template files are not tasks.** `resolve_task.py` skips
+  `_template.md`; never pass one to a subagent as a task target.

--- a/.gitignore
+++ b/.gitignore
@@ -530,4 +530,14 @@ hazma/_phase_space/stubgen.sh
 hazma/_positron/stubgen.sh
 notebooks/decay_spectra
 notebooks/dev/gev/
-scripts/
+# `scripts/` is local scratch and stays ignored, except the agent-workflow
+# helpers that `docs/agents/` and `.claude/skills/` shell out to.
+scripts/*
+!scripts/agents/
+
+# Agent-local state: per-session settings and task worktrees. The skills
+# under .claude/skills/ ARE tracked.
+.claude/settings.local.json
+.claude/worktrees/
+.codex/settings.local.json
+.codex/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,194 @@
+# AGENTS.md
+
+Repo-wide guidance for any coding agent working in Hazma — Claude Code,
+Codex, or otherwise. This file is the tie-breaker: when it conflicts with
+a skill, a task note, or a plan, this file wins.
+
+Agent-neutral rules that many skills share live one level down, in
+[`docs/agents/`](docs/agents/README.md). This file carries the
+repo-specific facts; that directory carries the shared invariants (the
+preflight gate, the doc-consistency checklist, the reviewer roster,
+environment gotchas, the lessons ledger). Neither restates the other.
+
+## What Hazma is
+
+Hazma computes indirect-detection observables for sub-GeV dark matter:
+gamma-ray, electron/positron, and neutrino spectra from dark matter
+annihilation; limits from existing gamma-ray data; discovery reach for
+future detectors; and CMB constraints. It is a scientific Python library
+with performance-critical inner loops written in Cython.
+
+The user-facing surface is the **public Python API** — module paths,
+function and class names, keyword arguments, return shapes and units, and
+the numerical values those functions produce. Everything in
+[`docs/versioning.md`](docs/versioning.md) is defined against that
+surface.
+
+## Layout
+
+```text
+hazma/
+├── spectra/            # dnde_photon / dnde_positron / dnde_neutrino
+│   ├── _photon/        #   per-final-state photon spectra + data
+│   ├── _positron/      #   per-final-state positron spectra + data
+│   ├── _neutrino/      #   per-final-state neutrino spectra + data
+│   ├── _nbody.py       #   N-body spectra via phase-space integration
+│   ├── boost.py        #   boost integrals (rest frame → lab frame)
+│   └── altarelli_parisi.py
+├── theory/             # Theory ABC: the model interface every model implements
+├── scalar_mediator/    # concrete models …
+├── vector_mediator/
+├── rh_neutrino/
+├── single_channel.py
+├── form_factors/       # hadronic form factors
+├── phase_space/        # RAMBO and friends
+├── _phase_space/       # Cython phase-space kernels
+├── _utils/             # Cython helpers (boost.pyx, constants.pxd, …)
+├── _decay/             # Cython decay spectra + interpolation data
+├── _gamma_ray/         # Cython gamma-ray generators (C++)
+├── _positron/          # Cython positron spectra
+├── _neutrino/          # Cython neutrino spectra
+├── limits/             # limit-setting machinery
+├── relic_density/
+├── cmb.py, pbh.py, gamma_ray.py, parameters.py, utils.py
+├── gamma_ray_data/     # detector response data (*.dat)
+├── deprecated/         # kept importable, not maintained
+└── experimental/       # excluded from lint gates; not a public surface
+test/                   # pytest suite, mirrors the package tree
+docs/source/            # Sphinx documentation (the published docs)
+notebooks/              # exploratory notebooks + spectrum-generation scripts
+examples/
+```
+
+### Layering
+
+The dependency direction is one-way; do not invert it.
+
+1. **Cython kernels** (`_utils/`, `_decay/`, `_gamma_ray/`, `_positron/`,
+   `_neutrino/`, `_phase_space/`) — numerics only. They import nothing
+   from the pure-Python layers above.
+2. **Primitives** (`parameters.py`, `utils.py`, `form_factors/`,
+   `phase_space/`) — physical constants, kinematics, shared helpers.
+3. **Spectra** (`spectra/`) — builds on 1 and 2. This is the layer most
+   new physics lands in.
+4. **Theory** (`theory/`) — the abstract model interface, plus the
+   gamma-ray-limit, CMB, and constraint mixins.
+5. **Models** (`scalar_mediator/`, `vector_mediator/`, `rh_neutrino/`,
+   `single_channel.py`) — concrete `Theory` implementations.
+6. **Analysis** (`limits/`, `relic_density/`, `cmb.py`, `pbh.py`,
+   `gamma_ray.py`) — consumes models.
+
+A leading underscore on a package (`_decay`, `_utils`) means *private
+implementation*. Public callers go through `hazma.spectra`,
+`hazma.theory`, and the model packages.
+
+## Commands
+
+```sh
+pip install -e .          # build the Cython extensions in place
+pytest                    # full suite
+pytest test/spectra -q    # one area
+black hazma test          # format
+isort hazma test          # import order
+ruff check hazma test     # lint
+pyright hazma             # types (advisory)
+```
+
+The one-command pre-commit gate is
+[`scripts/agents/preflight.sh`](scripts/agents/preflight.sh) — see
+[`docs/agents/preflight.md`](docs/agents/preflight.md). Run it before
+every commit; do not assume a hook covers it.
+
+**Editing a `.pyx` or `.pxd` requires a rebuild.** `pip install -e .`
+does not pick up Cython edits automatically on every setup — if a change
+to a kernel does not show up, rebuild explicitly and confirm with
+`python -c "import hazma; print(hazma.__file__)"` that you are importing
+the tree you edited, not an installed copy.
+
+## Conventions
+
+- **Python ≥ 3.10.** Type annotations on public functions; `from
+  __future__ import annotations` where it helps. Runtime introspection of
+  annotations is supported (`runtime-typing = true`), so do not stringify
+  annotations that users may resolve.
+- **Formatting is black (88 cols) + isort (black profile).** Do not
+  hand-format around them.
+- **Naming:** modules and functions `snake_case`, classes `UpperCamel`,
+  constants `SCREAMING_SNAKE`. Physics symbols keep their conventional
+  spelling in docstrings (`dN/dE`, `⟨σv⟩`), not in identifiers.
+- **NumPy-style docstrings** with `Parameters` / `Returns` sections, and
+  **units stated for every physical quantity**. A returned spectrum
+  without its units in the docstring is an incomplete public API.
+- **Arrays in, arrays out.** Spectrum functions accept scalars or NumPy
+  arrays and broadcast; new public functions follow that contract and
+  have a test for both.
+- **No bare `except:`.** Raise the errors in `hazma/hazma_errors.py`
+  where they fit.
+- **`hazma/experimental/` and `notebooks/` are excluded from the lint
+  gate** (CI's flake8 invocation excludes them). Do not treat code there
+  as a pattern to copy, and do not import from `experimental/` in the
+  library.
+- **`hazma/deprecated/` stays importable.** Removing or changing anything
+  there is a user-facing break — see `docs/versioning.md`.
+- **Never commit generated C/C++.** `_build.py` cythonizes on build; the
+  `.c` / `.cpp` output is not the source of truth.
+- **No `breakpoint()`, `pdb`, or stray `print()` in library code.** Use
+  the returned value or a logger.
+
+## Numerical correctness
+
+This is a physics library — a silently wrong number is worse than a
+crash, and neither a type checker nor a linter will catch one.
+
+- **Every new physics function needs a pinned numerical test.** A test
+  that only asserts "returns a positive float" is not a test. Pin against
+  an analytic limit, a published value (cite it), an independent
+  implementation, or a stored regression array.
+- **State the tolerance and why.** `np.isclose(..., rtol=1e-6)` with no
+  comment invites silent loosening later.
+- **Check the boundaries:** threshold energies, the endpoint of a
+  spectrum, `E → m/2`, zero mass, equal masses, and the massless limit.
+  Spectra routinely go NaN or negative exactly at the kinematic edge.
+- **Integrals need their range and units justified in the docstring.**
+  A `quad` call whose limits changed without a comment is a review
+  finding.
+- **Changing a number is a behavior change.** If a fix moves a published
+  spectrum, say so in the PR body and in `CHANGELOG.md` — even when every
+  test still passes because the tolerance absorbed it.
+
+## Git and branches
+
+- **Never commit directly to `master`.** Branch first. The trunk branch
+  is `master`, not `main` — every script and skill in this repo resolves
+  it from `origin/HEAD` with a `master` fallback.
+- Branches carry the driving agent's identity as their prefix:
+  `claude/<...>` for Claude Code, `codex/<...>` for Codex. Both are valid
+  and permanent; all tooling parses either.
+  - **Project work:** `<agent>/<project-slug>/<task-slug>`.
+  - **Ad-hoc work:** `<agent>/<short-description>`.
+- Commit messages and PR titles follow
+  [`docs/PR_GUIDELINES.md`](docs/PR_GUIDELINES.md) (Conventional
+  Commits). Validate a header with
+  `scripts/agents/check_pr_title.py "<header>"` rather than counting
+  characters by hand.
+
+## Where work is tracked
+
+Multi-commit efforts live under `projects/<slug>/` with a plan, task
+notes, ADRs, and learnings. Single-commit changes skip the scaffolding.
+The full contract — when to create a project, flat vs phased, ADR
+placement, the follow-up backlog, the project lifecycle — is
+[`docs/workflow.md`](docs/workflow.md).
+
+Durable decisions go in ADRs ([`docs/adrs/`](docs/adrs/README.md)
+repo-wide, `projects/<slug>/adrs/` project-scoped). Deferred work goes in
+[`docs/followups/`](docs/followups/README.md), not in a comment and not
+only in a PR description.
+
+## Skills
+
+`.claude/skills/` holds the workflow skills that automate this loop:
+`execute-single-task`, `commit-and-pr`, `review-pr`, `review-respond`,
+`review-cycle`, `task-pipeline`, `begin-phase`, `review-plan`. Each
+expects the filesystem contract above and points into `docs/agents/` for
+shared rules. Read a skill's `SKILL.md` for its exact inputs and outputs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,9 @@ the tree you edited, not an installed copy.
 - **No bare `except:`.** Raise the errors in `hazma/hazma_errors.py`
   where they fit.
 - **`hazma/experimental/` and `notebooks/` are excluded from the lint
-  gate** (CI's flake8 invocation excludes them). Do not treat code there
-  as a pattern to copy, and do not import from `experimental/` in the
-  library.
+  gate** (CI's ruff step passes `--exclude` for both). Do not treat code
+  there as a pattern to copy, and do not import from `experimental/` in
+  the library.
 - **`hazma/deprecated/` stays importable.** Removing or changing anything
   there is a user-facing break — see `docs/versioning.md`.
 - **Never commit generated C/C++.** `_build.py` cythonizes on build; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable user-facing changes to Hazma are recorded here. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+project adheres to [Semantic Versioning](https://semver.org/) over the
+public Python API as defined in [`docs/versioning.md`](docs/versioning.md).
+
+Sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`,
+`Security`. **Numerical changes go under `Changed` with the magnitude
+stated** — a spectrum that moves is a user-facing change even when no
+signature did.
+
+## [Unreleased]
+
+Nothing yet.
+
+## [2.0.2]
+
+Baseline. This changelog was introduced after 2.0.2 shipped; earlier
+releases are not itemized here. See the
+[release history](https://github.com/LoganAMorrison/Hazma/releases) and
+the git log for changes prior to this entry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/PR_GUIDELINES.md
+++ b/docs/PR_GUIDELINES.md
@@ -1,0 +1,106 @@
+# PR Title and Description Guidelines
+
+Commits and PR titles in this repo follow
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+## Title format
+
+```text
+type(scope): subject
+```
+
+**Rules:**
+
+| Constraint        | Rule                                                        |
+| ----------------- | ----------------------------------------------------------- |
+| Max header length | 69 characters total (including `type(scope): `).            |
+| Type              | Valid Conventional Commits type: `feat`, `fix`, `chore`, `ci`, `docs`, `test`, `refactor`, `perf`, `style`, `build`, `revert`. |
+| Scope             | Required. Lowercase alphanumeric with optional hyphens (`^[a-z0-9-]+$`), max 10 chars, no leading or trailing hyphen. Must not be a type name. |
+| Subject           | Start with an alphanumeric character. No trailing `.` or space. Prefer a lowercase first word. |
+
+Validate a header deterministically rather than counting by hand:
+
+```bash
+scripts/agents/check_pr_title.py "feat(spectra): add eta-prime photon channel"
+```
+
+## Scopes for hazma
+
+Use the most specific scope that applies. Common scopes (non-exhaustive):
+
+| Scope      | Area                                                        |
+| ---------- | ----------------------------------------------------------- |
+| `spectra`  | `hazma/spectra/` — photon / positron / neutrino spectra      |
+| `decay`    | `hazma/_decay/` Cython decay spectra and interpolation data  |
+| `phase`    | `hazma/phase_space/`, `hazma/_phase_space/` (RAMBO, N-body)  |
+| `theory`   | `hazma/theory/` — the model interface and its mixins         |
+| `models`   | `scalar_mediator/`, `vector_mediator/`, `rh_neutrino/`, …    |
+| `limits`   | `hazma/limits/`, `gamma_ray.py`, gamma-ray limit machinery   |
+| `cmb`      | `hazma/cmb.py`, CMB constraints                              |
+| `relic`    | `hazma/relic_density/`                                       |
+| `form`     | `hazma/form_factors/`                                        |
+| `params`   | `hazma/parameters.py`, `gamma_ray_parameters.py`             |
+| `utils`    | `hazma/utils.py`, `hazma/_utils/` Cython helpers             |
+| `build`    | `_build.py`, Cython build wiring, packaging                  |
+| `ci`       | CI workflows and automation                                  |
+| `docs`     | Sphinx docs, README, `docs/`                                 |
+| `deps`     | dependency updates                                           |
+| `test`     | test-only changes                                            |
+
+If none fit, pick the closest module name truncated to 10 chars. Avoid
+inventing a scope that will only appear once.
+
+## Title examples
+
+**Good:**
+
+- `feat(spectra): add eta-prime photon channel`
+- `fix(decay): correct charged-kaon endpoint interpolation`
+- `perf(phase): vectorize rambo momentum generation`
+- `docs(workflow): add project scaffolding guide`
+- `chore(deps): bump black to 24.x`
+
+**Bad:**
+
+- `feat(spectra): Add the eta-prime photon channel spectrum` — uppercase
+  first subject word (convention), likely over 69 chars.
+- `fix(Decay): correct endpoint` — uppercase in scope.
+- `feat: add neutrino spectra` — missing scope.
+- `feat(spectra): add eta-prime channel.` — trailing `.`.
+- `feat(phase-space): vectorize rambo` — scope is 11 chars, rejected on
+  length; use `phase`.
+
+## Description format
+
+Use this structure for PR descriptions:
+
+```markdown
+## Summary
+<1-3 bullets describing what changed and why>
+
+## Test plan
+- [ ] <how you verified the change, with real command output>
+```
+
+### For project work, add a Project section
+
+```markdown
+## Project
+`projects/<slug>/` — Task N: <title>.
+
+See `projects/<slug>/task-notes/task-N-<slug>.md` for implementation
+detail, decisions, and verification.
+```
+
+### When the numbers move
+
+If the change alters any value the library returns — a spectrum, a limit,
+a cross section, a width — say so explicitly in the Summary, even when
+the test suite stays green because a tolerance absorbed it. State the old
+value, the new value, and which is right. Silent numerical drift is the
+failure mode this section exists to prevent.
+
+Put task identifiers, links to related issues, and extra context in the
+body (Summary or Project section), not the title.
+
+For reverts, include a `Refs:` trailer linking to the original PR.

--- a/docs/PR_GUIDELINES.md
+++ b/docs/PR_GUIDELINES.md
@@ -24,6 +24,11 @@ Validate a header deterministically rather than counting by hand:
 scripts/agents/check_pr_title.py "feat(spectra): add eta-prime photon channel"
 ```
 
+**This convention is not enforced by CI.** No workflow rejects a malformed
+title, so a green CI run says nothing about the title. The checker above and
+review are what uphold it — run the checker before opening a PR rather than
+assuming something downstream will catch a mistake.
+
 ## Scopes for hazma
 
 Use the most specific scope that applies. Common scopes (non-exhaustive):

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,49 @@
+# Repo-Wide Architectural Decision Records
+
+This directory holds ADRs that apply across the whole codebase —
+decisions any future project should respect without needing context from
+the original project that produced them.
+
+For project-scoped ADRs (decisions meaningful only within one project),
+use `projects/<slug>/adrs/` instead. See
+[`../workflow.md`](../workflow.md#adr-placement) for the full placement
+heuristic.
+
+## Naming
+
+`ADR-XXXX-short-imperative-title.md`
+
+- `XXXX` — four-digit zero-padded sequential number (ADR-0001, ADR-0002,
+  …).
+- `short-imperative-title` — kebab-case, matches the ADR's H1.
+
+Sequence numbers are repo-wide. Project-scoped ADRs have their own
+sequence within each project's `adrs/` directory.
+
+## When to write a repo-wide ADR
+
+**Heuristic:** Could someone read this ADR without knowing which project
+produced it and still find it useful?
+
+- **Yes →** here.
+- **No →** `projects/<slug>/adrs/`.
+
+Default bias: start project-scoped. Promote a project-scoped ADR to
+repo-wide by re-filing it here (with a new repo-wide number) and leaving
+a one-line pointer in the original location that links to the new number.
+
+In a physics library the repo-wide tier is mostly for **contracts about
+what the numbers mean** — units, normalization conventions, frame
+choices, behavior outside the kinematic range, and how published values
+are pinned. Those outlive any single project and are exactly what a
+future implementer needs and cannot re-derive.
+
+## Template
+
+Copy [`template.md`](template.md) and fill in the sections.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| _none yet_ | | | |

--- a/docs/adrs/template.md
+++ b/docs/adrs/template.md
@@ -1,0 +1,26 @@
+# ADR XXXX: <Short, imperative title>
+
+**Date:** <YYYY-MM-DD>
+**Status:** <Proposed | Accepted | Superseded by ADR-YYYY>
+
+## Context
+
+<Describe the technical situation objectively. What was the original plan
+or assumption? What constraint, edge case, or system limitation was
+discovered that makes the original approach unworkable or newly
+necessary?>
+
+## Decision
+
+<State the specific architectural or contractual change being made to
+resolve the issue described in the Context.>
+
+## Consequences
+
+<List the downstream effects of this decision.>
+
+- **Positive:** <What benefits or safety guarantees does this provide?>
+- **Negative:** <What are the tradeoffs, performance hits, or new
+  limitations?>
+- **Mitigation:** <How will we handle the negative consequences? e.g.,
+  documentation, future work, migration plans.>

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,41 @@
+# Agent shared layer
+
+Agent-neutral, single-source guidance for any coding agent working in
+this repo — Claude Code, Codex, or otherwise. The skills under
+`.claude/skills/` are thin: they carry role, workflow, and gates, and
+they **point here** for the shared rules rather than restating them.
+
+## The contract
+
+- **One copy per invariant.** Each rule, checklist, roster, or command
+  block lives in exactly one file here. Skills reference it; they do not
+  paste it. This is what keeps parallel skill copies from drifting.
+- **Precedence.** When a rule in this layer conflicts with a skill, this
+  layer and [`AGENTS.md`](../../AGENTS.md) win. When two files here
+  disagree, `AGENTS.md` is the tie-breaker.
+- **Update in place.** Fix a rule where it lives, once. Never fork a
+  corrected rule back into a skill — that recreates the drift these files
+  exist to kill. If a skill needs an exception, state the exception in
+  the skill and link the canonical rule.
+- **Read before you work.** Implementers and reviewers skim the files
+  their task touches (below) before editing or reviewing.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`preflight.md`](preflight.md) | The before-every-commit / before-every-PR gate: format, lint, tests, import smoke, the sequential critical path. |
+| [`doc-consistency.md`](doc-consistency.md) | The canonical doc-consistency checklist — implementers run it pre-PR, Reviewer D verifies it. |
+| [`review-lenses.md`](review-lenses.md) | Reviewer roster, per-lens rubrics, selection rules, and the verdict rule. |
+| [`environment.md`](environment.md) | Environment and test-infra gotchas (fish shell, cwd resets, Cython rebuilds, pytest collection traps). |
+| [`lessons.md`](lessons.md) | The living review-lessons ledger: class-shaped mistakes that recur, cited by PR. |
+
+## Scripts
+
+Deterministic helpers live under
+[`scripts/agents/`](../../scripts/agents/) — `preflight.sh`,
+`check_pr_title.py`, `setup_task_worktree.sh`, `resolve_task.py`,
+`check_doc_citations.py`. They are the executable form of the rules in
+this layer; a skill calls the script rather than re-describing its steps.
+The same one-copy-per-invariant principle applies: the logic lives in the
+script, and the doc explains when and why to run it.

--- a/docs/agents/doc-consistency.md
+++ b/docs/agents/doc-consistency.md
@@ -1,0 +1,212 @@
+# Doc-consistency checklist
+
+The canonical checklist for keeping durable docs consistent with what a
+PR ships. Stale-sibling doc drift — counts, status, identifiers, units,
+and contract phrases that disagree across files — is a top review-defect
+class and drives most round 2–4 churn. This is the one copy; skills point
+here instead of restating it. Any Blocking divergence found here is a
+REQUEST CHANGES verdict: a durable-doc contradiction is a blocking
+severity anchor.
+
+## Two audiences, one list
+
+- **Implementers run it pre-PR (shift-left).** Before you commit, walk
+  every check below that your diff touches — cheaper than a review round.
+  `execute-single-task` and `review-respond` drive you through this list.
+- **Reviewer D verifies it** against the PR head as the primary review
+  activity — re-run the commands, don't trust the prose. See
+  [`review-lenses.md`](review-lenses.md) for the roster and verdict rule.
+
+## The checks
+
+Each check names the exact command where one exists; run commands against
+the current branch head, never the ambient checkout.
+
+1. **Reproduce every cited fact.** For every count, command, file path,
+   and identifier mentioned in a durable doc the diff touches or
+   references — task note, working-memory README, phase file, ADRs,
+   learnings docs, README, `CHANGELOG.md`, follow-ups, and the PR body —
+   re-run the listed command and re-grep the listed identifier. Treat the
+   task note's `## Verification` section as **regenerated, not curated**:
+   run each command, paste output verbatim, replace the section as a
+   unit; never hand-edit individual numbers. Any command that no longer
+   reproduces (wrong path, removed file, renamed test) must be fixed or
+   removed. External-behavior assertions ("matches the published value in
+   arXiv:1907.11846 Table 2", "reproduces PPPC4DMID within 1%") need a
+   primary-source citation in the same paragraph — a DOI, an arXiv id
+   plus equation number, a permalink, or a command + output.
+
+2. **Units and physical claims.** Every docstring, ADR, and plan sentence
+   that states a unit, a normalization, or a frame (`MeV⁻¹`, `per
+   annihilation`, `lab frame`, `dN/dE` vs `E dN/dE`) must agree with what
+   the code returns. Confirm against the code, not against a sibling
+   doc — sibling docs are where the wrong unit propagates.
+
+3. **Canonical-contract gates.** The phase-file gate text and ADR
+   sections must agree with what the PR shipped. If the PR changed the
+   contract, patch the phase file or ADR in this same PR — do not defer
+   the contract patch to a follow-up. On a project-closing PR (a
+   `status:` flipped to `Complete`), walk every gate bullet in PLAN /
+   phase file / ADRs and record one line of evidence per gate (test name,
+   measurement, command output). Block a closing PR with any open
+   canonical gate.
+
+4. **Intra-document coherence.** Inventory every count and arithmetic
+   claim in a touched doc — the prose sentences, not just the
+   authoritative table — plus every qualitative prose claim (mechanism,
+   failure mode, or derivation stated in words), and reconcile each
+   against the authoritative section. Prose counts must agree with their
+   tables; breakdowns must sum to their totals; described mechanisms must
+   match sibling sections. Do **not** `rg` for the authoritative value
+   and stop — that finds the correct number, never the stale one; the bug
+   is a sentence saying `12 channels` while the table says `14`, caught
+   only by reading the prose against the table. When a fact is corrected,
+   re-derive it from first principles rather than confirming it against
+   an adjacent corrected copy.
+
+5. **Four-corner cross-document consistency.** Whenever the diff touches
+   any one of `{PLAN.md, projects/<slug>/adrs/*,
+   projects/<slug>/task-notes/*, projects/<slug>/learnings/*,
+   docs/followups/*}`, open every other file in that set and `rg` the
+   changed concept. The PLAN summary line, phase README row, task-note
+   `Status`, working-memory Tasks row, ADR §Consequences vs §Body, and
+   follow-up status must all agree on status and concept; cite
+   line-numbered evidence.
+
+6. **Version-bump and CHANGELOG consistency (closing PRs).** If the diff
+   flips a `projects/<slug>/PLAN.md` `status:` to `Complete`, run
+   `scripts/agents/preflight.sh --closing` to verify that `VERSION` in
+   `hazma/__init__.py` moved relative to the trunk and that
+   `CHANGELOG.md` carries a matching `## [X.Y.Z] — YYYY-MM-DD` section
+   naming the project slug. Also confirm the bump **level** matches the
+   `version_bump:` frontmatter and that the frontmatter itself is still
+   right per [`../versioning.md`](../versioning.md) — a project that
+   ended up moving a published number is `minor`, not `patch`, even if it
+   started as one.
+
+7. **Docstring / inline-comment sweep on touched source files.** For
+   every `.py` / `.pyx` file the diff touches, read the module docstring
+   and the docstring above every public function or class, and flag any
+   sentence that describes the pre-change state — a `Parameters` section
+   listing a removed argument, a `Returns` section with the old units, a
+   "currently only supports two-body final states" surviving the change
+   that added three-body. The same sweep applies to task-note section
+   comments that say "Task N will…" / "still pending" / "today: stub".
+
+8. **Sphinx surface.** If the diff renames, moves, or removes a public
+   object, grep `docs/source/` for it. An `automodule` / `autofunction`
+   directive pointing at a gone symbol breaks the published docs build
+   without failing any test here.
+
+9. **Follow-up file mechanics.** If the PR closes a follow-up, confirm
+   the row in `docs/followups/README.md` flipped from Open to Done, that
+   the file was `git mv`d from `todo/` to `done/` (a closed status still
+   under `todo/` is blocking), that every inbound reference was repointed
+   (`rg -l 'followups/todo/<slug>\.md'` shows none stale), and that every
+   function name, module, or file path the stub cites still exists. If
+   the PR opens a follow-up, confirm the stub lives under `todo/`,
+   follows `docs/followups/_template.md`, has an index row, and its
+   references are valid. A closing-task retrospective must cross-check
+   **all** of `docs/followups/todo/` for entries sourced from this
+   project — not only the task's own diff.
+
+10. **PR title/body sanity.** Validate the title with
+
+    ```bash
+    scripts/agents/check_pr_title.py "<pr-title>"
+    ```
+
+    (Conventional Commits; scope `^[a-z0-9-]+$`, ≤10 chars, no trailing
+    `.` — `phase-space` is 11 chars, rejected on length, so use `phase`.)
+    Skip this while the title is still the pipeline placeholder. Then
+    verify every count, file name, and identifier in the PR body
+    reproduces against today's diff — stale bodies that name removed
+    functions or pre-fix test counts are a recurring blocking finding.
+
+11. **Stale-sibling sweep procedure.** Before fixing any factual claim —
+    a count, identifier, command, line number, unit, or qualitative prose
+    claim — run the class-wide sweep; do not point-fix the cited line:
+    `rg -n '<old-value>' projects/ docs/ hazma/ test/ README.md
+    CHANGELOG.md`. Paste the output under `### Pre-fix occurrences`.
+    Apply the fix to every listed occurrence, or explicitly justify each
+    one you skip. Re-run the same `rg` and paste under
+    `### Post-fix occurrences`. For **numeric** fixes, sweep on the bare
+    digit (`\b<old>\b`), not the surrounding phrase — numbers feel
+    localized but rarely are. Qualitative prose claims get the same
+    before/after treatment. This is what prevents a fix from introducing
+    an adjacent stale contradiction.
+
+12. **New artifacts count too.** A brand-new test, comment, or doc that
+    embeds a stale fact is the most common escape. Sweep new files, not
+    only edited ones: for each `??` entry from `git status --short`,
+    `git add -N <path>` so it appears in the diff, or open it and walk it
+    as a fresh creation. Re-derive every embedded count from a canonical
+    command rather than trusting the literal.
+
+## The sweep block (forcing function)
+
+Describing what to check is not enough — the forcing function is pasting
+actual output. Implementers append this block to the task note (above
+`## Handoff to Next Task`) before committing, running each command
+against the current branch. Skimming or omitting it is the single biggest
+cause of REQUEST CHANGES verdicts.
+
+Under a `## Stale-state sweep` heading, paste output for each sub-sweep
+(mark each hit KEPT / EDITED / DELETED):
+
+- **Identifier sweep** — every new/renamed/removed name and every
+  identifier cited in §Files Changed / §Decisions / §Findings:
+  `rg -n '<identifier>' projects/<slug>/ docs/ README.md hazma/ test/`.
+- **Line-number citation sweep** — `file:line` citations of touched
+  files: `rg -n '<file_basename>\.py:[0-9]+' projects/<slug>/ docs/`. To
+  bounds-check them all mechanically, run
+  `scripts/agents/check_doc_citations.py --changed-vs origin/master`
+  (add `--map <repo/relative/path.py>` for each short-form basename it
+  reports as ambiguous) and paste its summary.
+- **Forward-looking phrase sweep** — `rg -n '(Task [0-9]+ will|will be
+  added|still pending|today: ?stub|currently|In Progress)'
+  projects/<slug>/ hazma/`.
+- **Count sweep** — a table re-deriving every numeric claim from a
+  canonical command (`Claim location | Command | Actual | Status`).
+- **Numerical-impact statement** — for any diff that can reach a public
+  function: the grid you evaluated, whether values moved, and by how
+  much. `No public value changes (verified: <command>)` is a valid row;
+  silence is not.
+- **Exit Criteria → test mapping** — a table naming the test or artifact
+  that satisfies each Exit Criterion bullet; a missing row means not
+  done.
+- **Task-note self-consistency** — the `**Status:**` header, §Exit
+  Criteria checkboxes vs the mapping table, and that every
+  function/class/file/API cited in §Files Changed / §Decisions /
+  §Findings appears in `git diff --stat origin/master --` or a created
+  file.
+
+Three rules govern the block itself, in this order:
+
+1. **Sweep last.** Freeze every prose edit — including the `lessons.md`
+   ledger append that `review-respond` asks for — before re-deriving any
+   sweep. A ledger append is a content edit that enters the diff, so it
+   moves both the line numbers the sweep cites *and* the doc set a
+   `--changed-vs` run covers.
+2. **Then prove it is a fixed point.** Re-run every command once more
+   after pasting and require it to reproduce. But *"reproduce" is not
+   always "byte-identical"*: `rg` walks directories in parallel, so a
+   multi-directory sweep returns the same rows with the same line numbers
+   in a **different order** run to run. Compare `sort`ed captures for
+   those, and claim byte-identity only of the deterministic commands — an
+   explicit file list, `rg -c`, `wc -l`, `git diff`,
+   `check_doc_citations.py`.
+3. **Label anything hand-folded.** Collapsing many `rg` hits into one row
+   per file, or appending KEPT/EDITED dispositions, is fine and usually
+   clearer — but say the block is folded, and record the citing doc
+   itself as a match when the command matches it. "Pasted from the
+   command's real output" over a hand-annotated table is how a fabricated
+   row survives four reviewers.
+
+For a zero-touch sweep (a one-line fix with no identifier churn), rows
+may legitimately read "no occurrences" — but still produce the block to
+prove each command ran. Do not skip it because "this PR is too small":
+two-line deletions routinely shift stale references downstream.
+
+Read [`lessons.md`](lessons.md) before running this checklist and check
+the diff against each recurring class listed there.

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -88,20 +88,32 @@ of [`AGENTS.md`](../../AGENTS.md).
 
 ## Lint and CI
 
-**CI's flake8 pass is not a lint gate.** `.github/workflows/python-package.yml`
-runs flake8 twice: once with `--select=E9,F63,F7,F82` (syntax errors and
-undefined names only) and once with `--exit-zero` (advisory). Neither
-enforces the `[tool.ruff]` config. Run `ruff check` locally; do not infer
-"CI would have caught it".
+**CI's lint job does not enforce the repo's own ruff config.**
+`.github/workflows/ci.yml` runs
+`ruff check --isolated --select E9,F63,F7,F82` — syntax errors, undefined
+names, and broken comparisons/f-strings. `--isolated` is the load-bearing
+flag: it deliberately ignores `[tool.ruff]` in `pyproject.toml`, so the
+stricter rule set you get from a bare local `ruff check` is **not** what
+CI runs. Green CI does not mean the tree satisfies the configured rules.
+Run `ruff check` locally; do not infer "CI would have caught it".
 
-**`hazma/experimental/` and `notebooks/` are excluded from CI lint.**
-Code there is not held to the repo's standard. Do not cite it as
-precedent, and do not import from `experimental/` in the library.
+**There is no formatting check in CI.** The lint job carries an explicit
+comment saying `black --check` was omitted because the tree is not
+black-clean (85+ files differ). So `black` is in this repo's preflight
+gate but not its CI — a formatting regression will not turn anything red.
+Do not reformat files your task does not touch just because `black`
+wants to; that is how an unrelated 85-file diff gets attached to a
+one-line change.
 
-**CI tests on Python 3.9 and 3.10 while `pyproject.toml` requires
-≥3.10.** The matrix and the declared floor disagree. Do not use syntax
-newer than the lower of the two without checking which is actually
-authoritative for the change you are making.
+**`hazma/experimental/` and `notebooks/` are excluded from CI lint**
+(`--exclude` flags on the ruff step). Code there is not held to the
+repo's standard. Do not cite it as precedent, and do not import from
+`experimental/` in the library.
+
+**The CI test matrix is Python 3.10 / 3.11 / 3.12**, matching
+`pyproject.toml`'s `requires-python = ">=3.10"`. CI also runs an import
+smoke test before the suite, so a broken Cython build fails there rather
+than as a confusing collection error.
 
 ## Git and orchestration
 

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -1,0 +1,122 @@
+# Environment and test-infra gotchas
+
+Traps in this repo's shell, build, and test infrastructure. Each entry is
+a **symptom** followed by the fix. Skim before any task that runs
+commands; Reviewer E and the implementer both rely on it.
+
+This file is seeded from what the layout and tooling make predictable.
+When you hit a new trap, add it here in the same commit — that is what
+keeps it worth reading.
+
+## Shell and filesystem
+
+**The Bash tool shell may be fish, not bash.** `VAR=$(...)` assignment,
+`for` loops, and backtick substitution are mangled or rejected. Prefix
+one-shot env vars as `env VAR=val cmd`; avoid shell loops — call the tool
+once per command, or write a `.sh` and run it with `bash`.
+
+**`ls` may be aliased with color escape codes.** Parsing its output in a
+scripting context picks up ANSI garbage; use `command ls` (or a glob)
+when the result feeds another command.
+
+**`rg -rl` means `--replace` + `-l`, not recursive-list.** ripgrep has no
+`-r`-for-recursive flag (it recurses by default). To rewrite in place use
+`grep -rl PAT | xargs perl -pi -e 's/.../.../g'` and verify with
+`grep -rc`.
+
+**Bash-tool cwd resets between calls.** A `cd` lasts only for the command
+it is part of; the next call starts back at the worktree root. Always use
+absolute paths and `git -C <worktree>` for git writes — a bare
+`git commit` can land in the wrong tree.
+
+**Merge conflicts edited with `sed` or bulk line-deletes corrupt the
+file.** Edit the marked region by hand, then confirm zero markers remain
+(`grep -n '^<<<<<<<\|^=======\|^>>>>>>>'`).
+
+## Build and imports
+
+**Editing a `.pyx` / `.pxd` and re-running pytest tests the OLD kernel.**
+Cython sources are compiled at build time by `_build.py`. Until you
+rebuild (`pip install -e .`), every import resolves the previously-built
+extension — so a change can look like it had no effect, or a bug can look
+fixed when it isn't. Rebuild, then confirm.
+
+**You may be importing an installed hazma, not the worktree.** A
+site-packages install shadows the checkout depending on cwd and how the
+env was set up. `python -c "import hazma; print(hazma.__file__)"` before
+trusting any result you attribute to your edit — especially inside a git
+worktree under `.claude/worktrees/`, which is a *different directory*
+from the checkout the editable install points at.
+
+**`pip install -e .` needs Cython, NumPy, and a C/C++ compiler.** A
+missing toolchain surfaces as a build error deep in `_gamma_ray`
+(compiled as C++), not as a clear "install Cython" message.
+
+**Never hand-edit generated `.c` / `.cpp`.** They are cythonize output.
+Edit the `.pyx` and rebuild.
+
+## Tests
+
+**pytest exit code 5 means zero tests collected.** It is not a pass. A
+mistyped path, a `-k` filter that matches nothing, or a `collect_ignore`
+entry silently reduces the run to nothing. Read the summary line
+(`N passed`), not just the exit status.
+
+**`test/conftest.py` deliberately ignores part of the suite.** It builds
+a `collect_ignore` list that excludes `test/test_gamma_ray.py` and
+everything under `test/decay/`. A bare `pytest` therefore does **not**
+run those files, and "the full suite is green" does not cover them. If
+your change touches decay spectra or `gamma_ray.py`, run those paths
+explicitly and expect to deal with why they were parked.
+
+**The test tree does not mirror the package one-to-one.** `test/` has
+`decay/`, `positron/`, `rambo/`, `rh_neutrino/`, `scalar_mediator/`,
+`spectra/`, `vector_mediator/` plus a few loose `test_*.py`. There is no
+test package for several `hazma/` subpackages. Absence of a test
+directory is not evidence that an area is untested elsewhere, nor that it
+is covered — check before claiming either.
+
+**Floating-point assertions need an explicit tolerance and a reason.**
+`np.isclose` defaults (`rtol=1e-5`) are generous enough to hide a real
+physics regression. State the tolerance you chose and why in a comment;
+a reviewer will ask.
+
+**A test that only checks shape/sign/finiteness pins nothing.** For any
+new physics, assert against an analytic limit, a published number (cite
+it), or a stored regression array. See the numerical-correctness section
+of [`AGENTS.md`](../../AGENTS.md).
+
+## Lint and CI
+
+**CI's flake8 pass is not a lint gate.** `.github/workflows/python-package.yml`
+runs flake8 twice: once with `--select=E9,F63,F7,F82` (syntax errors and
+undefined names only) and once with `--exit-zero` (advisory). Neither
+enforces the `[tool.ruff]` config. Run `ruff check` locally; do not infer
+"CI would have caught it".
+
+**`hazma/experimental/` and `notebooks/` are excluded from CI lint.**
+Code there is not held to the repo's standard. Do not cite it as
+precedent, and do not import from `experimental/` in the library.
+
+**CI tests on Python 3.9 and 3.10 while `pyproject.toml` requires
+≥3.10.** The matrix and the declared floor disagree. Do not use syntax
+newer than the lower of the two without checking which is actually
+authoritative for the change you are making.
+
+## Git and orchestration
+
+**A shared worktree can sit on detached HEAD after an orchestrated run.**
+Check `git symbolic-ref -q HEAD` before committing; if detached,
+re-attach to the intended branch rather than committing into limbo.
+
+**The trunk is `master`, not `main`.** Every script here resolves it from
+`origin/HEAD` with a `master` fallback. A hand-written `origin/main`
+reference fails silently in the worst way: `git diff origin/main` errors,
+but `git rev-parse --abbrev-ref HEAD != "main"` *passes* on `master`, so
+a branch assertion written against `main` protects nothing.
+
+## Markdown
+
+**`markdownlint --fix` corrupts code spans documenting literal syntax.**
+After any `--fix`, word-diff the result and restore any semantic
+whitespace it stripped.

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -35,5 +35,17 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
 
 ## Ledger
 
-_Empty._ This ledger starts fresh with the agent workflow. The first
-entry lands the first time a review round catches something class-shaped.
+- [ported-file-stale-reference] A file copied in from another repo carries
+  that repo's references — workflow paths, CI actions, internal design docs
+  — and they read as authoritative here while pointing at infrastructure
+  that does not exist. Grep every ported file for paths and tool names and
+  confirm each resolves in *this* repo before shipping it (PR #18:
+  `check_pr_title.py` claimed to mirror `.github/workflows/pr_linter.yaml`,
+  which exists only upstream).
+- [normalized-id-in-path] An id that is normalized for display ("Phase 2")
+  must not be interpolated into a filesystem path when the on-disk name is
+  the un-normalized form (`phase-02/`). The two agree for most values and
+  diverge exactly at the padded ones, so a spot check passes and the bug
+  ships. When a value has both a display form and a path form, name them
+  separately and test a value where they differ (PR #18:
+  `resolve_phase.py`'s kickoff prompt sent agents to `task-notes/phase-2/`).

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -1,0 +1,39 @@
+# Review-lessons ledger
+
+A living ledger of review findings that are *class-shaped* — mistakes
+that could recur on unrelated tasks, not one-off typos. It is the
+feedback loop that otherwise goes missing: the same finding classes recur
+across PRs with nothing capturing the lesson in between.
+
+## Contract
+
+- **Append** (`review-respond`, the lessons step): when a review —
+  especially a verification or external round — catches a mistake that is
+  class-shaped, add a one-line entry in the same commit, citing the
+  PR(s). If an existing entry already covers the class, add the new PR to
+  its citation list rather than duplicating.
+- **Read** (`execute-single-task`, before writing code; every reviewer,
+  per the review-lenses baseline duties): read this file before working
+  and check the diff against each listed class.
+- **Promote and prune**: when an entry stabilizes, fold it into a
+  `docs/agents/` checklist, `AGENTS.md`, or a lint rule, then delete it
+  here. Keep this file under ~30 entries — it is a working set, not an
+  archive. Promoted lessons live in their destination; this ledger only
+  holds the classes not yet encoded elsewhere.
+
+## Format
+
+One line per class: `- [class] one-line rule (PR #N, PR #M)`. The
+`[class]` tag is a short kebab-case slug so recurrences are easy to match
+and merge.
+
+Every entry must cite at least one real PR. **Do not add an entry from
+intuition** — an uncited "lesson" is a guess wearing a citation's
+clothes, and it costs every future reviewer the time to check it. If you
+believe a class is worth pre-empting but have no PR for it, put it in the
+relevant `docs/agents/` checklist as a check, not here as a lesson.
+
+## Ledger
+
+_Empty._ This ledger starts fresh with the agent workflow. The first
+entry lands the first time a review round catches something class-shaped.

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -85,11 +85,15 @@ path for every git write.
 
 ## Do not trust hooks or CI for this list
 
-There is no committed `.pre-commit-config.yaml` in this repo, and CI's
-`flake8` invocation is deliberately permissive (the second pass runs
-`--exit-zero`, so lint findings never fail the build). CI runs `pytest`
-and a syntax-error-only flake8 pass — that is a floor, not this gate. Run
-this gate yourself.
+There is no committed `.pre-commit-config.yaml` in this repo. CI
+(`.github/workflows/ci.yml`) runs an import smoke test, `pytest` on
+Python 3.10–3.12, and a deliberately narrow lint pass —
+`ruff check --isolated --select E9,F63,F7,F82` — whose `--isolated` flag
+ignores `[tool.ruff]` in `pyproject.toml`. There is **no** formatting
+check in CI at all. So CI green means "no syntax errors, no undefined
+names, tests pass"; it says nothing about formatting, import order, or
+the configured lint rules. That is a floor, not this gate. Run this gate
+yourself.
 
 ## One-command form
 

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -1,0 +1,112 @@
+# Preflight gate
+
+The canonical gate to run **before every commit and before every PR**.
+Every implementing and review-response skill points here instead of
+restating it. The one-command form is
+[`scripts/agents/preflight.sh`](../../scripts/agents/preflight.sh); this
+document is the rationale and the manual fallback.
+
+## The gate
+
+Run these from the worktree root, in order. Each must pass on its own
+before you stage anything.
+
+1. **`black --check <paths>`** — the repo is black-formatted at 88
+   columns. If it fails, run `black <paths>` and re-run the check.
+   (`black` alone is not the gate; the `--check` is.)
+2. **`isort --check-only <paths>`** — black profile, configured in
+   `pyproject.toml`. Same rule: fix with `isort <paths>`, then re-check.
+3. **`ruff check <paths>`** — the configured rule set lives under
+   `[tool.ruff]` in `pyproject.toml`. `hazma/experimental/` and
+   `notebooks/` are outside the gate.
+4. **`pytest <targets>`** — **read the summary line.** `pytest` exits **5**
+   when it collects zero tests, and a wrapper that only checks "non-zero
+   exit" will happily treat a typo'd path as a failure while a
+   `-k` filter matching nothing exits 0 with `no tests ran`. Zero
+   collected means the gate FAILED, not passed. Name the real targets
+   (`pytest test/spectra`), not a filter you have not verified selects
+   something.
+5. **`python -c "import hazma"`** — the import smoke. Hazma ships Cython
+   extensions; a `.pyx` edit that was never rebuilt, or a rebuild against
+   a different interpreter, produces a tree that lints and formats
+   cleanly and fails at import. Run this after any change under
+   `_utils/`, `_decay/`, `_gamma_ray/`, `_positron/`, `_neutrino/`, or
+   `_phase_space/`, and after any `_build.py` change.
+6. **`markdownlint --dot <changed .md files>`** — when curated docs
+   changed. Word-diff after any `--fix`: it can corrupt code spans.
+7. **Version-bump check** — only when the diff flips a
+   `projects/<slug>/PLAN.md` `status:` to `Complete`.
+   `scripts/agents/preflight.sh --closing` verifies that `VERSION` in
+   `hazma/__init__.py` actually moved relative to the trunk and that
+   `CHANGELOG.md` carries a matching `## [X.Y.Z]` section. See
+   [`../versioning.md`](../versioning.md).
+8. **Forbidden-token scan** over the diff: `breakpoint()`,
+   `pdb.set_trace()`, `import pdb`, and stray `print()` added to library
+   code. Resolve or justify each hit. `git diff origin/master -- '*.py'`
+   is the surface.
+
+## Exit-code safety
+
+Never pipe a gate through `head`, `tail`, or `grep` — a pipeline reports
+the exit status of the **last** command, which masks the gate's own
+failure. Run each gate bare and read its status (and, for pytest, its
+summary line). If you must filter output, capture the exit code
+separately.
+
+## Sequential critical path
+
+The path from a finished edit to a landed commit is strictly sequential:
+
+```text
+edit → rebuild (if Cython) → run gates → read results → stage → commit → push → verify
+```
+
+**Never batch these steps into one parallel tool block.** A failure
+partway through a batch lands a half-done commit — the gates never ran,
+or ran against the wrong tree. Gate each step on the previous one's
+result. After pushing, verify the push landed: `git rev-parse HEAD` must
+equal `git rev-parse origin/<branch>`.
+
+## Branch and worktree assertion
+
+Immediately before `git commit`, confirm you are where you think you are:
+
+- `git rev-parse --abbrev-ref HEAD` is the intended branch — **never
+  `master`.** Direct commits to `master` are forbidden (see
+  [`AGENTS.md`](../../AGENTS.md)). Note the trunk here is `master`, not
+  `main`; an assertion written against `main` silently passes on a
+  `master` checkout and protects nothing.
+- `git rev-parse --show-toplevel` is the intended worktree, not the main
+  checkout.
+
+The Bash tool's cwd can reset between calls, so a bare `git commit` may
+run against the wrong tree. Prefer `git -C <worktree>` with an absolute
+path for every git write.
+
+## Do not trust hooks or CI for this list
+
+There is no committed `.pre-commit-config.yaml` in this repo, and CI's
+`flake8` invocation is deliberately permissive (the second pass runs
+`--exit-zero`, so lint findings never fail the build). CI runs `pytest`
+and a syntax-error-only flake8 pass — that is a floor, not this gate. Run
+this gate yourself.
+
+## One-command form
+
+[`scripts/agents/preflight.sh`](../../scripts/agents/preflight.sh) runs
+black, isort, ruff, pytest (with the zero-collection guard), the import
+smoke, and optionally markdownlint, the version-bump gate, and the
+forbidden-token scan:
+
+```bash
+scripts/agents/preflight.sh --paths "hazma/spectra test/spectra" --tests "test/spectra"
+```
+
+Add `--md "docs/agents/preflight.md"` when curated docs changed and
+`--closing` on a project-closing PR. It prints a PASS/FAIL/WARN/SKIP row
+per gate and exits non-zero on the first hard failure. A non-zero exit is
+a blocked commit — fix and re-run; do not commit around a red gate.
+
+A `WARN` row means a tool is not installed and its gate did **not** run —
+it is a hole in your coverage, not a pass. Install the tool
+(`pip install ruff isort`) rather than shipping on an unchecked gate.

--- a/docs/agents/review-lenses.md
+++ b/docs/agents/review-lenses.md
@@ -1,0 +1,263 @@
+# Review lenses
+
+The canonical reviewer roster, lens rubrics, selection rules, verdict
+rule, and baseline duties for every PR review in this repo. Applies to
+Claude Code, Codex, and any coding agent.
+
+Skills point here instead of restating the roster. `review-cycle` selects
+reviewers from this table; `review-pr` runs a single lens from it;
+`task-pipeline` delegates its review phase to `review-cycle`. When this
+file conflicts with a skill's inline prose, this file plus
+[`AGENTS.md`](../../AGENTS.md) win. Edit the roster or a rubric here once
+— never fork a copy into a skill.
+
+## Reviewer roster
+
+Each reviewer's identity — letter, role, model, `--lens` flag, and when
+its lens is load-bearing — is fixed below. A single prompt template
+spawns the selected subset, substituting these fields.
+
+| ID | Role | Model | Effort | `--lens` | When this lens is useful |
+|----|------|-------|--------|----------|--------------------------|
+| A | Generalist | `sonnet` | medium | (none) | Almost always — a broad pass over completeness, correctness, numerics, and conventions. The default safety net when no other reviewer clearly owns a concern. |
+| B | Completeness | `sonnet` | medium | `completeness` | Task has explicit Exit / Acceptance Criteria, multi-bullet objectives, or a phase-file gate; the diff might under- or over-deliver against the spec. |
+| C | Logic | `sonnet` | high | `logic` | Diff changes runtime behavior — control flow, error handling, array broadcasting, interpolation, integration bounds, or non-trivial branching. Pure-doc / pure-fixture / pure-rename PRs usually do not need C. |
+| D | Doc Consistency & Canonical Contract | `sonnet` | medium | `doc-consistency` | Diff touches durable docs (task notes, working-memory READMEs, phase files, ADRs, learnings, README, CHANGELOG, follow-ups), edits any module/function docstring, or asserts numeric / command / identifier claims that must reproduce. |
+| E | Numerics & Performance | `opus` | high | `numerics` | **Any diff that can move a number** — physics formulas, constants, interpolation, integration, phase space, spectra, limits — or that touches a hot loop or the Cython boundary. This is a physics library: E is the lens most likely to catch the defect that matters. |
+
+**Models.** The roster is calibrated for the current generation:
+
+- **A–D default to `sonnet`** (Sonnet 5). They are pattern-matching and
+  cross-referencing passes; Sonnet handles them at full quality.
+- **E defaults to `opus`** (Opus 5). Deciding whether a spectrum is
+  *right* — not merely finite — is the hardest judgment in this repo and
+  the one worth the strongest model.
+- The orchestrator MAY upgrade **A** to `opus` for high-risk or
+  project-closing PRs, and MAY downgrade **D** to `haiku` for a
+  docs-only diff with no numeric claims.
+- The `review-respond` synthesis agent and any implementation subagent
+  are `opus`.
+
+**Reasoning effort.** Pass the `Effort` column when the runner supports
+it. `high` for C and E, `medium` elsewhere; raise E to `xhigh` on a diff
+that changes a published spectrum or a limit. Do not raise effort as a
+substitute for giving the reviewer the right context.
+
+## Selection rules
+
+Selection happens **once per pipeline run**, at the start of the review
+phase, and the chosen set is used for every round (convergence
+comparisons assume a stable set — do not add or drop reviewers between
+rounds).
+
+- **Default-include A and D.** The set must be non-empty and must include
+  at least one reviewer that broadly covers correctness for the touched
+  area — in practice **A**. Drop A only when another lens fully covers
+  the diff (e.g. a doc-only PR where D suffices) and you can articulate
+  why.
+- **Include B** when the task has explicit Exit / Acceptance Criteria, a
+  phase-file gate, or multi-bullet objectives.
+- **Include C** when the diff changes runtime behavior.
+- **Always include E when the diff can move a number** — any change under
+  `hazma/` that is not purely a rename, a docstring, or a type
+  annotation. When in doubt, include E; the cost of a missed numerical
+  regression in a published library is not symmetric with the cost of one
+  extra reviewer.
+- **Always include D on project-closing PRs** — D verifies the version
+  bump and the CHANGELOG entry (see the D rubric).
+- **Bias toward inclusion when uncertain.** An extra reviewer costs one
+  parallel subagent; a missed lens costs a shipped regression. But do not
+  select a reviewer just to fill the slate — a lens with no plausible
+  findings dilutes the round with low-signal "LGTM" comments.
+- **Project-closing PRs: prefer the full roster.** Parallel independent
+  reviews of one PR produce largely non-overlapping findings, so the
+  redundancy is worth it on the highest-stakes diffs.
+
+Record the chosen set as `SELECTED_REVIEWERS` (e.g. `{A, C, D, E}`) with
+a one-sentence justification per chosen and per omitted reviewer; surface
+it in the first round's PR comment for the audit trail.
+
+## Verdict rule
+
+Canonical, for every reviewer:
+
+- **Any Blocking finding ⇒ REQUEST CHANGES.**
+- **Zero Blocking findings ⇒ APPROVE** (list non-blocking suggestions, if
+  any).
+- **COMMENT is not used inside orchestrated loops** (`review-cycle`,
+  `task-pipeline`) — only for standalone advisory reviews.
+
+Severity anchors:
+
+- **Blocking** = correctness bug, **a number that moves without being
+  acknowledged**, CI-breaking change, spec / Exit-Criterion violation,
+  durable-doc contradiction, or a missing mandated gate.
+- **Non-blocking** = style, optional improvement, or a deferred-scope
+  suggestion.
+
+Re-review vocabulary (verification rounds): mark each original comment
+**RESOLVED**, **PARTIALLY RESOLVED**, or **UNRESOLVED**.
+
+## Baseline duties (every reviewer)
+
+These apply regardless of lens.
+
+- **Fresh-eyes PR-head recipe.** Fetch the PR ref fresh each round —
+  delete any stale ref, then
+  `git fetch origin pull/<N>/head:refs/remotes/origin/pr/<N>`. Verify the
+  head SHA against `gh pr view`. Never test against the ambient checkout.
+  Treat `gh pr diff` output as possibly truncated — fall back to the
+  fetched ref.
+- **Zero-collection guard.** `pytest` exits 5 on zero tests collected,
+  and a `-k` filter matching nothing exits 0 with `no tests ran`. Assert
+  a real `N passed` count before trusting a cited green. Remember
+  `test/conftest.py` excludes `test/decay/` and `test_gamma_ray.py` from
+  a bare run.
+- **Empirical execution.** When the diff adds or edits a docstring
+  example, a README snippet, or claims a user-visible behavior, RUN it
+  and paste the output. Static review does not catch a wrong number.
+- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` / `_build.py`,
+  confirm the cited test results came from a tree that was rebuilt. A
+  green run against a stale extension proves nothing.
+- **Read [`lessons.md`](lessons.md) first**, then check the diff against
+  each listed recurring class.
+- **Apply the verdict rule** (above), including the re-review vocabulary
+  on verification rounds.
+- **New-code correctness shapes** — flag when the diff:
+  - adds a branch to a dispatch table (a final-state → spectrum-function
+    map, a channel list) without fanning it out to every sibling lookup,
+    `__all__`, and test;
+  - turns a hard-coded constant into a user-supplied argument without a
+    validity guard;
+  - defends an invariant on only one entry point rather than every public
+    one;
+  - writes to a cache or a module-level table before validating.
+
+## Per-lens FOCUS rubrics
+
+### A — Generalist
+
+Evaluate all dimensions — completeness, correctness, numerics, and
+conventions — with equal weight. Specifically confirm:
+
+1. **Public-surface hygiene.** New public objects are exported where
+   users will look for them (`hazma/spectra/__init__.py`, the model
+   package `__init__`), documented with NumPy-style docstrings, and have
+   **units stated** for every physical quantity.
+2. **Layering.** The dependency direction in
+   [`AGENTS.md`](../../AGENTS.md) holds — Cython kernels import nothing
+   from pure-Python layers; models depend on `theory`, not the reverse.
+3. **Broadcasting contract.** A new spectrum-shaped function accepts both
+   a scalar and an array energy and has a test for both.
+4. **No stray debug.** No `breakpoint()`, `pdb`, or `print()` added to
+   library code.
+5. **PR title/body** conform to
+   [`../PR_GUIDELINES.md`](../PR_GUIDELINES.md), and project work carries
+   an accurate `## Project` section.
+
+### B — Completeness
+
+Focus on task-spec satisfaction, Exit Criteria, scope discipline, and
+test coverage. **Build an explicit Exit-Criterion → test map:** copy each
+Exit / Acceptance Criterion bullet from the task spec verbatim, then cite
+the specific `pytest` node id, fixture, or regression array that pins it.
+Bullets with no pinning test are **blocking**.
+
+A cited test that **would still pass under a plausible regression**
+counts as *not* pinned — e.g. the assertion is `result > 0` and the bug
+returns a wrong positive number; the tolerance is loose enough to absorb
+the defect; only one final state of a multi-channel change is covered;
+the test asserts shape but never a value.
+
+Also flag any behavior delivered outside the task spec (scope creep) or
+any spec clause the diff narrows without amending the PLAN / phase file.
+
+### C — Logic
+
+Act adversarially — correctness bugs, edge cases, error handling, and
+**test validity**.
+
+- **Single-symbol mutation test.** For the most behavior-changing new or
+  modified test in the diff, name the specific regression in the
+  production code that would flip its assertions. If you cannot name one
+  ("any error path", "any wrong value", "I'm not sure"), raise the test
+  as **blocking**. Mentally invert one comparison, drop a factor of 2,
+  swap two arguments, or return the un-normalized value, and ask whether
+  the test catches it.
+- **Adversarial boundary case.** For the most behavior-changing function
+  in the diff, construct one boundary case the PR's own tests do not
+  cover. In this repo the productive ones are: energy exactly at
+  threshold; energy above the kinematic endpoint; zero or equal masses;
+  the massless limit; an empty array; a scalar where an array was
+  assumed (and vice versa); a negative or NaN input; and integration
+  limits that cross a singularity. If you can describe a concrete failing
+  case, raise it as **blocking** with the reproducer.
+- **Error handling.** Missing propagation, a bare `except`, a swallowed
+  `RuntimeWarning` from NumPy, or a silent `nan_to_num` that hides a real
+  divergence.
+
+### D — Doc consistency & canonical contract
+
+Run [`doc-consistency.md`](doc-consistency.md) as the reviewer pass —
+that file is the canonical checklist (count / command / identifier
+reproduction, canonical-contract gate evidence, intra-document coherence,
+four-corner cross-document consistency, version-bump and CHANGELOG
+consistency on closing PRs, the docstring sweep, follow-up file
+mechanics, PR title / body sanity, and the stale-sibling sweep). Report
+each check's result with line-numbered evidence; any contradiction is
+**blocking**.
+
+Two repo-specific additions:
+
+- **Units in docstrings** must match what the code returns. A docstring
+  saying `MeV^-1` over a function that returns `GeV^-1` is blocking.
+- **Sphinx docs** under `docs/source/` that reference a renamed or
+  removed public object must be updated in the same PR.
+
+### E — Numerics & performance
+
+The highest-value lens in this repo. Focus first on **whether the numbers
+are right**, then on how fast they are computed.
+
+**Numerical correctness:**
+
+- **Did any published value move?** Identify every public function the
+  diff can reach. For each, run it before and after on a representative
+  grid and diff the arrays. If a value moved and neither the PR body nor
+  `CHANGELOG.md` says so, that is **blocking** — regardless of whether
+  tests pass. A loose tolerance absorbing a real shift is exactly the
+  failure this lens exists to catch.
+- **Dimensional analysis.** Check the units of every new expression
+  against the docstring and against `hazma/parameters.py`. A missing
+  factor of `c`, `ħ`, or a MeV/GeV mix-up is the classic defect here.
+- **Limits and special cases.** Does the new expression reduce correctly
+  in the massless limit, the non-relativistic limit, or at threshold? Ask
+  for the check if the PR does not show it.
+- **Floating-point stability.** Catastrophic cancellation in a difference
+  of nearly equal terms; `exp` of a large negative argument; division by
+  a quantity that vanishes at the kinematic edge; `sqrt` of a value that
+  can go slightly negative from rounding. Flag `np.errstate` suppression
+  and `nan_to_num` that hide rather than handle these.
+- **Integration and interpolation.** Are the limits right and justified?
+  Is the quadrature appropriate for an integrand with an endpoint
+  singularity? Does an interpolator extrapolate silently outside its
+  tabulated range?
+- **Tolerances.** Every `isclose` / `allclose` tolerance in a new test
+  should have a stated reason. An unexplained `rtol=1e-2` is a
+  non-blocking finding at minimum; one that is loose enough to hide the
+  bug the test claims to guard is blocking.
+
+**Performance:**
+
+- Weight severity by how hot the path is: a per-energy-point inner loop
+  over a large grid matters; one-time setup does not.
+- Python-level loops over NumPy arrays where a vectorized expression
+  exists; repeated recomputation of an invariant inside a loop; array
+  copies where a view suffices; `np.append` in a loop.
+- **The Cython boundary.** Crossing from Python into a `.pyx` kernel once
+  per array element is the expensive pattern; crossing once per array is
+  the cheap one.
+- **Verify claimed properties.** When the diff claims a speedup, ask for
+  the measurement — a command and two numbers, on a stated grid size.
+  "Should be faster" is not a measurement, and an unmeasured perf claim
+  in a docstring or PR body is a finding.

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -1,0 +1,32 @@
+# Follow-ups
+
+The durable backlog of ideas and deferred work that hasn't been promoted
+to a `projects/<slug>/` plan yet.
+
+Open items live in [`todo/`](todo/); resolved items move to
+[`done/`](done/), so `ls todo/` is the live backlog at a glance. Items
+move between the two directories; they are never deleted — the historical
+reasoning is worth keeping.
+
+The full lifecycle (create → resolve → repoint inbound links), when to
+add one, and why this is not GitHub issues, live in
+[`../workflow.md#follow-ups`](../workflow.md#follow-ups).
+
+## Creating one
+
+```sh
+cp docs/followups/_template.md docs/followups/todo/<slug>.md
+# fill in the fields, then add a row to the Open table below
+```
+
+## Open
+
+| Item | Added | Source | Scope |
+|------|-------|--------|-------|
+| _none yet_ | | | |
+
+## Promoted / Done / Pruned
+
+| Item | Status | Resolution |
+|------|--------|------------|
+| _none yet_ | | |

--- a/docs/followups/_template.md
+++ b/docs/followups/_template.md
@@ -1,0 +1,44 @@
+# <Human-readable title>
+
+<!--
+  This is the follow-up template. Copy it into `todo/` with a
+  kebab-case slug (e.g. `todo/eta-prime-endpoint-drift.md`) and
+  fill in the fields below. Then add a row to `README.md` under "Open".
+
+  When the item is resolved, `git mv todo/<slug>.md done/<slug>.md`,
+  move its README row to the "Promoted / Done / Pruned" table, and
+  repoint any inbound links (the path changes from todo/ to done/).
+
+  See `docs/workflow.md#follow-ups` for the full lifecycle (promote,
+  done, prune) and how this slots in alongside the `projects/` directory.
+-->
+
+- **Added:** YYYY-MM-DD
+- **Source:** <projects/<slug>/learnings/project-retrospective.md §5 | TODO at file:line | GH issue #N | conversation>
+- **Scope:** <project | commit | cross-cutting>
+- **Status:** open
+- **Triggers / blockers:** <optional — when does this ripen? what must land first?>
+
+## Why
+
+<1-2 paragraphs: what observation prompted this, what gap or risk it
+addresses, why it's worth tracking now rather than letting it drift.>
+
+## What
+
+<Concrete description of the work. Files or modules touched, channels
+added, ADRs to amend, expected shape of the change. Enough detail
+that a future agent can scope it without re-deriving the context.>
+
+## Entry points
+
+- <File path : line>
+- <Related project: `projects/<slug>/`>
+- <Prior ADR: `projects/<slug>/adrs/ADR-XXXX-*.md`>
+- <Prerequisite follow-up: `docs/followups/todo/<slug>.md`>
+
+## Risks / open questions
+
+<Optional. Sequencing concerns, unresolved trade-offs, dependencies on
+external data (a tabulated form factor, a detector response
+file), open scope questions.>

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,127 @@
+# Versioning
+
+Hazma follows [Semantic Versioning](https://semver.org/) over its
+**public Python API**. This document defines that surface, gives the
+litmus test for choosing a bump, and lists the files a closing PR must
+touch.
+
+## The version lives in one place
+
+```python
+# hazma/__init__.py
+VERSION: Final[str] = "2.0.2"
+__version__ = VERSION
+```
+
+`pyproject.toml` reads it dynamically (`version = { attr =
+"hazma.VERSION" }`), so there is exactly one number to edit. Do not add a
+second copy.
+
+> `_build.py` carries an unrelated, stale `VERSION` constant that is not
+> the package version and is not read by the build metadata. Leave it
+> alone; it is not part of a version bump.
+
+## The public surface
+
+A change is user-facing if it changes any of these:
+
+1. **Import paths.** `hazma.spectra.dnde_photon`, `hazma.theory.Theory`,
+   the model packages — anything a user writes in an `import` statement.
+2. **Signatures.** Function and method names, positional order, keyword
+   names, defaults, and whether an argument is required.
+3. **Return shapes and units.** Scalar vs array, tuple arity, dict keys,
+   dtype, and the physical units of every returned quantity.
+4. **Numerical output.** The values the library computes. A spectrum that
+   moves is a user-facing change even when no signature changed.
+5. **Exception types.** What is raised, and when (`hazma/hazma_errors.py`).
+6. **`hazma/deprecated/`.** It stays importable; removing or changing
+   anything there is a break.
+7. **Supported Python versions** and required runtime dependencies.
+
+Explicitly **not** the public surface: `hazma/experimental/`, anything
+under a leading-underscore package that is not re-exported
+(`hazma/_decay/`, `hazma/_utils/`, …), `notebooks/`, `test/`, internal
+helper names, docstring wording, and performance characteristics.
+
+## Choosing the bump
+
+The litmus test, applied in order — the first line that matches wins:
+
+**`major`** — existing correct user code stops working or silently
+changes meaning:
+
+- A public function, class, module, or keyword argument is **removed or
+  renamed**.
+- A return shape or unit changes (`dN/dE` in `MeV⁻¹` becomes `GeV⁻¹`; a
+  scalar becomes an array).
+- A required argument is added, or an argument's default changes in a way
+  that changes results.
+- The minimum Python version rises.
+- Anything in `hazma/deprecated/` is removed.
+
+**`minor`** — additive, or a deliberate correction to a published number:
+
+- A new public function, class, model, channel, or keyword argument with
+  a backward-compatible default.
+- **A numerical result changes because a physics bug was fixed.** This is
+  the carve-out worth reading twice: the API is unchanged, so it is not
+  `major`, but a user's plot moves, so it is not `patch`. Name the
+  affected functions and the size of the change in `CHANGELOG.md`.
+- A previously-raising input now returns a value (or vice versa) as a
+  deliberate correctness fix.
+- A dependency's minimum version rises.
+
+**`patch`** — no user-visible behavior change:
+
+- Bug fix whose output was previously an exception, a NaN, or an obvious
+  crash — not a plausible-looking wrong number.
+- Performance work with numerically identical output.
+- Docs, tests, typing, packaging, CI, internal refactors.
+
+Default to `patch`. Raising `patch → minor → major` mid-project is fine
+and expected when scope shifts. Lowering requires a one-line note in
+`task-notes/README.md` explaining why the change is no longer
+user-facing.
+
+### The numerical-change rule
+
+If you cannot tell whether a change moves a number, **measure it**. Run
+the affected function before and after on a representative grid and diff
+the arrays. "The tests still pass" is not evidence: a `rtol=1e-3`
+assertion absorbs a 0.1% shift, and 0.1% on a published spectrum is a
+`minor`, not a `patch`.
+
+## What a closing PR must contain
+
+The PR that flips a `projects/<slug>/PLAN.md` frontmatter `status:` to
+`Complete` carries the bump in the same diff:
+
+1. **`hazma/__init__.py`** — `VERSION` set to the new value.
+2. **`CHANGELOG.md`** — a new `## [X.Y.Z] — YYYY-MM-DD` section that
+   names the project slug and lists user-facing changes under
+   `Added` / `Changed` / `Fixed` / `Removed`. Numerical changes go under
+   `Changed` with the magnitude stated.
+
+Verify locally before committing:
+
+```bash
+scripts/agents/preflight.sh --closing
+```
+
+It checks that `VERSION` actually moved relative to the trunk and that
+`CHANGELOG.md` has a matching section. A partial closure (status flipped,
+version untouched) fails the gate.
+
+## Cheat sheet
+
+| Change                                              | Bump    |
+|-----------------------------------------------------|---------|
+| New `dnde_photon` final state                        | `minor` |
+| Renamed a keyword argument                           | `major` |
+| Fixed a wrong interpolation → spectrum shifts 2%     | `minor` |
+| Fixed a crash on an empty energy array               | `patch` |
+| Vectorized a loop, identical output                  | `patch` |
+| Changed returned units from MeV to GeV               | `major` |
+| Added a new model package                            | `minor` |
+| Tightened a docstring                                | `patch` |
+| Dropped Python 3.10 support                          | `major` |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,395 @@
+# Workflow
+
+This repo uses a lightweight, project-scoped workflow for any change that
+spans more than a single trivial commit. The goal: give agents (and
+humans) enough structure to plan, track, and synthesize multi-task work
+without drowning the repo in process.
+
+## When to create a project
+
+Create a project under `projects/<slug>/` when the work:
+
+- Spans multiple commits or PRs,
+- Needs explicit scope bounds (what's in, what's out),
+- Would benefit from per-task notes that outlive the PR description, or
+- Requires architectural decisions that should be durable.
+
+Skip the project scaffolding for single-commit changes (bugfixes, dep
+bumps, typo fixes, one-file refactors). Just commit and open a PR.
+
+## Creating a project
+
+1. Pick a kebab-case slug (e.g. `neutrino-spectra-parity`,
+   `vectorize-boost-integrals`).
+2. Copy `projects/_template/` to `projects/<slug>/`.
+3. Fill in `projects/<slug>/PLAN.md` — set the frontmatter, write the
+   Goal, Scope, and initial Tasks (or Phases).
+4. Delete any optional files you don't need (e.g. `rules.md` for simple
+   projects, the whole `phases/` directory for flat projects). Leave the
+   `_template.md` reference files in place (see "Template files vs
+   artifacts" below).
+5. Add one line to `projects/README.md` under Active Projects.
+
+### Template files vs artifacts
+
+Each per-project subdirectory ships with a `_template.md` reference file
+(e.g. `task-notes/_template.md`). The leading underscore is the signal:
+**files named `_template.md` are in-project references, not real
+artifacts.** They stay in place after scaffolding so agents can copy
+their shape when creating new work.
+
+Real artifacts follow strict, globbable patterns:
+
+| Directory     | Artifact pattern                                         |
+|---------------|----------------------------------------------------------|
+| `adrs/`       | `ADR-XXXX-<slug>.md`                                     |
+| `task-notes/` | `task-N-<slug>.md` (flat), `task-X.Y-<slug>.md` (phased) |
+| `phases/`     | `phase-XX-<slug>.md`                                     |
+| `learnings/`  | `phase-XX-<slug>.md` or `project-retrospective.md`       |
+| `references/` | any `<topic>.md` (optional — see below)                  |
+
+Tooling and skills glob for these artifact patterns; they ignore
+`_template.md`. Never rename a `_template.md` to match an artifact
+pattern — create a fresh file from it instead.
+
+## The project tree
+
+```text
+projects/<slug>/
+├── PLAN.md              # scope, task shape (canonical), frontmatter
+├── rules.md             # OPTIONAL: project-specific cross-cutting rules
+├── task-notes/          # per-task notes + shared working memory
+│   ├── README.md                 # project-level live status + working memory
+│   ├── task-N-slug.md            (flat projects: per-task note)
+│   └── phase-XX/                 (phased projects)
+│       ├── README.md             # per-phase live Tasks table + working memory
+│       └── task-X.Y-slug.md      # per-task note
+├── phases/              # OPTIONAL: only for phased projects
+│   └── phase-XX-slug.md
+├── references/          # OPTIONAL: deeper reference material for big plans
+│   └── <topic>.md
+├── adrs/                # project-scoped decisions
+│   └── ADR-XXXX-slug.md
+└── learnings/           # phase or project synthesis
+    └── phase-XX-slug.md
+```
+
+**Split of concerns between `PLAN.md` and `task-notes/README.md`:**
+
+- `PLAN.md` is the **canonical shape** of the project: goal, scope,
+  per-task objectives and exit criteria, anticipated ADRs. For phased
+  projects it also lists the phase table. `PLAN.md` changes when
+  canonical behavior changes, and those changes need review.
+- `task-notes/README.md` is the project's **live state** hub.
+  - **Flat:** holds the numbered Tasks status table + cumulative
+    findings, open questions, and handoff.
+  - **Phased:** holds the Phases status table (mirroring each phase
+    file's frontmatter) + cross-phase findings, decisions, and handoff.
+    Per-task status inside a phase lives in
+    `task-notes/phase-XX/README.md` (the per-phase working memory).
+- `task-notes/phase-XX/README.md` (**phased only**) is the per-phase
+  working-memory file: the Tasks status table for that phase's tasks,
+  plus phase-scoped findings, decisions, open questions, and handoff.
+  This is the authoritative source the skills consult when asked to "pick
+  the next unfinished task in the current phase".
+
+Keeping these separate means `PLAN.md` stays reviewable as a contract
+while the status tables churn freely alongside the notes.
+
+## References (`references/`)
+
+Large projects tend to accumulate two kinds of content in `PLAN.md` that
+don't belong there:
+
+1. **Grounded facts** — exhaustive maps of where something lives today
+   (file paths, line numbers, call graphs). Useful context, but stable
+   enough to break out.
+2. **How-to detail** — derivation write-ups, translation tables,
+   checklists, output-contract specs. Scoped to one or two tasks, but too
+   verbose to inline in a Task Details block. In this repo that often
+   means **the physics**: a derivation, a published-value table, or the
+   provenance of a data file.
+
+When `PLAN.md` starts ballooning past ~15KB because of either, break that
+content out into `references/<topic>.md` and have each Task Details entry
+**point** to the references it needs. This keeps `PLAN.md` scan-friendly
+and cuts token cost for agents: they load PLAN + one or two relevant
+references per task, not the full plan.
+
+Guidelines:
+
+- **The PLAN stays canonical.** References are enrichment, not
+  substitute. Task objectives, scope, and deliverable/gate must live in
+  `PLAN.md`'s Task Details.
+- **Each reference file starts with an Audience + Nature header.**
+  Example: `**Audience:** Tasks 4, 5, 6.` `**Nature:** Derivation.` That
+  way an agent can skim the top and decide whether to load it.
+- **Name by topic, not by task.** `references/boost-integral-kernel.md`
+  ages better than `references/task-8-notes.md`.
+- **Don't create a reference for every task.** The pattern pays off when
+  the same material serves multiple tasks, or when one task needs >1 page
+  of supporting detail.
+- **Add a reference index to `PLAN.md`** under a short "Orientation"
+  section, one line per reference.
+
+Skills that read `PLAN.md` don't automatically fetch references — they
+follow the pointers when the active task's detail names a file.
+
+## Flat vs phased
+
+Most projects are flat — one `PLAN.md` plus one `task-notes/README.md`
+holding the numbered task table and cross-task working memory. Use phases
+only when **all three** hold:
+
+1. **One shipping deliverable** — the whole effort produces one thing.
+2. **Real temporal dependency** — later work can't be validated until
+   earlier work lands.
+3. **15+ tasks** — a flat list would be unreadable.
+
+If any of these fails, prefer multiple projects with cross-references
+(`Requires: projects/other-project/`) over phases within one project.
+
+**Signaling which style the project uses:**
+
+- Frontmatter: `phased: true | false` (machine-readable; skills branch on
+  this).
+- First body line of `PLAN.md`: `**Structure:** Flat task list.` or
+  `` **Structure:** Phased — see `phases/`. ``
+
+## ADR placement
+
+ADRs capture canonical decisions that future work should respect.
+
+**Heuristic:** Could someone read this ADR without knowing which project
+produced it and still find it useful?
+
+- **Yes** → `docs/adrs/ADR-XXXX-*.md` (repo-wide).
+- **No** → `projects/<slug>/adrs/ADR-XXXX-*.md` (project-scoped).
+
+**Default bias:** start project-scoped. Promote to repo-wide (by re-filing
+the ADR in `docs/adrs/` with a fresh repo-wide number) only when a second
+project needs the same decision.
+
+Examples of repo-wide ADRs:
+
+- "Spectrum functions broadcast over energy arrays and return NaN outside
+  the kinematic range"
+- "Cython kernels never import from pure-Python `hazma` modules"
+- "Published spectra are pinned by regression arrays, not tolerances"
+
+Examples of project-scoped ADRs:
+
+- "The N-body integrator uses RAMBO rather than adaptive sampling for
+  this project's multiplicities"
+- "This form factor is interpolated from the tabulated data rather than
+  evaluated analytically"
+
+## Task notes
+
+Every task gets a note. It captures:
+
+- What you reviewed before starting.
+- What you found (constraints, edge cases, surprises).
+- Decisions made and their alternatives.
+- Files changed.
+- How you verified.
+- Open questions.
+- Plan impact (None | ADR needed | phase file or `rules.md` update).
+- Handoff: what the next agent should read first.
+
+Use `projects/_template/task-notes/_template.md` as the starting shape.
+
+**Canonical path:**
+
+- Flat projects: `task-notes/task-N-<slug>.md`.
+- Phased projects: `task-notes/phase-XX/task-X.Y-<slug>.md`.
+
+One task note per meaningful work unit. Tiny sub-subtasks that naturally
+belong together can share one note.
+
+## Working memory (`task-notes/README.md`)
+
+Alongside per-task notes, each project keeps a **working-memory** file at
+`task-notes/README.md`. It is the project's shared scratchpad and holds
+live state that `PLAN.md` should not carry:
+
+- Flat projects: the **numbered Tasks status table** + cumulative
+  findings, open questions, and rolling handoff.
+- Phased projects: the **Phases status table** (mirroring each phase
+  file's frontmatter) + cross-phase findings, decisions, and handoff.
+
+**Phased projects also need per-phase working memory.** Each phase gets
+its own file at `task-notes/phase-XX/README.md`, copied from
+`projects/_template/task-notes/phase-XX/README.md`.
+
+Agents should read working-memory files before loading per-task notes,
+append to them as they learn, and promote stable entries to `PLAN.md` or
+an ADR once a finding is canonical.
+
+## Learnings
+
+When a phase closes (phased projects) or a project wraps up, synthesize
+the task notes into a learnings document. This is durable memory for
+future work that touches the same area — not a status log.
+
+A retrospective should also include a **§5 Follow-on seeds** section
+listing every substantive deferred item the project surfaced. Each seed
+gets a one- or two-paragraph entry in the retrospective (the historical
+record), and a corresponding stub in [`followups/`](followups/README.md)
+(the live actionable backlog). Duplication is intentional: the audiences
+differ.
+
+## Follow-ups
+
+[`docs/followups/`](followups/README.md) is the durable backlog of ideas
+and deferred work that hasn't been promoted to a `projects/<slug>/` plan
+yet. Each entry is a single markdown file with a fixed shape:
+description, source, scope, status, entry points. Open items live in
+[`todo/`](followups/todo/); resolved items move to
+[`done/`](followups/done/), so `ls todo/` is the live backlog at a
+glance.
+
+### Lifecycle
+
+1. **Create.** Copy `docs/followups/_template.md` to
+   `docs/followups/todo/<slug>.md`; fill the fields; add a row to
+   `docs/followups/README.md` under "Open".
+2. **Resolve.** When picked up or dropped, set the `Status:` field, then
+   `git mv docs/followups/todo/<slug>.md docs/followups/done/<slug>.md`
+   and move the README row to the **Promoted / Done / Pruned** table:
+   - *Promoted to a project:* scaffold `projects/<slug>/`, set
+     `Status: promoted`, link the project. The new project's PLAN should
+     backlink.
+   - *Done ad-hoc:* do the work, set `Status: done`, link the PR.
+   - *Pruned:* set `Status: pruned` plus a one-line reason. Don't
+     silently delete — the historical reasoning is useful.
+3. **Repoint inbound links.** The path encodes status, so resolving an
+   item changes its path (`todo/` → `done/`). Before committing,
+   `rg -l '<slug>\.md'` and update every reference (retrospectives, ADRs,
+   PLANs, code comments, the README tables).
+
+Items move between `todo/` and `done/`; they are never deleted.
+
+### When to add one
+
+- During or at the end of a project: every substantive §5 follow-on seed
+  gets a stub here.
+- When the current task **introduces** or **surfaces in its touched
+  area** a substantive `TODO`/`FIXME` representing real deferred work
+  rather than minor cleanup. Grep `docs/followups/` for the relevant
+  identifier first — don't file a duplicate.
+- When a code review surfaces a real out-of-scope issue.
+
+Skip the followup file for trivial cleanup that's faster to just do, and
+skip drive-by `TODO`s in unrelated files outside the task's touched area.
+This directory is for items worth tracking, not every passing thought —
+backlog bloat is the failure mode.
+
+### Why not GitHub issues
+
+GitHub issues stay for user-reported bugs and feature requests.
+`docs/followups/` is for internal sequencing decisions — markdown files
+version with the code, link cleanly to ADRs and retrospectives, and are
+agent-grep-friendly.
+
+## Branch and PR conventions
+
+The trunk branch is **`master`**. Branches carry the driving agent's
+identity as their prefix: Claude-driven work uses `claude/<...>`,
+Codex-driven work uses `codex/<...>`. Both prefixes are valid and
+permanent — all tooling (skills, helper scripts) parses either.
+
+- **Project work** (multi-task effort under `projects/<slug>/`):
+  `<agent>/<project-slug>/<task-slug>`.
+- **Ad-hoc work** (single-commit bugfix, dep bump, etc.):
+  `<agent>/<short-description>`.
+- Commit messages and PR titles follow
+  [`PR_GUIDELINES.md`](PR_GUIDELINES.md).
+
+## Project lifecycle
+
+1. **Active** — listed under Active Projects in `projects/README.md`;
+   `PLAN.md` frontmatter `status: In Progress`.
+2. **Complete** — all tasks done, final synthesis written. The closing PR
+   (the one that flips `status:` to `Complete`) **must also bump the
+   package version and add a `CHANGELOG.md` entry** per
+   [`versioning.md`](versioning.md). Then update `PLAN.md`
+   `status: Complete` and move the entry from Active to Completed in
+   `projects/README.md`.
+3. **Archived** — after a long time or when the project's decisions are
+   fully superseded, the folder may be moved or deleted. Default: keep
+   indefinitely for historical reference.
+
+## Versioning
+
+Hazma follows Semantic Versioning over the **public Python API** —
+module paths, function and class names, keyword arguments, return shapes
+and units, and the numerical values those functions produce.
+
+Every project declares a `version_bump` field in its `PLAN.md`
+frontmatter:
+
+```yaml
+---
+status: In Progress
+phased: false
+version_bump: patch     # patch | minor | major
+---
+```
+
+The closing PR for every project bumps `VERSION` in `hazma/__init__.py`
+per this field and adds a `CHANGELOG.md` entry naming the project slug.
+`scripts/agents/preflight.sh --closing` checks both.
+
+See [`versioning.md`](versioning.md) for the full policy: the litmus
+test, the public-surface inventory, examples, and the numerical-change
+carve-out.
+
+## Skills
+
+This repo defines Claude skills under `.claude/skills/`:
+
+- `execute-single-task` — scoped implementation of one task.
+- `commit-and-pr` — commit, push, and open a PR following the guidelines.
+- `review-pr` — focused single-lens review of a PR.
+- `review-respond` — synthesize review comments and implement fixes.
+- `review-cycle` — the single review-loop implementation: reviewer
+  selection, parallel review, commit+push of fixes, PR round comments,
+  and convergence. `task-pipeline`'s review phase delegates to it rather
+  than reimplementing the loop.
+- `task-pipeline` — end-to-end: implement → review → ship.
+- `begin-phase` — safe kickoff for the next phase (phased projects only).
+- `review-plan` — stress-test a project plan before implementation.
+
+Each skill expects the filesystem contract described above. Read the
+skill's `SKILL.md` for exact inputs, outputs, and reading order.
+
+### Shared agent layer
+
+Skills stay thin — role, when-to-use, workflow, gates, structured report
+— and point into a shared, agent-neutral layer rather than restating it.
+This layer is the one-copy-per-invariant source of truth:
+
+- [`docs/agents/`](agents/README.md) — reference files, one per
+  invariant: the preflight gate, the doc-consistency checklist, the
+  reviewer roster and lens rubrics, environment/test-infra gotchas, and
+  the review-lessons ledger.
+- [`scripts/agents/`](../scripts/agents/) — deterministic helper scripts
+  (preflight execution, PR title validation, task-worktree setup, task
+  resolution, doc-citation bounds checking) that skills shell out to
+  instead of re-deriving the logic inline.
+
+When a skill needs to state an invariant already captured under
+`docs/agents/`, it links there rather than duplicating the text.
+
+## Update discipline
+
+- Don't use `PLAN.md` as a running status log. Task progress lives in
+  task notes.
+- Don't stash task-level findings or transient debugging notes in an ADR.
+- Don't rely on PR descriptions as the only record of project knowledge —
+  those get lost.
+- When a canonical decision changes mid-project, add an ADR and patch the
+  affected `PLAN.md` / `phases/` / `rules.md`.
+- Verify counts (tests, channels, fixtures) by actually counting in
+  source, not from memory or task notes.

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,49 @@
+# Projects
+
+This directory holds scoped bodies of work. Each project is
+self-contained with its own plan, task notes, and (optionally) phases
+and architectural decisions.
+
+See [`../docs/workflow.md`](../docs/workflow.md) for:
+
+- When to create a project vs ship an ad-hoc commit.
+- How to scaffold a new project.
+- Flat vs phased projects.
+- The ADR placement heuristic.
+- The skills that automate the loop.
+
+## Starting a new project
+
+```sh
+cp -r projects/_template projects/<your-slug>
+# Edit projects/<your-slug>/PLAN.md (canonical task shape). Fill in the
+#   Numerical impact section — it drives version_bump and the CHANGELOG.
+# Edit projects/<your-slug>/task-notes/README.md (live task status
+#   table + working memory). This is NOT optional — agents read it
+#   every pass and treat it as the source of truth for what is done.
+# For phased projects, also create a task-notes/phase-XX/README.md
+#   from the template for each phase (the per-phase Tasks status
+#   table lives there).
+# Delete any optional files the project doesn't need (rules.md, phases/,
+#   references/, ...). Leave the `_template.md` reference files in
+#   the directories you keep.
+# For big plans that would push PLAN.md past ~15KB, use the
+#   references/ directory to break out topic-scoped reference docs —
+#   see `../docs/workflow.md#references-references`.
+# Add a row to the Active Projects table below.
+```
+
+See [`../docs/workflow.md#template-files-vs-artifacts`](../docs/workflow.md#template-files-vs-artifacts)
+for why `_template.md` files stay in place after scaffolding.
+
+## Active Projects
+
+| Slug | Deliverable | Phased | Started | Status |
+|------|-------------|--------|---------|--------|
+| _none yet_ | | | | |
+
+## Completed Projects
+
+| Slug | Deliverable | Phased | Started | Shipped |
+|------|-------------|--------|---------|---------|
+| _none yet_ | | | | |

--- a/projects/_template/PLAN.md
+++ b/projects/_template/PLAN.md
@@ -1,0 +1,143 @@
+---
+status: In Progress
+phased: false
+version_bump: patch
+deliverable: <one-line description of what ships when this project is done>
+created: <YYYY-MM-DD>
+---
+
+<!--
+`version_bump` declares the SemVer step the closing PR will take.
+See `../../docs/versioning.md` for the litmus test and examples.
+
+- `patch` (default) — no user-visible behavior change: internal
+  refactor, docs, tests, packaging, or a fix whose previous output was
+  an exception or an obvious crash.
+- `minor` — additive (a new public function, model, or channel), OR a
+  deliberate correction that MOVES A PUBLISHED NUMBER. The
+  numerical-change carve-out is the one people miss: the API is
+  unchanged, so it isn't `major`, but a user's plot moves, so it isn't
+  `patch`.
+- `major` — existing correct user code breaks or silently changes
+  meaning: a public name is removed or renamed, a return shape or unit
+  changes, a required argument is added, or the Python floor rises.
+
+Raising the level mid-project is fine and expected when scope shifts.
+Lowering it requires a one-line note in `task-notes/README.md`
+explaining why the change is no longer user-facing.
+-->
+
+
+# Project: <Title>
+
+**Structure:** Flat task list.
+<!-- For phased projects, replace the line above with:
+**Structure:** Phased — see [`phases/`](phases/).
+Also set `phased: true` in the frontmatter.
+-->
+
+## Goal
+
+<1-3 sentences describing what this project accomplishes and why it
+exists. If there's a GitHub issue or upstream context, link it from the
+Related section below, not here.>
+
+## Scope
+
+**In scope:**
+
+- <item>
+
+**Out of scope:**
+
+- <item>
+
+## Numerical impact
+
+<Does this project change any value the library returns? Name the public
+functions it can reach, and state the expected direction: "no public
+value changes", "corrects `dnde_photon` for K-long by up to ~3% near
+threshold", or "unknown — Task 1 measures it". This field drives the
+`version_bump` above and the CHANGELOG entry the closing PR writes.
+"Unknown" is a valid answer at plan time; it is not a valid answer at
+close time.>
+
+## Tasks
+
+The live task table, status, and dependency diagram are tracked in
+[`task-notes/README.md`](task-notes/README.md) (the project's working-
+memory file). This `PLAN.md` describes the canonical *shape* of each
+task in the "Task Details" section below; `task-notes/README.md` tracks
+their live *state*.
+
+<!--
+Phased projects: keep the PLAN pointer above, and use this Phases
+table in `task-notes/README.md` (mirroring each phase file's
+frontmatter `status:`):
+
+## Phases
+
+| # | Title              | File                                          | Status      |
+|---|--------------------|-----------------------------------------------|-------------|
+| 01 | <phase title>     | [`phases/phase-01-<slug>.md`](phases/phase-01-<slug>.md) | Not started |
+
+A phased project keeps a task breakdown inside each phase file's
+`## Tasks` section (canonical task shape) and a REQUIRED per-phase
+working-memory file at `task-notes/phase-XX/README.md` that holds
+the live Tasks status table for that phase. Copy the per-phase file
+from `projects/_template/task-notes/phase-XX/README.md` for each
+phase.
+-->
+
+## Task Details
+
+<!-- One subsection per task. Each subsection describes the canonical
+shape of the work: objective, scope, files to touch, exit criteria.
+Do NOT track live status here — that belongs in `task-notes/README.md`.
+
+### Task 1: <short task title>
+
+**Objective:** <one sentence>
+
+**Scope / implementation notes:** <what the task covers, with concrete
+file paths and API sketches where helpful>
+
+**Deliverable / gate:** <testable outcome that defines done — a pytest
+node id, a pinned numerical comparison, a measured benchmark>
+-->
+
+## Dependencies
+
+- Requires: <nothing | `projects/<other-slug>/` complete through task N
+  | specific upstream PR merged>
+
+## Related
+
+- GitHub Issue: <optional link>
+- Background: <optional — papers, published values, upstream
+  discussions, or the plan this emerged from>
+
+## Change control
+
+See [`../../docs/workflow.md#adr-placement`](../../docs/workflow.md#adr-placement)
+for when to write an ADR and where it lives (repo-wide vs project-scoped).
+Patch the affected `PLAN.md` / phase file / `rules.md` when canonical
+behavior changes.
+
+## Closing this project
+
+The PR that flips this `PLAN.md` `status:` to `Complete` must also bump
+`VERSION` in `hazma/__init__.py` per the `version_bump:` frontmatter and
+add a `CHANGELOG.md` entry naming this project slug. Re-check the level
+against the **Numerical impact** section above before bumping — a
+project that ended up moving a published number is `minor`, not `patch`.
+Verify with `scripts/agents/preflight.sh --closing`. See
+[`../../docs/versioning.md`](../../docs/versioning.md) for the full
+policy.
+
+### Anticipated ADRs
+
+<Decisions you already expect to require an ADR. Empty is fine — it just
+means no major architectural forks are known yet.>
+
+- <anticipated ADR topic>

--- a/projects/_template/adrs/_template.md
+++ b/projects/_template/adrs/_template.md
@@ -1,0 +1,32 @@
+# ADR XXXX: <Short, imperative title>
+
+**Date:** <YYYY-MM-DD>
+**Status:** <Proposed | Accepted | Superseded by ADR-YYYY>
+**Scope:** Project-scoped (applies only within `projects/<this-slug>/`).
+
+<!--
+If this decision turns out to apply repo-wide, re-file it under
+`docs/adrs/` with a new repo-wide number, and replace this file's body
+with a one-line pointer to the new ADR.
+-->
+
+## Context
+
+<Describe the technical situation objectively. What was the original
+plan or assumption within this project? What constraint, edge case, or
+system limitation was discovered that makes the original approach
+unworkable or newly necessary?>
+
+## Decision
+
+<State the specific architectural or contractual change being made to
+resolve the issue described in the Context.>
+
+## Consequences
+
+<List the downstream effects of this decision, scoped to this project.>
+
+- **Positive:** <What benefits or safety guarantees does this provide?>
+- **Negative:** <What are the tradeoffs, performance hits, or new
+  limitations?>
+- **Mitigation:** <How will we handle the negative consequences?>

--- a/projects/_template/learnings/_template.md
+++ b/projects/_template/learnings/_template.md
@@ -1,0 +1,55 @@
+# <Phase X | Project> Learnings: <Name>
+
+<!--
+For phased projects, create one learnings file per phase when the phase
+closes: `phase-XX-<slug>.md`.
+
+For flat projects, create one retrospective when the project wraps up:
+`project-retrospective.md` (or similar).
+
+Learnings are durable memory for future work that touches the same
+area — not a status log. Synthesize from task notes; don't just copy
+them.
+-->
+
+## 1. Implementation Reality Check
+
+<Summarize how execution matched or diverged from the plan. Link to any
+ADRs generated during this phase or project.>
+
+## 2. Critical Context for Future Work
+
+<List types, variable names, invariants, or internal API boundaries
+established here that future tasks should respect.>
+
+- <Rule or contract 1>
+
+## 3. Quirk Log & Edge Cases
+
+<Document language-level fights, dependency quirks, or specification
+ambiguities resolved here, so future work doesn't repeat the same
+mistakes.>
+
+- <Quirk 1>
+
+## 4. Test Infrastructure State
+
+<Note new test harnesses, fixtures, mocks, or specific commands
+established here that should be reused.>
+
+- <Testing tool or standard 1>
+
+## 5. Follow-on seeds
+
+<List substantive deferred items the project surfaced — work that's
+out of scope here but worth picking up later. Each seed gets one or
+two paragraphs explaining what it is, what triggers it, and which
+files / facets / ADRs are involved.
+
+For every seed, also drop a stub in `../../../docs/followups/` (one
+file per seed; from `projects/<slug>/learnings/` that resolves to
+the repo's `docs/followups/`). The retrospective entry is the
+historical record; the followup file is the live actionable form.
+See `../../../docs/workflow.md#follow-ups` for the lifecycle.>
+
+- <Seed 1>

--- a/projects/_template/phases/_template.md
+++ b/projects/_template/phases/_template.md
@@ -1,0 +1,76 @@
+---
+phase: <XX>
+title: <Phase Title>
+status: <Not started | In Progress | Complete>
+---
+
+# Phase <XX>: <Title>
+
+<!--
+Phased-project file. Delete `phases/` entirely for flat projects.
+One file per phase: `phase-XX-<slug>.md`.
+-->
+
+## Goal
+
+<What this phase delivers.>
+
+## Prerequisites
+
+- <Phase X-1 complete, or specific task outputs required>
+- <Active ADRs or `../rules.md` sections to read first>
+
+## Future Phases (read-only)
+
+<Optional: pointers to later phase files that build on this one. List
+them for context so you can skim what's coming, but do NOT edit those
+files while working on this phase — they belong to their own phase.>
+
+## Parts
+
+### Part 1: <Name>
+
+<Overview of what this part groups and why.>
+
+## Tasks
+
+<!--
+Each task heading below carries the same canonical hooks the flat
+`PLAN.md` task table gives: a pointer to the task note's canonical
+path and a dependency field. Replace `XX` with the phase number and
+`X.Y` with the phase/task number (e.g. `phase-03/task-3.2-<slug>.md`).
+-->
+
+### Task X.1: <Title>
+
+**Task note:** [`../task-notes/phase-XX/task-X.1-<slug>.md`](../task-notes/phase-XX/task-X.1-<slug>.md)
+**Depends on:** <— | Task X.0 | Task (X-1).N | ADR-XXXX>
+
+**Exit criteria:**
+
+- <Concrete, testable outcome>
+- <Gate test or verification>
+
+**Notes:**
+
+<Any detail too specific for the project `PLAN.md` but needed to
+implement.>
+
+### Task X.2: <Title>
+
+**Task note:** [`../task-notes/phase-XX/task-X.2-<slug>.md`](../task-notes/phase-XX/task-X.2-<slug>.md)
+**Depends on:** Task X.1
+
+**Exit criteria:**
+
+- <Concrete, testable outcome>
+
+**Notes:**
+
+<...>
+
+## Exit Criteria
+
+- All tasks in this phase complete.
+- <Specific gate: tests pass, integration validated, etc.>
+- Phase learnings written to `../learnings/phase-<XX>-<slug>.md`.

--- a/projects/_template/references/_template.md
+++ b/projects/_template/references/_template.md
@@ -1,0 +1,29 @@
+# Reference: <topic>
+
+**Audience:** <which tasks should load this — e.g. "Tasks 4, 5, 6"
+or "any task that touches the boost integrals">.
+**Nature:** <one of: Spec | Checklist | How-to | Grounded facts>.
+
+<!--
+This is an OPTIONAL per-project artifact. Use it when:
+
+- `PLAN.md`'s Task Details blocks would otherwise balloon with
+  mapping tables, code-path inventories, or checklists that several
+  tasks share.
+- You want to move grounded-facts content (line numbers, call graphs,
+  file paths) out of `PLAN.md` so the plan stays scan-friendly.
+
+Guidelines:
+
+- Keep the PLAN canonical. A reference enriches but never replaces
+  a Task Details block.
+- Name the file by topic, not by task number. Tasks cite the topic.
+- Start each reference with the Audience + Nature header above so
+  an agent can skim the top and decide whether to load it.
+
+See `docs/workflow.md#references-references` for the full pattern.
+-->
+
+## <Section>
+
+<Content.>

--- a/projects/_template/rules.md
+++ b/projects/_template/rules.md
@@ -1,0 +1,25 @@
+<!--
+OPTIONAL file. Delete it if this project has no cross-cutting rules.
+
+Use this file when the project has constraints that apply to many tasks:
+
+- Version pins or feature flags tied to this work.
+- Invariants that every task must preserve.
+- Conventions specific to the area being touched (e.g., a unit convention, a
+  reference implementation to check against, a tolerance policy, a
+  naming scheme for fixtures).
+- References to upstream specs or external docs that all tasks consult.
+
+If a rule applies to the whole repo (not just this project), put it in a
+repo-wide ADR under `docs/adrs/` instead of here.
+-->
+
+# <Project Slug> — Cross-Cutting Rules
+
+## <Section 1>
+
+- <Rule 1>
+
+## <Section 2>
+
+- <Rule 1>

--- a/projects/_template/task-notes/README.md
+++ b/projects/_template/task-notes/README.md
@@ -1,0 +1,190 @@
+# Working Memory: <Project Title>
+
+**Date:** <YYYY-MM-DD> (created)
+**Project:** <project slug>
+**Status:** <In Progress | Complete | Blocked>
+**Plan References:** `../PLAN.md` (all sections)
+**Related ADRs:** <none | ADR-XXXX (planned) | ADR-XXXX (accepted)>
+**Depends On:** <none | project/task dependency>
+
+<!--
+This is the project's shared working memory — not a per-task note.
+Agents working on any task in this project should:
+
+1. **Read this file first**, before loading per-task notes. It captures
+   the live task table, cumulative findings, decisions, and open
+   questions that outlive a single task.
+2. **Append to it as they learn.** When a task surfaces a fact that a
+   future task will need (a file path, a flake, a subtle invariant),
+   record it here rather than burying it in a task note.
+3. **Promote stable entries out.** Once a finding becomes canonical,
+   patch `../PLAN.md` or write an ADR and leave a one-line pointer
+   here.
+
+Per-task notes (`task-N-*.md`) remain the retrospective record of a
+single task's execution. This file is the running context + live
+status shared across tasks.
+-->
+
+## Objective
+
+<1-2 sentences. Usually: "Track cumulative context and live task
+status across all N tasks so any agent picking up work mid-project
+has the facts, decisions, and open questions needed to start without
+re-discovering them.">
+
+## Tasks
+
+Canonical task *shape* (objectives, exit criteria, implementation
+guidance) lives in `../PLAN.md` under "Task Details" (flat) or in
+`../phases/phase-XX-<slug>.md` (phased). This section tracks live
+*status* — update the Status column as tasks progress.
+
+<!-- Flat projects: use THIS table. Delete the phased block below. -->
+
+| # | Task                  | Depends on | Status      | Task Note                              |
+|---|-----------------------|------------|-------------|----------------------------------------|
+| 1 | <short task title>    | —          | Not started | `task-1-<slug>.md`                     |
+
+<!-- Optional dependency diagram for parallel workstreams.
+
+```text
+1 ──► 2 ──► 3
+4 ──► 5 ──► 6
+```
+-->
+
+<!--
+Phased projects: delete the flat Tasks table above and use this
+instead. Per-task status lives in each `phase-XX/README.md`, not here.
+
+This project-level README carries the Phases status table plus
+*cross-phase* findings, decisions, and handoff. Phase-scoped working
+memory (per-task Tasks table, phase-scoped findings) belongs in
+`phase-XX/README.md` (one file per phase, copied from
+`phase-XX/README.md` template).
+
+| # | Phase              | Phase file                                     | Working memory                     | Status      |
+|---|--------------------|------------------------------------------------|------------------------------------|-------------|
+| 01 | <phase title>     | `../phases/phase-01-<slug>.md`                 | `phase-01/README.md`               | Not started |
+| 02 | <phase title>     | `../phases/phase-02-<slug>.md`                 | `phase-02/README.md`               | Not started |
+
+The phase-level status above mirrors each phase file's frontmatter
+`status:` field. Phase frontmatter is authoritative for phase status;
+this table is a single-pane-of-glass for project-wide navigation.
+-->
+
+## Exit Criteria
+
+<When is this working-memory file retired? Typically: all tasks
+complete, all anticipated ADRs accepted or dropped, no open questions
+remain.>
+
+- <criterion 1>
+- <criterion 2>
+- Closing PR bumps `VERSION` in `hazma/__init__.py` per `PLAN.md`'s
+  `version_bump:` frontmatter and adds a `CHANGELOG.md` entry naming
+  this project slug. See
+  [`../../../docs/versioning.md`](../../../docs/versioning.md).
+
+## Inputs Reviewed
+
+<!-- Append as new sources are consulted. Keep entries terse: one line
+per source, with a `path:line` or URL and a short "what this tells us"
+note. -->
+
+- `../PLAN.md` — project plan, task details, anticipated ADRs.
+- <additional entries as they accumulate>
+
+## Findings
+
+<!-- Cumulative facts discovered while implementing. Group by theme or
+subsystem once there are enough entries to warrant it. Entries here
+are informational — decisions go in the next section. -->
+
+- <finding 1>
+
+## Numerical impact so far
+
+<!-- Running record of whether this project has moved any value the
+library returns. One line per task that touched a public code path:
+the function, the grid checked, and the result ("unchanged", or the
+magnitude and direction of the shift). This is what the closing PR's
+CHANGELOG entry and the `version_bump:` level are derived from — do
+not reconstruct it from memory at close time. -->
+
+_No public code paths touched yet._
+
+## Decisions and Implementation Notes
+
+<!-- Cumulative list of decisions made, including the "why". Link to
+ADRs where applicable. When a decision is formalized in an ADR, leave
+the one-liner here pointing to the ADR file. -->
+
+- <decision 1 — rationale — link to ADR-XXXX if applicable>
+
+## Files Changed
+
+<!-- Update as tasks land. Group by task. One line per file with a
+short purpose. When a task is complete, the per-task note
+(`task-N-*.md`) should have the authoritative list; this section is
+a cross-task roll-up for quick orientation. -->
+
+_None yet — project not started._
+
+<!--
+Example format (fill in as tasks land):
+
+### Task 1
+- `path/to/new_file.py` — <purpose>
+- `path/to/modified.py` — <what changed>
+-->
+
+## Verification
+
+<!-- Accumulate the commands that gate each task. Useful for picking up
+mid-project: "which test command corresponds to which task?" -->
+
+- Task 1: `<command>`
+- <additional entries>
+
+## Open Questions
+
+<!-- Keep only currently open items. When a question resolves, move
+the resolution into "Decisions and Implementation Notes" or an ADR. -->
+
+- <question 1, with enough context that a future agent knows why it
+  matters and where to find the relevant code/spec>
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+This working-memory file does not by itself change `../PLAN.md`. When
+a task's findings DO require a canonical change (e.g. ADR, task-table
+reordering, new in-scope/out-of-scope item), patch `../PLAN.md`
+directly and record a one-line pointer here under "Decisions and
+Implementation Notes".
+
+## Handoff to Next Task
+
+<!-- Rewrite this section at the end of each task. "Next" = whichever
+task the agent picks up next, not necessarily N+1. Three sub-sections:
+where to start, what's safe, what's risky. -->
+
+**For the next agent starting any task in this project:**
+
+1. Read `../PLAN.md` end-to-end once, then this file.
+2. Read the specific task's detail block in `../PLAN.md` ("Task N:
+   ..." under "Task Details").
+3. Check "Open Questions" above for anything relevant to your task.
+4. If your task is gated by an ADR, confirm the ADR is accepted
+   before implementing.
+
+**Currently safe to assume:**
+
+- <invariant 1>
+
+**Currently risky / unknown:**
+
+- <risk 1>

--- a/projects/_template/task-notes/_template.md
+++ b/projects/_template/task-notes/_template.md
@@ -1,0 +1,71 @@
+# Task <N>: <Short Title>
+
+**Date:** <YYYY-MM-DD>
+**Project:** <project slug>
+**Status:** <In Progress | Complete | Blocked | Superseded>
+**Plan References:** <sections of `../PLAN.md`, a phase file, or `../rules.md`>
+**Related ADRs:** <none | ADR-XXXX (project-scoped) | ADR-XXXX (`docs/adrs/`)>
+**Depends On:** <none | Task N-1 | ADR-XXXX>
+
+## Objective
+
+<One or two sentences stating what this task accomplishes.>
+
+## Exit Criteria
+
+<Concrete, testable outcomes that define when this task is done. Fill this
+in at task start, before implementation — it's the gate you're working
+toward. "Verification" below captures retrospectively what you actually did
+to check these.>
+
+- <criterion 1>
+- <criterion 2>
+
+## Inputs Reviewed
+
+- <`../PLAN.md` sections consulted>
+- <Phase file, if phased project>
+- <`../rules.md` sections, if any>
+- <Existing code, docs, specs, external references>
+- <Prior task notes or ADRs consulted>
+
+## Findings
+
+- <Key fact or constraint discovered>
+- <Edge case, limitation, or interoperability note>
+
+## Decisions and Implementation Notes
+
+- <Decision made while implementing>
+- <Why that decision was taken over the obvious alternative>
+
+## Files Changed
+
+- <Path> — <purpose>
+
+## Verification
+
+- <Tests run, with command — e.g., `pytest test/spectra -q`>
+- <Manual checks or fixture validation>
+- <Anything intentionally deferred>
+
+## Open Questions
+
+- <Unresolved question, or `None`>
+
+## Plan Impact
+
+**Impact Level:** <None | Follow-up in learnings | Update phase file or
+`../rules.md` | ADR required | Both ADR and phase/rules update>
+
+<Describe whether this task changed canonical behavior, future task
+ordering, acceptance criteria, or internal contracts. If impact is
+"None", say so explicitly. For canonical changes, patch the affected
+`PLAN.md` / phase file / `rules.md`; promote to a repo-wide ADR under
+`docs/adrs/` if the decision has implications outside this project.>
+
+## Handoff to Next Task
+
+- <What the next agent should read first>
+- <What assumptions are now safe to make>
+- <What remains risky or incomplete>

--- a/projects/_template/task-notes/phase-XX/README.md
+++ b/projects/_template/task-notes/phase-XX/README.md
@@ -1,0 +1,133 @@
+# Working Memory: Phase <XX> — <Phase Title>
+
+**Date:** <YYYY-MM-DD> (created)
+**Project:** <project slug>
+**Phase:** <XX>
+**Status:** <Not started | In Progress | Complete>
+**Plan References:** `../../phases/phase-<XX>-<slug>.md` (phase file)
+**Related ADRs:** <none | ADR-XXXX>
+**Depends On:** <prior phases / active ADRs>
+
+<!--
+This is the phase's shared working-memory file. It is analogous to
+the project-level `../README.md`, but scoped to a single phase:
+
+- The live Tasks status table for THIS PHASE (authoritative for the
+  skills' "next unfinished task in the current phase" lookup).
+- Findings, decisions, and open questions that are scoped to this
+  phase (cross-phase material belongs in the project-level
+  `../README.md`).
+- The rolling handoff for whoever picks up the next task in this
+  phase.
+
+Agents working on any task in this phase should read this file first,
+append to it as they learn, and update the Tasks Status cell when a
+task completes.
+-->
+
+## Objective
+
+Track cumulative context and live per-task status across the tasks in
+Phase <XX> so any agent picking up work within this phase has the
+facts, decisions, and handoff context needed to start immediately.
+
+## Tasks
+
+Canonical per-task shape (objective, exit criteria, implementation
+guidance) lives in `../../phases/phase-<XX>-<slug>.md`. This table is
+the live status — update the Status column as tasks progress.
+
+| # | Task                  | Depends on | Status      | Task Note                              |
+|---|-----------------------|------------|-------------|----------------------------------------|
+| X.1 | <short task title>  | —          | Not started | `task-X.1-<slug>.md`                   |
+| X.2 | <short task title>  | X.1        | Not started | `task-X.2-<slug>.md`                   |
+
+<!-- Optional dependency diagram if the phase has parallel workstreams.
+
+```text
+X.1 ──► X.2 ──► X.3
+```
+-->
+
+## Exit Criteria
+
+<When is this phase's working memory retired? Typically: every row in
+the Tasks table above is `Complete` and the phase file's frontmatter
+has been flipped to `status: Complete`.>
+
+- All tasks in the Tasks table above have Status `Complete`.
+- Phase file `../../phases/phase-<XX>-<slug>.md` frontmatter set to
+  `status: Complete`.
+- Phase learnings document written to
+  `../../learnings/phase-<XX>-<slug>.md`.
+
+## Inputs Reviewed
+
+<!-- Sources read while executing this phase. Append terse entries as
+sources are consulted. -->
+
+- `../../phases/phase-<XX>-<slug>.md` — phase file with per-task shape.
+- `../README.md` — project-level working memory.
+
+## Findings
+
+<!-- Phase-scoped findings. Cross-phase material belongs in
+../README.md. -->
+
+- <finding 1>
+
+## Decisions and Implementation Notes
+
+<!-- Phase-scoped decisions with rationale. Link to ADRs. -->
+
+- <decision 1 — rationale — ADR link if applicable>
+
+## Files Changed
+
+<!-- Cumulative files touched during this phase, grouped by task. -->
+
+_None yet — phase not started._
+
+<!--
+### Task X.1
+- `path/to/file.py` — <purpose>
+-->
+
+## Verification
+
+<!-- Commands gating each task in this phase. -->
+
+- Task X.1: `<command>`
+
+## Open Questions
+
+- <question 1>
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+Canonical changes to the phase file, `PLAN.md`, or `rules.md` go
+through the normal ADR / plan-patch path. This file only tracks live
+state.
+
+## Handoff to Next Task
+
+<!-- Rewrite this section at the end of each task. "Next" = whichever
+task in this phase the agent picks up next. -->
+
+**For the next agent working in Phase <XX>:**
+
+1. Read `../../PLAN.md` (project-level), then `../README.md`
+   (project-level working memory), then this file.
+2. Read the phase file `../../phases/phase-<XX>-<slug>.md` for the
+   specific task's shape and exit criteria.
+3. Check "Open Questions" above for anything relevant to your task.
+
+**Currently safe to assume:**
+
+- <invariant 1>
+
+**Currently risky / unknown:**
+
+- <risk 1>

--- a/scripts/agents/check_doc_citations.py
+++ b/scripts/agents/check_doc_citations.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Bounds-check every `<file>.py:<line>` citation in a set of markdown docs.
+
+Durable docs (PLANs, ADRs, task notes, follow-ups) cite source lines as
+`gamma_ray.py:142` or `hazma/spectra/_photon/_muon.py:73-88`. Those citations
+rot silently: the cited file keeps importing while the line number drifts to
+something unrelated. This checker resolves each citation to a tracked file and
+asserts the cited line is inside it, so the doc-consistency "line-number
+citation sweep" (`docs/agents/doc-consistency.md`) is a command anyone can
+re-run instead of a hand-audit.
+
+It bounds-checks; it cannot know whether line 142 still says what the doc
+claims. Load-bearing citations still deserve a read.
+
+Source extensions checked: `.py`, `.pyx`, `.pxd`.
+
+Resolution order for each cited path:
+  1. exact  — the citation is already a repo-relative path that exists
+  2. suffix — exactly one tracked source file ends with `/<citation>`
+  3. context — the citation is a bare basename and the *same doc* pins it
+     via a longer form (e.g. `spectra/_muon.py:83` fixes `_muon.py`)
+  4. map    — an explicit `--map <repo/relative/path.py>` override
+  5. otherwise: AMBIGUOUS (candidates exist, none chosen) → failure,
+     or EXTERNAL (no candidate at all, e.g. a numpy/scipy citation)
+     → skipped and reported by name so the skip stays visible
+
+Usage:
+    # every changed markdown doc on this branch
+    check_doc_citations.py --changed-vs origin/master
+
+    # explicit docs, with short-form overrides
+    check_doc_citations.py docs/foo.md \
+        --map hazma/spectra/_photon/_muon.py
+
+    # dump each citation and how it resolved
+    check_doc_citations.py --changed-vs origin/master --list
+
+Exit code: 0 when every citation is in range, 1 on any out-of-range or
+ambiguous citation, 2 on usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+SOURCE_GLOBS = ("*.py", "*.pyx", "*.pxd")
+
+# `gamma_ray.py:83`, `spectra/_muon.py:993-995`, `hazma/utils.py:1`, and
+# the run form `utils.py:71/76/85/104-110` (every element is bounds-checked).
+CITATION_RE = re.compile(
+    r"([A-Za-z0-9_][A-Za-z0-9_./-]*\.(?:py|pyx|pxd)):"
+    r"(\d+(?:-\d+)?(?:/\d+(?:-\d+)?)*)"
+)
+
+
+def run_git(repo_root: Path, *args: str) -> str:
+    """Run a git command in `repo_root` and return its stdout."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def repo_root() -> Path:
+    """Absolute path of the enclosing git worktree."""
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return Path(out.strip())
+
+
+def tracked_source_files(root: Path) -> list[str]:
+    """Repo-relative paths of every tracked Python/Cython source file."""
+    listing = run_git(root, "ls-files", "--", *SOURCE_GLOBS)
+    return [line for line in listing.splitlines() if line]
+
+
+def changed_docs(root: Path, ref: str) -> list[str]:
+    """Repo-relative paths of markdown docs changed since `ref`.
+
+    Uses the merge-base (`ref...HEAD`) so an out-of-date branch does not
+    pull unrelated files into the set, and drops deletions.
+    """
+    listing = run_git(
+        root, "diff", "--name-only", "--diff-filter=d", f"{ref}...HEAD"
+    )
+    return [line for line in listing.splitlines() if line.endswith(".md")]
+
+
+def line_count(path: Path) -> int:
+    """Number of lines in `path` (a trailing newline does not add one)."""
+    with path.open("rb") as handle:
+        return sum(1 for _ in handle)
+
+
+class Resolver:
+    """Maps a cited source path onto a tracked repo file."""
+
+    def __init__(self, root: Path, overrides: list[str]) -> None:
+        self.root = root
+        self.files = tracked_source_files(root)
+        self.by_suffix: dict[str, list[str]] = defaultdict(list)
+        for path in self.files:
+            parts = path.split("/")
+            # Index every path suffix so `utils.py`, `hazma/utils.py`, … all hit.
+            for start in range(len(parts)):
+                self.by_suffix["/".join(parts[start:])].append(path)
+        self.overrides: dict[str, str] = {}
+        for override in overrides:
+            self.overrides[Path(override).name] = override
+
+    def candidates(self, citation: str) -> list[str]:
+        return self.by_suffix.get(citation, [])
+
+    def resolve(
+        self, citation: str, context: dict[str, set[str]]
+    ) -> tuple[str | None, str]:
+        """Resolve `citation` to a repo path, returning (path, how)."""
+        if (self.root / citation).is_file() and citation in self.files:
+            return citation, "exact"
+
+        hits = self.candidates(citation)
+        if len(hits) == 1:
+            return hits[0], "suffix"
+
+        if "/" not in citation:
+            pinned = context.get(citation, set())
+            if len(pinned) == 1:
+                return next(iter(pinned)), "context"
+
+        override = self.overrides.get(Path(citation).name)
+        if override is not None and override in self.files:
+            return override, "map"
+
+        return None, "ambiguous" if hits else "external"
+
+
+def doc_context(
+    resolver: Resolver, citations: list[str]
+) -> dict[str, set[str]]:
+    """Basename → paths the doc itself pins via exact/unique-suffix forms."""
+    context: dict[str, set[str]] = defaultdict(set)
+    for citation in citations:
+        if "/" not in citation:
+            continue
+        hits = resolver.candidates(citation)
+        if len(hits) == 1:
+            context[Path(citation).name].add(hits[0])
+    return context
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bounds-check `<file>.py:<line>` citations in markdown docs."
+    )
+    parser.add_argument("docs", nargs="*", help="markdown docs to check")
+    parser.add_argument(
+        "--changed-vs",
+        metavar="REF",
+        help="also check every markdown doc changed since REF (merge-base)",
+    )
+    parser.add_argument(
+        "--map",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="repo-relative path pinning an otherwise ambiguous basename; "
+        "repeatable",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print every citation and how it resolved",
+    )
+    args = parser.parse_args(argv[1:])
+
+    root = repo_root()
+    docs = list(args.docs)
+    if args.changed_vs:
+        docs.extend(doc for doc in changed_docs(root, args.changed_vs)
+                    if doc not in docs)
+    if not docs:
+        print(
+            "error: no docs to check (pass paths or --changed-vs REF)",
+            file=sys.stderr,
+        )
+        return 2
+
+    resolver = Resolver(root, args.map)
+    how_counts: Counter[str] = Counter()
+    external_names: Counter[str] = Counter()
+    failures: list[str] = []
+    checked = 0
+
+    for doc in sorted(docs):
+        doc_path = root / doc
+        if not doc_path.is_file():
+            failures.append(f"{doc}: no such file")
+            continue
+        text = doc_path.read_text(encoding="utf-8")
+        matches = list(CITATION_RE.finditer(text))
+        context = doc_context(resolver, [m.group(1) for m in matches])
+
+        for match in matches:
+            citation = match.group(1)
+            spans = match.group(2).split("/")
+            line_no = text.count("\n", 0, match.start()) + 1
+
+            path, how = resolver.resolve(citation, context)
+            if path is None:
+                how_counts[how] += len(spans)
+                if how == "external":
+                    external_names[citation] += len(spans)
+                else:
+                    hits = resolver.candidates(citation)
+                    failures.append(
+                        f"{doc}:{line_no}: AMBIGUOUS {citation} — "
+                        f"{len(hits)} candidates, pin one with --map "
+                        f"(e.g. --map {hits[0]})"
+                    )
+                continue
+
+            total = line_count(root / path)
+            for span in spans:
+                how_counts[how] += 1
+                checked += 1
+                bounds = [int(part) for part in span.split("-")]
+                if args.list:
+                    print(f"{doc}:{line_no}\t{citation}:{span}\t{how}\t{path}")
+                if min(bounds) < 1 or max(bounds) > total:
+                    failures.append(
+                        f"{doc}:{line_no}: OUT OF RANGE {citation}:{span} — "
+                        f"{path} has {total} lines"
+                    )
+
+    print(f"docs scanned: {len(docs)}")
+    print(f"in-repo citations checked: {checked}")
+    for how in ("exact", "suffix", "context", "map"):
+        if how_counts[how]:
+            print(f"  resolved by {how}: {how_counts[how]}")
+    external_total = sum(external_names.values())
+    print(f"external citations skipped: {external_total}")
+    for name, count in sorted(external_names.items()):
+        print(f"  {name} ({count})")
+
+    if failures:
+        print(f"FAIL: {len(failures)} problem(s)")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+
+    print("out-of-range or ambiguous: NONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/agents/check_pr_title.py
+++ b/scripts/agents/check_pr_title.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python3
 """Validate a Conventional Commits PR-title / header string.
 
-Mirrors the enforced settings in .github/workflows/pr_linter.yaml
-(10XDev/pull-request-linter-action@v6) so agents can pre-check a title
-locally before opening a PR.
+A **local** validator, so an agent can deterministically pre-check a title
+instead of eyeballing a character count. The rules it enforces are the ones
+written down in docs/PR_GUIDELINES.md -- that document is authoritative and
+this script is its executable form. If the two ever disagree, the document
+wins and this script is the bug.
 
-Rules (see spec §8 in the skills-redesign design doc):
+There is **no CI job enforcing PR titles in this repo.** Nothing rejects a
+malformed title automatically; the convention is upheld by this checker and
+by review. Do not read a green CI run as a title that passed.
+
+Rules (see docs/PR_GUIDELINES.md "Title format"):
   - type   ∈ {feat fix chore ci docs test refactor perf style build revert}
   - scope  required; matches ^[a-z0-9-]+$; ≤10 chars; no leading/trailing
            hyphen; not equal to a type
   - header total length ≤69 chars
   - subject starts with an alphanumeric char; no trailing "." or space
 
-Deliberate divergence from the live workflow: the action sets
-`disallowTypesAsScopes: false`, but this checker rejects a scope equal to a
-type per the design spec (the stricter rule catches accidental
-`docs(docs):`-style titles). No real merged title uses a type as its scope.
+The "scope must not equal a type" rule is stricter than Conventional Commits
+itself requires; it catches accidental `docs(docs):`-style titles.
 
 Usage:
     check_pr_title.py "feat(lint): add a rule"   # title as argv

--- a/scripts/agents/check_pr_title.py
+++ b/scripts/agents/check_pr_title.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate a Conventional Commits PR-title / header string.
+
+Mirrors the enforced settings in .github/workflows/pr_linter.yaml
+(10XDev/pull-request-linter-action@v6) so agents can pre-check a title
+locally before opening a PR.
+
+Rules (see spec §8 in the skills-redesign design doc):
+  - type   ∈ {feat fix chore ci docs test refactor perf style build revert}
+  - scope  required; matches ^[a-z0-9-]+$; ≤10 chars; no leading/trailing
+           hyphen; not equal to a type
+  - header total length ≤69 chars
+  - subject starts with an alphanumeric char; no trailing "." or space
+
+Deliberate divergence from the live workflow: the action sets
+`disallowTypesAsScopes: false`, but this checker rejects a scope equal to a
+type per the design spec (the stricter rule catches accidental
+`docs(docs):`-style titles). No real merged title uses a type as its scope.
+
+Usage:
+    check_pr_title.py "feat(lint): add a rule"   # title as argv
+    echo "feat(lint): add a rule" | check_pr_title.py   # title on stdin
+
+Output: a single "OK: <title>" line on success, or one line per violation.
+Exit code: 0 when valid, 1 when any violation is found, 2 on usage error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+TYPES = frozenset(
+    {
+        "feat",
+        "fix",
+        "chore",
+        "ci",
+        "docs",
+        "test",
+        "refactor",
+        "perf",
+        "style",
+        "build",
+        "revert",
+    }
+)
+
+MAX_HEADER_LEN = 69
+MAX_SCOPE_LEN = 10
+SCOPE_RE = re.compile(r"^[a-z0-9-]+$")
+
+# type, optional (scope), optional breaking-change "!", ": ", subject.
+HEADER_RE = re.compile(
+    r"^(?P<type>[a-zA-Z]+)"
+    r"(?:\((?P<scope>[^)]*)\))?"
+    r"(?P<bang>!)?"
+    r": (?P<subject>.*)$"
+)
+
+
+def check(header: str) -> list[str]:
+    """Return a list of violation messages (empty means the title is valid)."""
+    violations: list[str] = []
+
+    if len(header) > MAX_HEADER_LEN:
+        violations.append(
+            f"header is {len(header)} chars; must be ≤{MAX_HEADER_LEN}"
+        )
+
+    match = HEADER_RE.match(header)
+    if match is None:
+        violations.append(
+            'not a conventional-commit header: expected "type(scope): subject"'
+        )
+        return violations
+
+    type_ = match.group("type")
+    scope = match.group("scope")
+    subject = match.group("subject")
+
+    if type_ not in TYPES:
+        allowed = " ".join(sorted(TYPES))
+        violations.append(f'type "{type_}" is not allowed; use one of: {allowed}')
+
+    if scope is None:
+        violations.append("scope is required, e.g. type(scope): subject")
+    else:
+        if scope == "":
+            violations.append("scope is empty; put a name inside the ()")
+        else:
+            if not SCOPE_RE.match(scope):
+                violations.append(
+                    f'scope "{scope}" must match ^[a-z0-9-]+$ '
+                    "(lowercase alphanumeric and hyphens)"
+                )
+            if len(scope) > MAX_SCOPE_LEN:
+                violations.append(
+                    f'scope "{scope}" is {len(scope)} chars; must be '
+                    f"≤{MAX_SCOPE_LEN}"
+                )
+            if scope.startswith("-") or scope.endswith("-"):
+                violations.append(
+                    f'scope "{scope}" must not start or end with a hyphen'
+                )
+            if scope in TYPES:
+                violations.append(
+                    f'scope "{scope}" must not be a commit type'
+                )
+
+    if subject == "":
+        violations.append("subject is empty")
+    else:
+        if not subject[0].isalnum():
+            violations.append(
+                f'subject must start with an alphanumeric char, not "{subject[0]}"'
+            )
+        if subject.endswith("."):
+            violations.append('subject must not end with a "."')
+        elif subject.endswith(" "):
+            violations.append("subject must not end with a space")
+
+    return violations
+
+
+def read_title(argv: list[str]) -> str:
+    """Get the title from argv (joined) or, if none given, from stdin."""
+    args = argv[1:]
+    if args:
+        return " ".join(args)
+    data = sys.stdin.read()
+    # Take the first non-empty line; a PR title is a single line.
+    for line in data.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return data.strip()
+
+
+def main(argv: list[str]) -> int:
+    title = read_title(argv)
+    if title == "":
+        print("error: no title provided (pass as an argument or on stdin)",
+              file=sys.stderr)
+        return 2
+
+    violations = check(title)
+    if not violations:
+        print(f"OK: {title}")
+        return 0
+
+    print(f"INVALID: {title}", file=sys.stderr)
+    for message in violations:
+        print(f"  - {message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/agents/preflight.sh
+++ b/scripts/agents/preflight.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+#
+# preflight.sh — the one-command pre-commit / pre-PR gate for hazma.
+#
+# This is the executable form of docs/agents/preflight.md. It runs the
+# mandatory gates in order, prints one PASS / FAIL / WARN / SKIP row per
+# gate, and exits non-zero if any first-class gate FAILs. WARN rows are
+# advisory (they never fail the run); SKIP rows mean the gate did not
+# apply to this invocation.
+#
+# Usage:
+#   scripts/agents/preflight.sh [--paths "hazma/spectra test/spectra"] \
+#       [--tests "test/spectra"] [--md "a.md b.md"] [--closing]
+#
+#   --paths "a b"    Space-separated files/dirs your diff touched. The
+#                    formatters and linters run against these. Defaults
+#                    to `hazma test` when omitted.
+#   --tests "a b"    Space-separated pytest targets. Defaults to `test`.
+#                    A run that collects ZERO tests FAILs the gate — a
+#                    green-but-nothing-ran run is a false pass.
+#   --md "a.md"      Also run `markdownlint --dot` on the given files
+#                    (pass the curated docs your diff changed).
+#   --closing        Also run the version-bump gate; pass this on a PR
+#                    that flips a project PLAN status to Complete.
+#
+# Gates, in order: black --check, isort --check-only, ruff check, pytest,
+# import smoke, markdownlint (with --md), version bump (with --closing),
+# and a forbidden-token scan of the diff against the trunk (WARN only).
+#
+# Design notes:
+#   - `set -uo pipefail` (NOT `-e`): every gate runs so the table is
+#     complete; the exit code is derived from the collected results.
+#   - Never pipe a gate through head/tail/grep in a way that masks its
+#     exit code — each gate's output is captured to a temp file and the
+#     bare exit status is read.
+#   - The repo root is anchored to this script's own location so the gate
+#     runs against the worktree that contains it, from any cwd.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}" || {
+    echo "error: cannot cd to repo root ${REPO_ROOT}" >&2
+    exit 2
+}
+
+# --------------------------------------------------------------------------
+# Arguments
+# --------------------------------------------------------------------------
+
+PATHS=""
+TESTS=""
+MD_FILES=""
+CLOSING=0
+
+usage() {
+    sed -n '3,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --paths)
+            [[ $# -ge 2 ]] || { echo "error: --paths needs a value" >&2; exit 2; }
+            PATHS="$2"; shift 2 ;;
+        --tests)
+            [[ $# -ge 2 ]] || { echo "error: --tests needs a value" >&2; exit 2; }
+            TESTS="$2"; shift 2 ;;
+        --md)
+            [[ $# -ge 2 ]] || { echo "error: --md needs a value" >&2; exit 2; }
+            MD_FILES="$2"; shift 2 ;;
+        --closing)
+            CLOSING=1; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "${PATHS}" ]] || PATHS="hazma test"
+[[ -n "${TESTS}" ]] || TESTS="test"
+
+# --------------------------------------------------------------------------
+# Result table
+# --------------------------------------------------------------------------
+
+ROWS=()
+HARD_FAIL=0
+TMPDIR_PF="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_PF}"' EXIT
+
+row() {
+    # row <status> <gate> <detail>
+    ROWS+=("$(printf '%-5s  %-22s  %s' "$1" "$2" "$3")")
+    [[ "$1" == "FAIL" ]] && HARD_FAIL=1
+    return 0
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Run a command, capture combined output, return its bare exit status.
+# Usage: capture <outfile> <cmd...>
+capture() {
+    local out="$1"; shift
+    "$@" >"${out}" 2>&1
+    return $?
+}
+
+tail_of() { tail -n 4 "$1" | sed 's/^/        /'; }
+
+# --------------------------------------------------------------------------
+# Trunk resolution (for diff-scoped gates)
+# --------------------------------------------------------------------------
+
+TRUNK="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
+    | sed 's#^origin/##')"
+[[ -n "${TRUNK}" ]] || TRUNK="master"
+BASE_REF="origin/${TRUNK}"
+git rev-parse --verify --quiet "${BASE_REF}" >/dev/null 2>&1 || BASE_REF="${TRUNK}"
+
+# --------------------------------------------------------------------------
+# Gate 1: black --check
+# --------------------------------------------------------------------------
+
+if have black; then
+    OUT="${TMPDIR_PF}/black.log"
+    # shellcheck disable=SC2086
+    capture "${OUT}" black --check ${PATHS}
+    if [[ $? -eq 0 ]]; then
+        row PASS "black --check" "${PATHS}"
+    else
+        row FAIL "black --check" "run \`black ${PATHS}\` and re-check"
+        tail_of "${OUT}"
+    fi
+else
+    row FAIL "black --check" "black not installed (pip install black)"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 2: isort --check-only
+# --------------------------------------------------------------------------
+
+if have isort; then
+    OUT="${TMPDIR_PF}/isort.log"
+    # shellcheck disable=SC2086
+    capture "${OUT}" isort --check-only ${PATHS}
+    if [[ $? -eq 0 ]]; then
+        row PASS "isort --check-only" "${PATHS}"
+    else
+        row FAIL "isort --check-only" "run \`isort ${PATHS}\` and re-check"
+        tail_of "${OUT}"
+    fi
+else
+    row WARN "isort --check-only" "isort not installed — import order unchecked"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 3: ruff check
+# --------------------------------------------------------------------------
+
+if have ruff; then
+    OUT="${TMPDIR_PF}/ruff.log"
+    # shellcheck disable=SC2086
+    capture "${OUT}" ruff check ${PATHS}
+    if [[ $? -eq 0 ]]; then
+        row PASS "ruff check" "${PATHS}"
+    else
+        row FAIL "ruff check" "see output below"
+        tail_of "${OUT}"
+    fi
+else
+    row WARN "ruff check" "ruff not installed — lint unchecked"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 4: pytest (with the zero-collection guard)
+# --------------------------------------------------------------------------
+
+if have pytest; then
+    OUT="${TMPDIR_PF}/pytest.log"
+    # shellcheck disable=SC2086
+    capture "${OUT}" pytest -q ${TESTS}
+    STATUS=$?
+    SUMMARY="$(grep -E '^(=+ )?[0-9]+ (passed|failed|error)' "${OUT}" | tail -n 1)"
+    [[ -n "${SUMMARY}" ]] || SUMMARY="$(tail -n 1 "${OUT}")"
+    if [[ ${STATUS} -eq 5 ]]; then
+        # pytest exit 5 == no tests collected. Green-looking, ran nothing.
+        row FAIL "pytest" "ZERO tests collected for '${TESTS}' — false green"
+    elif [[ ${STATUS} -eq 0 ]]; then
+        row PASS "pytest" "${SUMMARY}"
+    else
+        row FAIL "pytest" "${SUMMARY}"
+        tail_of "${OUT}"
+    fi
+else
+    row FAIL "pytest" "pytest not installed (pip install pytest)"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 5: import smoke — the compiled extensions still load
+# --------------------------------------------------------------------------
+
+OUT="${TMPDIR_PF}/import.log"
+capture "${OUT}" python -c "import hazma; print(hazma.__version__)"
+if [[ $? -eq 0 ]]; then
+    row PASS "import hazma" "version $(tr -d '\n' <"${OUT}")"
+else
+    row FAIL "import hazma" "package does not import — rebuild (pip install -e .)"
+    tail_of "${OUT}"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 6: markdownlint (only with --md)
+# --------------------------------------------------------------------------
+
+if [[ -n "${MD_FILES}" ]]; then
+    if have markdownlint; then
+        OUT="${TMPDIR_PF}/md.log"
+        # shellcheck disable=SC2086
+        capture "${OUT}" markdownlint --dot ${MD_FILES}
+        if [[ $? -eq 0 ]]; then
+            row PASS "markdownlint" "${MD_FILES}"
+        else
+            row FAIL "markdownlint" "see output below"
+            tail_of "${OUT}"
+        fi
+    else
+        row WARN "markdownlint" "markdownlint not installed — docs unchecked"
+    fi
+else
+    row SKIP "markdownlint" "no --md files given"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 7: version bump (only with --closing)
+# --------------------------------------------------------------------------
+
+if [[ ${CLOSING} -eq 1 ]]; then
+    # Read the version out of a file. Written as a standalone script (not a
+    # heredoc) because a heredoc claims stdin, which silently swallows a
+    # piped `git show` and makes the whole gate pass on an empty old value.
+    read_version() {
+        python -c '
+import re, sys
+try:
+    text = open(sys.argv[1], encoding="utf-8").read()
+except OSError:
+    sys.exit(1)
+m = re.search(r"VERSION\s*:\s*Final\[str\]\s*=\s*\"([^\"]+)\"", text)
+if not m:
+    sys.exit(1)
+print(m.group(1))
+' "$1"
+    }
+
+    OLD_FILE="${TMPDIR_PF}/old_init.py"
+    NEW_VER="$(read_version hazma/__init__.py)" || NEW_VER=""
+    if git show "${BASE_REF}:hazma/__init__.py" >"${OLD_FILE}" 2>/dev/null; then
+        OLD_VER="$(read_version "${OLD_FILE}")" || OLD_VER=""
+    else
+        OLD_VER=""
+    fi
+
+    if [[ -z "${NEW_VER}" ]]; then
+        row FAIL "version bump" "could not read VERSION from hazma/__init__.py"
+    elif [[ -z "${OLD_VER}" ]]; then
+        # No baseline means the comparison is vacuous — never report PASS.
+        row FAIL "version bump" \
+            "could not read VERSION from ${BASE_REF}:hazma/__init__.py — bump unverifiable"
+    elif [[ "${NEW_VER}" == "${OLD_VER}" ]]; then
+        row FAIL "version bump" "VERSION still ${OLD_VER} — closing PRs must bump it"
+    elif ! grep -q "\[${NEW_VER}\]" CHANGELOG.md 2>/dev/null; then
+        row FAIL "version bump" "no '## [${NEW_VER}]' section in CHANGELOG.md"
+    else
+        row PASS "version bump" "${OLD_VER} → ${NEW_VER} + CHANGELOG entry"
+    fi
+else
+    row SKIP "version bump" "not a closing PR (pass --closing)"
+fi
+
+# --------------------------------------------------------------------------
+# Gate 8: forbidden tokens in the diff (advisory)
+# --------------------------------------------------------------------------
+
+OUT="${TMPDIR_PF}/forbidden.log"
+git diff "${BASE_REF}" -- '*.py' '*.pyx' 2>/dev/null \
+    | grep -E '^\+' \
+    | grep -Ev '^\+\+\+' \
+    | grep -nE 'breakpoint\(\)|pdb\.set_trace|import pdb|XXX:|FIXME' \
+    >"${OUT}" 2>/dev/null
+if [[ -s "${OUT}" ]]; then
+    row WARN "forbidden tokens" "$(wc -l <"${OUT}" | tr -d ' ') hit(s) — resolve or justify"
+    tail_of "${OUT}"
+else
+    row PASS "forbidden tokens" "none added"
+fi
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+
+echo
+echo "preflight — ${REPO_ROOT} (base ${BASE_REF})"
+echo "-------------------------------------------------------------------"
+for line in "${ROWS[@]}"; do
+    echo "${line}"
+done
+echo "-------------------------------------------------------------------"
+
+if [[ ${HARD_FAIL} -eq 1 ]]; then
+    echo "RESULT: FAIL — blocked commit. Fix the red gates and re-run."
+    exit 1
+fi
+echo "RESULT: PASS"
+exit 0

--- a/scripts/agents/resolve_task.py
+++ b/scripts/agents/resolve_task.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Resolve the next actionable task for a project (flat or phased).
+
+Reads the live Tasks status table under ``projects/<slug>/`` and emits a
+single-line JSON object describing either the next unfinished task, the
+requested task, or a done/error state.
+
+Layouts handled:
+
+* Flat project: ``projects/<slug>/task-notes/README.md`` ``## Tasks`` table.
+* Phased project: the current phase is the lowest-numbered file under
+  ``projects/<slug>/phases/`` (ignoring ``_template.md``) whose frontmatter
+  ``status:`` is not ``Complete``; its table lives at
+  ``projects/<slug>/task-notes/phase-XX/README.md``. When every phase is
+  ``Complete`` the project itself is done.
+
+Without ``--task`` the lowest-numbered row whose Status is not terminal
+(Complete / Superseded / Dropped / Skipped — the full status vocabulary
+observed across ``projects/*/task-notes``) is chosen; if that row is
+``Blocked`` the script reports it rather than skipping ahead (a later task
+may depend on it) or starting it. With ``--task`` that exact row is
+returned — IDs compare as full normalized strings, so ``3`` and ``3a`` are
+distinct tasks.
+
+Output JSON keys: ``status`` (ready|done|blocked|error), ``task_id``,
+``task_title``, ``task_slug``, ``phase`` (or null), ``reason``.
+
+Exit codes: 0 when a task is resolved (status ready) or the project/phase
+is done (status done); 1 on a blocked next task (status blocked) or a
+resolvable-input error (status error); 2 on a usage/argument error
+(argparse). Run ``--self-test`` to exercise the parsing rules against
+representative task-table rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Status tokens that are terminal ("no longer actionable"). Derived from
+# the full status vocabulary in projects/*/task-notes tables: Complete,
+# Superseded, Dropped, Skipped are terminal; Not started / In Progress are
+# actionable; Blocked is non-actionable but NOT terminal (see BLOCKED_TOKENS).
+DONE_TOKENS = {"complete", "superseded", "dropped", "skipped"}
+
+# Non-terminal, non-startable: surfaced as status "blocked" instead of
+# being auto-selected or silently skipped (later tasks may depend on it).
+BLOCKED_TOKENS = {"blocked"}
+
+# Task-id shape: numeric core (1, 12, 1.2) + optional letter suffix (6c).
+# Used for SORTING only — exact --task matching compares normalized full
+# ids, so "3" and "3a" stay distinct.
+_ID_RE = re.compile(r"(\d+(?:\.\d+)*)\s*([a-z]*)", re.IGNORECASE)
+
+
+def repo_root() -> Path:
+    """Repo root, derived from this script's location (scripts/agents/x.py)."""
+    return Path(__file__).resolve().parents[2]
+
+
+def die(reason: str, *, phase: str | None = None) -> None:
+    """Emit an error JSON to stdout, a message to stderr, and exit 1."""
+    print(
+        json.dumps(
+            {
+                "status": "error",
+                "task_id": None,
+                "task_title": None,
+                "task_slug": None,
+                "phase": phase,
+                "reason": reason,
+            }
+        )
+    )
+    print(f"resolve_task: error: {reason}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def strip_md(text: str) -> str:
+    """Strip inline markdown emphasis/code/strikethrough from a cell."""
+    return text.replace("`", "").replace("*", "").replace("~", "").strip()
+
+
+def _status_head(status: str) -> str:
+    """First word of a status cell, sans annotations like ``(PR #537)``."""
+    cleaned = strip_md(status)
+    head = re.split(r"[(;]", cleaned, maxsplit=1)[0].strip()
+    return head.split()[0].lower() if head.split() else ""
+
+
+def status_is_done(status: str) -> bool:
+    """True when the status cell's leading word is a terminal token."""
+    return _status_head(status) in DONE_TOKENS
+
+
+def status_is_blocked(status: str) -> bool:
+    """True when the status cell's leading word marks the task Blocked."""
+    return _status_head(status) in BLOCKED_TOKENS
+
+
+def normalize_id(task_id: str) -> str:
+    """Normalize a task id for exact comparison.
+
+    ``Task 3`` → ``3``; ``**6c**`` → ``6c``; ``2.4`` → ``2.4``. Keeps the
+    letter suffix, so ``3`` and ``3a`` do NOT compare equal.
+    """
+    cleaned = strip_md(task_id).lower()
+    cleaned = re.sub(r"^task\s+", "", cleaned)
+    return cleaned.strip().rstrip(".")
+
+
+def parse_id_key(task_id: str) -> tuple[tuple[int, ...], str]:
+    """Sort key for a task id: (numeric tuple, lowercase letter suffix).
+
+    ``3`` → ``((3,), "")``; ``3a`` → ``((3,), "a")``; ``2.4`` →
+    ``((2, 4), "")``. Sorting only — never used for exact matching.
+    """
+    match = _ID_RE.search(task_id)
+    if not match:
+        return ((), "")
+    nums = tuple(int(part) for part in match.group(1).split("."))
+    return (nums, match.group(2).lower())
+
+
+def kebab(text: str) -> str:
+    """Lowercase kebab-case slug from arbitrary text."""
+    text = strip_md(text).lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
+
+def split_row(line: str) -> list[str]:
+    """Split a markdown table row into stripped cells (drop edge pipes)."""
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    return [cell.strip() for cell in line.split("|")]
+
+
+def is_separator(cells: list[str]) -> bool:
+    """A separator row is all cells like ``---`` / ``:--:``."""
+    return bool(cells) and all(
+        re.fullmatch(r":?-{1,}:?", cell) for cell in cells if cell != ""
+    ) and any(cell for cell in cells)
+
+
+class Task:
+    def __init__(self, task_id: str, title: str, status: str, note: str) -> None:
+        self.id = task_id
+        self.title = title
+        self.status = status
+        self.note = note
+
+    @property
+    def sort_key(self) -> tuple[tuple[int, ...], str]:
+        return parse_id_key(self.id)
+
+    @property
+    def done(self) -> bool:
+        return status_is_done(self.status)
+
+    @property
+    def blocked(self) -> bool:
+        return status_is_blocked(self.status)
+
+    @property
+    def slug(self) -> str:
+        note = strip_md(self.note)
+        if note.endswith(".md"):
+            note = note[: -len(".md")]
+        # Note filename (e.g. task-1-group-taxonomy) already is the slug.
+        if note.startswith("task-"):
+            return note
+        # Fallback: synthesize from id + title.
+        return f"task-{self.id}-{kebab(self.title)}".rstrip("-")
+
+
+def find_tasks_table(text: str, source: Path) -> list[Task]:
+    """Parse the ``## Tasks`` markdown table from a task-notes README."""
+    lines = text.splitlines()
+
+    # Locate the "## Tasks" heading.
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(r"^#{1,6}\s+Tasks\s*$", line.strip()):
+            start = i + 1
+            break
+    if start is None:
+        die(f"no '## Tasks' heading in {source}")
+
+    # Find the header row (first table-looking line after the heading).
+    header_idx = None
+    for i in range(start, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("|"):
+            cells = split_row(stripped)
+            if not is_separator(cells):
+                header_idx = i
+                break
+        # Stop if we hit the next section before any table.
+        if stripped.startswith("#") and i > start:
+            break
+    if header_idx is None:
+        die(f"no task table under '## Tasks' in {source}")
+
+    header = split_row(lines[header_idx])
+    col = {name.lower(): idx for idx, name in enumerate(header)}
+
+    def find_col(*candidates: str) -> int | None:
+        for cand in candidates:
+            for name, idx in col.items():
+                if name == cand or cand in name:
+                    return idx
+        return None
+
+    id_col = find_col("#", "id")
+    status_col = find_col("status")
+    title_col = find_col("task")
+    note_col = find_col("task note", "note")
+
+    if id_col is None or status_col is None:
+        die(f"task table missing '#' or 'Status' column in {source}")
+
+    tasks: list[Task] = []
+    for i in range(header_idx + 1, len(lines)):
+        stripped = lines[i].strip()
+        if not stripped.startswith("|"):
+            # Blank line or prose ends the table.
+            if stripped == "":
+                break
+            continue
+        cells = split_row(lines[i])
+        if is_separator(cells):
+            continue
+
+        def cell(idx: int | None) -> str:
+            if idx is None or idx >= len(cells):
+                return ""
+            return cells[idx]
+
+        raw_id = strip_md(cell(id_col))
+        if not parse_id_key(raw_id)[0]:
+            # Not a real task row (e.g. a continuation / stray line).
+            continue
+        tasks.append(
+            Task(
+                task_id=raw_id,
+                title=strip_md(cell(title_col)),
+                status=cell(status_col),
+                note=cell(note_col),
+            )
+        )
+
+    return tasks
+
+
+def phase_status(phase_file: Path) -> str:
+    """Read the ``status:`` value from a phase file's YAML frontmatter."""
+    text = phase_file.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        m = re.match(r"\s*status\s*:\s*(.+?)\s*$", line)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def resolve_phase(project_dir: Path) -> tuple[str | None, Path | None]:
+    """Return (phase_number, task_notes_readme) for the current phase.
+
+    ``(None, None)`` means every phase is Complete (project done).
+    """
+    phases_dir = project_dir / "phases"
+    phase_files = sorted(
+        p
+        for p in phases_dir.glob("phase-*.md")
+        if p.name != "_template.md"
+    )
+    if not phase_files:
+        die(f"phased project has no phase files under {phases_dir}")
+
+    def phase_num(p: Path) -> tuple[int, ...]:
+        m = re.search(r"phase-(\d+)", p.name)
+        return (int(m.group(1)),) if m else ()
+
+    phase_files.sort(key=phase_num)
+
+    for phase_file in phase_files:
+        status = phase_status(phase_file)
+        if status.lower() != "complete":
+            m = re.search(r"phase-(\d+)", phase_file.name)
+            num = m.group(1) if m else phase_file.stem
+            readme = project_dir / "task-notes" / f"phase-{num}" / "README.md"
+            if not readme.is_file():
+                die(
+                    f"phase {num} task-notes README not found: {readme}",
+                    phase=num,
+                )
+            return num, readme
+
+    # All phases complete.
+    return None, None
+
+
+def emit(task: Task, phase: str | None) -> None:
+    if task.done:
+        status = "done"
+        reason = f"task {task.id} already {strip_md(task.status).lower()}"
+    elif task.blocked:
+        status = "blocked"
+        reason = (
+            f"task {task.id} is Blocked — resolve the blocker (see its "
+            f"task note) or pick a different task explicitly"
+        )
+    else:
+        status = "ready"
+        reason = f"next actionable task: {task.id}"
+    print(
+        json.dumps(
+            {
+                "status": status,
+                "task_id": task.id,
+                "task_title": task.title,
+                "task_slug": task.slug,
+                "phase": phase,
+                "reason": reason,
+            }
+        )
+    )
+    if status == "blocked":
+        print(f"resolve_task: blocked: {reason}", file=sys.stderr)
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+
+def emit_done(phase: str | None, reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "status": "done",
+                "task_id": None,
+                "task_title": None,
+                "task_slug": None,
+                "phase": phase,
+                "reason": reason,
+            }
+        )
+    )
+    raise SystemExit(0)
+
+
+def self_test() -> None:
+    """Pin parsing rules against representative task-table row shapes.
+
+    The rows mirror real tables (lsp-code-actions' struck-through Dropped
+    row, lsp-assist-rules' 3a-before-3 ordering, annotated Complete cells)
+    so regressions in status/id handling fail here, not mid-pipeline.
+    """
+    # Status classification — full observed vocabulary.
+    assert status_is_done("Complete")
+    assert status_is_done("**Complete** (2026-06-06; PR #537)")
+    assert status_is_done("Superseded")
+    assert status_is_done("Dropped")
+    assert status_is_done("~~Skipped~~")
+    assert not status_is_done("Not started")
+    assert not status_is_done("In Progress")
+    assert not status_is_done("Blocked")
+    assert status_is_blocked("Blocked (waiting on ADR-0002)")
+    assert not status_is_blocked("Not started")
+
+    # Exact id matching — suffixes are significant.
+    assert normalize_id("3") != normalize_id("3a")
+    assert normalize_id("Task 3") == normalize_id("3")
+    assert normalize_id("**6c**") == "6c"
+    assert normalize_id("2.4") == "2.4"
+
+    # Sorting — numeric core first, then letter suffix.
+    ids = ["3a", "1", "2.4", "3", "10", "2"]
+    ordered = sorted(ids, key=parse_id_key)
+    assert ordered == ["1", "2", "2.4", "3", "3a", "10"], ordered
+
+    # Full-table parse over representative row shapes.
+    table = """\
+## Tasks
+
+| #  | Task                                  | Deps | Status      | Task note |
+|----|---------------------------------------|------|-------------|-----------|
+| 1  | Group taxonomy                        | —    | Complete (PR #631) | task-1-group-taxonomy.md |
+| 2  | Rule scaffolding                      | 1    | Blocked     | task-2-rule-scaffolding.md |
+| 3a | `resolve_source_member_set` API       | —    | Not started | task-3a-resolve-source-members.md |
+| 3  | Collapse-to-wildcard rule             | 2,3a | Not started | task-3-collapse-to-wildcard.md |
+| 6c | ~~Measure perf gate~~ (DROPPED)       | 6b   | Dropped     | (folded into 6b note) |
+"""
+    tasks = find_tasks_table(table, Path("<self-test>"))
+    by_id = {t.id: t for t in tasks}
+    assert len(tasks) == 5, [t.id for t in tasks]
+    assert by_id["6c"].done, "Dropped must be terminal"
+    assert by_id["2"].blocked and not by_id["2"].done
+    # Exact matching keeps 3 and 3a distinct.
+    assert [t.id for t in tasks if normalize_id(t.id) == "3"] == ["3"]
+    # Sorted order is by id (3 before 3a), regardless of table order; the
+    # first non-done task is the Blocked task 2 — surfaced, never skipped.
+    ordered_tasks = sorted(tasks, key=lambda t: t.sort_key)
+    assert [t.id for t in ordered_tasks] == ["1", "2", "3", "3a", "6c"]
+    first_open = next(t for t in ordered_tasks if not t.done)
+    assert first_open.id == "2" and first_open.blocked
+
+    print("self-test: all assertions passed")
+    raise SystemExit(0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Resolve the next actionable task for a project.",
+    )
+    parser.add_argument("--project", help="project slug")
+    parser.add_argument("--task", help="specific task id (e.g. 5, 1.2, 3a)")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the built-in parsing assertions and exit",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+    if not args.project:
+        parser.error("--project is required (unless running --self-test)")
+
+    project_dir = repo_root() / "projects" / args.project
+    if not project_dir.is_dir():
+        die(f"project not found: {project_dir}")
+
+    phases_dir = project_dir / "phases"
+    phased = phases_dir.is_dir() and any(
+        p.name != "_template.md" for p in phases_dir.glob("phase-*.md")
+    )
+
+    if phased:
+        phase_num, readme = resolve_phase(project_dir)
+        if phase_num is None or readme is None:
+            emit_done(None, "all phases complete")
+    else:
+        phase_num = None
+        readme = project_dir / "task-notes" / "README.md"
+        if not readme.is_file():
+            die(f"task-notes README not found: {readme}")
+
+    tasks = find_tasks_table(readme.read_text(encoding="utf-8"), readme)
+    if not tasks:
+        die(f"no task rows parsed from {readme}", phase=phase_num)
+
+    if args.task is not None:
+        want = normalize_id(args.task)
+        if not want:
+            die(f"unparseable task id: '{args.task}'", phase=phase_num)
+        matches = [t for t in tasks if normalize_id(t.id) == want]
+        if not matches:
+            die(f"task '{args.task}' not found in {readme}", phase=phase_num)
+        emit(matches[0], phase_num)
+
+    tasks.sort(key=lambda t: t.sort_key)
+    for task in tasks:
+        if not task.done:
+            emit(task, phase_num)
+
+    emit_done(phase_num, "all tasks complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agents/setup_task_worktree.sh
+++ b/scripts/agents/setup_task_worktree.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# setup_task_worktree.sh — create a fresh task worktree branched off the
+# trunk branch for an agent-driven task.
+#
+# This is the deterministic worktree-creation step for the task-pipeline
+# and execute-single-task skills. It always fetches origin, always
+# branches from origin/<trunk> (never from the ambient HEAD, which may be a
+# stale or unrelated checkout), picks a collision-free branch/worktree
+# name, and verifies the new worktree's HEAD matches origin/<trunk> before
+# reporting success.
+#
+# Usage:
+#   scripts/agents/setup_task_worktree.sh \
+#     --project <slug> --task-slug <slug> [--agent claude|codex] \
+#     [--trunk <branch>]
+#
+#   --project     project slug (e.g. lsp-inlay-hints)
+#   --task-slug   task slug (e.g. task-3-refresh)
+#   --agent       claude (default) or codex; selects the branch prefix
+#                 and the .{claude,codex}/worktrees/ base directory
+#   --trunk       trunk branch to branch from; defaults to origin's
+#                 default branch, falling back to 'master'
+#
+# On success prints a single line of JSON to stdout:
+#   {"branch":"…","wt_path":"<absolute>","head_sha":"…"}
+#
+# All diagnostics go to stderr; a non-zero exit indicates failure and no
+# JSON is printed.
+
+set -uo pipefail
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+# --- Argument parsing -------------------------------------------------
+
+PROJECT=""
+TASK_SLUG=""
+AGENT="claude"
+TRUNK=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project)
+            [[ $# -ge 2 ]] || die "--project requires a value"
+            PROJECT="$2"
+            shift 2
+            ;;
+        --task-slug)
+            [[ $# -ge 2 ]] || die "--task-slug requires a value"
+            TASK_SLUG="$2"
+            shift 2
+            ;;
+        --agent)
+            [[ $# -ge 2 ]] || die "--agent requires a value"
+            AGENT="$2"
+            shift 2
+            ;;
+        --trunk)
+            [[ $# -ge 2 ]] || die "--trunk requires a value"
+            TRUNK="$2"
+            shift 2
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ -n "$PROJECT" ]] || die "--project is required"
+[[ -n "$TASK_SLUG" ]] || die "--task-slug is required"
+
+case "$AGENT" in
+    claude|codex) ;;
+    *) die "--agent must be 'claude' or 'codex' (got: $AGENT)" ;;
+esac
+
+# --- Repo root --------------------------------------------------------
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || die "not inside a git repository"
+
+# --- Fetch ------------------------------------------------------------
+
+git -C "$REPO_ROOT" fetch origin \
+    || die "git fetch origin failed"
+
+# --- Trunk resolution -------------------------------------------------
+
+if [[ -z "$TRUNK" ]]; then
+    # origin/HEAD -> refs/remotes/origin/<trunk>, when the symref exists.
+    TRUNK="$(git -C "$REPO_ROOT" symbolic-ref --quiet --short \
+        refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+fi
+[[ -n "$TRUNK" ]] || TRUNK="master"
+
+git -C "$REPO_ROOT" rev-parse --verify --quiet "origin/${TRUNK}" >/dev/null \
+    || die "origin/${TRUNK} not found after fetch"
+
+# --- Collision-free branch / worktree name ----------------------------
+
+# Does a branch (local ref or remote ref) already exist?
+branch_exists() {
+    local branch="$1"
+    if git -C "$REPO_ROOT" show-ref --verify --quiet \
+        "refs/heads/${branch}"; then
+        return 0
+    fi
+    if git -C "$REPO_ROOT" ls-remote --exit-code --heads origin \
+        "$branch" >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+BASE_BRANCH="${AGENT}/${PROJECT}/${TASK_SLUG}"
+WT_BASE="${REPO_ROOT}/.${AGENT}/worktrees/${PROJECT}"
+
+FINAL_SLUG="$TASK_SLUG"
+BRANCH="$BASE_BRANCH"
+WT_PATH="${WT_BASE}/${FINAL_SLUG}"
+
+# The initial candidate has no numeric suffix; collisions try -2..-9.
+if branch_exists "$BRANCH" || [[ -e "$WT_PATH" ]]; then
+    found=""
+    for n in 2 3 4 5 6 7 8 9; do
+        FINAL_SLUG="${TASK_SLUG}-${n}"
+        BRANCH="${AGENT}/${PROJECT}/${FINAL_SLUG}"
+        WT_PATH="${WT_BASE}/${FINAL_SLUG}"
+        if ! branch_exists "$BRANCH" && [[ ! -e "$WT_PATH" ]]; then
+            found="yes"
+            break
+        fi
+    done
+    [[ -n "$found" ]] \
+        || die "no free branch/worktree name for ${BASE_BRANCH} (-2..-9 all taken)"
+fi
+
+# --- Create the worktree ----------------------------------------------
+
+mkdir -p "$WT_BASE" || die "could not create ${WT_BASE}"
+
+# Redirect git's progress/tracking chatter to stderr so stdout carries
+# only the final JSON line.
+git -C "$REPO_ROOT" worktree add "$WT_PATH" -b "$BRANCH" "origin/${TRUNK}" 1>&2 \
+    || die "git worktree add failed for ${WT_PATH}"
+
+# Absolute, normalized worktree path.
+WT_PATH_ABS="$(cd "$WT_PATH" && pwd)" \
+    || die "created worktree ${WT_PATH} is not accessible"
+
+# --- Verify HEAD == origin/<trunk> ------------------------------------
+
+HEAD_SHA="$(git -C "$WT_PATH_ABS" rev-parse HEAD)" \
+    || die "could not read HEAD of ${WT_PATH_ABS}"
+TRUNK_SHA="$(git -C "$REPO_ROOT" rev-parse "origin/${TRUNK}")" \
+    || die "could not read origin/${TRUNK}"
+
+if [[ "$HEAD_SHA" != "$TRUNK_SHA" ]]; then
+    die "worktree HEAD (${HEAD_SHA}) != origin/${TRUNK} (${TRUNK_SHA})"
+fi
+
+# --- Report -----------------------------------------------------------
+
+printf '{"branch":"%s","wt_path":"%s","head_sha":"%s"}\n' \
+    "$BRANCH" "$WT_PATH_ABS" "$HEAD_SHA"

--- a/test/agents/test_resolve_phase.py
+++ b/test/agents/test_resolve_phase.py
@@ -1,0 +1,165 @@
+"""Regression tests for `.claude/skills/begin-phase/scripts/resolve_phase.py`.
+
+The agent-workflow helpers are not importable as a package (they live under
+`.claude/` and `scripts/`, outside `hazma`), so they are loaded by path.
+
+The bug these guard: `build_prompt` used to interpolate the *canonical* phase
+id into filesystem paths. `phase_id_from_prefix("02")` normalizes to `"2"`, so
+a `phase-02-*.md` phase file produced a kickoff prompt pointing at
+`task-notes/phase-2/README.md` while the template and
+`scripts/agents/resolve_task.py` both use `task-notes/phase-02/README.md`.
+The next agent was sent to a directory that does not exist.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=Path(__file__).parent,
+    ).stdout.strip()
+)
+
+SCRIPT = REPO_ROOT / ".claude/skills/begin-phase/scripts/resolve_phase.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("resolve_phase", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["resolve_phase"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pytestmark = pytest.mark.skipif(
+    not SCRIPT.is_file(), reason=f"{SCRIPT} not present"
+)
+
+
+@pytest.fixture(scope="module")
+def resolve_phase():
+    return _load_module()
+
+
+def _scaffold(tmp_path: Path, prefix: str, slug: str = "demo") -> Path:
+    """Create a minimal phased project whose phase file uses `prefix`."""
+    project = tmp_path / "projects" / slug
+    (project / "phases").mkdir(parents=True)
+    (project / "task-notes" / f"phase-{prefix}").mkdir(parents=True)
+    (project / "learnings").mkdir(parents=True)
+
+    (project / "PLAN.md").write_text(
+        "---\nstatus: In Progress\nphased: true\nversion_bump: patch\n---\n\n"
+        "# Project: Demo\n"
+    )
+    (project / "phases" / f"phase-{prefix}-kernels.md").write_text(
+        f"---\nphase: {prefix}\ntitle: Kernels\nstatus: Not started\n---\n\n"
+        f"# Phase {prefix}: Kernels\n\n"
+        "## Prerequisites\n\n- None.\n\n"
+        "## Tasks\n\n### Task 1.1: Build it\n\n"
+        "**Exit criteria:**\n\n- green\n"
+    )
+    (project / "task-notes" / f"phase-{prefix}" / "README.md").write_text(
+        "# Working Memory\n\n## Tasks\n\n"
+        "| # | Task | Depends on | Status | Task Note |\n"
+        "|---|------|------------|--------|-----------|\n"
+        "| 1.1 | Build it | — | Not started | `task-1.1-build.md` |\n"
+    )
+    return project
+
+
+def test_phase_id_normalization_drops_zero_padding(resolve_phase):
+    """The canonical id is unpadded -- this is what makes the bug possible."""
+    assert resolve_phase.phase_id_from_prefix("02") == "2"
+    assert resolve_phase.phase_id_from_prefix("2") == "2"
+    assert resolve_phase.phase_id_from_prefix("10") == "10"
+
+
+@pytest.mark.parametrize("prefix", ["01", "02", "09", "10"])
+def test_prompt_paths_use_the_filename_prefix(resolve_phase, tmp_path, prefix):
+    """Kickoff-prompt paths must match the on-disk directory, zero-padding
+    included -- not the normalized display id."""
+    project = _scaffold(tmp_path, prefix)
+    phases = resolve_phase.load_phase_records(project)
+    phase_id = resolve_phase.phase_id_from_prefix(prefix)
+
+    prompt = resolve_phase.build_prompt(
+        project_slug="demo",
+        project_dir=project,
+        repo_root=tmp_path,
+        phases=phases,
+        phase_id=phase_id,
+    )
+
+    expected = f"task-notes/phase-{prefix}/README.md"
+    assert prompt.count(expected) == 2, (
+        f"expected both per-phase README references to use {expected!r}\n"
+        f"prompt was:\n{prompt}"
+    )
+
+    # And the directory the prompt names must actually exist on disk.
+    assert (project / "task-notes" / f"phase-{prefix}" / "README.md").is_file()
+
+    # The normalized id must never appear as a path segment when it differs
+    # from the padded prefix (this is the exact regression).
+    if phase_id != prefix:
+        assert f"task-notes/phase-{phase_id}/" not in prompt
+
+
+def test_prompt_still_uses_the_canonical_id_for_display(
+    resolve_phase, tmp_path
+):
+    """Display text keeps the unpadded id -- 'Phase 2', not 'Phase 02'."""
+    project = _scaffold(tmp_path, "02")
+    phases = resolve_phase.load_phase_records(project)
+
+    prompt = resolve_phase.build_prompt(
+        project_slug="demo",
+        project_dir=project,
+        repo_root=tmp_path,
+        phases=phases,
+        phase_id="2",
+    )
+
+    assert "You are starting Phase 2: Kernels" in prompt
+    assert "Work only within Phase 2." in prompt
+
+
+@pytest.mark.parametrize("prefix", ["01", "02", "09", "10"])
+def test_resolve_task_agrees_on_the_phase_directory(tmp_path, prefix):
+    """The two helpers must derive the same per-phase directory, or a
+    begin-phase handoff points somewhere resolve_task cannot read.
+
+    `resolve_task.resolve_phase()` is called directly rather than through the
+    CLI: the CLI locates the project via `git rev-parse`, so it would look
+    under the real repo rather than `tmp_path`.
+    """
+    resolver_path = REPO_ROOT / "scripts/agents/resolve_task.py"
+    if not resolver_path.is_file():
+        pytest.skip(f"{resolver_path} not present")
+
+    spec = importlib.util.spec_from_file_location("resolve_task", resolver_path)
+    assert spec is not None and spec.loader is not None
+    resolve_task = importlib.util.module_from_spec(spec)
+    sys.modules["resolve_task"] = resolve_task
+    spec.loader.exec_module(resolve_task)
+
+    project = _scaffold(tmp_path, prefix)
+    num, readme = resolve_task.resolve_phase(project)
+
+    # This is the shared convention: the directory name carries the phase
+    # filename's digits, zero-padding included.
+    assert num == prefix
+    assert readme == project / "task-notes" / f"phase-{prefix}" / "README.md"
+    assert readme.is_file()


### PR DESCRIPTION
## Summary

- Adopts the project-scoped agent workflow from the `rover` repo, adapted for a scientific Python package: an `AGENTS.md` contract, a `projects/<slug>/` planning tree, a shared `docs/agents/` invariant layer, deterministic helper scripts, and 8 `.claude/skills/` workflow skills.
- **Adapted, not copied.** The reviewer roster gains a `numerics` lens running on Opus at high reasoning effort — in a physics library, "did a published value move?" is the hardest judgment and the one worth the strongest model. Rover's Rust/LSP-specific lenses, gates, and scope tables are replaced with Python/Cython equivalents.
- **A numerical-impact contract runs end to end.** `PLAN.md` declares expected impact, the working-memory README logs it per task, the implementer must measure before/after on a real grid, the pipeline reports it as a required field, reviewers may only reject a numerics finding with pasted numbers, and `docs/versioning.md` makes a moved published value `minor` rather than `patch` — even when tests stay green because a tolerance absorbed the shift.
- **No library code is touched.** Nothing under `hazma/` or `test/` changes; `git diff --stat origin/master -- hazma test` is empty.

## Numerical impact

None — no public code path is touched. Verified:

```
$ git diff --stat origin/master -- hazma test
(no output)
```

## What's here

| Area | Contents |
|---|---|
| Repo contract | `AGENTS.md` (layout, one-way layering, commands, conventions, numerical correctness); `CLAUDE.md` → `@AGENTS.md` |
| Process docs | `docs/workflow.md`, `docs/PR_GUIDELINES.md`, `docs/versioning.md`, `CHANGELOG.md` (seeded at the 2.0.2 baseline) |
| Shared agent layer | `docs/agents/` — preflight gate, doc-consistency checklist, reviewer roster/lenses, environment gotchas, lessons ledger (empty by design) |
| Decision + backlog | `docs/adrs/`, `docs/followups/{todo,done}/` |
| Planning tree | `projects/README.md`, `projects/_template/` |
| Helper scripts | `scripts/agents/` — `preflight.sh`, `resolve_task.py`, `setup_task_worktree.sh`, `check_pr_title.py`, `check_doc_citations.py` |
| Skills | `.claude/skills/` — execute-single-task, commit-and-pr, review-pr, review-respond, review-cycle, task-pipeline, begin-phase, review-plan |

Repo-specific adaptations worth calling out:

- `preflight.sh` runs black/isort/ruff/pytest **plus an import smoke** — a `.pyx` edit that was never rebuilt lints and formats clean and then fails at import, so the smoke is the gate that catches it. It also treats pytest exit 5 (zero collected) as a FAIL rather than a pass.
- Helper scripts resolve the trunk from `origin/HEAD` with a `master` fallback, so nothing assumes `main`.
- `check_doc_citations.py` retargeted from `.rs` to `.py`/`.pyx`/`.pxd`.
- `docs/agents/environment.md` records that `test/conftest.py` excludes `test/decay/` and `test_gamma_ray.py` from a bare `pytest`, and that CI's flake8 pass is advisory (`--exit-zero`) rather than a lint gate.

## .gitignore change

`scripts/` was blanket-ignored with nothing tracked under it, so the new helpers could never have been committed. Narrowed to `scripts/*` + `!scripts/agents/` — every path that was ignored before is still ignored. Also added `.claude/worktrees/` and `.claude/settings.local.json` (agent-local state) while keeping `.claude/skills/` tracked.

## Test plan

**This environment has no dev tooling installed, so the lint/test gates could not run.** Reporting that plainly rather than claiming a green I did not get:

```
$ ./scripts/agents/preflight.sh
FAIL   black --check           black not installed (pip install black)
WARN   isort --check-only      isort not installed — import order unchecked
WARN   ruff check              ruff not installed — lint unchecked
FAIL   pytest                  pytest not installed (pip install pytest)
PASS   import hazma            version 2.0.2
SKIP   markdownlint            no --md files given
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
RESULT: FAIL — blocked commit.
```

Both FAIL rows are missing-tool rows, and this diff changes zero files those tools would check. What I could verify, I did:

- [x] All 5 shipped Python files compile — `python3 -m py_compile scripts/agents/*.py .claude/skills/begin-phase/scripts/resolve_phase.py`
- [x] Both shell scripts parse — `bash -n scripts/agents/*.sh`
- [x] `resolve_task.py` end-to-end on a scaffolded **flat** project → `{"status": "ready", "task_id": "2", "task_slug": "task-2-pion", ...}`; on a pinned complete task → `{"status": "done", ...}`
- [x] `resolve_phase.py` end-to-end on a scaffolded **phased** project → `status: ready` with a kickoff prompt; on a flat project → `status: error` (correctly refuses)
- [x] `preflight.sh --closing` across all three version-bump states: unchanged VERSION → `FAIL … still 2.0.2`; bumped without a CHANGELOG section → `FAIL … no '## [2.1.0]' section`; both present → `PASS 2.0.2 → 2.1.0`. Repo restored afterward.
- [x] `check_pr_title.py` validates this PR's title
- [x] Every relative markdown link across all 34 new docs resolves (script-checked; the only misses are `<slug>` placeholders inside `_template.md` files)
- [x] Layering claims in `AGENTS.md` verified against the source, not inferred — `theory/` imports `parameters` and not `spectra`; models import `theory`; no `.pyx` kernel imports a pure-Python `hazma` module

Found and fixed one real bug during that verification: `preflight.sh`'s version gate used a heredoc that claimed stdin, silently swallowing the piped `git show` and scoring **PASS** on an empty baseline. A missing baseline is now an explicit FAIL.

## Reviewer notes

- `docs/agents/lessons.md` ships empty on purpose — it carries a "cite a real PR or don't add an entry" rule, so seeding it with invented lessons would defeat it.
- `docs/agents/environment.md` is seeded from what the layout and CI config make verifiable; it's meant to grow as traps are hit.
- Agent docs live in `docs/` alongside the Sphinx tree. Sphinx only builds `docs/source/`, so they're siblings, not a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Rebased onto master (2026-08-02)

Rebased from `a2aca4a` onto `64218b4`, picking up 7 commits including the CI overhaul (#16, #17). Clean rebase, no conflicts — master touched only `hazma/`, CI config, and packaging; this PR touches only docs, `projects/`, `scripts/agents/`, `.claude/`, and `test/agents/`. Verified the 44 files came through byte-identically (`git diff 21ea6bd HEAD -- <my paths>` empty) with exec bits intact.

**CI is now green** — Lint, and Test on ubuntu 3.10/3.11/3.12 + macos 3.12. The flake8 `F824` failure reported earlier is gone: master replaced flake8 with `ruff check --isolated --select E9,F63,F7,F82`, which does not flag those `global` statements. No action needed, and the earlier "CI is red" note has been removed as stale.

### Docs corrected as a consequence

The CI overhaul invalidated five factual claims this PR made, so `61bf360` fixes them:

| Claim | Was | Now |
|---|---|---|
| `environment.md` lint gate | two flake8 passes in `python-package.yml`, second `--exit-zero` | one blocking `ruff check --isolated --select E9,F63,F7,F82` |
| `environment.md` matrix | "CI tests 3.9 and 3.10 vs a >=3.10 floor — they disagree" | matrix is 3.10/3.11/3.12; the mismatch no longer exists |
| `preflight.md` | "CI's flake8 is deliberately permissive" | describes the ruff gate + the new import smoke test |
| `commit-and-pr` | "CI's flake8 pass is advisory" | "CI's lint pass is narrow … no formatting check at all" |
| `AGENTS.md` | exclusion attributed to flake8 | attributed to the ruff step's `--exclude` flags |

Swept for the class rather than point-fixing the cited lines: no `flake8`, `python-package.yml`, `exit-zero`, or `3.9` reference survives anywhere under `AGENTS.md`, `docs/`, or `.claude/skills/`, and each new `ci.yml` claim was re-verified against the file.

Two properties are now documented that the old text missed, both live traps: `--isolated` means CI **ignores** `[tool.ruff]` in `pyproject.toml`, so a bare local `ruff check` is *stricter* than the gate; and there is **no formatting check in CI at all**, so `black` sits in the preflight gate but not CI — reformatting untouched files silently attaches an 85-file diff to a one-line change.

## Review fixes (`e3165e5`)

Both findings were confirmed against the code and fixed.

**[P1] Phase handoff used the normalized id in filesystem paths.** `phase_id_from_prefix("02")` → `"2"`, so `build_prompt` emitted `task-notes/phase-2/README.md` while `resolve_task.resolve_phase()` and the template both use `phase-02/`. Fixed by binding `dir_prefix = record.prefix.lower()` and using it for both path interpolations, with a comment stating the display-vs-path split so it isn't reintroduced. Display text still reads "Phase 2".

Regression test added at `test/agents/test_resolve_phase.py`, parametrized over `01/02/09/10`, asserting both path references, that the named directory exists, that the normalized id never appears as a path segment, and that `resolve_task.resolve_phase()` independently derives the same padded directory. **Verified discriminating**: replayed against the pre-fix `build_prompt`, the padded path occurs 0 times where the test requires 2, so it fails without the fix.

**[P2] `check_pr_title.py` cited infrastructure that doesn't exist here.** The docstring claimed to mirror `.github/workflows/pr_linter.yaml` and a `10XDev/pull-request-linter-action` — both artifacts of the upstream repo this was ported from, present in neither this PR nor this repository. Rewritten to describe it accurately as a local validator derived from `docs/PR_GUIDELINES.md`, and `PR_GUIDELINES.md` now states plainly that no workflow enforces the title, so a green CI run says nothing about it.

Both were logged to `docs/agents/lessons.md` as classes, per that file's cite-a-real-PR rule: `[ported-file-stale-reference]` and `[normalized-id-in-path]`.
