### PR TITLE
fix(compat): migrate off NumPy 2.0 and SciPy 1.14/1.15 removed APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
@@ -55,8 +55,6 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Build and install hazma
-        # Runtime pins (numpy < 2, scipy < 1.14) come from pyproject.toml;
-        # numpy < 2 is also why the matrix stops at Python 3.12.
         run: |
           python -m pip install --upgrade pip
           python -m pip install -v .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.1
         env:
-          # hazma still requires numpy < 2 at runtime (np.trapz,
-          # scipy.integrate.trapz/simps), which caps wheels at CPython 3.12.
-          CIBW_BUILD: "cp310-* cp311-* cp312-*"
-          # scipy < 1.14 ships no musllinux or i686 wheels, so testing there
-          # would compile scipy from source; not worth the build time.
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          # scipy ships no musllinux wheels, so testing there would compile
+          # scipy from source; not worth the build time.
           CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "arm64"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ include hazma/relic_density/*.dat
 include hazma/spectra/_photon/data/*.csv
 include hazma/spectra/_positron/data/*.csv
 include hazma/spectra/_neutrino/data/*.csv
+include hazma/limits/data/*.dat

--- a/hazma/_utils/boost.pyx
+++ b/hazma/_utils/boost.pyx
@@ -263,7 +263,7 @@ cdef double boost_integrate_linear_interp(double photon_energy, double beta, np.
             ihigh = ihigh - 1
 
     if ilow < ihigh:
-        integral += np.trapz(yy[ilow:ihigh], x=x[ilow:ihigh])
+        integral += np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])
 
     # Handle edges
     if ilow > 0 and fabs(x[ilow] - lb) > 1e-6:

--- a/hazma/parameters.py
+++ b/hazma/parameters.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 import numpy as np
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 from scipy.interpolate import InterpolatedUnivariateSpline, interp1d
 
 """
@@ -525,7 +525,7 @@ def convolved_spectrum_fn(
                 # further normalization is applied here; doing so would not
                 # conserve the total number of photons.
                 response = spec_res_fn(e, es_padded, energy_res)
-                return trapz(dnde_src * response, es_padded)
+                return trapezoid(dnde_src * response, es_padded)
 
             dnde_conv += np.vectorize(integral)(es)
 

--- a/hazma/phase_space/_dist.py
+++ b/hazma/phase_space/_dist.py
@@ -101,7 +101,7 @@ class PhaseSpaceDistribution1D(AbstractPhaseSpaceDistribution):
         else:
             integrands = ps * fs
 
-        expvals = method(integrands, xs, axis=0)
+        expvals = method(integrands, x=xs, axis=0)
         return expvals
 
     def _expect_quad(self, fn) -> RealArray:
@@ -134,8 +134,8 @@ class PhaseSpaceDistribution1D(AbstractPhaseSpaceDistribution):
         """
 
         methods = {
-            "trapz": lambda f: self._expect_fixed(f, np.trapz),
-            "simps": lambda f: self._expect_fixed(f, integrate.simps),
+            "trapz": lambda f: self._expect_fixed(f, np.trapezoid),
+            "simps": lambda f: self._expect_fixed(f, integrate.simpson),
             "quad": self._expect_quad,
         }
 

--- a/hazma/phase_space/_three_body.py
+++ b/hazma/phase_space/_three_body.py
@@ -182,12 +182,12 @@ class ThreeBody(AbstractPhaseSpaceIntegrator):
     def __trapz(self, fn, a: float, b: float, npts: int):
         xs = np.linspace(a, b, npts)
         fs = np.array([fn(x) for x in xs])
-        return integrate.trapz(fs, xs)
+        return integrate.trapezoid(fs, xs)
 
     def __simps(self, fn, a: float, b: float, npts: int):
         xs = np.linspace(a, b, npts)
         fs = np.array([fn(x) for x in xs])
-        return integrate.simps(fs, xs)
+        return integrate.simpson(fs, x=xs)
 
     def __quad(
         self,
@@ -682,8 +682,8 @@ class ThreeBody(AbstractPhaseSpaceIntegrator):
             Method used to integrate over phase space. Can be:
 
                 * 'quad': Numerical quadrature using scipy's 'quad',
-                * 'trapz': Trapiziod rule using scipy's 'trapz',
-                * 'simps': Simpson's rule using scipy's 'simps',
+                * 'trapz': Trapiziod rule using scipy's 'trapezoid',
+                * 'simps': Simpson's rule using scipy's 'simpson',
                 * 'rambo': Monte-Carlo integration.
         npts: int
             Number of phase-space points to use to integrate squared matrix

--- a/hazma/spectra/_nbody.py
+++ b/hazma/spectra/_nbody.py
@@ -299,7 +299,7 @@ def _conv_dnde_dist(
     dndes = np.expand_dims(dist.probabilities, expand) * dndes
     # Integrate over leading axis. Result has shape (3, n) for neutrinos and
     # (n,) otherwise.
-    dnde = np.trapz(dndes, dist.bin_centers, axis=0)
+    dnde = np.trapezoid(dndes, dist.bin_centers, axis=0)
 
     return dnde
 
@@ -624,8 +624,8 @@ def dnde_photon(
         Type of integrator used for three body final-states. Can be:
 
             * 'quad': for `scipy.integrate.quad`,
-            * 'trapz': for `scipy.integrate.trapz`,
-            * 'simps': for `scipy.integrate.simps`,
+            * 'trapz': for `scipy.integrate.trapezoid`,
+            * 'simps': for `scipy.integrate.simpson`,
             * 'rambo': for `hazma.phase_space.Rambo`.
 
         Default is 'quad'.
@@ -730,8 +730,8 @@ def dnde_positron(
         Type of integrator used for three body final-states. Can be:
 
             * 'quad': for `scipy.integrate.quad`,
-            * 'trapz': for `scipy.integrate.trapz`,
-            * 'simps': for `scipy.integrate.simps`,
+            * 'trapz': for `scipy.integrate.trapezoid`,
+            * 'simps': for `scipy.integrate.simpson`,
             * 'rambo': for `hazma.phase_space.Rambo`.
 
         Default is 'quad'.
@@ -818,8 +818,8 @@ def dnde_neutrino(
         Type of integrator used for three body final-states. Can be:
 
             * 'quad': for `scipy.integrate.quad`,
-            * 'trapz': for `scipy.integrate.trapz`,
-            * 'simps': for `scipy.integrate.simps`,
+            * 'trapz': for `scipy.integrate.trapezoid`,
+            * 'simps': for `scipy.integrate.simpson`,
             * 'rambo': for `hazma.phase_space.Rambo`.
 
         Default is 'quad'.

--- a/hazma/spectra/_neutrino/_utils.py
+++ b/hazma/spectra/_neutrino/_utils.py
@@ -5,7 +5,7 @@ import numpy.typing as npt
 import pathlib
 from scipy import interpolate
 
-RealArray = npt.NDArray[np.float_]
+RealArray = npt.NDArray[np.float64]
 
 
 def load_interp(fname, k=2):

--- a/hazma/spectra/_positron/_eta.py
+++ b/hazma/spectra/_positron/_eta.py
@@ -7,7 +7,7 @@ from hazma import parameters
 
 from ._utils import load_interp, dnde_positron_point, dnde_positron_array
 
-RealArray = npt.NDArray[np.float_]
+RealArray = npt.NDArray[np.float64]
 
 _eta_interp = load_interp("eta_positron.csv")
 

--- a/hazma/spectra/_positron/_kaon.py
+++ b/hazma/spectra/_positron/_kaon.py
@@ -8,7 +8,7 @@ from scipy import interpolate
 from hazma.parameters import electron_mass as me
 from hazma import parameters
 
-RealArray = npt.NDArray[np.float_]
+RealArray = npt.NDArray[np.float64]
 
 
 def _load_interp(fname):

--- a/hazma/spectra/_positron/_utils.py
+++ b/hazma/spectra/_positron/_utils.py
@@ -7,7 +7,7 @@ from scipy import interpolate
 
 from hazma.parameters import electron_mass as me
 
-RealArray = npt.NDArray[np.float_]
+RealArray = npt.NDArray[np.float64]
 
 
 def load_interp(fname):

--- a/hazma/spectra/boost.py
+++ b/hazma/spectra/boost.py
@@ -30,11 +30,6 @@ _integrate_defaults = {
         for key, p in inspect.signature(integrate.quad).parameters.items()
         if not p.default == p.empty
     },
-    "quadrature": {
-        key: p.default
-        for key, p in inspect.signature(integrate.quadrature).parameters.items()
-        if not p.default == p.empty
-    },
     "trapz": {
         key: p.default
         for key, p in inspect.signature(integrate.trapezoid).parameters.items()
@@ -46,6 +41,10 @@ _integrate_defaults = {
         if not p.default == p.empty
     },
 }
+
+# `scipy.integrate.quadrature` was removed in SciPy 1.15. The 'quadrature'
+# method is kept as an alias of 'quad' for backwards compatibility.
+_integrate_defaults["quadrature"] = _integrate_defaults["quad"]
 
 
 def _get_integrator_kwargs(method: str, **kwargs):
@@ -61,7 +60,7 @@ def _make_integrator(method, vectorized: bool, **kwargs):
     is_quadrature = method == "quadrature"
 
     if is_quad or is_quadrature:
-        integrator_ = integrate.quad if is_quad else integrate.quadrature
+        integrator_ = integrate.quad
 
         def quad(integrand, emin, emax):
             return np.array(
@@ -80,13 +79,13 @@ def _make_integrator(method, vectorized: bool, **kwargs):
         del integrate_kwargs["x"]
         integrate_kwargs["axis"] = 1
         npts = kwargs.get("npts", 100)
-        integrator_ = integrate.trapz if is_trapz else integrate.simps
+        integrator_ = integrate.trapezoid if is_trapz else integrate.simpson
 
         def fixed(f, a, b):
             es = np.array([np.linspace(a_, b_, npts) for a_, b_ in zip(a, b)])
             ff = f if vectorized else np.vectorize(f)
             integrands = np.array([ff(e) for e in es])
-            return integrator_(integrands, es, **integrate_kwargs)
+            return integrator_(integrands, x=es, **integrate_kwargs)
 
         return fixed
 
@@ -266,9 +265,10 @@ def make_boost_function(fn: Callable, mass: float, vectorized: bool = True):
             * `method`: Method used to integrate. Can be one of the following:
 
                 * 'quad': for adaptive quadrature using `scipy.integrate.quad`,
-                * 'quadrature': for adaptive quadrature using `scipy.integrate.quadrature`,
-                * 'trapz': trapizoid rule using `scipy.integrate.trapz`,
-                * 'simps': Simpson's rule using `scipy.integrate.simps`.
+                * 'quadrature': deprecated alias of 'quad'
+                  (`scipy.integrate.quadrature` was removed in SciPy 1.15),
+                * 'trapz': trapizoid rule using `scipy.integrate.trapezoid`,
+                * 'simps': Simpson's rule using `scipy.integrate.simpson`.
 
             * `kwargs`: Keyword arguments to pass to underlying method. See
               SciPy's quad available arguments. For `trapizoid` or `simpson`,
@@ -314,7 +314,7 @@ def make_boost_function(fn: Callable, mass: float, vectorized: bool = True):
     def fn_boosted(
         energies,
         beta: float,
-        method: str = "quadrature",
+        method: str = "quad",
         args: Tuple = tuple(),
         **kwargs,
     ):
@@ -327,8 +327,8 @@ def make_boost_function(fn: Callable, mass: float, vectorized: bool = True):
         beta: float
             Boost velocity. If beta < 0 or beta > 1, zeros are returned.
         method: str, optional
-            Method to use to integrate. Can be 'quad', 'trapizoid' or
-            'simpson'. Default is 'quadrature'.
+            Method to use to integrate. Can be 'quad', 'trapz' or
+            'simps'. Default is 'quad'.
         args: tuple, optional
             Additional arguments to pass to function.
 
@@ -346,8 +346,8 @@ def make_boost_function(fn: Callable, mass: float, vectorized: bool = True):
             Number of points to use in trapizoidal or simpson integration.
             Default is 100.
 
-        If method = 'quad' or 'quadrature, any keyword arguments compatible with
-        quad/quadrature can be specified.
+        If method = 'quad' (or its deprecated alias 'quadrature'), any keyword
+        arguments compatible with quad can be specified.
         """
         check_method(method)
         early = kinematic_early_return(energies, beta)
@@ -372,7 +372,7 @@ def dnde_boost(
     energies,
     beta: float,
     mass: float = 0.0,
-    method: str = "quadrature",
+    method: str = "quad",
     vectorized: bool = True,
     args: Tuple = tuple(),
     **kwargs,
@@ -388,8 +388,8 @@ def dnde_boost(
     mass: float, optional
         Mass of the product. Default is zero (i.e. for a photon.)
     method: str, optional
-        Method to use to integrate. Can be 'quad', 'trapizoid' or
-        'simpson'. Default is 'quadrature'.
+        Method to use to integrate. Can be 'quad', 'trapz' or
+        'simps'. Default is 'quad'.
     vectorized: bool, optional
        If True, `fn` is assumed to be vectorized. Default is True.
     args: tuple, optional

--- a/hazma/spectra/convolve.py
+++ b/hazma/spectra/convolve.py
@@ -66,14 +66,14 @@ def make_marginal_fn(
     integrand = np.vectorize(dnde_fn, excluded=excluded)
 
     if method == "trapz":
-        integrator = np.trapz
+        integrator = np.trapezoid
     else:
         integrator = integrate.simpson
 
     def marginalize(product_energies):
         es = np.expand_dims(product_energies, 0)
         vals = probs_ * integrand(es, cmes_, *args)
-        return integrator(vals, cmes, axis=0)
+        return integrator(vals, x=cmes, axis=0)
 
     return marginalize
 

--- a/hazma/theory/_theory_gamma_ray_limits.py
+++ b/hazma/theory/_theory_gamma_ray_limits.py
@@ -266,7 +266,7 @@ def fisher(
     tobs: float,
     vx: float = 1e-3,
     n_grid: int = 20,
-    e_grid: Optional[npt.NDArray[np.float_]] = None,
+    e_grid: Optional[npt.NDArray[np.float64]] = None,
     k: int = 1,
     ext: str = "raise",
 ) -> FisherResults:
@@ -610,7 +610,7 @@ class TheoryGammaRayLimits:
         vx: float = 1e-3,
         sigma_levels: List[float] = [5.0],
         n_grid: int = 2000,
-        e_grid: Optional[npt.NDArray[np.float_]] = None,
+        e_grid: Optional[npt.NDArray[np.float64]] = None,
         k: int = 1,
         ext: str = "raise",
     ) -> List[float]:

--- a/hazma/utils.py
+++ b/hazma/utils.py
@@ -50,11 +50,11 @@ def deprecate_fn(fn, alternative: Optional[str] = None):
 # ---- Types --------------------------------------------------------
 # ===================================================================
 
-RealArray = npt.NDArray[np.float_]
+RealArray = npt.NDArray[np.float64]
 RealOrRealArray = Union[float, RealArray]
-ComplexArray = npt.NDArray[np.complex_]
+ComplexArray = npt.NDArray[np.complex128]
 ComplexOrComplexArray = Union[complex, ComplexArray]
-RealOrComplexArray = npt.NDArray[Union[np.float_, np.complex_]]
+RealOrComplexArray = npt.NDArray[Union[np.float64, np.complex128]]
 
 # ===================================================================
 # ---- Enums --------------------------------------------------------

--- a/hazma/vector_mediator/_gev/model.py
+++ b/hazma/vector_mediator/_gev/model.py
@@ -29,7 +29,7 @@ from . import positron as gev_positron_spectra
 from . import spectra as gev_spectra
 from . import types as gev_types
 
-T = TypeVar("T", float, npt.NDArray[np.float_])
+T = TypeVar("T", float, npt.NDArray[np.float64])
 
 
 def with_cache(*, cache_name: str, name: str):

--- a/hazma/vector_mediator/_gev/neutrino.py
+++ b/hazma/vector_mediator/_gev/neutrino.py
@@ -81,7 +81,7 @@ def _make_spectrum_n_body_decay(
         bins = dist.bin_centers
         probs = dist.probabilities
         dec = np.array([dnde_decays[i](neutrino_energies, e, flavor) for e in bins])
-        dnde += np.trapz(np.expand_dims(probs, 1) * dec, x=bins, axis=0)
+        dnde += np.trapezoid(np.expand_dims(probs, 1) * dec, x=bins, axis=0)
 
     return dnde
 

--- a/hazma/vector_mediator/_gev/positron.py
+++ b/hazma/vector_mediator/_gev/positron.py
@@ -74,7 +74,7 @@ def _make_spectrum_n_body_decay(
         bins = dist.bin_centers
 
         dec = np.array([dnde_decays[i](positron_energies, e) for e in bins])
-        dnde += np.trapz(np.expand_dims(probs, 1) * dec, x=bins, axis=0)
+        dnde += np.trapezoid(np.expand_dims(probs, 1) * dec, x=bins, axis=0)
 
     return dnde
 

--- a/hazma/vector_mediator/_gev/spectra.py
+++ b/hazma/vector_mediator/_gev/spectra.py
@@ -81,7 +81,7 @@ def _make_spectrum_n_body_decay(
 
     for i, dist in enumerate(energy_distributions):
         dec = np.array([dnde_decays[i](photon_energies, e) for e in dist.bin_centers])
-        dnde += np.trapz(
+        dnde += np.trapezoid(
             np.expand_dims(dist.probabilities, 1) * dec, x=dist.bin_centers, axis=0
         )
 
@@ -461,7 +461,7 @@ def dnde_photon_pi_pi_pi0(
     fsr = np.array(
         [2.0 * dnde_photon_ap_scalar(photon_energies, m**2, mpi) for m in ms]
     )
-    dnde += np.trapz(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
+    dnde += np.trapezoid(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
 
     return dnde
 
@@ -706,7 +706,7 @@ def dnde_photon_pi_pi_pi_pi(
             [2.0 * dnde_photon_ap_scalar(photon_energies, m**2, mpi) for m in ms]
         )
         # 0.5 since each particle is counted twice
-        dnde += 0.5 * np.trapz(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
+        dnde += 0.5 * np.trapezoid(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
 
     return dnde
 
@@ -748,7 +748,7 @@ def dnde_photon_pi_pi_pi0_pi0(
     fsr = np.array(
         [2.0 * dnde_photon_ap_scalar(photon_energies, m**2, mpi) for m in ms]
     )
-    dnde += np.trapz(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
+    dnde += np.trapezoid(np.expand_dims(ps, 1) * fsr, x=ms, axis=0)
 
     return dnde
 

--- a/hazma/vector_mediator/_gev/utils.py
+++ b/hazma/vector_mediator/_gev/utils.py
@@ -5,7 +5,7 @@ import numpy.typing as npt
 
 from hazma import parameters
 
-RealArray = npt.NDArray[np.float_]
+RealArray = npt.NDArray[np.float64]
 BoolArray = npt.NDArray[np.bool_]
 
 

--- a/hazma/vector_mediator/form_factors/pi_pi_omega.py
+++ b/hazma/vector_mediator/form_factors/pi_pi_omega.py
@@ -132,7 +132,7 @@ class FormFactorPiPiOmega:
         dist_p = dnde_pi(es_p)
         dist_w = dnde_omega(es_w)
 
-        dist_p = dist_p / np.trapz(dist_p, x=es_p)
-        dist_w = dist_w / np.trapz(dist_w, x=es_w)
+        dist_p = dist_p / np.trapezoid(dist_p, x=es_p)
+        dist_w = dist_w / np.trapezoid(dist_w, x=es_w)
 
         return [(es_p, dist_p), (es_p, dist_p), (es_w, dist_w)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,7 @@
 [project]
 name = "hazma"
 readme = "README.md"
-# < 3.13: numpy < 2 (see dependencies) has no Python 3.13+ support, so pip
-# on newer Pythons would attempt a doomed NumPy 1.26 source build. Lift
-# together with the numpy/scipy caps.
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 authors = [
   { name = "Logan A. Morrison", email = "loanmorr@ucsc.edu" },
   { name = "Adam Coogan" },
@@ -16,12 +13,12 @@ classifiers = ["Programming Language :: Python"]
 
 dynamic = ["version"]
 
-# Upper bounds: hazma still uses APIs removed in NumPy 2.0 (np.trapz) and
-# SciPy 1.14 (scipy.integrate.trapz/simps). Lift these once the source is
-# migrated; NumPy < 2 also caps supported Python at 3.12.
+# numpy >= 2.0: the source uses np.trapezoid, which NumPy 2.0 introduced as
+# the replacement for the removed np.trapz. scipy >= 1.13 is the first
+# series with NumPy 2 support.
 dependencies = [
-  "numpy>=1.16.2,<2",
-  "scipy>=1.2.1,<1.14",
+  "numpy>=2.0",
+  "scipy>=1.13",
   "matplotlib>=2.2.3",
   "scikit-image", # hazma.theory: skimage.measure.find_contours
 ]
@@ -35,10 +32,10 @@ dev = ["black>=23.3,<25.0"]
 
 [build-system]
 build-backend = "setuptools.build_meta"
-# scipy is pinned to the same range as the runtime dependency: the
-# extensions cimport scipy.special.cython_special, whose exported C symbols
-# must match between build and runtime scipy.
-requires = ["numpy", "cython", "setuptools", "scipy>=1.2.1,<1.14"]
+# scipy shares the runtime dependency's lower bound: the extensions cimport
+# scipy.special.cython_special, whose exported C symbols must match between
+# build and runtime scipy.
+requires = ["numpy", "cython", "setuptools", "scipy>=1.13"]
 
 [tool.setuptools]
 zip-safe = false

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 
 from hazma.parameters import convolved_spectrum_fn, spec_res_fn
 
@@ -104,7 +104,7 @@ def test_convolution_conserves_photon_number():
         1e-1, 1e2, vectorized_energy_res, spec_fn=gaussian_line_source, n_pts=500
     )
 
-    assert trapz(dnde(energies), energies) == pytest.approx(1.0, rel=1e-3)
+    assert trapezoid(dnde(energies), energies) == pytest.approx(1.0, rel=1e-3)
 
 
 def test_spec_res_fn_arguments_are_not_interchangeable():

--- a/test/vector_mediator/herwig4dm/FEtaPiPi.py
+++ b/test/vector_mediator/herwig4dm/FEtaPiPi.py
@@ -133,8 +133,8 @@ def phase(s):
     # transform to new variables
     upp = math.atan((upp - mRho_[0] ** 2) / gRho_[0] / mRho_[0])
     low = math.atan((low - mRho_[0] ** 2) / gRho_[0] / mRho_[0])
-    return scipy.integrate.quadrature(
-        integrand, low, upp, args=s, tol=1e-12, maxiter=200
+    return scipy.integrate.quad(
+        lambda x, s_: integrand([x], s_)[0], low, upp, args=(s,), epsabs=1e-12
     )[0]
 
 

--- a/test/vector_mediator/herwig4dm/FEtaPrimePiPi.py
+++ b/test/vector_mediator/herwig4dm/FEtaPrimePiPi.py
@@ -144,8 +144,8 @@ def phase(s):
     # transform to new variables
     upp = math.atan((upp - mRho_[0] ** 2) / gRho_[0] / mRho_[0])
     low = math.atan((low - mRho_[0] ** 2) / gRho_[0] / mRho_[0])
-    return scipy.integrate.quadrature(
-        integrand, low, upp, args=s, tol=1e-12, maxiter=200
+    return scipy.integrate.quad(
+        lambda x, s_: integrand([x], s_)[0], low, upp, args=(s,), epsabs=1e-12
     )[0]
 
 

--- a/test/vector_mediator/herwig4dm/FOmegaPiPi.py
+++ b/test/vector_mediator/herwig4dm/FOmegaPiPi.py
@@ -139,8 +139,12 @@ def phase(s, mode):
         pre /= 2.0
     return (
         pre
-        * scipy.integrate.quadrature(
-            Integrand, low, upp, args=(s, mode), tol=1e-10, maxiter=200
+        * scipy.integrate.quad(
+            lambda x, s_, mode_: Integrand([x], s_, mode_)[0],
+            low,
+            upp,
+            args=(s, mode),
+            epsabs=1e-10,
         )[0]
     )
 


### PR DESCRIPTION
## Summary

Migrates the source off APIs removed in NumPy 2.0 and SciPy 1.14/1.15 and lifts the version caps that pinned hazma to numpy < 2, scipy < 1.14, and Python <= 3.12:

- `scipy.integrate.trapz`/`simps` -> `trapezoid`/`simpson`, and `np.trapz` -> `np.trapezoid` (including `hazma/_utils/boost.pyx`); `x=` is passed by keyword where `simpson` is involved since it became keyword-only in SciPy 1.14. User-facing `'trapz'`/`'simps'` method-name options are unchanged.
- `scipy.integrate.quadrature` (removed in SciPy 1.15) was evaluated at import time in `hazma.spectra.boost` and was the default boost method; `'quadrature'` is now a backwards-compatible alias of `'quad'` and the defaults changed to `'quad'`.
- `np.float_`/`np.complex_` (removed in NumPy 2.0) -> `np.float64`/`np.complex128`.
- pyproject: `requires-python = ">=3.10"`, runtime deps lifted to `numpy>=2.0`/`scipy>=1.13`, and the build-system scipy pin lifted to `scipy>=1.13` (the old `<1.14` pin would block Python 3.13+ builds).
- CI matrix extended to Python 3.10-3.14 (macOS job on 3.14); release wheels extended to `cp313`/`cp314`.
- Test helpers in `test/vector_mediator/herwig4dm` ported off `scipy.integrate.quadrature`, and the new `test/test_parameters.py` off `scipy.integrate.trapz`.

## Test plan

- Built and installed on Python 3.13 (editable) and 3.14 (regular wheel) against numpy 2.5.1 / scipy 1.18.0 with the new `setup.py`.
- `pytest` (CI configuration): 57 passed on both versions; ci.yml's import smoke test passes on 3.14.
- Full `pytest test` suite passes except known pre-existing failures, verified pre-existing by running the base commit on the old stack (numpy 1.26.4 / scipy 1.13.1): the stale `test/rambo` module, the `test_compute_decay_width_Zee` mmu/mz mismatch, the order-dependent `F2pi.py` global state, and unseeded Rambo Monte-Carlo flakiness.
- Migrated call paths exercised directly: all four boost methods agree ('quadrature' alias matches 'quad'), convolve integrators, `PhaseSpaceDistribution1D.expect`, `ThreeBody` internals, and the compiled `boost.pyx` trapezoid path via boosted eta/omega spectra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)