### PR TITLE
feat(agents): add codex workflow skills

### DIFF
--- a/.claude/skills/begin-phase/SKILL.md
+++ b/.claude/skills/begin-phase/SKILL.md
@@ -3,11 +3,12 @@ name: begin-phase
 description: Prepare a guarded, ready-to-paste kickoff prompt for the next eligible phase of a phased project, verifying strict prerequisite closeout first and refusing blocked or ambiguous phase starts.
 ---
 
-**Role:** Prepare a safe, ready-to-paste prompt for the next phase of a
-**phased** project without letting an agent start a blocked or ambiguous
-phase.
+# Begin Phase
 
-**When to use this skill**
+Prepare a safe, ready-to-paste prompt for the next phase of a **phased**
+project without letting an agent start a blocked or ambiguous phase.
+
+## When to use this skill
 
 - The user asks to begin the next phase of a phased project.
 - The user asks which phase is actually ready to start next.
@@ -17,7 +18,7 @@ This skill **prepares a handoff prompt only**. It does not start
 implementation or edit project files. First-task selection inside the
 chosen phase is delegated to `/execute-single-task`.
 
-**When NOT to use**
+## When not to use
 
 - Flat (non-phased) projects — refuse and point at
   `/execute-single-task` (see Step 2).
@@ -71,22 +72,21 @@ Map the user's request to helper arguments:
 
 ### Step 4: Run the shared helper
 
-The helper is at `.claude/skills/begin-phase/scripts/resolve_phase.py`.
+The shared helper is at `scripts/agents/resolve_phase.py`.
 **Run it from the repo root** — the Bash-tool cwd can reset between
 calls, so pass an absolute path or `cd` in the same command.
 
 ```sh
 # Current frontier:
-python3 .claude/skills/begin-phase/scripts/resolve_phase.py \
-  --project <slug>
+python3 scripts/agents/resolve_phase.py --project <slug> --agent claude
 
 # After a just-completed phase:
-python3 .claude/skills/begin-phase/scripts/resolve_phase.py \
-  --project <slug> --completed-phase 4
+python3 scripts/agents/resolve_phase.py --project <slug> --agent claude \
+  --completed-phase 4
 
 # Explicit target:
-python3 .claude/skills/begin-phase/scripts/resolve_phase.py \
-  --project <slug> --target-phase 6
+python3 scripts/agents/resolve_phase.py --project <slug> --agent claude \
+  --target-phase 6
 ```
 
 The helper emits JSON on stdout with `status`:

--- a/.codex/skills/begin-phase/SKILL.md
+++ b/.codex/skills/begin-phase/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: begin-phase
+description: "Safely determine whether a phased Hazma project can begin its next or a requested phase, then produce a guarded Codex kickoff prompt. Use when a user asks which phase is ready, asks to begin a phase, or needs a phase handoff; this skill does not implement the task."
+---
+
+# Begin a phased project phase
+
+Prepare a handoff only. Do not edit project files or start implementation.
+
+1. Resolve `--project <slug>` from an explicit argument or a project branch
+   (`claude/` and `codex/` both parse). Read `projects/<slug>/PLAN.md` and
+   refuse non-phased projects; direct those to `$execute-single-task`.
+2. Map an optional completed phase to `--completed-phase` and a requested one
+   to `--target-phase`, then run the readiness oracle from the repository root:
+
+   ```sh
+   python3 scripts/agents/resolve_phase.py --project <slug> --agent codex \
+     [--completed-phase <id>] [--target-phase <id>]
+   ```
+
+3. Follow its JSON result exactly:
+
+   - `ready`: state why it is eligible and paste `prompt` verbatim in a fenced
+     block. It directs the next agent to `$execute-single-task`, requires a
+     re-check, and specifies a `codex/` worktree.
+   - `choose`: list each eligible choice and its reason, then stop for the
+     user's selection.
+   - `blocked`: explain each blocker. A missing learning document means a
+     prerequisite is marked complete but was not closed out; `(none)` means no
+     phase remains in `Not started` state.
+   - `error`: report the message and request corrected input when needed.
+
+Never infer readiness by hand, choose among parallel phases automatically, or
+generate a prompt for a blocked phase. Ignore `_template.md` files.

--- a/.codex/skills/begin-phase/agents/openai.yaml
+++ b/.codex/skills/begin-phase/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Begin Phase"
+  short_description: "Prepare a guarded kickoff for the next phase."
+  default_prompt: "Use $begin-phase to prepare the next eligible phase of project my-project."

--- a/.codex/skills/commit-and-pr/SKILL.md
+++ b/.codex/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: commit-and-pr
+description: "Run Hazma's preflight gate, create or validate a Codex branch, commit intentionally with a valid Conventional Commit header, push, and open or update a pull request. Use when a user asks to commit, ship, or open a PR for current work."
+---
+
+# Commit and open a pull request
+
+Ship the current worktree without bypassing Hazma's gates. This is the commit
+authority for standalone work; a pipeline-owned branch keeps its existing
+branch and PR instead.
+
+1. Read [`docs/PR_GUIDELINES.md`](../../../docs/PR_GUIDELINES.md), inspect
+   `git status --short`, the full diff, and recent commit style. Stop if there
+   are no intended changes.
+2. Confirm numerical-impact evidence for any public code path, and confirm a
+   closing project carries its required `VERSION` and `CHANGELOG.md` updates.
+3. Work only on a feature branch. If a new branch is needed, create
+   `codex/<project>/<task>` for project work or `codex/<description>` for
+   ad-hoc work; never commit to `master`.
+4. Rebuild first when Cython sources changed, then run:
+
+   ```sh
+   scripts/agents/preflight.sh --paths "<touched paths>" \
+     --tests "<test targets>" [--md "<changed markdown>"] [--closing]
+   ```
+
+   Treat a non-zero result or `WARN` gate as a blocker. Read the literal pytest
+   summary and use the sequential critical path in
+   [`docs/agents/preflight.md`](../../../docs/agents/preflight.md).
+5. Stage only intended source, test, and documentation files. Do not stage
+   build outputs, credentials, scratch files, or generated C/C++.
+6. Compose and validate the commit/PR header before committing:
+
+   ```sh
+   scripts/agents/check_pr_title.py "type(scope): subject"
+   ```
+
+   Immediately before the commit, verify the intended non-`master` branch and
+   worktree. Commit with an explanatory body when it helps.
+7. Push without force, verify `HEAD` equals `origin/<branch>`, and create or
+   update a PR against `master`. Use the validated header as the title. The PR
+   body must contain `## Summary` and `## Test plan`, plus `## Project` for
+   project work. Reconcile all prose claims with the current diff and actual
+   command output; state every published numerical change explicitly.
+8. Watch CI to a bounded conclusion. If it fails, report the failing check or
+   fix it through the full gate again; never report a red PR as complete.
+
+End with:
+
+```text
+STATUS: Pushed | PR opened | Committed-only | Failed
+BRANCH: <branch>
+COMMIT_SHA: <short sha>
+PR_URL: <url or n/a>
+TITLE: <validated title>
+```

--- a/.codex/skills/commit-and-pr/agents/openai.yaml
+++ b/.codex/skills/commit-and-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit and PR"
+  short_description: "Commit, push, and open a compliant PR."
+  default_prompt: "Use $commit-and-pr to ship the current Hazma change as a pull request."

--- a/.codex/skills/execute-single-task/SKILL.md
+++ b/.codex/skills/execute-single-task/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: execute-single-task
+description: "Implement exactly one numbered task from a Hazma project plan, including task-note updates, numerical-impact measurement, documentation consistency, and the preflight gate. Use when a user asks to take a project task or the next project task; stop before committing unless the caller expressly owns the commit."
+---
+
+# Execute one project task
+
+Implement one bounded project task while preserving the repository's durable
+project memory. This skill is for project branches only; handle an ad-hoc
+change directly, then use `$commit-and-pr` when it is ready to ship.
+
+## Resolve and isolate the task
+
+1. Resolve the project slug from an explicit `--project <slug>` or a branch
+   named `<agent>/<project-slug>/<task-slug>`. Parse both `claude/` and
+   `codex/`; create only `codex/` branches. Confirm
+   `projects/<slug>/PLAN.md` exists.
+2. Resolve the requested task with
+   `scripts/agents/resolve_task.py --project <slug> [--task <id>]`. Its live
+   task-notes table, not `PLAN.md`, is authoritative for status. Work on one
+   task or tightly coupled, testable cluster; never cross a phase boundary.
+3. Before editing, create an isolated worktree from fresh trunk:
+
+   ```sh
+   scripts/agents/setup_task_worktree.sh \
+     --project <slug> --task-slug <task-slug> --agent codex
+   ```
+
+   Run all later commands in the reported `wt_path`, preferably as
+   `git -C <wt_path> ...`. If a pipeline already supplied its managed
+   worktree, skip this creation step and use that exact path.
+4. If the task edits `.pyx`, `.pxd`, or `_build.py`, rebuild inside that
+   worktree and confirm `python -c "import hazma; print(hazma.__file__)"`
+   resolves there before trusting any result.
+
+## Read the task context
+
+Read only the context needed for the chosen task, in this order:
+
+1. `projects/<slug>/PLAN.md`, including Numerical impact.
+2. `projects/<slug>/task-notes/README.md`, then `rules.md` if present.
+3. For phased projects, the target phase file, its per-phase task-notes
+   README, prerequisite files, and upstream learnings.
+4. The current task note and active relevant ADRs.
+5. [`docs/agents/lessons.md`](../../../docs/agents/lessons.md) and
+   [`docs/agents/environment.md`](../../../docs/agents/environment.md).
+
+Treat `_template.md` files as references, not live artifacts. If a bounded
+codebase survey is genuinely necessary, use a narrowly scoped Codex subagent;
+all agents share the filesystem, so direct it to read only and avoid edits.
+
+## Implement and record evidence
+
+Create or update the task note from `projects/_template/task-notes/_template.md`
+before implementing. Copy concrete Exit Criteria first. Keep its verification,
+files-changed, decisions, plan-impact, and handoff sections current.
+
+Apply the numerical-correctness and public-API rules in
+[`AGENTS.md`](../../../AGENTS.md). In particular:
+
+- Pin numerical behavior with an analytic limit, cited value, independent
+  implementation, or regression array; explain tolerance.
+- Cover relevant thresholds, endpoints, scalar/array broadcasting, error
+  paths, and dispatch-table siblings.
+- For every public path the diff can reach, compare representative before/after
+  values and record the grid and result. A verified no-change result is valid;
+  an unmeasured result is not.
+- Run the durable-doc and stale-state checks in
+  [`docs/agents/doc-consistency.md`](../../../docs/agents/doc-consistency.md).
+  Update a task note, phase file, ADR, or `PLAN.md` only according to its
+  canonical role; never turn `PLAN.md` into a live status log.
+
+For canonical architectural, interface, unit, normalization, or ordering
+changes, create the appropriate ADR and correct affected canonical documents in
+the same task. For deferred work, follow the deduplication and filing process in
+[`docs/workflow.md`](../../../docs/workflow.md).
+
+## Finish without committing
+
+Update the per-task note and the appropriate working-memory README. Complete
+phase or project closeout bookkeeping, including the version bump and
+`CHANGELOG.md`, when this is the final task. Run the mandatory gate:
+
+```sh
+scripts/agents/preflight.sh --paths "<touched paths>" --tests "<test targets>"
+```
+
+Add the `## Stale-state sweep` evidence block required by the doc-consistency
+checklist, then self-review the full diff against the task spec. Do not commit
+or push unless a caller explicitly directs it.
+
+End with:
+
+```text
+STATUS: Complete | Blocked | Superseded
+PROJECT: <slug>
+TASK_ID: <Task N or Task X.Y>
+TASK_NOTE: <path>
+FILES_CHANGED: <short list>
+TESTS: <command> — <literal pytest summary>
+NUMERICAL_IMPACT: <measurement or verified no-change>
+PLAN_IMPACT: None | Task note only | Phase file patched | ADR-XXXX | Both
+NEXT: <first item for the next agent to read>
+```

--- a/.codex/skills/execute-single-task/agents/openai.yaml
+++ b/.codex/skills/execute-single-task/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Execute One Task"
+  short_description: "Implement one project task with gates."
+  default_prompt: "Use $execute-single-task to complete the next task for a Hazma project."

--- a/.codex/skills/review-cycle/SKILL.md
+++ b/.codex/skills/review-cycle/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: review-cycle
+description: "Orchestrate a bounded, multi-agent Codex review loop for a pushed Hazma pull request: select independent reviewer lenses, collect reviews in parallel, apply and push justified fixes, verify them, post durable round summaries, and stop at convergence, escalation, or the iteration cap."
+---
+
+# Run a PR review cycle
+
+Use this skill only for a pushed PR or branch. It owns the single review loop;
+reviewer and responder agents must not invoke `$review-cycle` or
+`$task-pipeline` recursively.
+
+## Setup
+
+Normalize the PR number, URL, or pushed branch; record its head branch and
+SHA. Parse project metadata when applicable and create or reuse one worktree
+for fixes. The managed worktree is shared by Codex agents: give every editing
+agent its absolute path and branch, and tell it not to create another worktree.
+
+Read these canonical sources rather than reproducing their rules:
+
+- [`review-lenses.md`](../../../docs/agents/review-lenses.md) for lens choice,
+  Codex reasoning effort, verdicts, and rubrics.
+- [`preflight.md`](../../../docs/agents/preflight.md) for every commit.
+- [`doc-consistency.md`](../../../docs/agents/doc-consistency.md) and
+  [`lessons.md`](../../../docs/agents/lessons.md) for review evidence.
+
+Select the reviewer set once: normally A and D; B for explicit criteria; C for
+runtime behavior; E for any change that can move a number; prefer all lenses
+on project closeout. Record chosen and omitted lenses and retain this exact set
+for every round. Respect a caller override.
+
+## Execute each round (default cap: 3)
+
+1. Spawn the selected reviewers concurrently through Codex collaboration.
+   Assign one stable task name and one lens per agent. Each prompt must name the
+   PR, require `$review-pr`, require a fresh fetched PR head, prohibit edits,
+   and require only `APPROVE` or `REQUEST CHANGES`.
+2. If every internal reviewer approves with no comments, post the shortcut
+   round summary and converge. Otherwise spawn a fresh responder in the shared
+   worktree with the full tagged reviews and `$review-respond`. Require it to
+   commit, push, report `FINAL_COMMIT_SHA`, and quote the literal pytest
+   summary.
+3. Verify the PR head equals the reported pushed SHA and advanced from the
+   round's prior SHA. Stop if it did not; do not verify stale code.
+4. Spawn the same lenses concurrently as verification reviewers. Give each
+   reviewer its original comment and corresponding response; require a fresh
+   ref fetch, re-run any volume/numerics claim, status every original comment,
+   and report new issues.
+5. Converge only if all verifiers approve with no new blocking issue. Loop only
+   when at least one blocking issue was resolved. Escalate if the same blocker
+   persists for two rounds; stop un-converged at the cap.
+6. Post a PR comment for every round containing the lens selection (round 1),
+   verdicts, verification statuses, decisions, numerical impact, and fix SHA.
+   External reviews are advisory: surface them but do not count them toward
+   convergence or invent a verification round for them.
+
+Use this response shape so a caller can route the result:
+
+```text
+## Review Cycle Summary
+TARGET: PR #<N> / <branch>
+SELECTED_REVIEWERS: <A, B, ...>
+STATUS: CONVERGED | NOT_CONVERGED | ESCALATE
+ITERATIONS_USED: <N>
+UNRESOLVED: <list or none>
+TESTS: <literal pytest summary>
+NUMERICAL_IMPACT: <measurement or verified no-change>
+FINAL_COMMIT_SHA: <verified SHA>
+REVIEW_SUMMARY: <one paragraph>
+```
+
+Never force-push, skip the preflight gate, mutate the selected reviewer set,
+or treat an unmeasured numerical assertion as a verdict.

--- a/.codex/skills/review-cycle/agents/openai.yaml
+++ b/.codex/skills/review-cycle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Cycle"
+  short_description: "Run a bounded multi-agent PR review loop."
+  default_prompt: "Use $review-cycle to review and converge on PR #123."

--- a/.codex/skills/review-plan/SKILL.md
+++ b/.codex/skills/review-plan/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: review-plan
+description: "Perform a read-only, findings-first review of a Hazma project PLAN before implementation, covering feasibility, numerical correctness, architecture, Python conventions, and testability. Use when a user asks whether a project plan is ready or asks to review projects/<slug>/PLAN.md."
+---
+
+# Review a project plan
+
+Review the plan without editing it. Normalize the supplied slug, project path,
+or `PLAN.md`; require a non-empty `projects/<slug>/PLAN.md`. An unknown focus
+category is an input error. Missing plan-linked context is a finding, not a
+reason to fabricate it.
+
+## Read and ground the plan
+
+Read `PLAN.md`, `rules.md`, phase files, references, ADRs, live task-notes
+README, [`AGENTS.md`](../../../AGENTS.md),
+[`docs/workflow.md`](../../../docs/workflow.md),
+[`docs/versioning.md`](../../../docs/versioning.md),
+[`docs/PR_GUIDELINES.md`](../../../docs/PR_GUIDELINES.md), and
+[`docs/agents/lessons.md`](../../../docs/agents/lessons.md), plus files the
+plan cites. Ignore `_template.md`.
+
+Verify load-bearing current-state claims with `rg`, exact file reads, and the
+commands the plan asks an implementer to run. Distinguish pre-existing paths
+from paths the work will create. A green-but-noop test command is blocking;
+record every verified claim with concrete evidence.
+
+## Evaluate
+
+Assess every requested category (or all of them) and cite the exact plan
+location for each finding.
+
+- **Feasibility:** one-PR task sizing, explicit and acyclic dependencies,
+  testable exit criteria, and no unresolved decision that blocks dependents.
+- **Numerics:** a realistic Numerical impact section; correct version-bump
+  expectation; units, normalization, frame, and oracle for every new number;
+  endpoint, interpolation, and tolerance risks identified.
+- **Correctness:** error paths, physical limits, scalar/array inputs, NaN and
+  mass edge cases, dispatch-table fan-out, and downstream model interactions.
+- **Architecture:** layering, public/private placement and exports, existing
+  abstractions, justified Cython additions, package-data registration, and ADR
+  placement.
+- **Idiomatic Python:** public annotations, NumPy docstrings with units,
+  broadcast contract, appropriate Hazma errors, and black/isort/ruff
+  conventions from `AGENTS.md`.
+- **Other:** real pytest targets, scope boundaries, performance measurement,
+  dependency hygiene, documentation surface, and Conventional Commit scope.
+
+## Report
+
+Emit only this report. Use `[P1]` for a blocker, `[P2]` for needs work, and
+`[P3]` for a suggestion; any P1 means `REQUEST MAJOR REVISION`.
+
+```md
+# Plan Review: <project>
+
+## Findings
+<severity-ordered, cited findings and concrete resolutions>
+
+## Summary
+| Category | Verdict | Top finding |
+|---|---|---|
+| ... | Pass / Needs work / Blocker | ... |
+
+## Grounded-facts audit
+| Claim (plan location) | Verified? | Evidence |
+|---|---|---|
+
+## What the plan does well
+<concrete, cited strengths>
+
+## Verdict
+<APPROVE | APPROVE WITH CHANGES | REQUEST MAJOR REVISION>
+```

--- a/.codex/skills/review-plan/agents/openai.yaml
+++ b/.codex/skills/review-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Plan"
+  short_description: "Read-only review of a Hazma project plan."
+  default_prompt: "Use $review-plan to stress-test the plan for project my-project."

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: review-pr
+description: "Review a Hazma pull request against its project task or ad-hoc scope using one focused lens: generalist, completeness, logic, document consistency, or numerics. Use when a user asks for a PR review or when a Codex review cycle assigns a single reviewer lens."
+---
+
+# Review one pull request
+
+Review one PR and return one structured verdict. Do not implement fixes or
+orchestrate other reviewers; use `$review-cycle` for the bounded multi-agent
+loop and `$review-plan` for a pre-implementation plan.
+
+## Gather a fresh PR view
+
+Normalize a PR number, URL, or pushed branch. Fetch its metadata and fresh
+head ref; do not judge the ambient checkout:
+
+```sh
+git fetch origin pull/<N>/head:refs/remotes/origin/pr/<N>
+```
+
+Verify that SHA against `gh pr view <N>`. Treat a truncated `gh pr diff` as
+incomplete; read changed files from the fetched ref. Parse project branches as
+`<agent>/<slug>/<task>` for both agent prefixes. For project work, read
+`lessons.md`, the PLAN's numerical-impact section, optional rules, target
+phase, task note, relevant ADRs, and upstream learnings. For ad-hoc work,
+review against `AGENTS.md`, the PR guidelines, and the change itself.
+
+Read every changed non-trivial file in full context. Check common diff omissions:
+public exports, sibling dispatch tables, Cython rebuild evidence, stale Sphinx
+references, package data registration, and ignored tests.
+
+## Apply one lens
+
+Read the assigned section of
+[`docs/agents/review-lenses.md`](../../../docs/agents/review-lenses.md) and
+apply its baseline duties before the lens rubric. Reproduce PR-body claims,
+check a real pytest collection/result, run changed examples or observable
+claims, and require a rebuild after Cython edits.
+
+- `default`: public API, units/docstrings, layering, broadcasting, debug
+  residue, task completion, and PR conventions.
+- `completeness`: explicit Exit-Criterion-to-pinning-test map and scope.
+- `logic`: adversarial mutation, boundary/error cases, and test validity.
+- `doc-consistency`: execute every applicable check in
+  [`docs/agents/doc-consistency.md`](../../../docs/agents/doc-consistency.md)
+  with line-numbered evidence.
+- `numerics`: measure public before/after values, dimensional analysis,
+  limiting cases, stability, integration/interpolation bounds, tolerance, and
+  hot-path performance.
+
+Use `REQUEST CHANGES` for any blocking finding and `APPROVE` otherwise.
+`COMMENT` is only for a standalone advisory review. On a verification pass,
+classify every prior comment as `RESOLVED`, `PARTIALLY RESOLVED`, or
+`UNRESOLVED`.
+
+```text
+## Verdict
+<APPROVE | REQUEST CHANGES | COMMENT>
+
+## Issues (<lens> Focus)
+### Blocking
+<numbered, file-and-line-specific findings or None>
+### Non-blocking
+<numbered findings or None>
+
+## Cross-cutting
+<only clearly blocking issues outside the lens>
+
+## Lens-Specific Observations
+<required evidence for the selected lens>
+```
+
+If a required command or dependency cannot run, report the verification gap;
+never invent a result or turn environment noise into a code defect.

--- a/.codex/skills/review-pr/agents/openai.yaml
+++ b/.codex/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Pull Request"
+  short_description: "Review one Hazma pull request by lens."
+  default_prompt: "Use $review-pr to review PR #123 with the numerics lens."

--- a/.codex/skills/review-respond/SKILL.md
+++ b/.codex/skills/review-respond/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: review-respond
+description: "Synthesize existing Hazma PR review feedback, assess each comment on merit, implement justified in-scope fixes, run the preflight gate, and provide verification-ready responses. Use when reviews already exist; do not use to collect reviews."
+---
+
+# Respond to review feedback
+
+Act as the implementing engineer. Accept neither comments nor rejections on
+faith: assess each against the current PR head, task scope, ADRs, tests, and
+measurements. Use the caller-supplied worktree and branch; otherwise resolve
+the PR/branch and its true merge base.
+
+## Assess every comment
+
+Read applicable project context and
+[`docs/agents/lessons.md`](../../../docs/agents/lessons.md), then classify
+each comment as exactly one of:
+
+|Category|Meaning|Action|
+|--------|-------|------|
+|`fix`|Valid and in scope|Implement it.|
+|`fix-partial`|Valid concern; proposal is wrong|Make the smaller correct fix.|
+|`acknowledge`|Valid but out of scope|File or link a follow-up.|
+|`reject`|Incorrect or already handled|Explain with command evidence.|
+
+A numerics comment requires a measurement before accepting or rejecting it.
+For an acknowledged follow-up, use the lifecycle in
+[`docs/workflow.md`](../../../docs/workflow.md), including existing follow-ups
+and open-PR deduplication.
+
+## Implement and verify accepted changes
+
+Fix the whole class, not only the cited line. Before changing a factual claim,
+perform the before/after stale-sibling sweep required by
+[`docs/agents/doc-consistency.md`](../../../docs/agents/doc-consistency.md).
+Re-measure affected public paths and update durable records and the PR body if
+needed. Rebuild after Cython edits and run the preflight gate before staging.
+
+For class-shaped review findings, update the lessons ledger in the same commit
+only when a real PR citation is available. In a pipeline or review cycle,
+commit and push the approved fixes after the gate; standalone use leaves them
+uncommitted for `$commit-and-pr`.
+
+## Report
+
+Return one block per reviewer:
+
+```text
+## Response to <Reviewer ID>
+
+### Accepted
+| # | Comment Summary | Category | Action Taken |
+|---|---|---|---|
+
+### Acknowledged (deferred)
+| # | Comment Summary | Reason | Follow-up file |
+|---|---|---|---|
+
+### Rejected
+| # | Comment Summary | Reason (with evidence) |
+|---|---|---|
+
+### Verdict Requested: <ACCEPT | ITERATE>
+```
+
+Then give a combined count, files modified, literal test summary,
+numerical-impact result, and outstanding questions. Never do drive-by cleanup,
+silently revert a valid fix, or claim a green run without its summary line.

--- a/.codex/skills/review-respond/agents/openai.yaml
+++ b/.codex/skills/review-respond/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Respond to Review"
+  short_description: "Assess review feedback and apply justified fixes."
+  default_prompt: "Use $review-respond to address the review feedback for PR #123."

--- a/.codex/skills/task-pipeline/SKILL.md
+++ b/.codex/skills/task-pipeline/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: task-pipeline
+description: "Orchestrate one Hazma project task end to end in a dedicated Codex worktree: resolve, implement, open a draft PR, run a bounded review cycle, and finalize or retain the PR draft. Use when a user asks to implement and ship one project task; it requires projects/<slug>/PLAN.md."
+---
+
+# Run one task pipeline
+
+Keep the orchestrator small and use fresh Codex agents for implementation and
+finalization. All editing agents share the one pipeline worktree, so give them
+the absolute path and branch, prohibit nested worktrees, and make phase
+boundaries hard stop/go gates.
+
+## Phase A — resolve and create the worktree
+
+Resolve `--project <slug>` or a project branch (parse both prefixes), then use
+`scripts/agents/resolve_task.py --project <slug> [--task <id>]` to select the
+requested task or `next`. Stop on `done` or unresolved project state.
+
+Create the shared worktree from fresh trunk:
+
+```sh
+scripts/agents/setup_task_worktree.sh \
+  --project <slug> --task-slug <task-slug> --agent codex
+```
+
+Record `WT_PATH`, `BRANCH`, task ID, title, and task slug. Confirm the new
+worktree is clean and based on the reported trunk SHA.
+
+## Phase B — implement
+
+Spawn one implementation agent in the shared worktree. Direct it to use
+`$execute-single-task`, skip only that skill's worktree-creation step, execute
+every other gate and bookkeeping step, then stage intentionally, validate a
+Conventional Commit header, commit, push, and end with:
+
+```text
+## Pipeline Report
+STATUS: COMPLETE | BLOCKED
+PROJECT: <slug>
+TASK_ID: <id>
+TASK_TITLE: <title>
+TASK_NOTE_PATH: <path>
+BRANCH: <branch>
+COMMIT_SHA: <pushed SHA>
+FILES_CHANGED: <list>
+SUMMARY: <paragraph>
+NUMERICAL_IMPACT: <measurement>
+PLAN_IMPACT: <value>
+BLOCKER: <none or reason>
+```
+
+Parse this block, then independently verify `origin/<branch>` equals its SHA.
+Stop for `BLOCKED`, a missing report, or a mismatched SHA.
+
+## Phase C — draft PR
+
+Unless `skip-pr`, open a draft PR against `master` with a valid
+`chore(pipe): pipeline draft ...` placeholder title and a minimal task/body
+stub. Capture `PR_NUMBER`. A review still needs this draft even when final PR
+creation is skipped.
+
+## Phase D — review
+
+Unless `skip-review`, run `$review-cycle` inline with `PR_NUMBER`, `WT_PATH`,
+`BRANCH`, external advisory reviews, and the iteration cap. Route
+`CONVERGED` to finalization, retain a draft for `NOT_CONVERGED`, and stop for
+`ESCALATE`. Do not spawn a second orchestration agent for this phase.
+
+## Phase E — finalize
+
+Spawn one finalizer in the same worktree. It reads the PR guidelines and task
+note, reconciles the current diff, validates the final title, and updates the
+draft body with Summary, Project, Numerical impact, Review, Test plan, and
+Versioning when closing a project. It makes a converged PR ready and watches
+CI to a bounded conclusion; it leaves an unconverged PR as a draft. It reports:
+
+```text
+## Pipeline Report
+STATUS: PR_READY | PR_DRAFT | PR_FAILED
+PR_URL: <url or none>
+PR_TITLE: <title>
+CI_STATUS: passing | failing | pending | not-watched
+ERROR: <none or reason>
+```
+
+Verify the PR head against the final commit before reporting. Leave the
+worktree and branch for the user to inspect; do not clean them up implicitly.
+
+## Final summary
+
+Report project, task, branch, worktree, implementation SHA and summary,
+numerical impact, review status/rounds/unresolved issues, PR URL/title/CI, and
+plan/versioning impact. Never batch tasks, commit to `master`, accept a
+missing pipeline report, or let a public numerical change go unmeasured.

--- a/.codex/skills/task-pipeline/agents/openai.yaml
+++ b/.codex/skills/task-pipeline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Task Pipeline"
+  short_description: "Implement, review, and ship one project task."
+  default_prompt: "Use $task-pipeline to implement and ship the next task in project my-project."

--- a/.gitignore
+++ b/.gitignore
@@ -531,12 +531,13 @@ hazma/_positron/stubgen.sh
 notebooks/decay_spectra
 notebooks/dev/gev/
 # `scripts/` is local scratch and stays ignored, except the agent-workflow
-# helpers that `docs/agents/` and `.claude/skills/` shell out to.
+# helpers that `docs/agents/`, `.claude/skills/`, and `.codex/skills/`
+# shell out to.
 scripts/*
 !scripts/agents/
 
 # Agent-local state: per-session settings and task worktrees. The skills
-# under .claude/skills/ ARE tracked.
+# under .claude/skills/ and .codex/skills/ ARE tracked.
 .claude/settings.local.json
 .claude/worktrees/
 .codex/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,9 @@ only in a PR description.
 
 ## Skills
 
-`.claude/skills/` holds the workflow skills that automate this loop:
-`execute-single-task`, `commit-and-pr`, `review-pr`, `review-respond`,
-`review-cycle`, `task-pipeline`, `begin-phase`, `review-plan`. Each
-expects the filesystem contract above and points into `docs/agents/` for
-shared rules. Read a skill's `SKILL.md` for its exact inputs and outputs.
+`.claude/skills/` and `.codex/skills/` hold parallel workflow skills for
+this loop: `execute-single-task`, `commit-and-pr`, `review-pr`,
+`review-respond`, `review-cycle`, `task-pipeline`, `begin-phase`, and
+`review-plan`. Each expects the filesystem contract above and points into
+`docs/agents/` for shared rules. Read the active agent's `SKILL.md` for
+its exact inputs and outputs.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -2,8 +2,9 @@
 
 Agent-neutral, single-source guidance for any coding agent working in
 this repo — Claude Code, Codex, or otherwise. The skills under
-`.claude/skills/` are thin: they carry role, workflow, and gates, and
-they **point here** for the shared rules rather than restating them.
+`.claude/skills/` and `.codex/skills/` are thin: they carry role,
+workflow, and gates, and they **point here** for the shared rules rather
+than restating them.
 
 ## The contract
 
@@ -35,6 +36,7 @@ they **point here** for the shared rules rather than restating them.
 Deterministic helpers live under
 [`scripts/agents/`](../../scripts/agents/) — `preflight.sh`,
 `check_pr_title.py`, `setup_task_worktree.sh`, `resolve_task.py`,
+`resolve_phase.py`,
 `check_doc_citations.py`. They are the executable form of the rules in
 this layer; a skill calls the script rather than re-describing its steps.
 The same one-copy-per-invariant principle applies: the logic lives in the

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -45,8 +45,8 @@ fixed when it isn't. Rebuild, then confirm.
 site-packages install shadows the checkout depending on cwd and how the
 env was set up. `python -c "import hazma; print(hazma.__file__)"` before
 trusting any result you attribute to your edit — especially inside a git
-worktree under `.claude/worktrees/`, which is a *different directory*
-from the checkout the editable install points at.
+worktree under `.claude/worktrees/` or `.codex/worktrees/`, which is a
+*different directory* from the checkout the editable install points at.
 
 **`pip install -e .` needs Cython, NumPy, and a C/C++ compiler.** A
 missing toolchain surfaces as a build error deep in `_gamma_ray`

--- a/docs/agents/review-lenses.md
+++ b/docs/agents/review-lenses.md
@@ -13,30 +13,48 @@ file conflicts with a skill's inline prose, this file plus
 
 ## Reviewer roster
 
-Each reviewer's identity — letter, role, model, `--lens` flag, and when
-its lens is load-bearing — is fixed below. A single prompt template
-spawns the selected subset, substituting these fields.
+Each reviewer's identity — letter, role, agent-specific capability target, and
+`--lens` flag — is fixed below. A single prompt template spawns the selected
+subset, substituting these fields. The Model column applies to Claude; Codex
+inherits the active model.
 
-| ID | Role | Model | Effort | `--lens` | When this lens is useful |
-|----|------|-------|--------|----------|--------------------------|
-| A | Generalist | `sonnet` | medium | (none) | Almost always — a broad pass over completeness, correctness, numerics, and conventions. The default safety net when no other reviewer clearly owns a concern. |
-| B | Completeness | `sonnet` | medium | `completeness` | Task has explicit Exit / Acceptance Criteria, multi-bullet objectives, or a phase-file gate; the diff might under- or over-deliver against the spec. |
-| C | Logic | `sonnet` | high | `logic` | Diff changes runtime behavior — control flow, error handling, array broadcasting, interpolation, integration bounds, or non-trivial branching. Pure-doc / pure-fixture / pure-rename PRs usually do not need C. |
-| D | Doc Consistency & Canonical Contract | `sonnet` | medium | `doc-consistency` | Diff touches durable docs (task notes, working-memory READMEs, phase files, ADRs, learnings, README, CHANGELOG, follow-ups), edits any module/function docstring, or asserts numeric / command / identifier claims that must reproduce. |
-| E | Numerics & Performance | `opus` | high | `numerics` | **Any diff that can move a number** — physics formulas, constants, interpolation, integration, phase space, spectra, limits — or that touches a hot loop or the Cython boundary. This is a physics library: E is the lens most likely to catch the defect that matters. |
+|ID|Role|Model|Effort|Codex|Lens|
+|--|----|-----|------|-----|----|
+|A|Generalist|`sonnet`|medium|inherit|none|
+|B|Completeness|`sonnet`|medium|inherit|`completeness`|
+|C|Logic|`sonnet`|high|inherit|`logic`|
+|D|Doc consistency|`sonnet`|medium|inherit|`doc-consistency`|
+|E|Numerics|`opus`|high|inherit|`numerics`|
 
-**Models.** The roster is calibrated for the current generation:
+- **A — Generalist:** Use almost always as the broad safety net for
+  completeness, correctness, numerics, and conventions.
+- **B — Completeness:** Use for explicit Exit / Acceptance Criteria,
+  multi-bullet objectives, or a phase-file gate.
+- **C — Logic:** Use for runtime behavior, control flow, error handling,
+  broadcasting, interpolation, integration bounds, or non-trivial branching.
+  Pure docs, fixtures, and renames usually do not need C.
+- **D — Doc Consistency & Canonical Contract:** Use when a diff touches
+  durable docs, a public docstring, or claims that must reproduce.
+- **E — Numerics & Performance:** Use whenever a change can move a number or
+  touches a hot loop or Cython boundary. This is the highest-value physics
+  lens.
+
+**Agent models and effort.** The roster is calibrated for the current
+generation:
 
 - **A–D default to `sonnet`** (Sonnet 5). They are pattern-matching and
   cross-referencing passes; Sonnet handles them at full quality.
 - **E defaults to `opus`** (Opus 5). Deciding whether a spectrum is
   *right* — not merely finite — is the hardest judgment in this repo and
   the one worth the strongest model.
-- The orchestrator MAY upgrade **A** to `opus` for high-risk or
-  project-closing PRs, and MAY downgrade **D** to `haiku` for a
-  docs-only diff with no numeric claims.
-- The `review-respond` synthesis agent and any implementation subagent
-  are `opus`.
+- Claude's orchestrator MAY upgrade **A** to `opus` for high-risk or
+  project-closing PRs, and MAY downgrade **D** to `haiku` for a docs-only
+  diff with no numeric claims. Claude implementation and review-response
+  agents are `opus`.
+- Codex reviewers inherit the active Codex model unless the caller has
+  authorized an override. Use the table's effort target, and raise E to
+  `xhigh` for a changed published spectrum or limit. Codex implementation
+  and review-response agents use the active model with high effort.
 
 **Reasoning effort.** Pass the `Effort` column when the runner supports
 it. `high` for C and E, `medium` elsewhere; raise E to `xhigh` on a diff

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -347,7 +347,8 @@ carve-out.
 
 ## Skills
 
-This repo defines Claude skills under `.claude/skills/`:
+This repo defines equivalent workflow skills under `.claude/skills/` and
+`.codex/skills/`:
 
 - `execute-single-task` — scoped implementation of one task.
 - `commit-and-pr` — commit, push, and open a PR following the guidelines.
@@ -362,7 +363,7 @@ This repo defines Claude skills under `.claude/skills/`:
 - `review-plan` — stress-test a project plan before implementation.
 
 Each skill expects the filesystem contract described above. Read the
-skill's `SKILL.md` for exact inputs, outputs, and reading order.
+active agent's `SKILL.md` for exact inputs, outputs, and reading order.
 
 ### Shared agent layer
 
@@ -375,8 +376,8 @@ This layer is the one-copy-per-invariant source of truth:
   reviewer roster and lens rubrics, environment/test-infra gotchas, and
   the review-lessons ledger.
 - [`scripts/agents/`](../scripts/agents/) — deterministic helper scripts
-  (preflight execution, PR title validation, task-worktree setup, task
-  resolution, doc-citation bounds checking) that skills shell out to
+  (preflight execution, PR title validation, task-worktree setup, task and
+  phase resolution, doc-citation bounds checking) that skills shell out to
   instead of re-deriving the logic inline.
 
 When a skill needs to state an invariant already captured under

--- a/scripts/agents/resolve_phase.py
+++ b/scripts/agents/resolve_phase.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""
-Resolve which phase of a phased project is eligible to start next and build a
-kickoff prompt for the next agent.
+"""Resolve which phase of a phased project is eligible to start next.
 
-This script is the readiness oracle for the ``begin-phase`` skill. It inspects
+Build a kickoff prompt for the next agent. This script is the readiness oracle
+for the agent-specific ``begin-phase`` skills. It inspects
 the frontmatter of each ``projects/<slug>/phases/phase-XX-*.md`` file plus the
 project's ``PLAN.md`` frontmatter, then emits JSON with one of three states:
 
@@ -25,25 +24,22 @@ import argparse
 import json
 import re
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
-
 
 # ---------------------------------------------------------------------------
 # Phase-id helpers
 
 
 def normalize_phase_id(value: str) -> str:
-    """Normalize a user-provided phase id like ``phase-03``, ``3.1``, or
-    ``8A`` into the canonical form used internally.
+    """Normalize a user-provided phase ID.
 
-    Canonical forms:
+    Accept ``phase-03``, ``3.1``, and ``8A``; canonical forms are:
       - ``"3"`` for major-only phases
       - ``"3.1"`` for decimal sub-phases
       - ``"8A"`` for letter-suffixed parallel phases
     """
-
     token = value.strip().lower()
     token = re.sub(r"^phase[\s_-]*", "", token)
     token = token.replace("_", ".").replace(" ", "")
@@ -66,9 +62,10 @@ def normalize_phase_id(value: str) -> str:
 
 
 def phase_id_from_prefix(prefix: str) -> str:
-    """Turn the ``XX`` (or ``XX_Y``, or ``XXa``) prefix of a phase filename
-    into the canonical id."""
+    """Return the canonical phase ID from a filename prefix.
 
+    Accept ``XX``, ``XX_Y``, and ``XXa`` prefixes.
+    """
     lower = prefix.lower()
     if lower and lower[-1].isalpha():
         return f"{int(lower[:-1])}{lower[-1].upper()}"
@@ -84,7 +81,6 @@ def phase_sort_key(phase_id: str) -> tuple[int, int, int, str]:
     Order: major phases < decimal sub-phases within a major < lettered
     parallel phases within a major.
     """
-
     if phase_id and phase_id[-1].isalpha():
         return (int(phase_id[:-1]), 2, 0, phase_id[-1])
     if "." in phase_id:
@@ -98,18 +94,17 @@ def phase_sort_key(phase_id: str) -> tuple[int, int, int, str]:
 
 
 _FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n?", re.S)
-_KEY_VALUE_RE = re.compile(
-    r"^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$"
-)
+_KEY_VALUE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$")
 _PHASE_NUMBER_RE = re.compile(
     r"Phase\s+(?P<id>[0-9]+(?:\.[0-9]+)?|[0-9]+[A-Za-z])",
     re.I,
 )
 _COMPLETE_MENTION_RE = re.compile(
-    r"Phase\s+(?P<id>[0-9]+(?:\.[0-9]+)?|[0-9]+[A-Za-z])"
-    r"\s+(?:is\s+)?complete",
+    r"Phase\s+(?P<id>[0-9]+(?:\.[0-9]+)?|[0-9]+[A-Za-z])" r"\s+(?:is\s+)?complete",
     re.I,
 )
+_MIN_QUOTED_VALUE_LENGTH = 2
+_REPO_ROOT_PARENT_DEPTH = 2
 
 
 def parse_frontmatter(text: str) -> dict[str, str]:
@@ -118,7 +113,6 @@ def parse_frontmatter(text: str) -> dict[str, str]:
     We do not depend on a YAML library -- frontmatter in this repo is always
     simple ``key: value`` lines. Quoted values are unquoted.
     """
-
     match = _FRONTMATTER_RE.match(text)
     if not match:
         return {}
@@ -129,7 +123,11 @@ def parse_frontmatter(text: str) -> dict[str, str]:
         if not kv:
             continue
         value = kv.group(2).strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        if (
+            len(value) >= _MIN_QUOTED_VALUE_LENGTH
+            and value[0] == value[-1]
+            and value[0] in ("'", '"')
+        ):
             value = value[1:-1]
         data[kv.group(1)] = value
     return data
@@ -153,9 +151,10 @@ def extract_phase_title(text: str, default: str) -> str:
 
 
 def extract_prerequisite_section(text: str) -> str:
-    """Return the body of the ``## Prerequisites`` block, or ``""`` if the
-    section is missing."""
+    """Return the body of the ``## Prerequisites`` block.
 
+    Return ``""`` if the section is missing.
+    """
     match = re.search(
         r"^## Prerequisites\s*\n(?P<body>.*?)(?=^## |\Z)",
         text,
@@ -167,8 +166,7 @@ def extract_prerequisite_section(text: str) -> str:
 
 
 def extract_prereq_phase_ids(prereq_text: str) -> tuple[tuple[str, ...], bool]:
-    """Extract machine-resolvable phase-id prerequisites from free-form
-    prose.
+    """Extract machine-resolvable phase-ID prerequisites from prose.
 
     Returns ``(ids, machine_resolvable)`` where ``machine_resolvable`` is:
       - ``True`` if the section is empty, or mentions no phases, or mentions
@@ -179,7 +177,6 @@ def extract_prereq_phase_ids(prereq_text: str) -> tuple[tuple[str, ...], bool]:
     We're intentionally strict: ambiguous prose is flagged rather than
     optimistically resolved.
     """
-
     stripped = prereq_text.strip()
     if not stripped:
         return (tuple(), True)
@@ -195,12 +192,7 @@ def extract_prereq_phase_ids(prereq_text: str) -> tuple[tuple[str, ...], bool]:
         # Some phase references don't have matching "complete" wording.
         # Return what we found but flag as not machine-resolvable.
         ids = tuple(
-            sorted(
-                {
-                    normalize_phase_id(m.group("id"))
-                    for m in complete_mentions
-                }
-            )
+            sorted({normalize_phase_id(m.group("id")) for m in complete_mentions})
         )
         return (ids, False)
 
@@ -264,18 +256,14 @@ def load_phase_records(project_dir: Path) -> dict[str, PhaseRecord]:
         status = frontmatter.get("status")
 
         prereq_section = extract_prerequisite_section(text)
-        prereq_ids, machine_resolvable = extract_prereq_phase_ids(
-            prereq_section
-        )
+        prereq_ids, machine_resolvable = extract_prereq_phase_ids(prereq_section)
 
         learnings_paths: tuple[Path, ...] = tuple()
         if learnings_dir.is_dir():
             pattern = f"phase-{prefix.lower()}-*.md"
             learnings_paths = tuple(
                 sorted(
-                    p
-                    for p in learnings_dir.glob(pattern)
-                    if not p.name.startswith("_")
+                    p for p in learnings_dir.glob(pattern) if not p.name.startswith("_")
                 )
             )
 
@@ -303,12 +291,11 @@ def relpath(repo_root: Path, path: Path) -> str:
         return str(path)
 
 
-def phase_closeout_issues(
-    repo_root: Path, record: PhaseRecord
-) -> list[str]:
-    """Reasons a phase is not considered fully closed out. Empty list means
-    the phase is closed out and its downstream dependents may proceed."""
+def phase_closeout_issues(repo_root: Path, record: PhaseRecord) -> list[str]:
+    """Return reasons a phase is not fully closed out.
 
+    An empty list allows downstream phases to proceed.
+    """
     issues: list[str] = []
     if not status_is_complete(record.status):
         issues.append(
@@ -335,7 +322,6 @@ def prerequisite_blockers(
     - ``unknown_prereqs`` -- raw prereq ids referenced but not present as
       phase files in the project.
     """
-
     record = phases[phase_id]
     blockers: list[dict[str, object]] = []
     unknown: list[str] = []
@@ -356,12 +342,11 @@ def prerequisite_blockers(
     return blockers, unknown
 
 
-def eligible_frontier(
-    repo_root: Path, phases: dict[str, PhaseRecord]
-) -> list[str]:
-    """Phases whose ``status: Not started`` and whose prerequisites are all
-    closed out and machine-resolvable."""
+def eligible_frontier(repo_root: Path, phases: dict[str, PhaseRecord]) -> list[str]:
+    """Return eligible not-started phases.
 
+    Every prerequisite must be closed out and machine-resolvable.
+    """
     frontier: list[str] = []
     for phase_id, record in sorted(
         phases.items(), key=lambda item: phase_sort_key(item[0])
@@ -371,9 +356,7 @@ def eligible_frontier(
         if not record.prereqs_machine_resolvable:
             # Don't silently promote prereqs-unknown phases to the frontier.
             continue
-        blockers, unknown = prerequisite_blockers(
-            repo_root, phases, phase_id
-        )
+        blockers, unknown = prerequisite_blockers(repo_root, phases, phase_id)
         if blockers or unknown:
             continue
         frontier.append(phase_id)
@@ -383,8 +366,7 @@ def eligible_frontier(
 def blocked_frontier_candidates(
     repo_root: Path, phases: dict[str, PhaseRecord]
 ) -> list[dict[str, object]]:
-    """Phases that look like the next candidates to start but are currently
-    blocked.
+    """Return not-started phases that are blocked.
 
     A phase makes the blocked-candidate list when its own status is
     ``Not started`` but one or more of the following is true:
@@ -410,9 +392,7 @@ def blocked_frontier_candidates(
             # Continue to also list any prereqs we *did* recognize so
             # the operator sees concrete context.
 
-        blockers, unknown = prerequisite_blockers(
-            repo_root, phases, phase_id
-        )
+        blockers, unknown = prerequisite_blockers(repo_root, phases, phase_id)
         for prereq_id in unknown:
             issues.append(
                 f"Phase {prereq_id} referenced as a prerequisite but "
@@ -458,18 +438,17 @@ def phase_summary(
         payload["reason"] = "No phase-level prerequisites."
     else:
         labels = [f"Phase {p}" for p in prereqs]
-        payload["reason"] = (
-            f"Prerequisites satisfied: {', '.join(labels)}."
-        )
+        payload["reason"] = f"Prerequisites satisfied: {', '.join(labels)}."
     return payload
 
 
-def build_prompt(
+def build_prompt(  # noqa: PLR0913, PLR0917
     project_slug: str,
     project_dir: Path,
     repo_root: Path,
     phases: dict[str, PhaseRecord],
     phase_id: str,
+    agent: str = "claude",
 ) -> str:
     record = phases[phase_id]
 
@@ -498,21 +477,20 @@ def build_prompt(
     rules_path = relpath(repo_root, project_dir / "rules.md")
     phase_path = relpath(repo_root, record.phase_file)
     recheck = (
-        f"python3 .claude/skills/begin-phase/scripts/resolve_phase.py "
-        f"--project {project_slug} --target-phase {phase_id}"
+        f"python3 scripts/agents/resolve_phase.py --project "
+        f"{project_slug} --agent {agent} --target-phase {phase_id}"
     )
 
     return (
-        f"Use the `/execute-single-task` skill.\n\n"
+        f"Use the `$execute-single-task` skill.\n\n"
         f"You are starting Phase {phase_id}: {record.title} for project "
         f"`{project_slug}` (root `{repo_root}`).\n\n"
         "Before editing:\n"
         f"1. Re-run `{recheck}` and refuse to proceed unless the result "
         f"is still `ready`.\n"
-        "2. Create your worktree as Step 3 of `/execute-single-task` "
-        "instructs -- path `.claude/worktrees/"
-        f"{project_slug}/<task-slug>/`, branch "
-        f"`claude/{project_slug}/<task-slug>`.\n\n"
+        "2. Create your worktree as Step 3 of `$execute-single-task` "
+        f"instructs -- path `.{agent}/worktrees/{project_slug}/"
+        f"<task-slug>/`, branch `{agent}/{project_slug}/<task-slug>`.\n\n"
         "Scope:\n"
         f"- Work only within Phase {phase_id}.\n"
         "- Do not start sibling or downstream phases.\n"
@@ -539,7 +517,7 @@ def build_prompt(
         f"{phase_id} task, if one exists\n\n"
         "Guardrails:\n"
         "- Avoid reading unrelated phase files.\n"
-        "- Follow `/execute-single-task` to keep scope to one task or "
+        "- Follow `$execute-single-task` to keep scope to one task or "
         "tightly related task cluster.\n"
         "- If prerequisite closeout or repo state has drifted since this "
         "prompt was generated, stop and report it instead of beginning "
@@ -558,23 +536,23 @@ def resolve_project_dir(
         return project_dir_arg.resolve()
     if project_arg is not None:
         return (repo_root / "projects" / project_arg).resolve()
-    raise ValueError(
-        "one of --project <slug> or --project-dir <path> is required"
-    )
+    raise ValueError("one of --project <slug> or --project-dir <path> is required")
 
 
-def resolve_phase(
+def resolve_phase(  # noqa: PLR0911, PLR0912, PLR0913, PLR0917
     repo_root: Path,
     project_slug: str,
     project_dir: Path,
     completed_phase: str | None = None,
     target_phase: str | None = None,
+    agent: str = "claude",
 ) -> dict[str, object]:
+    if agent not in {"claude", "codex"}:
+        raise ValueError(f"unsupported agent: {agent!r}")
     plan_path = project_dir / "PLAN.md"
     if not plan_path.exists():
         raise ValueError(
-            f"project PLAN not found at "
-            f"{relpath(repo_root, plan_path)}"
+            f"project PLAN not found at " f"{relpath(repo_root, plan_path)}"
         )
     plan_frontmatter = parse_frontmatter(plan_path.read_text())
     phased_flag = plan_frontmatter.get("phased", "").strip().lower()
@@ -616,9 +594,7 @@ def resolve_phase(
     normalized_completed = (
         normalize_phase_id(completed_phase) if completed_phase else None
     )
-    normalized_target = (
-        normalize_phase_id(target_phase) if target_phase else None
-    )
+    normalized_target = normalize_phase_id(target_phase) if target_phase else None
     if normalized_completed and normalized_completed not in phases:
         raise ValueError(f"unknown completed phase: {completed_phase}")
     if normalized_target and normalized_target not in phases:
@@ -651,8 +627,7 @@ def resolve_phase(
                 "status": "blocked",
                 "project": project_slug,
                 "message": (
-                    f"Phase {normalized_target} is not in the "
-                    "`Not started` state."
+                    f"Phase {normalized_target} is not in the " "`Not started` state."
                 ),
                 "eligible_frontier": frontier_payload,
                 "blockers": [
@@ -693,9 +668,7 @@ def resolve_phase(
                 "prompt": None,
             }
 
-        blockers, unknown = prerequisite_blockers(
-            repo_root, phases, normalized_target
-        )
+        blockers, unknown = prerequisite_blockers(repo_root, phases, normalized_target)
         for prereq_id in unknown:
             blockers.append(
                 {
@@ -734,6 +707,7 @@ def resolve_phase(
                 repo_root,
                 phases,
                 normalized_target,
+                agent,
             ),
         }
 
@@ -810,8 +784,7 @@ def resolve_phase(
             ),
             "eligible_frontier": frontier_payload,
             "choices": [
-                phase_summary(repo_root, phases, phase_id)
-                for phase_id in candidates
+                phase_summary(repo_root, phases, phase_id) for phase_id in candidates
             ],
             "notes": notes,
             "prompt": None,
@@ -826,7 +799,7 @@ def resolve_phase(
         "phase": phase_summary(repo_root, phases, phase_id),
         "notes": notes,
         "prompt": build_prompt(
-            project_slug, project_dir, repo_root, phases, phase_id
+            project_slug, project_dir, repo_root, phases, phase_id, agent
         ),
     }
 
@@ -838,14 +811,16 @@ def resolve_phase(
 def default_repo_root() -> Path:
     """Walk up from the script looking for a checkout root.
 
-    This script lives at
-    ``<repo>/.claude/skills/begin-phase/scripts/resolve_phase.py``, so the
-    repo root is four ``parents`` up. If that doesn't look like a checkout
-    (no ``projects/`` and no ``.git``), fall back to CWD.
+    This script lives at ``<repo>/scripts/agents/resolve_phase.py``, so the
+    repo root is two ``parents`` up. If that doesn't look like a checkout (no
+    ``projects/`` and no ``.git``), fall back to CWD.
     """
-
     here = Path(__file__).resolve()
-    candidate = here.parents[4] if len(here.parents) > 4 else here.parent
+    candidate = (
+        here.parents[_REPO_ROOT_PARENT_DEPTH]
+        if len(here.parents) > _REPO_ROOT_PARENT_DEPTH
+        else here.parent
+    )
     if (candidate / "projects").is_dir() or (candidate / ".git").exists():
         return candidate
     return Path.cwd()
@@ -890,6 +865,15 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--agent",
+        choices=("claude", "codex"),
+        default="claude",
+        help=(
+            "Agent identity to embed in the generated kickoff prompt. "
+            "Defaults to claude for backward compatibility."
+        ),
+    )
+    parser.add_argument(
         "--repo-root",
         type=Path,
         default=None,
@@ -902,17 +886,13 @@ def main(argv: Iterable[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
 
     if args.project is None and args.project_dir is None:
-        sys.stderr.write(
-            "error: one of --project or --project-dir is required\n"
-        )
+        sys.stderr.write("error: one of --project or --project-dir is required\n")
         return 2
 
     repo_root = (args.repo_root or default_repo_root()).resolve()
 
     try:
-        project_dir = resolve_project_dir(
-            repo_root, args.project, args.project_dir
-        )
+        project_dir = resolve_project_dir(repo_root, args.project, args.project_dir)
         # Infer the slug if only --project-dir was supplied.
         project_slug = args.project or project_dir.name
         result = resolve_phase(
@@ -921,8 +901,9 @@ def main(argv: Iterable[str] | None = None) -> int:
             project_dir=project_dir,
             completed_phase=args.completed_phase,
             target_phase=args.target_phase,
+            agent=args.agent,
         )
-    except Exception as exc:  # CLI error path
+    except (OSError, ValueError) as exc:
         payload = {
             "status": "error",
             "project": args.project,

--- a/test/agents/test_resolve_phase.py
+++ b/test/agents/test_resolve_phase.py
@@ -1,7 +1,7 @@
-"""Regression tests for `.claude/skills/begin-phase/scripts/resolve_phase.py`.
+"""Regression tests for `scripts/agents/resolve_phase.py`.
 
 The agent-workflow helpers are not importable as a package (they live under
-`.claude/` and `scripts/`, outside `hazma`), so they are loaded by path.
+`scripts/`, outside `hazma`), so they are loaded by path.
 
 The bug these guard: `build_prompt` used to interpolate the *canonical* phase
 id into filesystem paths. `phase_id_from_prefix("02")` normalizes to `"2"`, so
@@ -17,6 +17,7 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -30,10 +31,11 @@ REPO_ROOT = Path(
     ).stdout.strip()
 )
 
-SCRIPT = REPO_ROOT / ".claude/skills/begin-phase/scripts/resolve_phase.py"
+SCRIPT = REPO_ROOT / "scripts/agents/resolve_phase.py"
+EXPECTED_PHASE_README_MENTIONS = 2
 
 
-def _load_module():
+def _load_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("resolve_phase", SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -46,7 +48,7 @@ pytestmark = pytest.mark.skipif(not SCRIPT.is_file(), reason=f"{SCRIPT} not pres
 
 
 @pytest.fixture(scope="module")
-def resolve_phase():
+def resolve_phase() -> ModuleType:
     return _load_module()
 
 
@@ -77,7 +79,7 @@ def _scaffold(tmp_path: Path, prefix: str, slug: str = "demo") -> Path:
     return project
 
 
-def test_phase_id_normalization_drops_zero_padding(resolve_phase):
+def test_phase_id_normalization_drops_zero_padding(resolve_phase: ModuleType) -> None:
     """The canonical id is unpadded -- this is what makes the bug possible."""
     assert resolve_phase.phase_id_from_prefix("02") == "2"
     assert resolve_phase.phase_id_from_prefix("2") == "2"
@@ -85,9 +87,13 @@ def test_phase_id_normalization_drops_zero_padding(resolve_phase):
 
 
 @pytest.mark.parametrize("prefix", ["01", "02", "09", "10"])
-def test_prompt_paths_use_the_filename_prefix(resolve_phase, tmp_path, prefix):
-    """Kickoff-prompt paths must match the on-disk directory, zero-padding
-    included -- not the normalized display id."""
+def test_prompt_paths_use_the_filename_prefix(
+    resolve_phase: ModuleType, tmp_path: Path, prefix: str
+) -> None:
+    """Use the filename prefix in kickoff-prompt paths.
+
+    Preserve zero padding rather than interpolating the normalized display ID.
+    """
     project = _scaffold(tmp_path, prefix)
     phases = resolve_phase.load_phase_records(project)
     phase_id = resolve_phase.phase_id_from_prefix(prefix)
@@ -101,7 +107,7 @@ def test_prompt_paths_use_the_filename_prefix(resolve_phase, tmp_path, prefix):
     )
 
     expected = f"task-notes/phase-{prefix}/README.md"
-    assert prompt.count(expected) == 2, (
+    assert prompt.count(expected) == EXPECTED_PHASE_README_MENTIONS, (
         f"expected both per-phase README references to use {expected!r}\n"
         f"prompt was:\n{prompt}"
     )
@@ -115,7 +121,9 @@ def test_prompt_paths_use_the_filename_prefix(resolve_phase, tmp_path, prefix):
         assert f"task-notes/phase-{phase_id}/" not in prompt
 
 
-def test_prompt_still_uses_the_canonical_id_for_display(resolve_phase, tmp_path):
+def test_prompt_still_uses_the_canonical_id_for_display(
+    resolve_phase: ModuleType, tmp_path: Path
+) -> None:
     """Display text keeps the unpadded id -- 'Phase 2', not 'Phase 02'."""
     project = _scaffold(tmp_path, "02")
     phases = resolve_phase.load_phase_records(project)
@@ -132,10 +140,33 @@ def test_prompt_still_uses_the_canonical_id_for_display(resolve_phase, tmp_path)
     assert "Work only within Phase 2." in prompt
 
 
+def test_prompt_uses_the_requested_agent_identity(
+    resolve_phase: ModuleType, tmp_path: Path
+) -> None:
+    """The shared readiness helper must generate a Codex-safe handoff."""
+    project = _scaffold(tmp_path, "02")
+    phases = resolve_phase.load_phase_records(project)
+
+    prompt = resolve_phase.build_prompt(
+        project_slug="demo",
+        project_dir=project,
+        repo_root=tmp_path,
+        phases=phases,
+        phase_id="2",
+        agent="codex",
+    )
+
+    assert "scripts/agents/resolve_phase.py" in prompt
+    assert "--agent codex" in prompt
+    assert ".codex/worktrees/demo/<task-slug>/" in prompt
+    assert "`codex/demo/<task-slug>`" in prompt
+
+
 @pytest.mark.parametrize("prefix", ["01", "02", "09", "10"])
-def test_resolve_task_agrees_on_the_phase_directory(tmp_path, prefix):
-    """The two helpers must derive the same per-phase directory, or a
-    begin-phase handoff points somewhere resolve_task cannot read.
+def test_resolve_task_agrees_on_the_phase_directory(
+    tmp_path: Path, prefix: str
+) -> None:
+    """Keep both helpers aligned on the per-phase directory.
 
     `resolve_task.resolve_phase()` is called directly rather than through the
     CLI: the CLI locates the project via `git rev-parse`, so it would look


### PR DESCRIPTION
## Summary

- Add Codex-native counterparts for the repository's eight workflow skills.
- Promote the phase-readiness helper to `scripts/agents/` and generate agent-specific kickoff prompts.
- Document shared agent behavior and bring the moved helper and tests into the linted scope.

## Test plan

- [x] `scripts/agents/preflight.sh` for the changed Python, tests, and Markdown files (`11 passed`).