### PR TITLE
docs(agents): stop advertising type names as commit scopes

### DIFF
--- a/docs/PR_GUIDELINES.md
+++ b/docs/PR_GUIDELINES.md
@@ -33,24 +33,40 @@ assuming something downstream will catch a mistake.
 
 Use the most specific scope that applies. Common scopes (non-exhaustive):
 
-| Scope      | Area                                                        |
-| ---------- | ----------------------------------------------------------- |
-| `spectra`  | `hazma/spectra/` — photon / positron / neutrino spectra      |
-| `decay`    | `hazma/_decay/` Cython decay spectra and interpolation data  |
-| `phase`    | `hazma/phase_space/`, `hazma/_phase_space/` (RAMBO, N-body)  |
-| `theory`   | `hazma/theory/` — the model interface and its mixins         |
-| `models`   | `scalar_mediator/`, `vector_mediator/`, `rh_neutrino/`, …    |
-| `limits`   | `hazma/limits/`, `gamma_ray.py`, gamma-ray limit machinery   |
-| `cmb`      | `hazma/cmb.py`, CMB constraints                              |
-| `relic`    | `hazma/relic_density/`                                       |
-| `form`     | `hazma/form_factors/`                                        |
-| `params`   | `hazma/parameters.py`, `gamma_ray_parameters.py`             |
-| `utils`    | `hazma/utils.py`, `hazma/_utils/` Cython helpers             |
-| `build`    | `_build.py`, Cython build wiring, packaging                  |
-| `ci`       | CI workflows and automation                                  |
-| `docs`     | Sphinx docs, README, `docs/`                                 |
-| `deps`     | dependency updates                                           |
-| `test`     | test-only changes                                            |
+| Scope       | Area                                                         |
+| ----------- | ------------------------------------------------------------ |
+| `spectra`   | `hazma/spectra/` — photon / positron / neutrino spectra      |
+| `decay`     | `hazma/_decay/` Cython decay spectra and interpolation data  |
+| `phase`     | `hazma/phase_space/`, `hazma/_phase_space/` (RAMBO, N-body)  |
+| `theory`    | `hazma/theory/` — the model interface and its mixins         |
+| `models`    | `scalar_mediator/`, `vector_mediator/`, `rh_neutrino/`, …    |
+| `limits`    | `hazma/limits/`, `gamma_ray.py`, gamma-ray limit machinery   |
+| `cmb`       | `hazma/cmb.py`, CMB constraints                              |
+| `relic`     | `hazma/relic_density/`                                       |
+| `form`      | `hazma/form_factors/`                                        |
+| `params`    | `hazma/parameters.py`, `gamma_ray_parameters.py`             |
+| `utils`     | `hazma/utils.py`, `hazma/_utils/` Cython helpers             |
+| `packaging` | `_build.py`, Cython build wiring, `pyproject.toml`           |
+| `actions`   | `.github/workflows/` — CI and release automation             |
+| `sphinx`    | `docs/source/` — the published docs and their build          |
+| `readme`    | `README.md` and other top-level prose                        |
+| `agents`    | `AGENTS.md`, `docs/agents/`, and the agent skills            |
+| `deps`      | dependency updates                                           |
+| `suite`     | `test/` — suite-wide test infrastructure                     |
+
+**No scope may be a type name.** The Title format rule above forbids
+`feat`, `fix`, `chore`, `ci`, `docs`, `test`, `refactor`, `perf`,
+`style`, `build`, and `revert` as scopes, and `check_pr_title.py` rejects
+them. That is why the rows above read `actions`, `packaging`, `sphinx`,
+and `suite` rather than the type names they would otherwise collide
+with — `ci(ci):` and `test(test):` are hard failures, not warnings.
+
+The scope names the *area*, so a `docs` or `test` change usually scopes
+to the area it touches rather than to a generic bucket:
+`docs(spectra): document the endpoint convention`,
+`test(phase): pin the rambo weight regression`. Reach for `sphinx`,
+`readme`, or `suite` when the change is to the docs or test machinery
+itself.
 
 If none fit, pick the closest module name truncated to 10 chars. Avoid
 inventing a scope that will only appear once.
@@ -64,16 +80,21 @@ inventing a scope that will only appear once.
 - `perf(phase): vectorize rambo momentum generation`
 - `docs(workflow): add project scaffolding guide`
 - `chore(deps): bump black to 24.x`
+- `ci(actions): publish to pypi via trusted publishing`
+- `test(suite): make monte-carlo tests deterministic`
 
 **Bad:**
 
 - `feat(spectra): Add the eta-prime photon channel spectrum` — uppercase
-  first subject word (convention), likely over 69 chars.
+  first subject word. A convention the checker does not enforce, so this
+  one is caught in review, not by a red exit code.
 - `fix(Decay): correct endpoint` — uppercase in scope.
 - `feat: add neutrino spectra` — missing scope.
 - `feat(spectra): add eta-prime channel.` — trailing `.`.
 - `feat(phase-space): vectorize rambo` — scope is 11 chars, rejected on
   length; use `phase`.
+- `ci(ci): publish to pypi via trusted publishing` — scope is a type
+  name; use `ci(actions)`.
 
 ## Description format
 


### PR DESCRIPTION
## Summary

- **Fix a self-contradiction in `docs/PR_GUIDELINES.md` that blocked a documented
  workflow.** The "Scopes for hazma" table advertised `ci`, `build`, `docs`, and
  `test` as scopes, while the Title format rule one section above forbids a scope
  that is a commit type — and `scripts/agents/check_pr_title.py` enforces it. Anyone
  scoping a CI, build, docs, or test change off that table hit a hard failure.
- **Fixed the table, not the validator.** The type-name check is deliberate:
  `check_pr_title.py` documents it as intentionally stricter than Conventional
  Commits to catch accidental `docs(docs):` titles, and the guidelines' own Title
  format rule already states the same constraint. The four colliding scopes become
  `actions`, `packaging`, `sphinx`/`readme`/`agents`, and `suite`. A new note under
  the table names every forbidden scope so the table cannot drift back into
  collision, plus a good and a bad example (`ci(actions)` vs `ci(ci)`).
- **One adjacent correction:** the uppercase-subject bad example claimed it was
  "likely over 69 chars". It is 56 and passes the checker, so it is caught in
  review, not by a red exit code. Reworded.
- **No code changes.** Zero `.py` files touched; no library value moves.

## Test plan

- [x] Every scope in the revised table passes the validator (18/18):

  ```
  $ grep -oE '^\| `[a-z0-9-]+`' docs/PR_GUIDELINES.md | tr -d '|` ' \
      | while read s; do scripts/agents/check_pr_title.py "feat($s): probe scope validity"; done
  OK: feat(spectra): probe scope validity
  ... (18 lines, all OK)
  OK: feat(packaging): probe scope validity
  OK: feat(actions): probe scope validity
  OK: feat(sphinx): probe scope validity
  OK: feat(readme): probe scope validity
  OK: feat(agents): probe scope validity
  OK: feat(suite): probe scope validity
  ```

- [x] Every "Good" example exits 0; every "Bad" example fails for exactly its
  documented reason:

  ```
  OK: ci(actions): publish to pypi via trusted publishing
  OK: test(suite): make monte-carlo tests deterministic
  INVALID: ci(ci): publish to pypi via trusted publishing
    - scope "ci" must not be a commit type
  INVALID: feat(phase-space): vectorize rambo
    - scope "phase-space" is 11 chars; must be ≤10
  ```

- [x] `pytest` (full suite, via `scripts/agents/preflight.sh`):

  ```
  PASS   pytest                  52 passed, 20 skipped in 257.05s (0:04:17)
  ```

- [x] `markdownlint --dot docs/PR_GUIDELINES.md`: **26 errors → 10**. Aligning the
  scopes table cleared 16. The 10 that remain are all on lines 14–19 (the
  Title-format table), which this diff does not touch — `git diff` for this file
  starts at line 36. They fail identically on `master`. Clearing them would mean
  restructuring the authoritative rules table, since MD013 (80 cols) cannot be met
  by a table with a 166-char row.

### Preflight gate status — read before merging

`scripts/agents/preflight.sh --md docs/PR_GUIDELINES.md` exits **FAIL**. None of the
red gates are caused by this change, and this is stated plainly rather than papered
over:

| Gate | Result | Attribution |
|------|--------|-------------|
| `black --check` | FAIL | 34 files would be reformatted — **identical with this diff stashed** |
| `isort --check-only` | FAIL | 190 lines of findings — pre-existing |
| `ruff check` | FAIL | 6844 errors, 947 fixable — **identical with this diff stashed** |
| `pytest` | PASS | 52 passed, 20 skipped |
| `import hazma` | PASS | 2.0.2 |
| `markdownlint` | FAIL | 10 errors, all on untouched lines 14–19 (see above) |
| forbidden tokens | PASS | none added |

Those three lint gates read only `.py` files under `hazma/` and `test/`; this diff
changes one `.md` file. Verified by re-running them against the stashed tree — the
counts are byte-identical. The repo's standing Python lint debt is a separate
concern from this PR.

Worth noting for whoever picks that up: this worktree had never been built (no
`.so` files, and `hazma/__init__.py` is only a version constant, so preflight's
"import hazma" smoke test passes without any extension compiled). The suite above
ran against a real editable build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
