### PR TITLE
chore(release): bump to 2.1.0 and document numerical changes

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -84,8 +84,9 @@ scripts/agents/preflight.sh --paths "<touched paths>" \
 See [`preflight.md`](../../../docs/agents/preflight.md) for the
 rationale, the zero-collection trap, and the manual fallback. There are
 no pre-commit hooks in this repo, and CI's lint pass is narrow
-(`ruff check --isolated --select E9,F63,F7,F82`, with no formatting check
-at all) — so this gate catches far more than CI will. A non-zero exit is
+(`black --check` plus `ruff check --isolated --select E9,F63,F7,F82`, so
+no import-order or configured-rule check) — this gate catches more than
+CI will. A non-zero exit is
 a blocked commit; a `WARN` row is an unrun gate, not a pass.
 
 If the diff touched `.pyx` / `.pxd` / `_build.py`, rebuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,93 @@ signature did.
 
 Nothing yet.
 
+## [2.1.0]
+
+**This release changes numbers.** Gamma-ray spectra from the GeV
+vector-mediator models and every detector-convolved spectrum move. Plots
+and limits produced with 2.0.2 will not reproduce exactly. Read the
+`Changed` section before upgrading a published analysis.
+
+### Changed
+
+- **Detector-convolved spectra move everywhere.**
+  `hazma.parameters.convolved_spectrum_fn`, and with it
+  `Theory.total_conv_spectrum_fn` and
+  `Theory.total_conv_positron_spectrum_fn`, built the Gaussian detector
+  response with a width set by the *reconstructed* energy rather than the
+  true energy, then normalized over the true energy. Where a detector's
+  resolution degrades with energy this leaked sharp spectral features to
+  arbitrarily high reconstructed energies. For a 10 MeV scalar decaying to
+  e⁺e⁻ observed by e-ASTROGAM — resolution 0.5% at 10 MeV rising to 20% at
+  30 MeV — the FSR spectrum cuts off at ~4.95 MeV, but the convolved
+  spectrum carried a spurious ~1e-7 tail from 25 MeV out to 1 GeV. That
+  tail is now identically zero and total photon number is conserved to
+  3e-5. The response is now R(e | e′) with width set by the true energy
+  e′, normalized over the reconstructed energy and not renormalized
+  afterwards. The old normalization was incidentally cancelling grid
+  undersampling error; removing it exposed an 8% pointwise error at the
+  default `n_pts=1000`, so the convolution integral now runs on its own
+  grid sized from the finest resolution in range (capped at 200k points).
+  This converges to better than 0.05% at a cost of roughly 6× runtime per
+  call.
+
+- **GeV vector-mediator photon spectra were a factor of 2 low in FSR.**
+  The Altarelli-Parisi functions in `hazma.spectra`
+  (`dnde_photon_ap_fermion`, `dnde_photon_ap_scalar`) give the spectrum
+  radiated by a *single* particle (α/2π), whereas Eq. 4.6 of
+  [arXiv:1907.11846](https://arxiv.org/abs/1907.11846) and the deprecated
+  `hazma.utils` implementations give the pair-summed result (α/π). This
+  convention is now documented, and five call sites in `VectorMediatorGeV`
+  (and `KineticMixingGeV`, `BLGeV`) that applied the per-leg spectrum once
+  for a charged pair were corrected: the FSR component of
+  `dnde_photon_e_e`, `dnde_photon_mu_mu`, `dnde_photon_pi_pi`,
+  `dnde_photon_k_k`, and `dnde_photon_pi_pi_pi0_pi0` **doubles**. The
+  corrected e⁺e⁻ result now agrees exactly with the pair-summed
+  `hazma.utils.dnde_altarelli_parisi_fermion`.
+
+- **Minimum dependency versions raised** to `numpy>=2.0` and
+  `scipy>=1.13`, and `scikit-image` is now a declared runtime dependency.
+  The `requires-python` upper bound (`<3.13`) is removed; Python 3.10
+  through 3.14 are supported and tested.
+
+- `hazma.spectra.boost` no longer offers SciPy's removed
+  `scipy.integrate.quadrature`. The `"quadrature"` method name is retained
+  as a backwards-compatible alias for `"quad"`, and the default method is
+  now `"quad"`. Results change where `"quadrature"` was previously
+  selected.
+
+### Fixed
+
+- `VectorMediatorGeV.dnde_photon_k_k` counted the charged-kaon decay
+  spectrum once for a K⁺K⁻ final state; it is now counted twice. The
+  decay component of this channel **doubles**, independently of the FSR
+  fix above.
+
+- `VectorMediatorGeV.dnde_photon_pi_pi_pi0_pi0` used charged-*kaon* decay
+  spectra for a π⁺π⁻π⁰π⁰ final state, copy-pasted from a neighboring
+  function. It now uses charged-pion spectra. This channel's decay
+  contribution changes shape entirely, not by a constant factor.
+
+- `energy_res` callbacks that accept only scalars (for example
+  `lambda e: 0.1 if e < 10 else 0.2`) raised when passed an array. Both
+  call sites now route through a helper that uses the vectorized call when
+  the callback supports it and falls back to element-wise evaluation
+  otherwise. A callback returning a single value for an array input is
+  treated as a constant resolution. The convolution grid is also now built
+  only when there is a continuum spectrum to convolve, so line-only
+  convolutions no longer fail.
+
+- `hazma.limits` now works from a wheel: `hazma/limits/data` was missing
+  from the packaged distribution.
+
+- Migrated off APIs removed in NumPy 2.0 and SciPy 1.14/1.15
+  (`scipy.integrate.trapz`/`simps`, `np.trapz`, `np.float_`,
+  `np.complex_`, `pkg_resources`). User-facing `"trapz"` and `"simps"`
+  method names are unchanged.
+
+Thanks to Chris Cappiello for reporting the energy-resolution and
+Altarelli-Parisi issues.
+
 ## [2.0.2]
 
 Baseline. This changelog was introduced after 2.0.2 shipped; earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ signature did.
 
 Nothing yet.
 
-## [2.1.0]
+## [2.1.0] — 2026-08-03
 
 **This release changes numbers.** Gamma-ray spectra from the GeV
 vector-mediator models and every detector-convolved spectrum move. Plots
@@ -101,7 +101,7 @@ and limits produced with 2.0.2 will not reproduce exactly. Read the
 Thanks to Chris Cappiello for reporting the energy-resolution and
 Altarelli-Parisi issues.
 
-## [2.0.2]
+## [2.0.2] — 2024-07-30
 
 Baseline. This changelog was introduced after 2.0.2 shipped; earlier
 releases are not itemized here. See the

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -97,10 +97,9 @@ stricter rule set you get from a bare local `ruff check` is **not** what
 CI runs. Green CI does not mean the tree satisfies the configured rules.
 Run `ruff check` locally; do not infer "CI would have caught it".
 
-**There is no formatting check in CI.** The lint job carries an explicit
-comment saying `black --check` was omitted because the tree is not
-black-clean (85+ files differ). So `black` is in this repo's preflight
-gate but not its CI — a formatting regression will not turn anything red.
+**CI does check formatting.** The lint job runs
+`black --check --diff hazma test`, so a formatting regression turns CI
+red. `black` is in both this repo's preflight gate and its CI.
 Do not reformat files your task does not touch just because `black`
 wants to; that is how an unrelated 85-file diff gets attached to a
 one-line change.
@@ -110,8 +109,9 @@ one-line change.
 repo's standard. Do not cite it as precedent, and do not import from
 `experimental/` in the library.
 
-**The CI test matrix is Python 3.10 / 3.11 / 3.12**, matching
-`pyproject.toml`'s `requires-python = ">=3.10"`. CI also runs an import
+**The CI test matrix is Python 3.10 through 3.14 on Linux, plus macOS on
+3.14**, matching `pyproject.toml`'s `requires-python = ">=3.10"`. CI also
+runs an import
 smoke test before the suite, so a broken Cython build fails there rather
 than as a confusing collection error.
 

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -49,3 +49,13 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   ships. When a value has both a display form and a path form, name them
   separately and test a value where they differ (PR #18:
   `resolve_phase.py`'s kickoff prompt sent agents to `task-notes/phase-2/`).
+- [stale-ci-capability-claim] A change to `.github/workflows/` silently
+  falsifies every prose description of what CI does. Those descriptions
+  live in `docs/agents/` and the skills, not next to the workflow, so
+  nothing fails when they rot — and agents then skip a gate CI no longer
+  covers, or run one it now does. After editing a workflow, grep the
+  Python versions, tool names, and "CI does/does not check X" claims out
+  of `docs/agents/` and `.claude/skills/` and re-derive each from the
+  workflow file (PR #33: the matrix had gone 3.10–3.12 → 3.10–3.14 and
+  `black --check` had been re-enabled, while three docs still said
+  otherwise).

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -58,7 +58,8 @@ separately.
 The path from a finished edit to a landed commit is strictly sequential:
 
 ```text
-edit → rebuild (if Cython) → run gates → read results → stage → commit → push → verify
+edit → rebuild (if Cython) → run gates → read results
+     → stage → commit → push → verify
 ```
 
 **Never batch these steps into one parallel tool block.** A failure
@@ -87,13 +88,12 @@ path for every git write.
 
 There is no committed `.pre-commit-config.yaml` in this repo. CI
 (`.github/workflows/ci.yml`) runs an import smoke test, `pytest` on
-Python 3.10–3.12, and a deliberately narrow lint pass —
-`ruff check --isolated --select E9,F63,F7,F82` — whose `--isolated` flag
-ignores `[tool.ruff]` in `pyproject.toml`. There is **no** formatting
-check in CI at all. So CI green means "no syntax errors, no undefined
-names, tests pass"; it says nothing about formatting, import order, or
-the configured lint rules. That is a floor, not this gate. Run this gate
-yourself.
+Python 3.10–3.14, `black --check --diff hazma test`, and a deliberately
+narrow lint pass — `ruff check --isolated --select E9,F63,F7,F82` — whose
+`--isolated` flag ignores `[tool.ruff]` in `pyproject.toml`. So CI green
+means "no syntax errors, no undefined names, black-formatted, tests
+pass"; it says nothing about import order or the configured lint rules.
+That is a floor, not this gate. Run this gate yourself.
 
 ## One-command form
 

--- a/hazma/__init__.py
+++ b/hazma/__init__.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-VERSION: Final[str] = "2.0.2"
+VERSION: Final[str] = "2.1.0"
 __version__ = VERSION
 
 # import warnings


### PR DESCRIPTION
## Summary

- Bumps `VERSION` 2.0.2 → 2.1.0 in `hazma/__init__.py` and writes the `[2.1.0]` CHANGELOG entry.
- **`minor`, not `patch`** — two independent triggers under [docs/versioning.md](docs/versioning.md): physics bug fixes that move published numbers, and dependency minimums rising (`numpy>=2.0`, `scipy>=1.13`).
- The `[Unreleased]` section read "Nothing yet" while 80 files under `hazma/` had changed since the 2.0.2 tag. Two of those commits move user-visible numbers, and the changelog's own rule requires magnitudes.

### The numbers that move

**`1d4ebc3` — detector energy resolution.** `convolved_spectrum_fn`, and with it `Theory.total_conv_spectrum_fn` / `total_conv_positron_spectrum_fn`, built the Gaussian response with a width set by the *reconstructed* energy rather than the true one. For a 10 MeV scalar → e⁺e⁻ under e-ASTROGAM (0.5% resolution at 10 MeV, 20% at 30 MeV), the FSR spectrum cuts off at ~4.95 MeV but the convolved spectrum carried a spurious ~1e-7 tail from 25 MeV to 1 GeV. Now identically zero, photon number conserved to 3e-5. Removing the old normalization exposed an 8% pointwise error at the default `n_pts=1000`; the convolution now runs on its own grid and converges to better than 0.05%, at ~6× runtime per call.

**`1d4ebc3` — Altarelli-Parisi convention.** `hazma.spectra`'s AP functions give the spectrum off a *single* radiating particle (α/2π); Eq. 4.6 of [arXiv:1907.11846](https://arxiv.org/abs/1907.11846) and the deprecated `hazma.utils` versions give the pair-summed result (α/π). Five `VectorMediatorGeV` call sites applied the per-leg spectrum once for a charged pair. The FSR component of `dnde_photon_e_e`, `dnde_photon_mu_mu`, `dnde_photon_pi_pi`, `dnde_photon_k_k`, `dnde_photon_pi_pi_pi0_pi0` **doubles**.

**`1d4ebc3` — two channel bugs.** `dnde_photon_k_k` counted the charged-kaon decay spectrum once for K⁺K⁻ (decay component doubles, independent of the FSR fix). `dnde_photon_pi_pi_pi0_pi0` used charged-*kaon* decay spectra for a π⁺π⁻π⁰π⁰ final state — that channel changes shape, not by a constant factor.

**`4905fc3`** — scalar-only `energy_res` callbacks raised once the convolution started passing arrays; line-only convolutions failed outright.

## Test plan

- [x] The factor-of-2 claim verified directly rather than taken from the commit message — corrected `VectorMediatorGeV` e⁺e⁻ FSR vs. the pair-summed deprecated implementation:

```
deprecated (pair-summed): [6.56316697e-02 1.38039818e-02 2.81853933e-03 5.00533825e-04 4.48317871e-05]
fixed VectorMediatorGeV : [6.56316697e-02 1.38039818e-02 2.81853933e-03 5.00533825e-04 4.48317871e-05]
ratio new/old           : [1. 1. 1. 1. 1.]
```

and against the per-leg AP function, `ratio model / per-leg AP: [2. nan]` (nan where both are identically zero).

- [x] `scripts/agents/preflight.sh --paths "hazma/__init__.py" --tests "test" --md "CHANGELOG.md" --closing`:

```
PASS   black --check           hazma/__init__.py
PASS   isort --check-only      hazma/__init__.py
PASS   ruff check              hazma/__init__.py
PASS   pytest                  52 passed, 20 skipped in 251.79s (0:04:11)
PASS   import hazma            version 2.1.0
PASS   markdownlint            CHANGELOG.md
PASS   version bump            2.0.2 → 2.1.0 + CHANGELOG entry
PASS   forbidden tokens        none added
-------------------------------------------------------------------
RESULT: PASS
```

- [x] `scripts/agents/check_pr_title.py "chore(release): bump to 2.1.0 and document numerical changes"` → `OK`

## After merge

Release step, for you to trigger — `gh release create 2.1.0 --generate-notes` — which creates the tag and fires the trusted-publishing path for the first time. A build-only dry run of the release workflow on `master` ([run 30865203255](https://github.com/LoganAMorrison/Hazma/actions/runs/30865203255)) confirmed the wheels and sdist build.

---

## Review round 1 (`a50633e`)

**Blocking — changelog release date.** `docs/versioning.md` mandates `## [X.Y.Z] — YYYY-MM-DD`; the `[2.1.0]` header had no date. Added `2026-08-03`, and applied the same format to `[2.0.2]` using its tag date (`2024-07-30`) — the rule isn't specific to the release being cut. Note the `--closing` gate passes either way, so it does not enforce this.

**Cross-cutting — stale CI claims in durable docs.** Confirmed and swept. `docs/agents/environment.md:113` and `docs/agents/preflight.md:90` both said CI tests Python 3.10–3.12; `ci.yml:45` is `["3.10", "3.11", "3.12", "3.13", "3.14"]` plus macOS on 3.14.

Sweeping that class surfaced a **second** stale claim in the same sentences: both files, plus `.claude/skills/commit-and-pr/SKILL.md:87`, stated CI runs no formatting check. `ci.yml:26` has run `black --check --diff hazma test` since `3a1ec2d` re-enabled it (after `ea2d216` reformatted the tree). All three corrected against `ci.yml` rather than against each other.

```
### Post-fix occurrences
(none — all swept)
```

**Disclosed, not requested:** wrapped a pre-existing 86-char line at `docs/agents/preflight.md:61` that MD013 flagged once the file entered the gate's `--md` list. It reproduces with this branch's changes stashed; folded in rather than left to block the gate.

**Lessons ledger:** added `[stale-ci-capability-claim]` — a workflow edit silently falsifies every prose description of CI, and those descriptions live in `docs/agents/` and the skills, far from the workflow, so nothing fails when they rot.

### Post-fix gate

```
PASS   black --check           hazma/__init__.py
PASS   isort --check-only      hazma/__init__.py
PASS   ruff check              hazma/__init__.py
PASS   pytest                  52 passed, 20 skipped in 257.49s (0:04:17)
PASS   import hazma            version 2.1.0
PASS   markdownlint            CHANGELOG.md docs/agents/preflight.md docs/agents/environment.md docs/agents/lessons.md
PASS   version bump            2.0.2 → 2.1.0 + CHANGELOG entry
PASS   forbidden tokens        none added
-------------------------------------------------------------------
RESULT: PASS
```

No code path changed in this round — the diff is `CHANGELOG.md`, three `docs/agents/` files, and one skill file. Numerical impact unchanged from the original body.
