### PR TITLE
ci(release): publish to pypi via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,14 @@ jobs:
     if: github.event_name == 'release'
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
+    # Registered as the environment on PyPI's trusted publisher for hazma, so
+    # only this job can mint an upload token.  Its deployment rule restricts
+    # runs to tag refs matching *.* (the release tags: 2.0.2, 1.1, ...).
+    environment: pypi
+    permissions:
+      # Mint the OIDC token that PyPI exchanges for a short-lived, project-
+      # scoped upload token.  No PyPI credential is stored in this repo.
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -69,6 +77,3 @@ jobs:
           merge-multiple: true
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace the static `PYPI_API_TOKEN` secret with OIDC trusted publishing. GitHub mints a short-lived token per run; PyPI exchanges it for an upload token scoped to this project and valid for minutes. No long-lived PyPI credential remains in the repo.
- The publish job declares `environment: pypi`, registered as the environment on PyPI's trusted publisher for `hazma` so only this job can mint a token. That environment carries a deployment rule limiting runs to tag refs matching `*.*` — matching the release tags (`2.0.2`, `1.1`) and never a branch ref.
- Job-level `permissions` replaces rather than merges with the top-level block, so the publish job holds `id-token: write` and nothing else. It never checks out the repo, and same-run artifact downloads authenticate with the runner's artifact token rather than `GITHUB_TOKEN`, so dropping `contents: read` costs nothing.

No library code changed — the diff is one workflow file. No returned value moves.

**Merge order matters:** the trusted publisher must be registered on PyPI (with Environment set to `pypi`, not blank) before this merges. Otherwise the next release builds fine and then fails at the publish step. After the first successful release, delete the `PYPI_API_TOKEN` repo secret and revoke the token on PyPI.

## Test plan

- [x] Workflow YAML parses and the publish job resolves as intended:

```
top-level permissions: {"contents"=>"read"}
{"name": "Publish to PyPI", "if": "github.event_name == 'release'",
 "needs": ["build-wheels", "build-sdist"], "runs-on": "ubuntu-latest",
 "environment": "pypi", "permissions": {"id-token": "write"},
 "steps": [{"uses": "actions/download-artifact@v8", ...},
           {"name": "Publish package", "uses": "pypa/gh-action-pypi-publish@release/v1"}]}
```

- [x] No credential references remain: `grep -n "PYPI_API_TOKEN\|password\|user:" .github/workflows/release.yml` exits 1 (no matches).

- [x] GitHub environment verified via API — `{"name": "*.*", "type": "tag"}`, with `custom_branch_policies: true`.

- [x] `scripts/agents/preflight.sh`:

```
PASS   black --check           hazma test
FAIL   isort --check-only      run `isort hazma test` and re-check
FAIL   ruff check              see output below
PASS   pytest                  52 passed, 20 skipped in 255.09s (0:04:15)
PASS   import hazma            version 2.0.2
PASS   forbidden tokens        none added
```

The two red rows are pre-existing repo-wide lint debt on `master`, not introduced here. Re-running them with this diff stashed gives identical counts (190 isort errors, 6844 ruff errors), and the linted paths (`hazma test`) do not include the changed file. CI's ruff step is narrower (`--isolated --select E9,F63,F7,F82`) and unaffected.

- [x] `scripts/agents/check_pr_title.py "ci(release): publish to pypi via trusted publishing"` → `OK`