### PR TITLE
docs(projects): scaffold the cython-to-rust migration plan

### DIFF
--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -49,6 +49,18 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   ships. When a value has both a display form and a path form, name them
   separately and test a value where they differ (PR #18:
   `resolve_phase.py`'s kickoff prompt sent agents to `task-notes/phase-2/`).
+- [derived-count-not-rederived] A count that appears in a plan (extensions,
+  entry points, files) must be re-derived from source with a stated command
+  at write time, not carried over from analysis prose — three counts in one
+  plan drifted (32→"19" survivors vs 20 actual; "43" corpus entry points vs
+  41 consumed; "44 .pyx/.pxd" conflating 44 .pyx + 33 .pxd), and each read
+  as authoritative until review recounted (PR #35).
+- [wheel-tag-vs-extension-abi] A wheel's tag is per-distribution, not
+  per-extension: while any version-specific extension (e.g. Cython) remains
+  in the package, wheels stay CPython-tagged no matter how many extensions
+  use the limited API — claim abi3 *wheels* only after the last
+  version-specific extension is gone, and verify extension-level abi3 via
+  the `.abi3.so` filename instead (PR #35).
 - [stale-ci-capability-claim] A change to `.github/workflows/` silently
   falsifies every prose description of what CI does. Those descriptions
   live in `docs/agents/` and the skills, not next to the workflow, so

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -22,11 +22,11 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 ## Open
 
 | Item | Added | Source | Scope |
-|------|-------|--------|-------|
-| _none yet_ | | | |
+| --- | --- | --- | --- |
+| [markdownlint config for templates](todo/markdownlint-config-for-templates.md) | 2026-08-03 | cython-to-rust scaffolding | cross-cutting |
 
 ## Promoted / Done / Pruned
 
 | Item | Status | Resolution |
-|------|--------|------------|
+| --- | --- | --- |
 | _none yet_ | | |

--- a/docs/followups/todo/markdownlint-config-for-templates.md
+++ b/docs/followups/todo/markdownlint-config-for-templates.md
@@ -1,0 +1,56 @@
+# Add a repo markdownlint config so template-shaped docs lint clean
+
+- **Added:** 2026-08-03
+- **Source:** conversation (cython-to-rust project scaffolding PR)
+- **Scope:** cross-cutting
+- **Status:** open
+- **Triggers / blockers:** none — ripe whenever; touches only lint
+  config and docs.
+
+## Why
+
+Scaffolding `projects/cython-to-rust/` surfaced a conflict between the
+preflight markdownlint gate (which runs with **no config**, so all
+defaults apply) and the repo's own canonical shapes:
+
+- The phase-file schema (`projects/_template/phases/_template.md`) puts
+  `title:` in frontmatter *and* an H1 in the body — MD025 flags every
+  phase file, including the template itself.
+- The `_template.md` reference files use `<angle-bracket>` placeholders —
+  MD033 (inline HTML) flags all of them.
+- Grounded-fact tables (dead-code maps, call-site tables) are
+  legitimately wider than MD013's 80-column default; the repo already
+  tolerates this in `docs/PR_GUIDELINES.md` (10 standing MD013 table
+  errors). Under the installed markdownlint, link-bearing lines are
+  exempt from MD013 but plain wide table rows are not — an accidental
+  and surprising distinction.
+
+The scaffolding PR worked around this with inline
+`markdownlint-disable` pragmas, which is fine once but should not
+become the per-project ritual.
+
+## What
+
+Add a committed `.markdownlint.jsonc` (or `.yaml`) encoding the de
+facto conventions, roughly: `MD013: {tables: false}`, `MD025:
+{front_matter_title: ""}`, `MD033: {allowed_elements: []}` relaxed for
+the placeholder idiom or scoped via `.markdownlintignore` for
+`**/_template.md`. Then remove the now-redundant inline pragmas from
+`projects/cython-to-rust/` and re-run `markdownlint --dot` over
+`docs/` and `projects/` to confirm the net error count only goes down.
+Update `docs/agents/preflight.md`'s markdownlint section to mention
+the config.
+
+## Entry points
+
+- `scripts/agents/preflight.sh` (markdownlint gate, ~line 214)
+- `docs/agents/preflight.md` (gate 6)
+- `projects/_template/` (the shapes that must lint clean)
+- `projects/cython-to-rust/phases/*.md` (inline pragmas to remove)
+- `projects/cython-to-rust/references/*.md` (inline pragmas to remove)
+
+## Risks / open questions
+
+Loosening MD013 for tables repo-wide also stops flagging genuinely
+sloppy wide prose in tables; acceptable given the alternative is
+pragma noise. Keep prose (non-table) lines at 80.

--- a/projects/README.md
+++ b/projects/README.md
@@ -39,11 +39,11 @@ for why `_template.md` files stay in place after scaffolding.
 ## Active Projects
 
 | Slug | Deliverable | Phased | Started | Status |
-|------|-------------|--------|---------|--------|
-| _none yet_ | | | | |
+| --- | --- | --- | --- | --- |
+| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | In Progress |
 
 ## Completed Projects
 
 | Slug | Deliverable | Phased | Started | Shipped |
-|------|-------------|--------|---------|---------|
+| --- | --- | --- | --- | --- |
 | _none yet_ | | | | |

--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -1,0 +1,149 @@
+---
+status: In Progress
+phased: true
+version_bump: minor
+deliverable: Hazma's compiled layer rebuilt in Rust (PyO3, one abi3 `hazma._core` extension, maturin-built), with zero Cython remaining and a permanent parity-test corpus
+created: 2026-08-03
+---
+
+# Project: cython-to-rust
+
+**Structure:** Phased — see [`phases/`](phases/).
+
+## Goal
+
+Replace Hazma's Cython layer with Rust + PyO3 packaged by maturin,
+because the layer's cost is toolchain churn rather than physics
+development (3 kernel commits in 3 years, two of them forced
+migrations). Ship the same public API and — within declared, measured
+budgets — the same numbers, from a single abi3 extension that ends the
+per-CPython wheel matrix, the scipy build-ABI pin, and the Cython 3
+deprecation debt. Full analysis: the August 2026 assessment
+(`references/` distills its durable facts).
+
+## Scope
+
+**In scope:**
+
+- Deleting the ~6,500 lines of dead/broken Cython and its data
+  (Phase 00) — worth doing even if the port stopped there.
+- A golden parity corpus over all 43 live compiled entry points,
+  wired into pytest + CI (Phase 01).
+- Porting the live surface (~19 modules) to one Rust cdylib,
+  `hazma._core`: spectra kernels, boost/interp/constants foundation,
+  QUADPACK-subset integrator, cephes-lineage special functions,
+  mediator cross sections + thermal ⟨σv⟩, mediator spectrum modules
+  (Phases 02–06).
+- Packaging cutover to maturin with abi3 wheels; docs/CI sweep;
+  project close with aggregated numerical-drift declaration (Phase 07).
+
+**Out of scope:**
+
+- Any physics change, new channel, or API addition.
+- Consolidating the divergent constants tables (deliberately preserved
+  bit-for-bit — see `rules.md` rule 4; consolidation is a follow-up).
+- Pure-Python subsystems that happen to be numeric (`hazma/phase_space/`,
+  form factors, relic-density ODEs, spline utilities) — they stay on
+  NumPy/SciPy.
+- Windows / linux-aarch64 wheel support (recorded as a cheap follow-up;
+  Phase 07 Task 7.2 makes the call explicitly).
+- Performance work beyond what parity-preserving redesign yields
+  (measured, not chased — `rules.md` rule 12).
+
+## Numerical impact
+
+Intended: none beyond tolerance-level drift. Two knowable exceptions,
+both declared: (1) quadrature moves from scipy's QUADPACK binding to an
+in-tree QUADPACK port — corpus budgets start at 1e-8 relative for
+quad-backed functions and tighten after measurement (closed-form
+kernels: ≤1e-13); (2) Cython-`assert` edge guards become unconditional
+raises (behavior tightening at invalid inputs only). The Phase 00
+`hazma.gamma_ray` decision (Task 0.5) may raise `version_bump` to
+`major` if deletion is chosen over reimplementation — the frontmatter
+must be updated when that decision lands. The running record lives in
+`task-notes/README.md` ("Numerical impact so far"); the closing
+CHANGELOG aggregates it per function.
+
+## Orientation
+
+| Reference | What it holds |
+| --- | --- |
+| [`references/cython-inventory.md`](references/cython-inventory.md) | Dead-code map with evidence, live surface + entry-point tables, C-level dependency DAG, data files, audit bug list |
+| [`references/numerics-replacements.md`](references/numerics-replacements.md) | quad call-site/tolerance table, specfun facts + conventions, `np.interp`/boost-integral specs, cyphus-crate assessment, dispatch contract |
+| [`adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md`](adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md) | Framework choice (Accepted) |
+| [`adrs/ADR-0002-license-clean-numerics.md`](adrs/ADR-0002-license-clean-numerics.md) | GSL/GPL boundary, cephes + netlib-QUADPACK provenance (**Proposed — sign-off gates Phase 03**) |
+| [`rules.md`](rules.md) | Parity discipline, constants bit-parity, licensing, Rust conventions |
+
+## Phases
+
+Canonical per-task shape lives in each phase file; live status lives in
+`task-notes/README.md` (project) and `task-notes/phase-XX/README.md`
+(per phase). Estimates are focused dev-days from the analysis; the
+total landed at 21–32 days across ~33 tasks.
+
+| # | Phase | File | Days | Delivers |
+| --- | ------- | ------ | ------ | ---------- |
+| 00 | Dead-code purge | [`phases/phase-00-dead-code-purge.md`](phases/phase-00-dead-code-purge.md) | 1–2 | −6,500 lines, 32→19 extensions, zero C++, `gamma_ray` decision |
+| 01 | Golden parity corpus | [`phases/phase-01-parity-corpus.md`](phases/phase-01-parity-corpus.md) | 2–3 | Pinned reference arrays for all 43 entry points, one pytest gate |
+| 02 | Rust scaffold | [`phases/phase-02-rust-scaffold.md`](phases/phase-02-rust-scaffold.md) | 1–2 | `hazma._core` (abi3) building beside Cython via setuptools-rust |
+| 03 | Numerics foundation | [`phases/phase-03-numerics-foundation.md`](phases/phase-03-numerics-foundation.md) | 3–5 | constants, spence/K-Bessels, QUADPACK port, interp, boost, dispatch |
+| 04 | Spectra kernels | [`phases/phase-04-spectra-kernels.md`](phases/phase-04-spectra-kernels.md) | 4–6 | 16 entry points swapped; twins deleted (4 capi survivors defer to 06) |
+| 05 | Mediator cross sections | [`phases/phase-05-mediator-cross-sections.md`](phases/phase-05-mediator-cross-sections.md) | 2–3 | 19 kernels + 2 thermal ⟨σv⟩ swapped; relic-density validation |
+| 06 | Mediator spectra | [`phases/phase-06-mediator-spectra.md`](phases/phase-06-mediator-spectra.md) | 3–4 | Table-struct redesign; last Cython deleted |
+| 07 | Cutover + close | [`phases/phase-07-cutover.md`](phases/phase-07-cutover.md) | 2–3 | maturin backend, 2 abi3 wheels, docs sweep, version bump + CHANGELOG |
+
+Ordering constraints: 00 → 01 → 02 → 03 → {04, 05} → 06 → 07. Phase 05
+shares no files with 04 and may run in parallel with it. Within 04 the
+cimport DAG in the inventory reference governs task order. Phase 06
+Task 6.4 is the only place the four capi-survivor spectra extensions
+and `_utils` headers are deleted.
+
+## Task Details
+
+Per-task objective, dependencies, and exit criteria live in the phase
+files (`phases/phase-XX-*.md`, "Tasks" sections) — 33 tasks total.
+This PLAN intentionally holds only the phase table; do not duplicate
+task blocks here.
+
+## Dependencies
+
+- Requires: nothing upstream. ADR-0002 acceptance gates Phase 03
+  Tasks 3.2/3.3.
+- External facts this plan leans on (re-verify if stale): `spec_math`
+  0.1.6 (MIT OR Apache-2.0) provides `bessel_k1`/`bessel_kn`/`li2`;
+  PyO3 abi3-py310 wheels cover CPython ≥3.10; the rust-cyphus crates
+  are GPL-3 and stay out of the tree (ADR-0002).
+
+## Related
+
+- Background: August 2026 migration cost analysis (session artifact
+  "Hazma · Cython → Rust migration analysis"); rust-cyphus crate
+  assessment 2026-08-03 (`references/numerics-replacements.md`).
+- GitHub Issue: none — internal modernization.
+
+## Change control
+
+See [`../../docs/workflow.md#adr-placement`](../../docs/workflow.md#adr-placement)
+for when to write an ADR and where it lives. Patch the affected
+`PLAN.md` / phase file / `rules.md` when canonical behavior changes —
+known pending: the Task 0.5 `gamma_ray` outcome (possible ADR-0003 +
+`version_bump` change), and ADR-0002's status flip.
+
+## Closing this project
+
+The PR that flips this `PLAN.md` `status:` to `Complete` must also bump
+`VERSION` in `hazma/__init__.py` per the `version_bump:` frontmatter and
+add a `CHANGELOG.md` entry naming this project slug. Re-check the level
+against the **Numerical impact** section above before bumping.
+Verify with `scripts/agents/preflight.sh --closing` (note Task 7.1
+relocates the version's source of truth — the closing check must run
+against the post-cutover plumbing). See
+[`../../docs/versioning.md`](../../docs/versioning.md).
+
+### Anticipated ADRs
+
+- ADR-0003 (conditional): removal of `hazma.gamma_ray` if Phase 00
+  Task 0.5 chooses deletion over reimplementation.
+- Possible: QUADPACK-port deviation record, if faithful translation
+  proves impractical for `qelg` and a documented algorithmic
+  substitution is made instead (would revise corpus budgets).

--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -1,7 +1,7 @@
 ---
 status: In Progress
 phased: true
-version_bump: minor
+version_bump: major
 deliverable: Hazma's compiled layer rebuilt in Rust (PyO3, one abi3 `hazma._core` extension, maturin-built), with zero Cython remaining and a permanent parity-test corpus
 created: 2026-08-03
 ---
@@ -27,9 +27,12 @@ deprecation debt. Full analysis: the August 2026 assessment
 
 - Deleting the ~6,500 lines of dead/broken Cython and its data
   (Phase 00) — worth doing even if the port stopped there.
-- A golden parity corpus over all 43 live compiled entry points,
-  wired into pytest + CI (Phase 01).
-- Porting the live surface (~19 modules) to one Rust cdylib,
+- A golden parity corpus over all 41 consumed compiled entry points
+  (of 43 public defs — the two unimported `sigma_xx_to_all` exports
+  are dropped in Phase 05, not ported), wired into pytest + CI
+  (Phase 01).
+- Porting the live surface (20 extensions: 19 kernel modules +
+  `_utils.boost`) to one Rust cdylib,
   `hazma._core`: spectra kernels, boost/interp/constants foundation,
   QUADPACK-subset integrator, cephes-lineage special functions,
   mediator cross sections + thermal ⟨σv⟩, mediator spectrum modules
@@ -57,12 +60,15 @@ both declared: (1) quadrature moves from scipy's QUADPACK binding to an
 in-tree QUADPACK port — corpus budgets start at 1e-8 relative for
 quad-backed functions and tighten after measurement (closed-form
 kernels: ≤1e-13); (2) Cython-`assert` edge guards become unconditional
-raises (behavior tightening at invalid inputs only). The Phase 00
-`hazma.gamma_ray` decision (Task 0.5) may raise `version_bump` to
-`major` if deletion is chosen over reimplementation — the frontmatter
-must be updated when that decision lands. The running record lives in
-`task-notes/README.md` ("Numerical impact so far"); the closing
-CHANGELOG aggregates it per function.
+raises (behavior tightening at invalid inputs only).
+
+`version_bump: major` is driven by API removals, not by numbers:
+Phase 00 deletes `hazma/deprecated/rambo.py` (any removal from
+`hazma/deprecated/` is `major` per `docs/versioning.md` and
+`AGENTS.md`) and, per ADR-0003 (proposed), removes the
+broken-on-import `hazma.gamma_ray` module. The running numerical
+record lives in `task-notes/README.md` ("Numerical impact so far");
+the closing CHANGELOG aggregates it per function.
 
 ## Orientation
 
@@ -72,6 +78,7 @@ CHANGELOG aggregates it per function.
 | [`references/numerics-replacements.md`](references/numerics-replacements.md) | quad call-site/tolerance table, specfun facts + conventions, `np.interp`/boost-integral specs, cyphus-crate assessment, dispatch contract |
 | [`adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md`](adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md) | Framework choice (Accepted) |
 | [`adrs/ADR-0002-license-clean-numerics.md`](adrs/ADR-0002-license-clean-numerics.md) | GSL/GPL boundary, cephes + netlib-QUADPACK provenance (**Proposed — sign-off gates Phase 03**) |
+| [`adrs/ADR-0003-remove-gamma-ray-module.md`](adrs/ADR-0003-remove-gamma-ray-module.md) | Remove broken `hazma.gamma_ray` (**Proposed — sign-off gates Task 0.2/0.5**) |
 | [`rules.md`](rules.md) | Parity discipline, constants bit-parity, licensing, Rust conventions |
 
 ## Phases
@@ -83,12 +90,12 @@ total landed at 21–32 days across ~33 tasks.
 
 | # | Phase | File | Days | Delivers |
 | --- | ------- | ------ | ------ | ---------- |
-| 00 | Dead-code purge | [`phases/phase-00-dead-code-purge.md`](phases/phase-00-dead-code-purge.md) | 1–2 | −6,500 lines, 32→19 extensions, zero C++, `gamma_ray` decision |
-| 01 | Golden parity corpus | [`phases/phase-01-parity-corpus.md`](phases/phase-01-parity-corpus.md) | 2–3 | Pinned reference arrays for all 43 entry points, one pytest gate |
+| 00 | Dead-code purge | [`phases/phase-00-dead-code-purge.md`](phases/phase-00-dead-code-purge.md) | 1–2 | −6,500 lines, 32→20 extensions, zero C++, `gamma_ray` removal (ADR-0003) |
+| 01 | Golden parity corpus | [`phases/phase-01-parity-corpus.md`](phases/phase-01-parity-corpus.md) | 2–3 | Pinned reference arrays for all 41 consumed entry points, one pytest gate |
 | 02 | Rust scaffold | [`phases/phase-02-rust-scaffold.md`](phases/phase-02-rust-scaffold.md) | 1–2 | `hazma._core` (abi3) building beside Cython via setuptools-rust |
 | 03 | Numerics foundation | [`phases/phase-03-numerics-foundation.md`](phases/phase-03-numerics-foundation.md) | 3–5 | constants, spence/K-Bessels, QUADPACK port, interp, boost, dispatch |
 | 04 | Spectra kernels | [`phases/phase-04-spectra-kernels.md`](phases/phase-04-spectra-kernels.md) | 4–6 | 16 entry points swapped; twins deleted (4 capi survivors defer to 06) |
-| 05 | Mediator cross sections | [`phases/phase-05-mediator-cross-sections.md`](phases/phase-05-mediator-cross-sections.md) | 2–3 | 19 kernels + 2 thermal ⟨σv⟩ swapped; relic-density validation |
+| 05 | Mediator cross sections | [`phases/phase-05-mediator-cross-sections.md`](phases/phase-05-mediator-cross-sections.md) | 2–3 | 16 kernels + 2 thermal ⟨σv⟩ swapped, 2 dead exports dropped; relic validation |
 | 06 | Mediator spectra | [`phases/phase-06-mediator-spectra.md`](phases/phase-06-mediator-spectra.md) | 3–4 | Table-struct redesign; last Cython deleted |
 | 07 | Cutover + close | [`phases/phase-07-cutover.md`](phases/phase-07-cutover.md) | 2–3 | maturin backend, 2 abi3 wheels, docs sweep, version bump + CHANGELOG |
 
@@ -126,8 +133,9 @@ task blocks here.
 See [`../../docs/workflow.md#adr-placement`](../../docs/workflow.md#adr-placement)
 for when to write an ADR and where it lives. Patch the affected
 `PLAN.md` / phase file / `rules.md` when canonical behavior changes —
-known pending: the Task 0.5 `gamma_ray` outcome (possible ADR-0003 +
-`version_bump` change), and ADR-0002's status flip.
+known pending: the status flips of ADR-0002 (license-clean numerics)
+and ADR-0003 (`hazma.gamma_ray` removal), both Proposed and awaiting
+sign-off.
 
 ## Closing this project
 
@@ -142,8 +150,8 @@ against the post-cutover plumbing). See
 
 ### Anticipated ADRs
 
-- ADR-0003 (conditional): removal of `hazma.gamma_ray` if Phase 00
-  Task 0.5 chooses deletion over reimplementation.
+- ADR-0003 (written, Proposed): removal of the broken-on-import
+  `hazma.gamma_ray` module — Task 0.5 executes it once accepted.
 - Possible: QUADPACK-port deviation record, if faithful translation
   proves impractical for `qelg` and a documented algorithmic
   substitution is made instead (would revise corpus budgets).

--- a/projects/cython-to-rust/adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md
+++ b/projects/cython-to-rust/adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md
@@ -1,0 +1,68 @@
+# ADR 0001: Replace Cython with Rust + PyO3, packaged by maturin
+
+**Date:** 2026-08-03
+**Status:** Accepted
+**Scope:** Project-scoped (applies only within `projects/cython-to-rust/`).
+
+## Context
+
+Hazma's compiled layer is 32 Cython extension modules whose maintenance
+cost is concentrated in the toolchain, not the physics: 3 of the last 45
+commits touched `.pyx` files and two of those were forced migrations
+(NumPy 2.0 / SciPy API removals; build-system rework). Standing pains:
+a `scipy>=1.13` *build-time* ABI pin caused by
+`scipy.special.cython_special` cimports; 10 version-specific wheels per
+release (cp310–cp314 × 2 platforms) that must be rebuilt for every new
+CPython; the eager-extension-declaration hack required to avoid
+mistagged wheels; Cython 3 deprecations (`DEF`, implicit relative
+cimports) already breaking unbuilt files; and no unit-test story for the
+compiled math outside Python.
+
+The August 2026 analysis (see `../references/cython-inventory.md`)
+established the live surface is small (~19 modules, 43 entry points,
+~2,500–3,000 lines of distinct logic), scalar float64 math with no
+OpenMP, no C++ classes, and no complex numbers — i.e. cheap to port.
+Candidates evaluated: Rust + PyO3 + maturin, and pybind11 (+
+scikit-build-core). Estimated effort is comparable (21–32 focused days
+either way).
+
+## Decision
+
+Port the live compiled surface to **Rust**, exposed through **PyO3** as
+a **single `hazma._core` extension** (submodules per domain), built with
+**abi3-py310** so one wheel per platform covers all supported CPythons.
+During the migration (Phases 02–06) the Rust extension is built
+alongside the remaining Cython via **setuptools-rust** under the
+existing setuptools backend, so `pip install -e .` keeps producing one
+importable package and the extension already lives at its final import
+path `hazma._core`. At cutover (Phase 07) the build backend switches to
+**maturin** and setuptools/Cython are removed.
+
+pybind11 is rejected because it retains the cost centers this project
+exists to remove: a C-family toolchain with per-platform compiler
+variance, CMake in place of setup.py, no stable-ABI wheels (the 10-wheel
+matrix survives), and the same undefined-behavior class in which this
+audit found real bugs (out-of-bounds vector write, uninitialized read).
+Its genuine advantages — C++ familiarity for physicist contributors and
+marginally smoother hybrid builds — are outweighed given kernel churn is
+~1 commit/year and the Python-facing API layer stays pure Python.
+
+## Consequences
+
+- **Positive:** wheel matrix drops 10 → 2 (linux x86_64, macOS arm64)
+  and stops tracking CPython releases; the scipy build-ABI pin and
+  `numpy.get_include()` coupling disappear; kernel math becomes
+  GIL-free `cargo test`-able; memory safety by construction; cargo
+  replaces vendored/ad-hoc dependency handling; adding
+  aarch64/Windows wheels later is a CI-matrix line, not a port.
+- **Negative:** contributors touching kernels need Rust; source builds
+  need a Rust toolchain; two build systems coexist during Phases 02–06;
+  quadrature moves off QUADPACK-via-scipy so numerical drift must be
+  measured and declared (versioning.md numerical-change carve-out).
+- **Mitigation:** kernel churn is near zero and transliterated math
+  reads like the Cython it replaces; the public API and all wrapper
+  modules stay pure Python; the Phase 01 parity corpus gates every
+  swap; setuptools-rust coexistence is bounded to the migration window;
+  drift budgets are set per function in the corpus tolerance file
+  (`test/parity/`), and ADR-0002 keeps the integrator QUADPACK-faithful
+  to minimize drift at the source.

--- a/projects/cython-to-rust/adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md
+++ b/projects/cython-to-rust/adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md
@@ -19,9 +19,11 @@ cimports) already breaking unbuilt files; and no unit-test story for the
 compiled math outside Python.
 
 The August 2026 analysis (see `../references/cython-inventory.md`)
-established the live surface is small (~19 modules, 43 entry points,
-~2,500–3,000 lines of distinct logic), scalar float64 math with no
-OpenMP, no C++ classes, and no complex numbers — i.e. cheap to port.
+established the live surface is small (20 surviving extensions — 19
+kernel modules plus one C-level helper — exposing 43 public defs of
+which 41 are consumed, ~2,500–3,000 lines of distinct logic), scalar
+float64 math with no OpenMP, no C++ classes, and no complex numbers —
+i.e. cheap to port.
 Candidates evaluated: Rust + PyO3 + maturin, and pybind11 (+
 scikit-build-core). Estimated effort is comparable (21–32 focused days
 either way).

--- a/projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md
+++ b/projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md
@@ -1,0 +1,71 @@
+# ADR 0002: License-clean numerics — cephes in-tree, GSL-derived code out
+
+**Date:** 2026-08-03
+**Status:** Proposed (needs Logan's sign-off — it forecloses the
+"relicense Hazma to GPL" alternative)
+**Scope:** Project-scoped (applies only within `projects/cython-to-rust/`).
+
+## Context
+
+The Rust core needs three special functions (`spence`/Li₂, `K₁`, `Kₙ`)
+and a finite-interval adaptive integrator matching
+`scipy.integrate.quad` (QUADPACK `qags`/`qagp`). Logan's existing
+rust-cyphus crates cover much of this and were assessed on 2026-08-03
+(full results in `../references/numerics-replacements.md`):
+`cyphus-integration` passes 43/44 tests on rustc 1.96 after a one-line
+fix and includes exactly the needed `qags`/`qagp`; `cyphus-specfun`
+passes 99/102 and has Bessel K but no dilogarithm.
+
+Both crates are **GPL-3**: they are ports of the GNU Scientific Library
+and carry GSL's copyright headers. Authorship does not help — a port of
+GPL code is a derivative work, so they cannot be relicensed. Hazma is
+MIT (LICENSE, © Logan Morrison and Adam Coogan). Linking or vendoring
+GPL-3 code into the extension would make the distributed wheels GPL-3.
+
+Meanwhile scipy's own `spence`/`k1`/`kn` are **cephes** wrappers, and
+QUADPACK itself (Piessens et al., netlib Fortran — what scipy vendors)
+is **public domain**; GSL's GPL applies to GSL's reimplementation, not
+to the upstream QUADPACK sources or the published algorithms.
+
+## Decision
+
+1. **No GSL-derived code enters this repository or its dependency graph**
+   — not vendored, not a crates.io/git dependency, not a dev-dependency.
+2. Special functions come from the **cephes lineage**: the `spec_math`
+   crate (MIT OR Apache-2.0, pure-Rust cephes; `bessel_k1`, `bessel_kn`,
+   `Polylog::li2` → `cephes64::spence`). If a gap or parity miss
+   appears, the fallback is a direct in-tree Rust translation of the
+   specific cephes routine. This is also the numerically correct choice:
+   scipy's functions are cephes, so cephes-lineage code matches scipy
+   more closely than GSL-lineage code would.
+3. The integrator is a Rust port of **netlib QUADPACK** (`qk15`, `qk21`,
+   `qelg`, `qags`, `qagp`; finite intervals only), translated from the
+   public-domain Fortran — explicitly *not* from GSL or from
+   cyphus-integration.
+4. The cyphus crates are used only as **out-of-repo, dev-time oracles**:
+   running them locally to cross-check values or subdivision behavior is
+   fine (no different from testing against GSL itself); their code is
+   not read side-by-side while writing the Hazma port, and nothing from
+   them is committed. Primary parity oracle remains scipy, via the
+   Phase 01 corpus and direct comparisons in `test/`.
+
+## Consequences
+
+- **Positive:** Hazma stays MIT with an unambiguous provenance chain
+  (public-domain QUADPACK + permissive cephes); parity with scipy is
+  algorithm-for-algorithm, minimizing corpus drift; a second independent
+  implementation (cyphus) is available as a cross-check without license
+  exposure.
+- **Negative:** the QUADPACK port (~1,500–2,500 lines) is written fresh
+  instead of reusing cyphus-integration, costing roughly 2–3 days that
+  reuse might have saved; Fortran-to-Rust translation of `qelg`
+  ε-extrapolation is fiddly.
+- **Mitigation:** scope is the finite-interval subset only (`qagi` has
+  zero live callers); the corpus and per-integrand scipy comparisons
+  catch translation faults; cyphus-integration's passing test suite
+  demonstrates the job is bounded and was done once by the same author.
+- **Foreclosed alternative (why sign-off is needed):** accepting GPL-3
+  for the wheels and depending on modernized cyphus crates directly.
+  Rejected by default because it changes Hazma's license terms for
+  every downstream user and requires co-author agreement, to save at
+  most a few days of foundation work.

--- a/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
+++ b/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
@@ -30,10 +30,21 @@ incremental versioning cost.
 
 Delete `hazma/gamma_ray.py` in Phase 00 (Task 0.2, gated on this ADR's
 acceptance) along with the `hazma._gamma_ray` extensions. Do not ship
-a shim. The n-body photon-spectrum use case it once served is covered
-by the live, tested `hazma.spectra` machinery
-(`hazma/spectra/_nbody.py` over `hazma.phase_space`); docs that
-reference `hazma.gamma_ray` are updated to point there.
+a shim. The module's public API and its replacement status:
+
+- `gamma_ray_decay` — N-body decay photon spectrum: superseded by the
+  live, tested `hazma.spectra.dnde_photon`
+  (`hazma/spectra/_nbody.py` over `hazma.phase_space`).
+- `gamma_ray_fsr` — Monte-Carlo FSR spectrum from a user-supplied
+  matrix element: **removed without a direct replacement.** The
+  nearest live equivalents are the Altarelli–Parisi approximations
+  (`hazma.spectra.dnde_photon_ap_fermion` / `_ap_scalar`); a general
+  `msqrd`-driven FSR generator would be a new feature via
+  `docs/followups/`.
+
+(`gamma`/`gamma_point` are the compiled `_gamma_ray` names the module
+wraps, not its public surface.) Docs that reference `hazma.gamma_ray`
+are updated to point at `hazma.spectra`.
 
 ## Consequences
 
@@ -46,7 +57,9 @@ reference `hazma.gamma_ray` are updated to point there.
   *textually* imports it will fail at import with `ModuleNotFoundError`
   instead of today's confusing transitive error.
 - **Mitigation:** the project is `major` already (deprecated-module
-  deletion); the CHANGELOG names the removal and the `hazma.spectra`
-  replacement. If a maintained equivalent is ever wanted, it enters as
-  a designed feature via `docs/followups/` with its own validation
-  plan, not as part of this migration.
+  deletion); the CHANGELOG names both removed functions with their
+  replacement status (`gamma_ray_decay` → `hazma.spectra.dnde_photon`;
+  `gamma_ray_fsr` → none; nearest: the Altarelli–Parisi
+  approximations). If a maintained equivalent is ever wanted, it
+  enters as a designed feature via `docs/followups/` with its own
+  validation plan, not as part of this migration.

--- a/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
+++ b/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
@@ -1,0 +1,52 @@
+# ADR 0003: Remove the broken `hazma.gamma_ray` module
+
+**Date:** 2026-08-03
+**Status:** Proposed (needs Logan's sign-off — it removes a public name)
+**Scope:** Project-scoped (applies only within `projects/cython-to-rust/`).
+
+## Context
+
+`hazma/gamma_ray.py` is a public-named module that cannot be imported:
+it (and the compiled `hazma._gamma_ray.gamma_ray_generator` it wraps)
+does `from hazma import rambo`, and `hazma/rambo.py` was deleted long
+ago (the export in `hazma/__init__.py` is commented out). Every current
+release ships it in this broken state, so no working user code can
+depend on it.
+
+The original plan let Phase 00 Task 0.5 choose between deletion and
+reimplementation over `hazma.phase_space`. Plan review (round 1)
+correctly observed the reimplementation branch has no numerical oracle:
+the module cannot run, so there is no behavior to pin a
+"behavior-preserving rebuild" against, and the Phase 01 corpus cannot
+supply a baseline because it postdates the deletion. A rebuild would
+therefore be a *new feature* with a fresh validation burden — outside
+this project's migration scope. Separately, the project's
+`version_bump` is `major` regardless, because Phase 00 also deletes
+`hazma/deprecated/rambo.py` and any removal from `hazma/deprecated/`
+is `major` per `docs/versioning.md` — so deletion carries no
+incremental versioning cost.
+
+## Decision
+
+Delete `hazma/gamma_ray.py` in Phase 00 (Task 0.2, gated on this ADR's
+acceptance) along with the `hazma._gamma_ray` extensions. Do not ship
+a shim. The n-body photon-spectrum use case it once served is covered
+by the live, tested `hazma.spectra` machinery
+(`hazma/spectra/_nbody.py` over `hazma.phase_space`); docs that
+reference `hazma.gamma_ray` are updated to point there.
+
+## Consequences
+
+- **Positive:** removes an unimportable public module instead of
+  shipping it broken again; Task 0.5 becomes an execution step rather
+  than an open design question; no unpinnable "rebuild" enters the
+  migration's parity scope.
+- **Negative:** the name `hazma.gamma_ray` disappears — formally a
+  breaking removal (`major`), and any downstream code that still
+  *textually* imports it will fail at import with `ModuleNotFoundError`
+  instead of today's confusing transitive error.
+- **Mitigation:** the project is `major` already (deprecated-module
+  deletion); the CHANGELOG names the removal and the `hazma.spectra`
+  replacement. If a maintained equivalent is ever wanted, it enters as
+  a designed feature via `docs/followups/` with its own validation
+  plan, not as part of this migration.

--- a/projects/cython-to-rust/adrs/_template.md
+++ b/projects/cython-to-rust/adrs/_template.md
@@ -1,0 +1,32 @@
+# ADR XXXX: <Short, imperative title>
+
+**Date:** <YYYY-MM-DD>
+**Status:** <Proposed | Accepted | Superseded by ADR-YYYY>
+**Scope:** Project-scoped (applies only within `projects/<this-slug>/`).
+
+<!--
+If this decision turns out to apply repo-wide, re-file it under
+`docs/adrs/` with a new repo-wide number, and replace this file's body
+with a one-line pointer to the new ADR.
+-->
+
+## Context
+
+<Describe the technical situation objectively. What was the original
+plan or assumption within this project? What constraint, edge case, or
+system limitation was discovered that makes the original approach
+unworkable or newly necessary?>
+
+## Decision
+
+<State the specific architectural or contractual change being made to
+resolve the issue described in the Context.>
+
+## Consequences
+
+<List the downstream effects of this decision, scoped to this project.>
+
+- **Positive:** <What benefits or safety guarantees does this provide?>
+- **Negative:** <What are the tradeoffs, performance hits, or new
+  limitations?>
+- **Mitigation:** <How will we handle the negative consequences?>

--- a/projects/cython-to-rust/learnings/_template.md
+++ b/projects/cython-to-rust/learnings/_template.md
@@ -1,0 +1,55 @@
+# <Phase X | Project> Learnings: <Name>
+
+<!--
+For phased projects, create one learnings file per phase when the phase
+closes: `phase-XX-<slug>.md`.
+
+For flat projects, create one retrospective when the project wraps up:
+`project-retrospective.md` (or similar).
+
+Learnings are durable memory for future work that touches the same
+area — not a status log. Synthesize from task notes; don't just copy
+them.
+-->
+
+## 1. Implementation Reality Check
+
+<Summarize how execution matched or diverged from the plan. Link to any
+ADRs generated during this phase or project.>
+
+## 2. Critical Context for Future Work
+
+<List types, variable names, invariants, or internal API boundaries
+established here that future tasks should respect.>
+
+- <Rule or contract 1>
+
+## 3. Quirk Log & Edge Cases
+
+<Document language-level fights, dependency quirks, or specification
+ambiguities resolved here, so future work doesn't repeat the same
+mistakes.>
+
+- <Quirk 1>
+
+## 4. Test Infrastructure State
+
+<Note new test harnesses, fixtures, mocks, or specific commands
+established here that should be reused.>
+
+- <Testing tool or standard 1>
+
+## 5. Follow-on seeds
+
+<List substantive deferred items the project surfaced — work that's
+out of scope here but worth picking up later. Each seed gets one or
+two paragraphs explaining what it is, what triggers it, and which
+files / facets / ADRs are involved.
+
+For every seed, also drop a stub in `../../../docs/followups/` (one
+file per seed; from `projects/<slug>/learnings/` that resolves to
+the repo's `docs/followups/`). The retrospective entry is the
+historical record; the followup file is the live actionable form.
+See `../../../docs/workflow.md#follow-ups` for the lifecycle.>
+
+- <Seed 1>

--- a/projects/cython-to-rust/phases/_template.md
+++ b/projects/cython-to-rust/phases/_template.md
@@ -1,0 +1,76 @@
+---
+phase: <XX>
+title: <Phase Title>
+status: <Not started | In Progress | Complete>
+---
+
+# Phase <XX>: <Title>
+
+<!--
+Phased-project file. Delete `phases/` entirely for flat projects.
+One file per phase: `phase-XX-<slug>.md`.
+-->
+
+## Goal
+
+<What this phase delivers.>
+
+## Prerequisites
+
+- <Phase X-1 complete, or specific task outputs required>
+- <Active ADRs or `../rules.md` sections to read first>
+
+## Future Phases (read-only)
+
+<Optional: pointers to later phase files that build on this one. List
+them for context so you can skim what's coming, but do NOT edit those
+files while working on this phase — they belong to their own phase.>
+
+## Parts
+
+### Part 1: <Name>
+
+<Overview of what this part groups and why.>
+
+## Tasks
+
+<!--
+Each task heading below carries the same canonical hooks the flat
+`PLAN.md` task table gives: a pointer to the task note's canonical
+path and a dependency field. Replace `XX` with the phase number and
+`X.Y` with the phase/task number (e.g. `phase-03/task-3.2-<slug>.md`).
+-->
+
+### Task X.1: <Title>
+
+**Task note:** [`../task-notes/phase-XX/task-X.1-<slug>.md`](../task-notes/phase-XX/task-X.1-<slug>.md)
+**Depends on:** <— | Task X.0 | Task (X-1).N | ADR-XXXX>
+
+**Exit criteria:**
+
+- <Concrete, testable outcome>
+- <Gate test or verification>
+
+**Notes:**
+
+<Any detail too specific for the project `PLAN.md` but needed to
+implement.>
+
+### Task X.2: <Title>
+
+**Task note:** [`../task-notes/phase-XX/task-X.2-<slug>.md`](../task-notes/phase-XX/task-X.2-<slug>.md)
+**Depends on:** Task X.1
+
+**Exit criteria:**
+
+- <Concrete, testable outcome>
+
+**Notes:**
+
+<...>
+
+## Exit Criteria
+
+- All tasks in this phase complete.
+- <Specific gate: tests pass, integration validated, etc.>
+- Phase learnings written to `../learnings/phase-<XX>-<slug>.md`.

--- a/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
@@ -110,9 +110,16 @@ Everything else is behavior-invisible.
   with no numerical oracle, since the module cannot run to produce a
   baseline; it would re-enter via `docs/followups/` with its own
   validation plan, not through this project).
-- Confirmed (and recorded in the task note) that `hazma.spectra`'s
-  n-body machinery (`spectra/_nbody.py` over `hazma.phase_space`)
-  covers the documented `gamma`/`gamma_point` use cases.
+- Replacement status of the module's actual public API confirmed and
+  recorded in the task note: `gamma_ray_decay` is superseded by
+  `hazma.spectra.dnde_photon` (the n-body path in `spectra/_nbody.py`
+  over `hazma.phase_space`); `gamma_ray_fsr` (Monte-Carlo FSR from a
+  user `msqrd`) has **no direct replacement** — the nearest live
+  equivalents are the Altarelli–Parisi approximations
+  (`hazma.spectra.dnde_photon_ap_{fermion,scalar}`), and the removal
+  is declared as replacement-free for the general-`msqrd` case in the
+  CHANGELOG. (`gamma`/`gamma_point` are the *compiled* names the
+  module wraps, not its public API.)
 - Docs referencing `hazma.gamma_ray` repointed to `hazma.spectra`.
 
 **Notes:** The module is broken on import today (transitively imports

--- a/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
@@ -1,0 +1,120 @@
+---
+phase: 00
+title: Dead-code purge
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 00: Dead-code purge
+
+## Goal
+
+Delete the ~6,500 lines of unbuilt, unimported, or broken-on-import
+Cython (and its data) so later phases port only live code. After this
+phase the build has ~19 extensions, zero C++, and no `.pyx` outside the
+live surface. No user-visible behavior changes except the resolved
+`hazma.gamma_ray` decision (Task 0.5).
+
+## Prerequisites
+
+- Read `../references/cython-inventory.md` (dead-code map + constants
+  entanglement) and `../rules.md` rule 10 (verify-before-delete).
+
+## Future Phases (read-only)
+
+- Phase 01 builds the parity corpus over the survivors; keep anything a
+  corpus entry point needs.
+
+## Tasks
+
+### Task 0.1: Relocate legacy constants header
+
+**Task note:** [`../task-notes/phase-00/task-0.1-relocate-constants.md`](../task-notes/phase-00/task-0.1-relocate-constants.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `hazma/_decay/parameters.pxd` moved verbatim (byte-identical values)
+  to `hazma/_utils/legacy_parameters.pxd`.
+- The four live `include "../_decay/parameters.pxd"` sites (both
+  `scalar_mediator/*_spec*.pyx`, both `vector_mediator/*_spec*.pyx`)
+  repointed; `pip install -e .` rebuilds; import smoke passes.
+- Do **not** merge values into `_utils/constants.pxd` (rules.md rule 4).
+
+### Task 0.2: Delete the phase-space / gamma-ray slice
+
+**Task note:** [`../task-notes/phase-00/task-0.2-delete-mc-slice.md`](../task-notes/phase-00/task-0.2-delete-mc-slice.md)
+**Depends on:** Task 0.1, Task 0.5 (gamma_ray decision)
+
+**Exit criteria:**
+
+- Deleted: `hazma/_phase_space/`, `hazma/_gamma_ray/`,
+  `hazma/deprecated/rambo.py`,
+  `hazma/rh_neutrino/_rh_neutrino_fsr_four_body.{pyx,pyi}`.
+- `hazma/gamma_ray.py` handled per Task 0.5's decision.
+- Importer check re-run at delete time and quoted in the PR body.
+- `versioning.md` call for the `deprecated/rambo.py` removal stated
+  explicitly in the PR body.
+
+### Task 0.3: Delete superseded per-particle kernels and helpers
+
+**Task note:** [`../task-notes/phase-00/task-0.3-delete-superseded.md`](../task-notes/phase-00/task-0.3-delete-superseded.md)
+**Depends on:** Task 0.1
+
+**Exit criteria:**
+
+- Deleted: `hazma/_positron/`, `hazma/_neutrino/`, `hazma/_decay/`
+  (incl. `interpolation_data/` and backups), `hazma/__decay.py`,
+  `hazma/__positron_spectra.py`, `hazma/__neutrino_spectra.py`,
+  `hazma/spectra/_positron/_kaon.pyx`,
+  `hazma/field_theory_helper_functions/` (both modules), the dead
+  ~165-line half of `hazma/_utils/boost.pyx`, and
+  `test/decay/` (already collect_ignored and importing a nonexistent
+  module).
+- `cross_section_prefactor` callers use `hazma.utils`;
+  `minkowski_dot` given a pure-Python home and
+  `hazma/experimental/axial_vector_mediator/avm_msqrd.py` repointed.
+- Import smoke (`hazma.theory`, `hazma.limits`, `hazma.cmb`,
+  `hazma.pbh`, both mediators, `hazma.spectra._photon._muon`) passes.
+
+### Task 0.4: Prune build and packaging config
+
+**Task note:** [`../task-notes/phase-00/task-0.4-prune-build.md`](../task-notes/phase-00/task-0.4-prune-build.md)
+**Depends on:** Tasks 0.2, 0.3
+
+**Exit criteria:**
+
+- `setup.py` extension list matches the survivors exactly (count the
+  built `.so`s in a fresh `pip install -e .`); no `cpp=True` groups
+  remain.
+- `pyproject.toml` package-data globs and `MANIFEST.in` no longer ship
+  deleted directories; sdist builds and contains no deleted paths.
+- CI green on the full matrix.
+
+### Task 0.5: Decide and execute the `hazma.gamma_ray` fate
+
+**Task note:** [`../task-notes/phase-00/task-0.5-gamma-ray-decision.md`](../task-notes/phase-00/task-0.5-gamma-ray-decision.md)
+**Depends on:** — (decision precedes Task 0.2's delete)
+
+**Exit criteria:**
+
+- Investigated whether `hazma.spectra` n-body machinery supersedes
+  `gamma_ray.gamma`/`gamma_point` for every documented use.
+- One of: (a) `hazma/gamma_ray.py` reimplemented over
+  `hazma.phase_space`/`hazma.spectra` (keeps project `version_bump:
+  minor`), or (b) module deleted with an ADR-0003 recording the
+  `major` implication, PLAN frontmatter updated accordingly.
+- Docs referencing the module updated either way.
+
+**Notes:** The module is broken on import today, so no working user
+exists; the decision is about the public-name contract, not behavior.
+
+## Exit Criteria
+
+- All tasks complete; preflight green; CI green.
+- `find hazma -name "*.pyx"` lists only the live surface (19 modules +
+  `_utils/boost.pyx`).
+- No `language="c++"` extension remains; `git grep -l "std::"` over
+  `hazma/` is empty.
+- Phase learnings written to `../learnings/phase-00-dead-code-purge.md`.

--- a/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
@@ -12,9 +12,15 @@ status: Not started
 
 Delete the ~6,500 lines of unbuilt, unimported, or broken-on-import
 Cython (and its data) so later phases port only live code. After this
-phase the build has ~19 extensions, zero C++, and no `.pyx` outside the
-live surface. No user-visible behavior changes except the resolved
-`hazma.gamma_ray` decision (Task 0.5).
+phase the build has 20 extensions (19 kernel modules + the C-level-only
+`_utils.boost`), zero C++, and no `.pyx` outside the live surface.
+
+This phase carries the project's two `major`-version removals (both
+covered by `PLAN.md` `version_bump: major`): `hazma/deprecated/rambo.py`
+(any removal from `hazma/deprecated/` is `major` per
+`docs/versioning.md`) and the broken-on-import `hazma.gamma_ray`
+module (ADR-0003, Proposed — Task 0.2 is gated on its acceptance).
+Everything else is behavior-invisible.
 
 ## Prerequisites
 
@@ -45,17 +51,17 @@ live surface. No user-visible behavior changes except the resolved
 ### Task 0.2: Delete the phase-space / gamma-ray slice
 
 **Task note:** [`../task-notes/phase-00/task-0.2-delete-mc-slice.md`](../task-notes/phase-00/task-0.2-delete-mc-slice.md)
-**Depends on:** Task 0.1, Task 0.5 (gamma_ray decision)
+**Depends on:** Task 0.1, ADR-0003 accepted (via Task 0.5)
 
 **Exit criteria:**
 
 - Deleted: `hazma/_phase_space/`, `hazma/_gamma_ray/`,
-  `hazma/deprecated/rambo.py`,
+  `hazma/deprecated/rambo.py`, `hazma/gamma_ray.py` (per ADR-0003),
   `hazma/rh_neutrino/_rh_neutrino_fsr_four_body.{pyx,pyi}`.
-- `hazma/gamma_ray.py` handled per Task 0.5's decision.
 - Importer check re-run at delete time and quoted in the PR body.
-- `versioning.md` call for the `deprecated/rambo.py` removal stated
-  explicitly in the PR body.
+- PR body states both `major` calls explicitly (`deprecated/rambo.py`
+  per `versioning.md`; `gamma_ray` per ADR-0003) and notes they are
+  absorbed by the project-level `version_bump: major`.
 
 ### Task 0.3: Delete superseded per-particle kernels and helpers
 
@@ -92,29 +98,35 @@ live surface. No user-visible behavior changes except the resolved
   deleted directories; sdist builds and contains no deleted paths.
 - CI green on the full matrix.
 
-### Task 0.5: Decide and execute the `hazma.gamma_ray` fate
+### Task 0.5: Ratify and execute ADR-0003 (`hazma.gamma_ray` removal)
 
 **Task note:** [`../task-notes/phase-00/task-0.5-gamma-ray-decision.md`](../task-notes/phase-00/task-0.5-gamma-ray-decision.md)
-**Depends on:** — (decision precedes Task 0.2's delete)
+**Depends on:** — (precedes Task 0.2's delete)
 
 **Exit criteria:**
 
-- Investigated whether `hazma.spectra` n-body machinery supersedes
-  `gamma_ray.gamma`/`gamma_point` for every documented use.
-- One of: (a) `hazma/gamma_ray.py` reimplemented over
-  `hazma.phase_space`/`hazma.spectra` (keeps project `version_bump:
-  minor`), or (b) module deleted with an ADR-0003 recording the
-  `major` implication, PLAN frontmatter updated accordingly.
-- Docs referencing the module updated either way.
+- ADR-0003 status flipped to Accepted by Logan (or, if rejected, the
+  phase halts and the plan is revised — a rebuild is a *new feature*
+  with no numerical oracle, since the module cannot run to produce a
+  baseline; it would re-enter via `docs/followups/` with its own
+  validation plan, not through this project).
+- Confirmed (and recorded in the task note) that `hazma.spectra`'s
+  n-body machinery (`spectra/_nbody.py` over `hazma.phase_space`)
+  covers the documented `gamma`/`gamma_point` use cases.
+- Docs referencing `hazma.gamma_ray` repointed to `hazma.spectra`.
 
-**Notes:** The module is broken on import today, so no working user
-exists; the decision is about the public-name contract, not behavior.
+**Notes:** The module is broken on import today (transitively imports
+the deleted `hazma.rambo`), so no working user exists and no
+behavior-preserving baseline can be captured — which is why rebuild is
+not offered as an in-project branch (plan-review round 1).
 
 ## Exit Criteria
 
 - All tasks complete; preflight green; CI green.
-- `find hazma -name "*.pyx"` lists only the live surface (19 modules +
-  `_utils/boost.pyx`).
+- `find hazma -name "*.pyx"` lists exactly the 20 surviving extension
+  sources (8 `spectra/_photon` + 2 `spectra/_positron` + 3
+  `spectra/_neutrino` + 6 mediator + `_utils/boost.pyx`), and a fresh
+  `pip install -e .` builds exactly 20 `.so`s.
 - No `language="c++"` extension remains; `git grep -l "std::"` over
   `hazma/` is empty.
 - Phase learnings written to `../learnings/phase-00-dead-code-purge.md`.

--- a/projects/cython-to-rust/phases/phase-01-parity-corpus.md
+++ b/projects/cython-to-rust/phases/phase-01-parity-corpus.md
@@ -1,0 +1,105 @@
+---
+phase: 01
+title: Golden parity corpus
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 01: Golden parity corpus
+
+## Goal
+
+Stand up the regression harness the repo currently lacks: pinned
+reference arrays for **all 43 live compiled entry points**, generated
+from the pre-port Cython, wired into pytest and CI. This is the gate
+every later phase swaps against, and it doubles as the before/after
+evidence `docs/versioning.md` requires for numerical changes.
+
+## Prerequisites
+
+- Phase 00 complete (corpus covers survivors only).
+- Read `../references/numerics-replacements.md` (call-site tolerances)
+  and `../rules.md` rules 1–3.
+- Context: today **zero** pinned-value tests over compiled code execute
+  anywhere — CI's `pytest` collects only `hazma/**` (setup.cfg
+  `testpaths = hazma`), and every `.npy`-backed suite under `test/` is
+  skipped, collect_ignored, or never collected
+  (`test/spectra/integration.py` matches no pytest filename pattern;
+  `test/positron/test_positron.py` is 0 bytes).
+
+## Tasks
+
+### Task 1.1: Corpus specification and generator
+
+**Task note:** [`../task-notes/phase-01/task-1.1-corpus-generator.md`](../task-notes/phase-01/task-1.1-corpus-generator.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `test/parity/generate.py` produces `test/parity/data/*.npz` covering
+  every entry point in `../references/cython-inventory.md` ("Entry
+  points by module"): log-spaced energy grids bracketing thresholds and
+  kinematic endpoints (`E → m/2`, table edges), ≥4 parent
+  energies per spectrum (rest frame + ε, mildly and strongly boosted),
+  and for the mediators ≥3 model-parameter points including a
+  near-resonance configuration; thermal ⟨σv⟩ over an x grid spanning
+  freeze-out.
+- A manifest (JSON) records generator git SHA, package versions, and
+  per-array hashes. Total data size ≤ ~10 MB.
+- Grids deliberately include the known NaN/negative-prone kinematic
+  edges; captured values are stored as-is (edge behavior is part of the
+  contract).
+
+### Task 1.2: Pytest runner and tolerance budgets
+
+**Task note:** [`../task-notes/phase-01/task-1.2-parity-runner.md`](../task-notes/phase-01/task-1.2-parity-runner.md)
+**Depends on:** Task 1.1
+
+**Exit criteria:**
+
+- `test/parity/test_parity.py` parametrizes over the manifest and
+  compares live imports against stored arrays.
+- Per-function budgets live in `test/parity/tolerances.py` (or `.toml`)
+  with a one-line justification each: exact (bit-equal) for pure
+  closed-form kernels against the capturing commit, documented budgets
+  for quad-backed kernels (start 1e-8 rel, tighten after Phase 03
+  measurement; nested-ρ gets its own line).
+- Running against unmodified Cython passes bit-exact.
+
+### Task 1.3: Wire both suites into one gate
+
+**Task note:** [`../task-notes/phase-01/task-1.3-test-wiring.md`](../task-notes/phase-01/task-1.3-test-wiring.md)
+**Depends on:** Task 1.2
+
+**Exit criteria:**
+
+- pytest config moved to `pyproject.toml`
+  (`[tool.pytest.ini_options]`), collecting `hazma` **and** `test`
+  (the `test/` suite is green post-PR #31: 51 passed / 20 skipped).
+- `test/spectra/integration.py` renamed to be collected; its property
+  assertions pass.
+- CI and `scripts/agents/preflight.sh` run the same collection;
+  `docs/agents/` env notes updated.
+
+### Task 1.4: Retire or regenerate the legacy `.npy` suites
+
+**Task note:** [`../task-notes/phase-01/task-1.4-legacy-npy.md`](../task-notes/phase-01/task-1.4-legacy-npy.md)
+**Depends on:** Task 1.2
+
+**Exit criteria:**
+
+- The skipped `test/scalar_mediator/` and `test/vector_mediator/`
+  classes (159 reference arrays, `skip("Needs to be updated")`) are
+  either regenerated-and-unskipped or deleted with their intent
+  explicitly mapped to corpus coverage in the task note.
+- `test/positron/test_positron.py` (0 bytes) deleted or filled.
+- No `@pytest.mark.skip` remains whose reason is "needs update".
+
+## Exit Criteria
+
+- All tasks complete; `pytest` (bare) runs unit + property + parity
+  suites and is green in CI on all matrix entries.
+- Corpus regeneration is documented and reproducible
+  (`python test/parity/generate.py --check` verifies hashes).
+- Phase learnings written to `../learnings/phase-01-parity-corpus.md`.

--- a/projects/cython-to-rust/phases/phase-01-parity-corpus.md
+++ b/projects/cython-to-rust/phases/phase-01-parity-corpus.md
@@ -11,8 +11,10 @@ status: Not started
 ## Goal
 
 Stand up the regression harness the repo currently lacks: pinned
-reference arrays for **all 43 live compiled entry points**, generated
-from the pre-port Cython, wired into pytest and CI. This is the gate
+reference arrays for **all 41 consumed compiled entry points** (of 43
+public defs — the two unimported `sigma_xx_to_all` exports are
+excluded here and dropped in Phase 05), generated from the pre-port
+Cython, wired into pytest and CI. This is the gate
 every later phase swaps against, and it doubles as the before/after
 evidence `docs/versioning.md` requires for numerical changes.
 
@@ -38,8 +40,11 @@ evidence `docs/versioning.md` requires for numerical changes.
 **Exit criteria:**
 
 - `test/parity/generate.py` produces `test/parity/data/*.npz` covering
-  every entry point in `../references/cython-inventory.md` ("Entry
-  points by module"): log-spaced energy grids bracketing thresholds and
+  every **consumed** entry point in `../references/cython-inventory.md`
+  ("Entry points by module" — 41 functions; the two unimported
+  `sigma_xx_to_all` are excluded, with the exclusion asserted by an
+  import re-check in the generator): log-spaced energy grids
+  bracketing thresholds and
   kinematic endpoints (`E → m/2`, table edges), ≥4 parent
   energies per spectrum (rest frame + ε, mildly and strongly boosted),
   and for the mediators ≥3 model-parameter points including a

--- a/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
+++ b/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
@@ -1,0 +1,77 @@
+---
+phase: 02
+title: Rust scaffold
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 02: Rust scaffold
+
+## Goal
+
+A building, testing, CI-green Rust extension skeleton at its final
+import path — `hazma._core` — coexisting with the remaining Cython
+under the setuptools backend via setuptools-rust (ADR-0001). No physics
+yet: the walking skeleton proves the toolchain end to end.
+
+## Prerequisites
+
+- Phase 01 complete (the corpus exists before any Rust lands).
+- ADR-0001 (accepted); `../rules.md` rules 6–8.
+
+## Tasks
+
+### Task 2.1: Crate + setuptools-rust integration
+
+**Task note:** [`../task-notes/phase-02/task-2.1-crate-skeleton.md`](../task-notes/phase-02/task-2.1-crate-skeleton.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `rust/Cargo.toml` (edition 2024) with `pyo3` (`abi3-py310`,
+  `extension-module`) and `numpy` crates; `rust/src/lib.rs` defines
+  `#[pymodule] _core` with empty submodules (`photon`, `positron`,
+  `neutrino`, `scalar_mediator`, `vector_mediator`) plus one trivial
+  round-trip function (array in → array out) for plumbing tests.
+- `setup.py` gains `RustExtension("hazma._core", ...)`;
+  `pip install -e .` (uv env) builds Cython + Rust in one pass;
+  `python -c "import hazma._core"` works.
+- `hazma/_core.pyi` stub started; py.typed unaffected.
+
+### Task 2.2: CI, preflight, and dev-loop documentation
+
+**Task note:** [`../task-notes/phase-02/task-2.2-ci-devloop.md`](../task-notes/phase-02/task-2.2-ci-devloop.md)
+**Depends on:** Task 2.1
+
+**Exit criteria:**
+
+- CI installs the Rust toolchain on both OS matrices; full matrix
+  green; wheel-build job (release.yml) still succeeds with the hybrid
+  build and wheels contain `hazma/_core.*.so` (abi3 tag verified).
+- `scripts/agents/preflight.sh` grows `cargo fmt --check`,
+  `cargo clippy -- -D warnings`, `cargo test` (skipped gracefully when
+  `rust/` absent, so pre-Phase-02 branches still preflight).
+- `docs/agents/` env notes + `AGENTS.md` Commands section document the
+  rebuild loop (when a `.rs` edit requires re-running the editable
+  install vs. plain `cargo test`).
+
+### Task 2.3: Cross-language plumbing test
+
+**Task note:** [`../task-notes/phase-02/task-2.3-plumbing-test.md`](../task-notes/phase-02/task-2.3-plumbing-test.md)
+**Depends on:** Task 2.1
+
+**Exit criteria:**
+
+- pytest exercises the round-trip function for: float in/float out,
+  1-D array in/out (dtype, shape, ownership), 0-d array, wrong-dtype
+  and 2-D error paths raising `ValueError` with the contract message
+  (see `../references/numerics-replacements.md`, dispatch contract).
+- The same test module is the template later kernel swaps copy.
+
+## Exit Criteria
+
+- All tasks complete; CI + preflight green; wheels build on both
+  platforms with the abi3 tag.
+- No public API change; `hazma._core` exists but nothing imports it yet.
+- Phase learnings written to `../learnings/phase-02-rust-scaffold.md`.

--- a/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
+++ b/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
@@ -48,7 +48,13 @@ yet: the walking skeleton proves the toolchain end to end.
 
 - CI installs the Rust toolchain on both OS matrices; full matrix
   green; wheel-build job (release.yml) still succeeds with the hybrid
-  build and wheels contain `hazma/_core.*.so` (abi3 tag verified).
+  build. **Hybrid wheels stay CPython-version-tagged** (the Cython
+  extensions force that; the 10-wheel matrix is unchanged until
+  Phase 07) — what is verified here is extension-level only: each
+  wheel contains `hazma/_core.abi3.so`, i.e. the Rust extension is
+  built against the limited API (`abi3-py310`). Distribution-level
+  abi3 wheel tags and the 2-wheel matrix are asserted in Phase 07,
+  never earlier.
 - `scripts/agents/preflight.sh` grows `cargo fmt --check`,
   `cargo clippy -- -D warnings`, `cargo test` (skipped gracefully when
   `rust/` absent, so pre-Phase-02 branches still preflight).
@@ -71,7 +77,8 @@ yet: the walking skeleton proves the toolchain end to end.
 
 ## Exit Criteria
 
-- All tasks complete; CI + preflight green; wheels build on both
-  platforms with the abi3 tag.
+- All tasks complete; CI + preflight green; hybrid (CPython-tagged)
+  wheels build on both platforms, each containing an
+  `hazma/_core.abi3.so` built against the limited API.
 - No public API change; `hazma._core` exists but nothing imports it yet.
 - Phase learnings written to `../learnings/phase-02-rust-scaffold.md`.

--- a/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
@@ -66,13 +66,27 @@ uses it.
 - Finite-interval `qags` and `qagp` in `rust/src/quad.rs`, translated
   from netlib QUADPACK Fortran (provenance header per rules.md rule 5),
   closure-based API carrying `epsabs`/`epsrel`/`limit`/breakpoints.
+- **Breakpoint preprocessing contract, pinned empirically against
+  scipy** (do not design it from the QUADPACK docs alone): determine
+  by experiment what `scipy.integrate.quad(points=...)` does with
+  unsorted lists, duplicates, points coinciding with the endpoints,
+  and points outside `[a, b]` — then replicate that behavior
+  (including any raised errors) exactly. Both degenerate cases occur
+  live: the spectra calls pass `points=[-1, 1]` on the interval
+  `[-1, 1]` (all breakpoints endpoint-coincident), and the thermal
+  ⟨σv⟩ calls pass `[2, m_med/mx, 2·m_med/mx]` where the mediator
+  points can exceed the upper bound `max(50/x, 100|150)` for heavy
+  mediators (out-of-interval). Tests cover three parameter regimes per
+  thermal call: breakpoints interior (resonance active), breakpoints
+  at/near threshold, and breakpoints outside the interval (inactive).
 - Unit tests: QUADPACK's own reference problems, plus every live
   integrand *shape* from the call-site table in
   `../references/numerics-replacements.md`, compared against
   `scipy.integrate.quad` at matching settings — agreement within 10×
   the requested tolerance, and within 1e-12 rel on smooth cases.
 - Error/abnormal-termination behavior mapped (roundoff, max
-  subdivisions) — returns a Result, never panics across FFI.
+  subdivisions, invalid breakpoints) — returns a Result, never panics
+  across FFI.
 
 ### Task 3.4: Interpolation + boost kernels
 

--- a/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
@@ -1,0 +1,111 @@
+---
+phase: 03
+title: Numerics foundation
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 03: Numerics foundation
+
+## Goal
+
+The shared numeric substrate every kernel port stands on: constants,
+special functions, the QUADPACK port, `np.interp`-exact interpolation,
+the boost integrals, and the scalar/array dispatch layer. Everything
+here is unit-tested against scipy/analytic references before any kernel
+uses it.
+
+## Prerequisites
+
+- Phase 02 complete; **ADR-0002 accepted** (gates Tasks 3.2/3.3 —
+  confirm status before starting them).
+- Read `../references/numerics-replacements.md` in full.
+
+## Tasks
+
+### Task 3.1: Constants module
+
+**Task note:** [`../task-notes/phase-03/task-3.1-constants.md`](../task-notes/phase-03/task-3.1-constants.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `rust/src/constants.rs` carries every `DEF` from
+  `_utils/constants.pxd` and every value from
+  `_utils/legacy_parameters.pxd`, in **two distinct namespaces**
+  preserving the known divergences verbatim (rules.md rule 4).
+- A test extracts values from the `.pxd` sources (script or generated
+  fixture) and asserts bit-equality — no hand-transcription trust.
+- Derived module-local `DEF`s (e.g. `eng_mu_pi_rf`) become `const fn`
+  or literal consts with the same float semantics.
+
+### Task 3.2: Special functions
+
+**Task note:** [`../task-notes/phase-03/task-3.2-specfun.md`](../task-notes/phase-03/task-3.2-specfun.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `spence`, `bessel_k1`, `bessel_kn` exposed via a thin
+  `rust/src/special.rs` over `spec_math` (or in-tree cephes translation
+  on any gap — ADR-0002 fallback).
+- Convention pinned: Rust `spence`-wrapper matches
+  `scipy.special.spence` (Li₂(1−z) convention) on a grid covering
+  (0,1), [1,∞), z→0⁺, z=1, z=2 — rtol ≤ 1e-13.
+- `k1`/`kn` swept vs scipy over the thermal domain incl. large-argument
+  underflow region — rtol ≤ 1e-13.
+
+### Task 3.3: QUADPACK port (qk15, qk21, qelg, qags, qagp)
+
+**Task note:** [`../task-notes/phase-03/task-3.3-quadpack.md`](../task-notes/phase-03/task-3.3-quadpack.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- Finite-interval `qags` and `qagp` in `rust/src/quad.rs`, translated
+  from netlib QUADPACK Fortran (provenance header per rules.md rule 5),
+  closure-based API carrying `epsabs`/`epsrel`/`limit`/breakpoints.
+- Unit tests: QUADPACK's own reference problems, plus every live
+  integrand *shape* from the call-site table in
+  `../references/numerics-replacements.md`, compared against
+  `scipy.integrate.quad` at matching settings — agreement within 10×
+  the requested tolerance, and within 1e-12 rel on smooth cases.
+- Error/abnormal-termination behavior mapped (roundoff, max
+  subdivisions) — returns a Result, never panics across FFI.
+
+### Task 3.4: Interpolation + boost kernels
+
+**Task note:** [`../task-notes/phase-03/task-3.4-interp-boost.md`](../task-notes/phase-03/task-3.4-interp-boost.md)
+**Depends on:** Task 3.1
+
+**Exit criteria:**
+
+- `interp` replicating `np.interp` exactly (ascending grid, edge
+  clamping, node hits) — property-tested against numpy over random
+  grids.
+- `boost_beta`/`boost_gamma`/`boost_delta_function` +
+  `boost_integrate_linear_interp` ported with per-branch unit tests
+  (interior, both partial edge cells, below-table `1/E` tail,
+  above-table clamp, β→0 guard) pinned against the Cython originals
+  via dedicated micro-fixtures captured in Phase 01.
+
+### Task 3.5: Dispatch and error layer
+
+**Task note:** [`../task-notes/phase-03/task-3.5-dispatch.md`](../task-notes/phase-03/task-3.5-dispatch.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- One generic helper implementing the scalar-or-1D contract
+  (`../references/numerics-replacements.md`, dispatch section),
+  including the neutrino tuple/`(3,N)` variant; kernel crates stay
+  PyO3-free (rules.md rule 8).
+- Error messages byte-match the Cython ones the tests assert on.
+
+## Exit Criteria
+
+- All tasks complete; `cargo test` covers the foundation GIL-free; the
+  scipy-comparison suite passes in CI.
+- No kernel swapped yet — `hazma._core` still unreferenced by wrappers.
+- Phase learnings written to `../learnings/phase-03-numerics-foundation.md`.

--- a/projects/cython-to-rust/phases/phase-04-spectra-kernels.md
+++ b/projects/cython-to-rust/phases/phase-04-spectra-kernels.md
@@ -1,0 +1,135 @@
+---
+phase: 04
+title: Spectra kernels
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 04: Spectra kernels
+
+## Goal
+
+Port all 13 `hazma/spectra/_{photon,positron,neutrino}` kernels to
+`hazma._core` and swap the three wrapper `__init__.py`s. 16 public
+entry points move; every swap gates on the corpus.
+
+**Scoped exception to rules.md rule 1 (delete-twin-same-PR):** the four
+extensions the mediator spectrum `.pyx` files cimport C symbols from —
+`_photon/_muon`, `_photon/_pion`, `_positron/_muon`, `_positron/_pion` —
+stay **built but Python-unreferenced** through this phase (their
+`__pyx_capi__` capsules keep the still-Cython mediator modules
+importable). They, the other spectra twins' shared `.pxd` headers, and
+`hazma/_utils/{boost,constants,kinematics}` are deleted in Phase 06
+Task 6.4 once the last cimporter is gone. All other twins (rho, kaon,
+eta family, neutrino pair) delete in their swap PR as usual.
+
+## Prerequisites
+
+- Phase 03 complete. Read the cimport DAG in
+  `../references/cython-inventory.md` — order within this phase follows
+  it (muon before pion before rho; struct module before neutrino pair).
+- `../rules.md` rules 1–3 (parity discipline) and 9 (edge guards).
+
+## Parts
+
+### Part 1: Closed-form kernels (no quadrature)
+
+Cheapest first — exercises constants + dispatch on pure math.
+
+### Part 2: Table-driven family (interp + boost integral)
+
+### Part 3: Quadrature-backed kernels (the drift-sensitive ones)
+
+## Tasks
+
+### Task 4.1: `_positron/_muon` (walking-skeleton kernel)
+
+**Task note:** [`../task-notes/phase-04/task-4.1-positron-muon.md`](../task-notes/phase-04/task-4.1-positron-muon.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `dnde_positron_muon` on Rust; corpus exact-or-≤1e-13; wrapper
+  swapped. (Twin is a Phase 06 capi survivor — see Goal.)
+- Establishes the per-kernel PR template (port → corpus diff → swap →
+  delete-or-defer → drift note) later tasks copy.
+
+### Task 4.2: Photon table family (`_kaon`, `_eta`, `_omega`, `_eta_prime`, `_phi`)
+
+**Task note:** [`../task-notes/phase-04/task-4.2-photon-table-family.md`](../task-notes/phase-04/task-4.2-photon-table-family.md)
+**Depends on:** Task 4.1
+
+**Exit criteria:**
+
+- One shared Rust implementation parameterized by (embedded table,
+  mass, delta terms); the 7 CSVs under `spectra/_photon/data/` embedded
+  via `include_str!` parsed once at init (CSVs stay in-repo as source
+  of truth).
+- 7 entry points swapped, corpus-green; Cython twins + their ~170 lines
+  of commented-out dead code gone.
+- Import-time file I/O for these modules eliminated (note the
+  package-data globs to retire in Phase 07).
+
+### Task 4.3: `_photon/_muon` (spence)
+
+**Task note:** [`../task-notes/phase-04/task-4.3-photon-muon.md`](../task-notes/phase-04/task-4.3-photon-muon.md)
+**Depends on:** Task 4.1
+
+**Exit criteria:**
+
+- `dnde_photon` (radiative muon decay, hep-ph/9909265 spectrum incl.
+  the `spence(xm) - spence(xp)` term) corpus-green at ≤1e-12 rel.
+- This kernel stays cimport-compatible-in-spirit: its Rust `fn` is
+  callable natively by Phase 06 (mediator spectra) — keep it in the
+  PyO3-free kernel layer.
+
+### Task 4.4: `_photon/_pion`
+
+**Task note:** [`../task-notes/phase-04/task-4.4-photon-pion.md`](../task-notes/phase-04/task-4.4-photon-pion.md)
+**Depends on:** Task 4.3 (cimports muon point function)
+
+**Exit criteria:**
+
+- Both entry points (charged: π→ℓνγ radiative + boosted-μ `qagp` over
+  cosθ; neutral: π⁰→γγ box) corpus-green within the quad budget.
+- First real `qagp` consumer — record measured drift vs the corpus in
+  the task note and tighten the budget if warranted.
+
+### Task 4.5: `_photon/_rho` (nested quadrature)
+
+**Task note:** [`../task-notes/phase-04/task-4.5-photon-rho.md`](../task-notes/phase-04/task-4.5-photon-rho.md)
+**Depends on:** Task 4.4
+
+**Exit criteria:**
+
+- Both ρ entry points corpus-green; the nested integral (ρ quad over
+  `_pion`, which quads over `_muon`) gets a dedicated drift analysis in
+  the task note (this is the project's numerical stress test).
+- The Cython version's untyped `cdef` locals (Python-boxed) are ported
+  as plain f64 — confirm no value shift beyond budget.
+
+### Task 4.6: `_positron/_pion` + neutrino pair (`_muon`, `_pion`, struct)
+
+**Task note:** [`../task-notes/phase-04/task-4.6-positron-pion-neutrino.md`](../task-notes/phase-04/task-4.6-positron-pion-neutrino.md)
+**Depends on:** Tasks 4.1, 4.3 (neutrino `_pion` boosts the muon spectrum)
+
+**Exit criteria:**
+
+- `dnde_positron_charged_pion`, `dnde_neutrino_muon`,
+  `dnde_neutrino_charged_pion` corpus-green; the `NeutrinoSpectrumPoint`
+  struct becomes a plain Rust struct; tuple/`(3,N)` return contract
+  verified against existing wrapper tests.
+- Neutrino/rho/kaon/eta-family twins deleted; only the four capi
+  survivors (see Goal) plus `_utils` headers remain as `.pyx`/`.pxd`
+  under `spectra/` + `_utils/`.
+
+## Exit Criteria
+
+- All 16 spectra entry points served by `hazma._core`; corpus green in
+  CI; cumulative drift table recorded in
+  `../task-notes/README.md` ("Numerical impact so far").
+- Remaining Cython under `hazma/spectra/` + `hazma/_utils/` is exactly
+  the four capi survivors and their headers, each still built and
+  importable (mediator modules unbroken — CI import smoke proves it).
+- Phase learnings written to `../learnings/phase-04-spectra-kernels.md`.

--- a/projects/cython-to-rust/phases/phase-05-mediator-cross-sections.md
+++ b/projects/cython-to-rust/phases/phase-05-mediator-cross-sections.md
@@ -10,12 +10,27 @@ status: Not started
 
 ## Goal
 
-Port `_c_vector_mediator_cross_sections` (6 kernels) and
-`_c_scalar_mediator_cross_sections` (13 kernels) plus both
-`thermal_cross_section`s to `hazma._core`. These are self-contained
-(no hazma cimports — only `libc.math` + `k1`/`kn`), so they depend
-only on the Phase 03 foundation and can run in parallel with Phase 04
-if staffing allows (they share no files with it).
+Port the **18 consumed public defs** of the two cross-section modules
+to `hazma._core` and drop the 2 unconsumed exports. Exact accounting
+(source-verified 2026-08-03; re-verify imports at execution time):
+
+- `_c_scalar_mediator_cross_sections` — 13 defs, **12 consumed**:
+  `sigma_xx_to_s_to_{ff,gg,pi0pi0,pipi}`, `sigma_xx_to_ss`,
+  `sigma_ss_to_xx`, `sigma_x{l,pi,pi0,g,s}_to_x{l,pi,pi0,g,s}` (11
+  cross-section kernels) + `thermal_cross_section`. The 13th def,
+  `sigma_xx_to_all`, is imported by nothing → dropped, not ported.
+- `_c_vector_mediator_cross_sections` — 7 defs, **6 consumed**:
+  `sigma_xx_to_v_to_{ff,pipi,pi0g,pi0v}`, `sigma_xx_to_vv` (5
+  cross-section kernels) + `thermal_cross_section`. Its
+  `sigma_xx_to_all` is likewise unimported → dropped.
+
+Total ported: 16 cross-section kernels + 2 thermal functions = 18
+consumed defs; with the 16 spectra and 7 mediator-spectrum entry
+points this reproduces the project's 43-defs / 41-consumed tally.
+These modules are self-contained (no hazma cimports — only
+`libc.math` + `k1`/`kn`), so they depend only on the Phase 03
+foundation and can run in parallel with Phase 04 if staffing allows
+(they share no files with it).
 
 ## Prerequisites
 
@@ -33,15 +48,17 @@ if staffing allows (they share no files with it).
 
 **Exit criteria:**
 
-- The 6 vector kernels transliterated **mechanically** (scripted or
-  expression-by-expression copy, never retyped — rules.md; the
-  expressions are Mathematica dumps where a dropped digit is silent);
-  tiers 2–3 replaced by the generic dispatch helper.
+- The 5 consumed vector kernels transliterated **mechanically**
+  (scripted or expression-by-expression copy, never retyped —
+  rules.md; the expressions are Mathematica dumps where a dropped
+  digit is silent); tiers 2–3 replaced by the generic dispatch helper.
 - `thermal_cross_section` on Rust `qagp` (breakpoints `[2, mv/mx,
-  2mv/mx]`) + `bessel_k1`/`bessel_kn`.
-- Corpus green across the parameter grid incl. near-resonance; the
-  unused `sigma_xx_to_all` export dropped from the Python wrapper
-  surface only if truly unimported (verify at execution time).
+  2mv/mx]`, incl. the out-of-interval regime — Task 3.3 contract) +
+  `bessel_k1`/`bessel_kn`.
+- `sigma_xx_to_all` dropped after re-running the importer check
+  (`rg sigma_xx_to_all` outside the `_c_*` modules must be empty) and
+  quoting it in the PR body.
+- Corpus green across the parameter grid incl. near-resonance.
 - Wrapper `_vector_mediator_cross_sections.py` swapped; Cython twin
   deleted.
 
@@ -52,10 +69,13 @@ if staffing allows (they share no files with it).
 
 **Exit criteria:**
 
-- All 13 scalar kernels ported, incl. the two 90-line expressions
-  (`__sigma_xpi_to_xpi`, `__sigma_xpi0_to_xpi0`) — factor the 8×
-  repeated subexpression into a named local (identical arithmetic
-  order; confirm no value shift).
+- All 11 consumed scalar kernels ported, incl. the two 90-line
+  expressions (`__sigma_xpi_to_xpi`, `__sigma_xpi0_to_xpi0`) — factor
+  the 8× repeated subexpression into a named local (identical
+  arithmetic order; confirm no value shift). `sigma_xx_to_all`
+  dropped under the same importer-check rule as Task 5.1.
+- `thermal_cross_section` on Rust `qagp` (breakpoints
+  `[2, ms/mx, 2ms/mx]`).
 - `np.log(4)` at line 283 becomes the constant `LN_4` (value change:
   none — record in task note).
 - Corpus green; wrapper swapped; twin deleted.
@@ -78,7 +98,8 @@ if staffing allows (they share no files with it).
 
 ## Exit Criteria
 
-- 19 cross-section kernels + 2 thermal functions on Rust; both
-  `_c_*` `.pyx` files deleted; corpus + relic-density checks green.
+- 16 cross-section kernels + 2 thermal functions (18 consumed defs)
+  on Rust; the 2 `sigma_xx_to_all` exports dropped; both `_c_*`
+  `.pyx` files deleted; corpus + relic-density checks green.
 - Drift table updated in `../task-notes/README.md`.
 - Phase learnings written to `../learnings/phase-05-mediator-cross-sections.md`.

--- a/projects/cython-to-rust/phases/phase-05-mediator-cross-sections.md
+++ b/projects/cython-to-rust/phases/phase-05-mediator-cross-sections.md
@@ -1,0 +1,84 @@
+---
+phase: 05
+title: Mediator cross sections
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 05: Mediator cross sections
+
+## Goal
+
+Port `_c_vector_mediator_cross_sections` (6 kernels) and
+`_c_scalar_mediator_cross_sections` (13 kernels) plus both
+`thermal_cross_section`s to `hazma._core`. These are self-contained
+(no hazma cimports — only `libc.math` + `k1`/`kn`), so they depend
+only on the Phase 03 foundation and can run in parallel with Phase 04
+if staffing allows (they share no files with it).
+
+## Prerequisites
+
+- Phase 03 complete (specfun + qags for the thermal integrals; the
+  dispatch helper).
+- `../references/cython-inventory.md` (structure: three-tier layout,
+  Mathematica-dump characteristics) and `../rules.md` rules 1–3, 12.
+
+## Tasks
+
+### Task 5.1: Vector cross sections (template)
+
+**Task note:** [`../task-notes/phase-05/task-5.1-vector-xs.md`](../task-notes/phase-05/task-5.1-vector-xs.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- The 6 vector kernels transliterated **mechanically** (scripted or
+  expression-by-expression copy, never retyped — rules.md; the
+  expressions are Mathematica dumps where a dropped digit is silent);
+  tiers 2–3 replaced by the generic dispatch helper.
+- `thermal_cross_section` on Rust `qagp` (breakpoints `[2, mv/mx,
+  2mv/mx]`) + `bessel_k1`/`bessel_kn`.
+- Corpus green across the parameter grid incl. near-resonance; the
+  unused `sigma_xx_to_all` export dropped from the Python wrapper
+  surface only if truly unimported (verify at execution time).
+- Wrapper `_vector_mediator_cross_sections.py` swapped; Cython twin
+  deleted.
+
+### Task 5.2: Scalar cross sections
+
+**Task note:** [`../task-notes/phase-05/task-5.2-scalar-xs.md`](../task-notes/phase-05/task-5.2-scalar-xs.md)
+**Depends on:** Task 5.1 (reuses its layout and dispatch pattern)
+
+**Exit criteria:**
+
+- All 13 scalar kernels ported, incl. the two 90-line expressions
+  (`__sigma_xpi_to_xpi`, `__sigma_xpi0_to_xpi0`) — factor the 8×
+  repeated subexpression into a named local (identical arithmetic
+  order; confirm no value shift).
+- `np.log(4)` at line 283 becomes the constant `LN_4` (value change:
+  none — record in task note).
+- Corpus green; wrapper swapped; twin deleted.
+
+### Task 5.3: Thermal ⟨σv⟩ validation sweep
+
+**Task note:** [`../task-notes/phase-05/task-5.3-thermal-sweep.md`](../task-notes/phase-05/task-5.3-thermal-sweep.md)
+**Depends on:** Tasks 5.1, 5.2
+
+**Exit criteria:**
+
+- End-to-end check through the live consumer:
+  `hazma/relic_density/_thermal_functions.py` paths that call
+  `thermal_cross_section` produce relic densities matching pre-port
+  values within the corpus budget (extend the corpus with one
+  relic-density scenario per mediator if Phase 01 didn't).
+- Benchmark recorded (rules.md rule 12) — this path re-entered Python
+  per Bessel evaluation and per quad node before; the speedup is the
+  headline side effect.
+
+## Exit Criteria
+
+- 19 cross-section kernels + 2 thermal functions on Rust; both
+  `_c_*` `.pyx` files deleted; corpus + relic-density checks green.
+- Drift table updated in `../task-notes/README.md`.
+- Phase learnings written to `../learnings/phase-05-mediator-cross-sections.md`.

--- a/projects/cython-to-rust/phases/phase-06-mediator-spectra.md
+++ b/projects/cython-to-rust/phases/phase-06-mediator-spectra.md
@@ -1,0 +1,92 @@
+---
+phase: 06
+title: Mediator spectra
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 06: Mediator spectra
+
+## Goal
+
+Replace the four mediator decay/positron spectrum modules — the last
+Cython — with a Rust redesign, then delete the four capi-survivor
+spectra twins and the `_utils` headers Phase 04 left behind. This is a
+**redesign, not a transliteration**: the Cython versions use mutable
+module-global interp tables with a broken memo-cache, string-keyed mode
+dispatch inside the integrand, and cross-extension cimports (the 8 cdef
+symbols) — none of which survives contact with Rust.
+
+## Prerequisites
+
+- Phases 04 and 05 complete.
+- `../references/cython-inventory.md` (the 8-symbol cimport list, the
+  dead-cache bug) and `../references/numerics-replacements.md`.
+
+## Tasks
+
+### Task 6.1: Spectrum-table struct design
+
+**Task note:** [`../task-notes/phase-06/task-6.1-table-struct.md`](../task-notes/phase-06/task-6.1-table-struct.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- A Rust struct owning the precomputed 500-point log-spaced rest-frame
+  tables (built once per parameter set by calling the Phase 04 kernel
+  `fn`s natively — no Python round trips), with genuine memoization
+  keyed on the mediator mass + partial widths (fixing the dead-cache
+  bug; same numbers, declared as performance-only per rules.md 3, 12).
+- Mode dispatch (`"total"`, `"e e g"`, `"pi pi g"`, …) becomes an enum
+  at the PyO3 boundary; string parsing happens once per call, not per
+  quadrature node. Accepted strings and error text byte-match today's.
+- Design reviewed against both decay + both positron modules before
+  implementation (they are two clone-pairs — one parameterized
+  implementation each).
+
+### Task 6.2: Decay spectrum pair (`scalar`, `vector`)
+
+**Task note:** [`../task-notes/phase-06/task-6.2-decay-spectra.md`](../task-notes/phase-06/task-6.2-decay-spectra.md)
+**Depends on:** Task 6.1
+
+**Exit criteria:**
+
+- `scalar_mediator_decay_spectrum`, `dnde_decay_v`/`dnde_decay_v_pt`
+  on Rust; corpus green (quad budget); wrappers swapped; both Cython
+  twins deleted.
+- Benchmark vs pre-swap Cython recorded (expected large win — the old
+  path rebuilt two quad-backed tables per call).
+
+### Task 6.3: Positron spectrum pair
+
+**Task note:** [`../task-notes/phase-06/task-6.3-positron-spectra.md`](../task-notes/phase-06/task-6.3-positron-spectra.md)
+**Depends on:** Task 6.1
+
+**Exit criteria:**
+
+- `dnde_decay_s`/`dnde_decay_s_pt` (scalar) and the vector clone on
+  Rust; corpus green; wrappers swapped; twins deleted.
+
+### Task 6.4: Retire the capi survivors and `_utils` headers
+
+**Task note:** [`../task-notes/phase-06/task-6.4-retire-survivors.md`](../task-notes/phase-06/task-6.4-retire-survivors.md)
+**Depends on:** Tasks 6.2, 6.3
+
+**Exit criteria:**
+
+- `rg "cimport|__pyx_capi__|\.pxd"` over `hazma/` confirms zero
+  consumers; then delete the four capi-survivor extensions
+  (`_photon/_muon`, `_photon/_pion`, `_positron/_muon`,
+  `_positron/_pion` `.pyx`+`.pxd`), `hazma/_utils/boost.{pyx,pxd}`,
+  `constants.pxd`, `kinematics.pxd`, `legacy_parameters.pxd`, and the
+  `spectra/_neutrino/_neutrino` struct module.
+- `find hazma -name "*.pyx" -o -name "*.pxd"` returns **nothing**;
+  `setup.py` builds only `hazma._core`; full suite + corpus green.
+
+## Exit Criteria
+
+- Zero Cython in the tree; all 43 entry points on `hazma._core`.
+- Drift table complete in `../task-notes/README.md` — this is the
+  input to Phase 07's CHANGELOG aggregation.
+- Phase learnings written to `../learnings/phase-06-mediator-spectra.md`.

--- a/projects/cython-to-rust/phases/phase-06-mediator-spectra.md
+++ b/projects/cython-to-rust/phases/phase-06-mediator-spectra.md
@@ -86,7 +86,8 @@ symbols) — none of which survives contact with Rust.
 
 ## Exit Criteria
 
-- Zero Cython in the tree; all 43 entry points on `hazma._core`.
+- Zero Cython in the tree; all 41 consumed entry points on
+  `hazma._core`.
 - Drift table complete in `../task-notes/README.md` — this is the
   input to Phase 07's CHANGELOG aggregation.
 - Phase learnings written to `../learnings/phase-06-mediator-spectra.md`.

--- a/projects/cython-to-rust/phases/phase-07-cutover.md
+++ b/projects/cython-to-rust/phases/phase-07-cutover.md
@@ -1,0 +1,114 @@
+---
+phase: 07
+title: Packaging cutover and close
+status: Not started
+---
+
+<!-- markdownlint-disable-file MD025 -- frontmatter title is the schema -->
+
+# Phase 07: Packaging cutover and close
+
+## Goal
+
+Remove the setuptools/Cython toolchain, make maturin the build backend,
+modernize the release pipeline to abi3 wheels, sweep the docs, and
+close the project (version bump + CHANGELOG per `PLAN.md`).
+
+## Prerequisites
+
+- Phase 06 complete (zero Cython).
+- Current packaging facts (verify still true at execution):
+  build-system requires `numpy`, `cython`, `setuptools`, `scipy>=1.13`;
+  version is dynamic via `attr: hazma.VERSION`; pytest config moved to
+  pyproject in Phase 01; release.yml uses cibuildwheel
+  (cp310–cp314 × {linux x86_64, macos arm64} = 10 wheels, sdist job,
+  PyPI trusted publishing).
+
+## Tasks
+
+### Task 7.1: Backend switch to maturin
+
+**Task note:** [`../task-notes/phase-07/task-7.1-maturin-backend.md`](../task-notes/phase-07/task-7.1-maturin-backend.md)
+**Depends on:** —
+
+**Exit criteria:**
+
+- `[build-system] requires = ["maturin>=1.x"]`; `[tool.maturin]`
+  mixed-layout config (python packages + `rust/Cargo.toml`,
+  `module-name = "hazma._core"`); setuptools-rust, `setup.py`, and the
+  cython/scipy/numpy build requirements deleted.
+- Version becomes static in `[project]`; `hazma.VERSION` reads
+  `importlib.metadata.version` (attribute preserved — it is public
+  API); `scripts/agents/preflight.sh --closing` version check updated
+  to the new source of truth.
+- `uv pip install -e .` and plain `pip install .` build from a clean
+  clone; import smoke green; package-data globs pruned to what pure
+  Python still reads (positron/neutrino CSVs etc.); `MANIFEST.in`
+  deleted (maturin sdist includes `rust/` + data via its own config —
+  verify sdist contents explicitly).
+
+### Task 7.2: Release pipeline
+
+**Task note:** [`../task-notes/phase-07/task-7.2-release-pipeline.md`](../task-notes/phase-07/task-7.2-release-pipeline.md)
+**Depends on:** Task 7.1
+
+**Exit criteria:**
+
+- release.yml rebuilt on maturin (PyO3/maturin-action or cibuildwheel's
+  maturin support — pick and record): **2 abi3 wheels** (manylinux
+  x86_64, macOS arm64) + sdist; trusted-publishing job preserved;
+  wheel abi3 tags and importability verified in the workflow
+  (`CIBW_TEST_COMMAND`-equivalent import check on the oldest supported
+  CPython, 3.10, and the newest).
+- Decision recorded (one line in task note): whether to add
+  linux aarch64 / Windows wheels now that they are cheap — default no,
+  matching current support surface.
+- ci.yml: drop per-version rebuild caching of Cython; add
+  cargo caching; matrix unchanged.
+
+### Task 7.3: Documentation sweep
+
+**Task note:** [`../task-notes/phase-07/task-7.3-docs-sweep.md`](../task-notes/phase-07/task-7.3-docs-sweep.md)
+**Depends on:** Task 7.1
+
+**Exit criteria:**
+
+- `AGENTS.md` rewritten where it states Cython facts (layout tree,
+  "Editing a .pyx requires a rebuild", layering §1, commands);
+  `docs/agents/` env notes updated (Rust toolchain requirement, uv +
+  editable-rebuild loop); `CLAUDE.md`/skills references checked by the
+  doc-consistency checklist.
+- README / docs/source install instructions updated (Rust toolchain
+  only needed for source builds; wheels cover normal installs);
+  Sphinx/RTD build verified against the maturin-built package.
+- Stale artifacts removed: `requirements.txt`, `Dockerfile` (both
+  contradict pyproject today) — or updated if kept deliberately.
+
+### Task 7.4: Close the project
+
+**Task note:** [`../task-notes/phase-07/task-7.4-close.md`](../task-notes/phase-07/task-7.4-close.md)
+**Depends on:** Tasks 7.1–7.3
+
+**Exit criteria:**
+
+- `CHANGELOG.md` entry: the migration summary + the aggregated
+  numerical-drift table from `../task-notes/README.md` (per-function
+  max shifts), naming this project slug.
+- `VERSION` bumped per `PLAN.md` `version_bump` (re-check the level
+  against actual recorded drift and the Task 0.5 outcome);
+  `scripts/agents/preflight.sh --closing` green.
+- Project retrospective written to
+  `../learnings/project-retrospective.md` incl. §5 follow-on seeds
+  (candidates surfaced so far: constants-table consolidation as a
+  declared numerical change; free-threaded abi3t wheels when the
+  ecosystem settles; relic-density ODEs to Rust if ever justified —
+  each gets a `docs/followups/todo/` stub if still relevant at close).
+- `PLAN.md` `status: Complete`; `projects/README.md` row moved to
+  Completed.
+
+## Exit Criteria
+
+- All tasks complete; a release candidate builds, tests, and publishes
+  from CI; no Cython, setuptools, or cibuildwheel-version-matrix
+  residue anywhere.
+- Phase learnings written to `../learnings/phase-07-cutover.md`.

--- a/projects/cython-to-rust/references/_template.md
+++ b/projects/cython-to-rust/references/_template.md
@@ -1,0 +1,29 @@
+# Reference: <topic>
+
+**Audience:** <which tasks should load this — e.g. "Tasks 4, 5, 6"
+or "any task that touches the boost integrals">.
+**Nature:** <one of: Spec | Checklist | How-to | Grounded facts>.
+
+<!--
+This is an OPTIONAL per-project artifact. Use it when:
+
+- `PLAN.md`'s Task Details blocks would otherwise balloon with
+  mapping tables, code-path inventories, or checklists that several
+  tasks share.
+- You want to move grounded-facts content (line numbers, call graphs,
+  file paths) out of `PLAN.md` so the plan stays scan-friendly.
+
+Guidelines:
+
+- Keep the PLAN canonical. A reference enriches but never replaces
+  a Task Details block.
+- Name the file by topic, not by task number. Tasks cite the topic.
+- Start each reference with the Audience + Nature header above so
+  an agent can skim the top and decide whether to load it.
+
+See `docs/workflow.md#references-references` for the full pattern.
+-->
+
+## <Section>
+
+<Content.>

--- a/projects/cython-to-rust/references/cython-inventory.md
+++ b/projects/cython-to-rust/references/cython-inventory.md
@@ -141,7 +141,11 @@ after the foundation (Phase 05 needs only `k1`/`kn` + `qags`).
 
 `_utils/boost.pyx` (the compiled half: `boost_delta_function`,
 `boost_integrate_linear_interp`) stays compiled until the last Cython
-cimporter dies — that is the end of Phase 04.
+cimporter dies — that is **Phase 06 Task 6.4**, not Phase 04: the four
+capi-survivor extensions live through Phase 05/06, and one of them,
+`spectra/_positron/_pion.pyx:10`, cimports the *linked*
+`boost_delta_function` (not just the header-inline `boost_beta`/
+`boost_gamma`).
 
 ### Data files read by live compiled modules
 

--- a/projects/cython-to-rust/references/cython-inventory.md
+++ b/projects/cython-to-rust/references/cython-inventory.md
@@ -11,15 +11,20 @@ in code review — this file records a snapshot.
 
 ## Headline numbers
 
-- 44 `.pyx`/`.pxd` files, 11,613 lines total.
+- **44 `.pyx` + 33 `.pxd` files** (77 files; 11,613 lines combined,
+  counted by `find hazma -name "*.pyx"` / `-name "*.pxd"` — keep the
+  two counts separate so later zero-Cython checks stay auditable).
 - `setup.py` builds **32 extension modules** in 11 groups; 3 groups
   (`_gamma_ray`, `_phase_space`, `field_theory_helper_functions`) compile
   as C++ (`-std=c++11`), the rest as C.
 - **12 `.pyx` are never compiled** (all of `_decay/`,
   `_neutrino/neutrino.pyx`, `rh_neutrino/_rh_neutrino_fsr_four_body.pyx`,
   `spectra/_positron/_kaon.pyx`).
-- Live surface: **~19 modules, ~5,000 live lines, 43 public entry points,
-  behind 11 Python import statements.**
+- Live surface: **20 built extensions after the Phase 00 purge** (19
+  kernel modules with Python `def`s + the C-level-only `_utils.boost`),
+  ~5,000 live lines, **43 public `def`s of which 41 are consumed**
+  (the two `sigma_xx_to_all` exports have zero importers), behind 11
+  Python import statements.
 - Churn: 3 commits touched `.pyx`/`.pxd` in the 3 years to Aug 2026; two
   were toolchain-forced (NumPy 2.0 migration, build-system upgrade).
 
@@ -60,14 +65,15 @@ to `hazma/_utils/legacy_parameters.pxd`, repoint the four includes, then
 delete `_decay/`. `_decay/common.pxd` is included only by `_positron/`
 modules and dies with them.
 
-### `hazma.gamma_ray` decision (Phase 00, Task 0.5)
+### `hazma.gamma_ray` removal (Phase 00, Task 0.5 / ADR-0003)
 
 `hazma/gamma_ray.py` is a public-named module that cannot be imported
-today (transitively imports deleted `hazma.rambo`). Options:
-(a) rebuild its `gamma`/`gamma_point` over `hazma.phase_space` /
-`hazma.spectra` machinery (keeps `version_bump: minor`);
-(b) delete it (a `major` event per versioning.md, even though it is
-already broken). Decide in Task 0.5; record as ADR-0003 if (b).
+today (transitively imports deleted `hazma.rambo`). ADR-0003
+(Proposed) removes it: no working baseline exists to pin a rebuild
+against, and the n-body use case is covered by `hazma.spectra` +
+`hazma.phase_space`. The removal is `major` and is absorbed by the
+project-level `version_bump: major` (which Phase 00's
+`deprecated/rambo.py` deletion forces regardless).
 
 ## Live surface (the port targets)
 
@@ -90,6 +96,13 @@ already broken). Decide in Task 0.5; record as ADR-0003 if (b).
 | `vector_mediator/vector_mediator_decay_spectrum` | `dnde_decay_v`, `dnde_decay_v_pt` |
 | `vector_mediator/vector_mediator_positron_spec` | `dnde_decay_v`, `dnde_decay_v_pt` |
 <!-- markdownlint-enable MD013 -->
+
+Tally (source-verified 2026-08-03): 16 spectra + 7 mediator-spectrum +
+13 scalar-XS + 7 vector-XS = **43 public `def`s**. Consumed: 41 — the
+scalar wrapper imports 12 of 13 symbols and the vector wrapper 6 of 7;
+`sigma_xx_to_all` (both modules) has zero importers
+(`rg sigma_xx_to_all` outside the `_c_*` modules is empty) and is
+dropped in Phase 05 rather than ported.
 
 Python-side import sites (the wrapper layer to repoint during ports, one
 file each): `spectra/_photon/__init__.py:12`,

--- a/projects/cython-to-rust/references/cython-inventory.md
+++ b/projects/cython-to-rust/references/cython-inventory.md
@@ -1,0 +1,202 @@
+# Reference: Cython inventory — dead-code map and live surface
+
+**Audience:** Phase 00 (purge), Phases 04–06 (ports), and any task that
+needs to know what exists, what is reachable, and what calls what.
+**Nature:** Grounded facts.
+
+Verified against Hazma 2.1.0 (August 2026) by reading every `.pyx`/`.pxd`
+in full, cross-referenced with `setup.py`, the Python import graph, and
+`test/conftest.py` collection rules. Re-verify line numbers before citing
+in code review — this file records a snapshot.
+
+## Headline numbers
+
+- 44 `.pyx`/`.pxd` files, 11,613 lines total.
+- `setup.py` builds **32 extension modules** in 11 groups; 3 groups
+  (`_gamma_ray`, `_phase_space`, `field_theory_helper_functions`) compile
+  as C++ (`-std=c++11`), the rest as C.
+- **12 `.pyx` are never compiled** (all of `_decay/`,
+  `_neutrino/neutrino.pyx`, `rh_neutrino/_rh_neutrino_fsr_four_body.pyx`,
+  `spectra/_positron/_kaon.pyx`).
+- Live surface: **~19 modules, ~5,000 live lines, 43 public entry points,
+  behind 11 Python import statements.**
+- Churn: 3 commits touched `.pyx`/`.pxd` in the 3 years to Aug 2026; two
+  were toolchain-forced (NumPy 2.0 migration, build-system upgrade).
+
+## Dead-code map (Phase 00 targets)
+
+<!-- markdownlint-disable MD013 -- grounded-fact table; width is the content -->
+| Target | Lines | Why it is safe to delete |
+| --- | --- | --- |
+| `hazma/_decay/*.pyx` + backups | ~1,850 | Not in `setup.py`; sole importer `hazma/__decay.py` is itself imported by nothing (the `hazma/__init__.py` block referencing it is commented out). `decay_charged_kaon.pyx` uses Cython-2 implicit relative cimports and cannot compile under Cython 3. **Keep** `parameters.pxd` until its includes are repointed (below). |
+| `hazma/_positron/` (3 built mods) | 443 | `positron_decay.pyx:11-13` does `from hazma import rambo` — deleted module → ImportError at import today. Superseded by `hazma/spectra/_positron/`. Importer `hazma/__positron_spectra.py` is legacy; verify zero importers at delete time. |
+| `hazma/_neutrino/` (2 built mods) | 492 | `muon.pyx` and `charged_pion.pyx` cimport plain cdef functions from `hazma._neutrino.neutrino`, which is **not built** → `__Pyx_ImportFunction` fails at import. Superseded by `hazma/spectra/_neutrino/`. |
+| `hazma/_phase_space/` (3 built mods, C++) | 626 | Sole consumer is `hazma/deprecated/rambo.py` (imports at lines 22-24), which nothing imports. Live RAMBO is pure NumPy: `hazma/phase_space/` (`np.random.default_rng`, no compiled deps). |
+| `hazma/_gamma_ray/` (2 built mods, C++) | 618 | `gamma_ray_generator.pyx:11-13` imports deleted `hazma.rambo` → broken at import; `gamma_ray_fsr` has zero Python importers and its C-function-pointer half exists solely for the never-built rh_neutrino file. |
+| `hazma/rh_neutrino/_rh_neutrino_fsr_four_body.pyx` (+ stale `.pyi`) | 681 | Never built; the three references in `rh_neutrino/__init__.py:78-80` are commented out; live pure-Python replacements exist in `_rh_neutrino_fsr.py` (Altarelli–Parisi). |
+| `hazma/spectra/_positron/_kaon.pyx` | 126 | Not in `setup.py`; references undefined names (`short_data`, `eta_data_*`) — would not compile. Live implementation is pure Python (`_kaon.py` + `_utils.py`). |
+| `hazma/field_theory_helper_functions/three_body_phase_space.pyx` | 315 | Built, zero importers repo-wide. Pure scalar arithmetic. |
+| `hazma/field_theory_helper_functions/common_functions.pyx` | 84 | 2 live functions: `cross_section_prefactor` (imported by broken `hazma/gamma_ray.py`; an algebraically identical pure-Python copy already exists at `hazma/utils.py:81`) and `minkowski_dot` (imported by `hazma/experimental/axial_vector_mediator/avm_msqrd.py:8` and the dead `_decay` data-regen script). Replace with pure Python, then delete. |
+| `hazma/_decay/interpolation_data/` | ~1.05 MB | 21 `.dat` files + 3 stale top-level `.dat` + regen script, all serving the unbuilt `_decay` package. Shipped as package-data for nothing. |
+| `hazma/deprecated/rambo.py` | — | Unimported (no `hazma/deprecated/__init__.py` exports; grep finds zero importers). NOTE: `hazma/deprecated/` removal policy is `major` per versioning.md — deleting `rambo.py` specifically needs the versioning call made explicitly in the purge PR. |
+| `hazma/__decay.py`, `hazma/__positron_spectra.py`, `hazma/__neutrino_spectra.py` | — | Double-underscore legacy API shims; the `__init__.py` references are commented out. Verify zero external importers at delete time. |
+| `hazma/_utils/boost.pyx` internal dead half | ~165 | `boost_integrate_linear_interp_massive`, `integrate_linear_interp_edge`, `integration_bounds`: not in `.pxd`, no `def` wrapper, and contain real index-pairing bugs (`boost.pyx:427,447,456`). Delete, never port. |
+| `hazma/_positron/parameters.pxd` | 67 | Orphan — nothing includes it. |
+<!-- markdownlint-enable MD013 -->
+
+### Constants-header entanglement (must precede `_decay/` deletion)
+
+Textual `include "../_decay/parameters.pxd"` (a filesystem-relative paste,
+no compiled module involved) appears in **four live built modules**:
+
+- `hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx:14`
+- `hazma/scalar_mediator/scalar_mediator_positron_spec.pyx:11`
+- `hazma/vector_mediator/vector_mediator_decay_spectrum.pyx:14`
+- `hazma/vector_mediator/vector_mediator_positron_spec.pyx:12`
+
+(plus the doomed `_gamma_ray/gamma_ray_generator.pyx:24`). Relocate the
+file **verbatim** (see the constants-divergence rule in `../rules.md`)
+to `hazma/_utils/legacy_parameters.pxd`, repoint the four includes, then
+delete `_decay/`. `_decay/common.pxd` is included only by `_positron/`
+modules and dies with them.
+
+### `hazma.gamma_ray` decision (Phase 00, Task 0.5)
+
+`hazma/gamma_ray.py` is a public-named module that cannot be imported
+today (transitively imports deleted `hazma.rambo`). Options:
+(a) rebuild its `gamma`/`gamma_point` over `hazma.phase_space` /
+`hazma.spectra` machinery (keeps `version_bump: minor`);
+(b) delete it (a `major` event per versioning.md, even though it is
+already broken). Decide in Task 0.5; record as ADR-0003 if (b).
+
+## Live surface (the port targets)
+
+### Entry points by module
+
+<!-- markdownlint-disable MD013 -- grounded-fact table; width is the content -->
+| Module | Entry points (all scalar-or-1D-array in/out, float64) |
+| --- | --- |
+| `spectra/_photon/_muon` | `dnde_photon(egam, emu)` |
+| `spectra/_photon/_pion` | `dnde_photon_charged_pion`, `dnde_photon_neutral_pion` |
+| `spectra/_photon/_rho` | `dnde_photon_charged_rho`, `dnde_photon_neutral_rho` |
+| `spectra/_photon/_kaon` | `dnde_photon_charged_kaon`, `dnde_photon_long_kaon`, `dnde_photon_short_kaon` |
+| `spectra/_photon/_eta`, `_omega`, `_eta_prime`, `_phi` | `dnde_photon_eta`, `dnde_photon_omega`, `dnde_photon_eta_prime`, `dnde_photon_phi` |
+| `spectra/_positron/_muon`, `_pion` | `dnde_positron_muon`, `dnde_positron_charged_pion` |
+| `spectra/_neutrino/_muon`, `_pion` | `dnde_neutrino_muon`, `dnde_neutrino_charged_pion` — scalar → 3-tuple, array → `(3, N)` array |
+| `scalar_mediator/_c_scalar_mediator_cross_sections` | 13 `def`s: `sigma_xx_to_s_to_{ff,gg,pi0pi0,pipi}`, `sigma_xx_to_ss`, `sigma_ss_to_xx`, `sigma_x{l,pi,pi0,g,s}_to_x{l,pi,pi0,g,s}`, `sigma_xx_to_all`(unused), `thermal_cross_section` |
+| `vector_mediator/_c_vector_mediator_cross_sections` | 7 `def`s: `sigma_xx_to_v_to_{ff,pipi,pi0g,pi0v}`, `sigma_xx_to_vv`, `sigma_xx_to_all`(unused), `thermal_cross_section` |
+| `scalar_mediator/scalar_mediator_decay_spectrum` | `scalar_mediator_decay_spectrum` |
+| `scalar_mediator/scalar_mediator_positron_spec` | `dnde_decay_s`, `dnde_decay_s_pt` |
+| `vector_mediator/vector_mediator_decay_spectrum` | `dnde_decay_v`, `dnde_decay_v_pt` |
+| `vector_mediator/vector_mediator_positron_spec` | `dnde_decay_v`, `dnde_decay_v_pt` |
+<!-- markdownlint-enable MD013 -->
+
+Python-side import sites (the wrapper layer to repoint during ports, one
+file each): `spectra/_photon/__init__.py:12`,
+`spectra/_neutrino/__init__.py:11-12`, `spectra/_positron/__init__.py:12`,
+`scalar_mediator/_scalar_mediator_cross_sections.py:1`,
+`scalar_mediator/_scalar_mediator_spectra.py:7`,
+`scalar_mediator/_scalar_mediator_positron_spectra.py:4`,
+`vector_mediator/_vector_mediator_cross_sections.py:8-24`,
+`vector_mediator/_vector_mediator_spectra.py:7`,
+`vector_mediator/_vector_mediator_positron_spectra.py:4`.
+
+### C-level dependency graph (dictates port order)
+
+```text
+_utils/constants.pxd  — textual include of 151 compile-time DEFs → all live kernels
+_utils/kinematics.pxd — 3 cdef inline fns → _photon/_rho, _neutrino/_pion
+_utils/boost.pxd      — boost_beta, boost_gamma (inline);
+                        boost_delta_function, boost_integrate_linear_interp (linked)
+                        → 10 spectra kernels
+
+_photon/_muon ──► _photon/_pion ──► _photon/_rho          (cimport chains)
+_positron/_muon ──► _positron/_pion
+_neutrino/_muon ──► _neutrino/_pion   (+ both use the _neutrino struct module)
+
+mediator decay/positron spectra ──cimport──► 8 cdef symbols:
+  dnde_photon_muon_{point,array}, dnde_photon_charged_pion_{point,array},
+  dnde_photon_neutral_pion_{point,array},
+  dnde_positron_muon_array, dnde_positron_charged_pion_array
+```
+
+The mediator spectrum modules link against other extensions'
+`__pyx_capi__` capsules — a mechanism Rust cannot join. They therefore
+port **after** the spectra kernels (Phase 06 after Phase 04). The two
+cross-section modules cimport nothing from hazma and can port any time
+after the foundation (Phase 05 needs only `k1`/`kn` + `qags`).
+
+`_utils/boost.pyx` (the compiled half: `boost_delta_function`,
+`boost_integrate_linear_interp`) stays compiled until the last Cython
+cimporter dies — that is the end of Phase 04.
+
+### Data files read by live compiled modules
+
+All in `hazma/spectra/_photon/data/`, loaded at module import via
+`np.loadtxt(..., delimiter=",")`, path via `spectra/_photon/path.py`:
+
+<!-- markdownlint-disable MD013 -- grounded-fact table; width is the content -->
+| File | Shape | Consumer |
+| --- | --- | --- |
+| `charged_kaon_photon.csv` | 501×8 | `_kaon.pyx` |
+| `long_kaon_photon.csv` | 501×7 | `_kaon.pyx` |
+| `short_kaon_photon.csv` | 501×3 | `_kaon.pyx` |
+| `eta_photon.csv` | 101×6 | `_eta.pyx` |
+| `eta_prime_photon.csv` | 501×7 | `_eta_prime.pyx` |
+| `omega_photon.csv` | 501×7 | `_omega.pyx` |
+| `phi_photon.csv` | 501×11 | `_phi.pyx` |
+<!-- markdownlint-enable MD013 -->
+
+Pattern: transpose, column 0 = energies, dnde = sum of remaining
+channel columns, `emin`/`emax` from the grid ends. The
+positron/neutrino CSVs are read by pure Python and are out of scope.
+
+## Structural facts that shrink the port
+
+- `_eta`/`_omega`/`_eta_prime`/`_phi` are one ~70-line template (table +
+  boost + delta terms); `_kaon` is the same template ×3 with the interp
+  factored out. `_kaon.pyx` also carries ~120 lines of commented-out dead
+  code; `_eta`-family files carry ~50 each.
+- The two cross-section modules are three-tier: 19 `cdef` scalar kernels
+  (Mathematica `CForm` dumps — magic rationals like `419904.0` = 2⁵·3⁸,
+  90-line single expressions, one subexpression repeated verbatim 8×),
+  then per-kernel `__vec_*` loops, then per-kernel `def` dispatchers.
+  Tiers 2+3 (~1,200 lines) collapse into one generic dispatch helper.
+- The four mediator spectrum modules are two designs cloned scalar↔vector
+  (the positron pair differs by `ms`→`mv` renaming).
+- Distinct logic across the whole live surface: **~2,500–3,000 lines.**
+- Entry-point polymorphism is uniform: dispatch on
+  `hasattr(x, "__len__")`, `float` in → `float` out, 1-D array in →
+  1-D array out (neutrino: 3-tuple / `(3, N)`).
+
+## Bugs found during the audit (fix or avoid during ports)
+
+Live code:
+
+1. **Dead memo-cache** — `scalar_mediator_positron_spec.pyx:21-22,49-55`
+   and `vector_mediator_positron_spec.pyx:22-23,50-56`: `cache_ms`/
+   `cache_pws` are read but never assigned, so `__set_spectra` (two
+   500-point tables, each point a `quad`) reruns on **every call**, and
+   per point in the `_pt` variants. Numbers correct; performance awful.
+   Fix lands with the Phase 06 redesign (identical numbers, declared as
+   performance-only).
+2. **`np.log(4)`** at `_c_scalar_mediator_cross_sections.pyx:283` inside
+   `cdef double __sigma_xl_to_xl` — a Python round-trip amid `libc.math`
+   calls. Value is correct; port as the constant.
+3. **Constants divergence** — `MASS_E` = 0.510998928 in
+   `_decay/common.pxd` / `_decay/parameters.pxd` / `_positron/parameters.pxd`
+   vs 0.5109989461 in `_utils/constants.pxd`; `BR_PI_TO_ENU` has three
+   spellings (0.000123 / 1.2e-4 / 1.230e-4); `WIDTH_K = 3.3406**-13.`
+   and `WIDTH_PI = 2.528511206475808**-14.` are `**` exponentiation
+   where `e-` notation was meant (~10⁶ off; both currently unused).
+   Governed by the bit-parity rule in `../rules.md`.
+4. Unused cimports in mediator decay modules (safe to drop at port time):
+   `dnde_photon_charged_pion_point` + `dnde_photon_neutral_pion_array`
+   in the scalar module, `dnde_photon_neutral_pion_array` in the vector
+   module, `exp` in both.
+
+Dead code (do not resurrect): out-of-bounds `std::vector` write in
+`gamma_ray_fsr.pyx` Python-callback path (`momenta[nfsp][0]` on an empty
+inner vector); uninitialized `prefactor` read at
+`gamma_ray_generator.pyx:196,234` plus `is`-vs-`==` string compares;
+off-by-one index pairing in `boost_integrate_linear_interp_massive`.

--- a/projects/cython-to-rust/references/numerics-replacements.md
+++ b/projects/cython-to-rust/references/numerics-replacements.md
@@ -1,0 +1,153 @@
+# Reference: Numerics replacements — quadrature, special functions, interpolation
+
+**Audience:** Phase 01 (corpus tolerances), Phase 03 (foundation), and
+any Phase 04–06 task that touches an integrand.
+**Nature:** Grounded facts + spec.
+
+## SciPy C-level dependencies being replaced
+
+### `scipy.special.cython_special` (the build-time ABI pin)
+
+Only three functions are cimported anywhere live:
+
+<!-- markdownlint-disable MD013 -- grounded-fact table; width is the content -->
+| Function | Live call sites | Math |
+| --- | --- | --- |
+| `spence` | `spectra/_photon/_muon.pyx:13,113` (`spence(xm) - spence(xp)`) | Dilogarithm. **Convention trap:** scipy's `spence(z)` = Li₂(1−z), not Li₂(z). |
+| `k1` | `_c_scalar_mediator_cross_sections.pyx:1361`, `_c_vector_mediator_cross_sections.pyx:606` (`k1(x*z)` in `__thermal_cross_section_integrand`) | Modified Bessel K₁ (Maxwell–Boltzmann weight). |
+| `kn` | scalar `:1404`, vector `:650` (`kn(2, x)` in the ⟨σv⟩ prefactor `x/(2*kn(2,x))**2`) | Modified Bessel K_n, integer order. |
+<!-- markdownlint-enable MD013 -->
+
+This cimport is why `pyproject.toml` pins `scipy>=1.13` in
+`[build-system].requires` (exported C symbols must ABI-match between
+build and runtime). The pin disappears when these move to Rust.
+
+**Replacement:** the `spec_math` crate (v0.1.6, June 2026,
+**MIT OR Apache-2.0**, pure Rust) is a cephes re-implementation:
+
+- `Bessel` trait: `bessel_k0`, `bessel_k0e`, `bessel_k1`, `bessel_k1e`,
+  `bessel_kn(n)`.
+- `Polylog` trait: `li2` — which per its docs delegates to
+  `cephes64::spence`.
+
+scipy's `spence`, `k1`, `kn` are themselves cephes wrappers, so this is
+algorithm-for-algorithm parity, not merely value parity. Two
+implementation-time checks are mandatory (Task 3.2):
+
+1. Pin the `li2`/`spence` argument convention against
+   `scipy.special.spence` on a grid spanning (0, 1), (1, ∞), and the
+   branch point — do not assume which convention `li2` exposes.
+2. Sweep `bessel_k1`/`bessel_kn` vs scipy over the thermal-integral
+   domain (arguments roughly `x·z ∈ [2, 3000]`, watch underflow at large
+   argument — cephes K1 underflows near x≈705) at rtol ≤ 1e-13.
+
+Fallback if `spec_math` has a gap or a parity miss: vendor a direct Rust
+translation of the specific cephes routine (`spence.c` ≈ 100 lines,
+`k1.c`/`kn.c` similar; cephes licensing is permissive — scipy ships it
+under its BSD stack).
+
+### `scipy.integrate.quad` (QUADPACK) call sites
+
+All live sites call `quad` from Cython with a `cdef`-function callback
+(Cython auto-wraps it as a Python callable → QUADPACK re-enters Python
+per node). Sites and their settings:
+
+<!-- markdownlint-disable MD013 -- grounded-fact table; width is the content -->
+| Call site | Interval | Settings |
+| --- | --- | --- |
+| `spectra/_photon/_pion.pyx:123` | cosθ ∈ [−1, 1] | `points=[-1,1]` (QAGP), `epsabs=1e-10`, `epsrel=1e-5` |
+| `spectra/_photon/_rho.pyx:52,123` | cosθ | `epsabs=1e-10`, `epsrel=1e-5`; integrand itself calls `_pion`'s quad → **nested adaptive quadrature** |
+| `spectra/_positron/_pion.pyx:58` | cosθ | `epsabs=1e-10`, `epsrel=1e-4` |
+| `spectra/_neutrino/_pion.pyx:124,127` | energy-space | two quads, scipy default tolerances (`epsabs=1.49e-8`, `epsrel=1.49e-8`), integer selector via `args` |
+| scalar `thermal_cross_section` (`:1370` region) | z ∈ [2, max(50/x, 100)] | `points=[2, ms/mx, 2ms/mx]` (QAGP) |
+| vector `thermal_cross_section` (`:615` region) | z ∈ [2, max(50/x, 150)] | `points=[2, mv/mx, 2mv/mx]` (QAGP) |
+| 4 × mediator spectrum modules | cosθ ∈ [−1, 1] | `points=[-1,1]`, `epsabs=1e-10`, `epsrel=1e-5` |
+<!-- markdownlint-enable MD013 -->
+
+**Replacement decision (ADR-0002):** port finite-interval QUADPACK —
+`qk15`/`qk21` rules, the `qelg` ε-algorithm extrapolation, `qags`, and
+`qagp` — to Rust **from the public-domain netlib Fortran sources**
+(QUADPACK by Piessens et al. is public domain; scipy vendors that exact
+Fortran, GSL's GPL reimplementation is *not* the source we translate
+from). This gives scipy-matching subdivision behavior, which is what
+keeps corpus drift near zero, at ~1,500–2,500 lines of Rust. Infinite
+intervals (`qagi`) are not needed — every live integral is finite.
+
+Oracle strategy: primary oracle is scipy itself, via (a) direct
+Python-side comparisons on each live integrand shape and (b) the Phase
+01 corpus. See ADR-0002 for what the cyphus crates may and may not be
+used for.
+
+Expected drift: with a faithful QUADPACK port, quad-backed spectra
+should reproduce to ~1e-12 relative or better; budget 1e-8 in the
+corpus tolerance file and tighten after measurement. The nested ρ
+integral is the stress test and gets its own budget line.
+
+### `np.interp` semantics
+
+`np.interp(x, xp, fp)` is called inside `cdef` functions in the kaon/eta
+photon family and both cross-section spectrum-table paths. The Rust
+`interp` routine must replicate exactly:
+
+- linear interpolation on an ascending grid;
+- **clamping** outside the grid: returns `fp[0]` below, `fp[-1]` above
+  (no extrapolation, no error);
+- exact-node hits return the node value.
+
+Note the kaon/eta family separately implements a `1/E`-weighted
+power-law tail *below* the table minimum inside
+`boost_integrate_linear_interp` — that is part of the boost integral
+(next section), not of `np.interp`.
+
+### `boost_integrate_linear_interp` (`hazma/_utils/boost.pyx`)
+
+The one genuinely subtle numeric in the foundation (~90 live lines).
+Integrates `y/x` between `E·γ(1∓β)` over a tabulated `(x, y)` spectrum:
+`np.trapezoid` over interior whole cells + closed-form linear-interpolant
+partial-cell corrections at both edges + analytic `1/E` tail when the
+lower bound is below `x[0]` + hard clamp above `x[-1]`; edge detection
+uses a 1e-6 absolute tolerance; `assert 0.0 < beta < 1.0` guards the
+β→0 singularity (callers short-circuit to the rest-frame value when
+`E − M < DBL_EPSILON`). Port with dedicated unit tests per branch
+(interior, both partial-cell edges, below-table tail, above-table clamp,
+β→0 short-circuit) before any consumer kernel ports.
+
+`boost_delta_function` (boosted Dirac δ for two-body lines) is closed
+form: `1/(2γβk₀)` inside the boosted support window, else 0.
+
+## The cyphus crates (assessed 2026-08-03)
+
+Logan's 2020–2022 GSL ports at github.com/rust-cyphus, evaluated for
+reuse. Test runs on rustc 1.96.0:
+
+<!-- markdownlint-disable MD013 -- grounded-fact table; width is the content -->
+| Crate | Verdict on quality | License | Reusable? |
+| --- | --- | --- | --- |
+| `cyphus-integration` (3.8k lines) | GSL `qag/qags/qagp/qagi` + `qk` + ε-table. After deleting a stale `#![feature(const_option)]` gate (stabilized since), **43/44 tests pass**; the one failure is doubly-infinite `qagi`, which Hazma never uses. Builder API (`epsabs/epsrel/limit/order/singular_points`) mirrors the scipy surface. | **GPL-3** (explicit GSL copyright headers — "Adapted from the GNU Scientific Library", Brian Gough copyright) | Not in-repo (license). See ADR-0002: manual dev-time cross-check oracle only. |
+| `cyphus-specfun` (20.8k lines) | Compiles clean; **99/102 tests pass** (failures: `cyl_bessel_yn_e`, `exprel_n_e`, `choose_e` — none needed here). Has `cyl_bessel_k*`; **no dilog/spence**. | **GPL-3** (GSL port) | Not in-repo. `spec_math` (cephes) is the better parity match for scipy anyway — scipy's k1/kn/spence are cephes, not GSL. |
+| `cyphus-interpolation` (2.8k lines) | FITPACK/dierckx curfit/splev port + GSL-style `interp1d` with accel. | No license file; mixed GSL-idiom provenance | Out of scope — Hazma's spline use is pure-Python scipy and stays. |
+| `cyphus-diffeq` (3.9k lines) | Hairer dopri5/dop853/radau/rodas ports. | No license file | Out of scope — relic-density ODEs are Python-level scipy and stay. Possible future interest if relic density ever moves to Rust. |
+<!-- markdownlint-enable MD013 -->
+
+Key conclusions: (1) GPL-3 provenance bars vendoring or linking any of
+it into MIT-licensed Hazma — Logan authored the ports but cannot
+relicense GSL-derived work; (2) their value is as *independent oracles*
+and as proof the QUADPACK-class port is a known, bounded job (done once
+already); (3) for the specfun surface Hazma needs, the cephes lineage
+(`spec_math`) is both license-clean *and* numerically closer to scipy
+than the GSL lineage. Formalized in ADR-0002.
+
+## Entry-point dispatch contract (Phase 03, Task 3.5)
+
+Every public function follows one shape; implement once as a helper:
+
+- Accept `Bound<'_, PyAny>`: `float`/0-d array → scalar path → Python
+  `float`; 1-D array (via `PyReadonlyArray1<f64>`) → array path →
+  `PyArray1<f64>`. Anything else → `ValueError` matching the current
+  message ("Photon energies must be 0 or 1-dimensional.").
+- Neutrino pair returns a 3-tuple (scalar in) or `(3, N)` `PyArray2`
+  (array in) — the one non-uniform return shape.
+- Current Cython `assert`s become explicit `PyValueError`/`PyAssertionError`
+  raises; note today's asserts vanish under `-O` — replicating them as
+  unconditional checks is a (desirable, tiny) behavior tightening to
+  note in the CHANGELOG.

--- a/projects/cython-to-rust/references/numerics-replacements.md
+++ b/projects/cython-to-rust/references/numerics-replacements.md
@@ -73,6 +73,17 @@ from). This gives scipy-matching subdivision behavior, which is what
 keeps corpus drift near zero, at ~1,500–2,500 lines of Rust. Infinite
 intervals (`qagi`) are not needed — every live integral is finite.
 
+**Breakpoint degeneracies present in the live calls** (they shape the
+Task 3.3 preprocessing contract): the four spectra/mediator-spectrum
+`points=[-1, 1]` calls pass breakpoints that coincide with *both*
+integration endpoints; the thermal ⟨σv⟩ calls pass
+`[2, m_med/mx, 2·m_med/mx]`, whose lower entry equals the lower bound
+and whose mediator entries can exceed the upper bound
+`max(50/x, 100|150)` for heavy mediators. What scipy does with
+sorted/duplicate/endpoint-coincident/out-of-interval points must be
+pinned *empirically* and replicated exactly, errors included — do not
+derive the contract from QUADPACK documentation alone (Task 3.3).
+
 Oracle strategy: primary oracle is scipy itself, via (a) direct
 Python-side comparisons on each live integrand shape and (b) the Phase
 01 corpus. See ADR-0002 for what the cyphus crates may and may not be

--- a/projects/cython-to-rust/rules.md
+++ b/projects/cython-to-rust/rules.md
@@ -1,0 +1,75 @@
+# cython-to-rust — Cross-Cutting Rules
+
+Rules every task in this project must follow. Repo-wide invariants
+(preflight gate, PR conventions, versioning) are not restated here —
+see `AGENTS.md` and `docs/agents/`.
+
+## Parity discipline
+
+1. **The corpus gates every swap.** A kernel's Python wrapper is
+   repointed to `hazma._core` only when the Rust implementation passes
+   the Phase 01 parity corpus within that function's budget in
+   `test/parity/tolerances.*`. The Cython twin is deleted in the same PR
+   as the swap — no dual-implementation drift window.
+2. **Corpus data is generated only from pre-port Cython.** The corpus
+   manifest records the git SHA and environment that produced it.
+   Never regenerate reference arrays from a tree in which any kernel
+   already runs on Rust. Widening a tolerance budget requires a one-line
+   justification in the tolerance file and a note in the task note.
+3. **Every numerical shift is declared.** If a swapped kernel moves any
+   value beyond 1e-12 relative, the PR body and the working-memory
+   "Numerical impact so far" section record the function, grid, and
+   max shift — even when the corpus tolerance absorbs it. The Phase 07
+   closing CHANGELOG aggregates these.
+
+## Constants
+
+1. **Bit-parity first, cleanup second.** Ported code uses the exact
+   constant values its Cython source used — including the known
+   divergences between `_utils/constants.pxd` and the legacy
+   `parameters.pxd` tables (see `references/cython-inventory.md`,
+   "Bugs" §3). Consolidating to one table is a *separate, declared*
+   numerical change after the port, not a silent side effect of it.
+   The relocated `legacy_parameters` header keeps its values verbatim.
+
+## Licensing
+
+1. **No GSL-derived code in the repo or its dependency graph** (ADR-0002).
+   Numerics provenance is restricted to: public-domain netlib QUADPACK,
+   cephes-lineage code (`spec_math` or in-tree cephes translations),
+   and original work. Every vendored or translated routine cites its
+   upstream source and license in a header comment.
+
+## Rust conventions
+
+1. Edition 2024; `cargo fmt --check` and `cargo clippy -- -D warnings`
+   are part of the preflight gate from Phase 02 on; `cargo test` runs
+   the kernel unit tests (analytic limits, edge cases) — the Python-side
+   corpus tests remain the cross-language gate.
+2. **The extension is `hazma._core`** — one cdylib, PyO3 submodules per
+   domain (`photon`, `positron`, `neutrino`, `scalar_mediator`,
+   `vector_mediator`). Public Python import paths never change; wrapper
+   modules re-export from `hazma._core` behind the existing names.
+3. Kernel functions are plain `fn(f64, ...) -> f64` in modules free of
+   PyO3 types; the PyO3 layer (dispatch, error mapping, array glue)
+   lives separately. This keeps `cargo test` GIL-free and the math
+   readable next to the Cython it replaces.
+4. Every `.pyx` numeric edge guard survives the port explicitly:
+   threshold short-circuits (`E − M < f64::EPSILON` → rest frame),
+   below-threshold zeros, and the β→0 singularity guard. Cython
+   `assert`s become unconditional error returns (declared once in the
+   CHANGELOG as a tightening — today they compile out under `-O`).
+
+## Process
+
+1. **Verify-before-delete.** Phase 00 deletions re-run the importer
+    check (`rg` for the module path) at execution time rather than
+    trusting the inventory snapshot, and each deletion PR states the
+    check in its body.
+2. Phases land in order; within Phases 04–06 tasks may proceed in any
+    order consistent with the cimport DAG in
+    `references/cython-inventory.md`.
+3. Performance claims require a benchmark in the task note (hyperfine
+    or pytest-benchmark), compared against the pre-swap Cython on the
+    same machine. Expected wins (mediator spectra, thermal ⟨σv⟩) are
+    side effects to measure, not goals to chase at parity's expense.

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -103,6 +103,16 @@ this section — do not reconstruct it from memory.)
   (77 files). QAGP breakpoint preprocessing (endpoint-coincident and
   out-of-interval points both occur live) added to Task 3.3's exit
   criteria.
+- **Plan-review round 2 (2026-08-03)**, two completeness fixes: the
+  inventory's boost-retirement claim corrected to Phase 06 Task 6.4
+  (capi survivor `spectra/_positron/_pion.pyx:10` cimports the
+  _linked_ `boost_delta_function`, so the compiled `_utils.boost`
+  extension must outlive Phase 04); Task 0.5/ADR-0003 now name the
+  module's real public API — `gamma_ray_decay` (superseded by
+  `hazma.spectra.dnde_photon`) and `gamma_ray_fsr` (removed with no
+  direct replacement; nearest are the Altarelli–Parisi
+  approximations) — instead of the wrapped compiled names
+  `gamma`/`gamma_point`.
 
 ## Files Changed
 

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -5,8 +5,8 @@
 **Status:** In Progress
 **Plan References:** `../PLAN.md` (all sections)
 **Related ADRs:** ADR-0001 (accepted), ADR-0002 (**proposed — needs
-Logan's sign-off before Phase 03 Tasks 3.2/3.3**), ADR-0003 (conditional
-on Phase 00 Task 0.5)
+Logan's sign-off before Phase 03 Tasks 3.2/3.3**), ADR-0003
+(**proposed — needs Logan's sign-off before Phase 00 Task 0.2**)
 **Depends On:** none
 
 ## Objective
@@ -35,9 +35,10 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 
 ## Exit Criteria
 
-- All eight phases Complete; zero `.pyx`/`.pxd` in the tree; all 43
-  entry points served by `hazma._core`; maturin backend live.
-- ADR-0002 accepted (or superseded) and ADR-0003 resolved or moot.
+- All eight phases Complete; zero `.pyx`/`.pxd` in the tree; all 41
+  consumed entry points served by `hazma._core` (the 2 unconsumed
+  `sigma_xx_to_all` exports dropped in Phase 05); maturin backend live.
+- ADR-0002 and ADR-0003 accepted (or superseded).
 - Closing PR bumps `VERSION` in `hazma/__init__.py` per `PLAN.md`'s
   `version_bump:` frontmatter and adds a `CHANGELOG.md` entry naming
   this project slug, with the aggregated drift table. See
@@ -88,6 +89,20 @@ this section — do not reconstruct it from memory.)
   `.pyx` cimport their `__pyx_capi__` symbols — recorded in the
   Phase 04 file's Goal block.
 - Constants bit-parity before consolidation → `../rules.md` rule 4.
+- **Plan-review round 1 (2026-08-03)** forced four canonical changes:
+  (1) `version_bump` → `major` (Phase 00 deletes
+  `hazma/deprecated/rambo.py`; any `deprecated/` removal is `major`
+  per versioning.md); (2) `hazma.gamma_ray` default is now _delete_
+  via ADR-0003 — the rebuild branch was dropped because the module
+  cannot run, so no behavior-preserving baseline exists; (3) hybrid
+  wheels stay CPython-tagged through Phases 02–06, only `hazma._core`
+  itself is abi3 (limited API); distribution-level abi3 tags are a
+  Phase 07 assertion; (4) counts re-derived from source: 20 surviving
+  extensions (not 19), 43 public defs / 41 consumed (corpus covers
+  41; 2 `sigma_xx_to_all` dropped in Phase 05), 44 `.pyx` + 33 `.pxd`
+  (77 files). QAGP breakpoint preprocessing (endpoint-coincident and
+  out-of-interval points both occur live) added to Task 3.3's exit
+  criteria.
 
 ## Files Changed
 
@@ -102,9 +117,12 @@ _None yet — project scaffolding only (this PR)._
 ## Open Questions
 
 - **ADR-0002 sign-off** (Logan): accept the license-clean-numerics
-  decision, or deliberately take the GPL route? Gates Phase 03.
-- **Task 0.5**: `hazma.gamma_ray` — reimplement over `hazma.phase_space`
-  (keeps `minor`) or delete (raises to `major`, needs ADR-0003)?
+  decision, or deliberately take the GPL route? Gates Phase 03
+  Tasks 3.2/3.3.
+- **ADR-0003 sign-off** (Logan): confirm deletion of the
+  broken-on-import `hazma.gamma_ray`. Gates Phase 00 Task 0.2; if
+  rejected, the phase halts for a plan revision (rebuild would be a
+  new feature via `docs/followups/`, not this project).
 - Phase 05 parallelism: run 05 alongside 04 (no shared files) or keep
   strictly serial? Decide when Phase 04 starts, based on who's driving.
 

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -1,0 +1,140 @@
+# Working Memory: cython-to-rust
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Status:** In Progress
+**Plan References:** `../PLAN.md` (all sections)
+**Related ADRs:** ADR-0001 (accepted), ADR-0002 (**proposed — needs
+Logan's sign-off before Phase 03 Tasks 3.2/3.3**), ADR-0003 (conditional
+on Phase 00 Task 0.5)
+**Depends On:** none
+
+## Objective
+
+Track cross-phase context and live phase status for the Cython→Rust
+migration so any agent picking up work mid-project starts from facts,
+not re-discovery. Per-task status lives in each `phase-XX/README.md`.
+
+## Phases
+
+| # | Phase | Phase file | Working memory | Status |
+| --- | ------- | ----------- | ---------------- | -------- |
+| 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | Not started |
+| 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | Not started |
+| 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | Not started |
+| 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | Not started |
+| 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
+| 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | Not started |
+| 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | Not started |
+| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | Not started |
+
+```text
+00 ──► 01 ──► 02 ──► 03 ──► 04 ──► 06 ──► 07
+                        └──► 05 ──┘
+```
+
+## Exit Criteria
+
+- All eight phases Complete; zero `.pyx`/`.pxd` in the tree; all 43
+  entry points served by `hazma._core`; maturin backend live.
+- ADR-0002 accepted (or superseded) and ADR-0003 resolved or moot.
+- Closing PR bumps `VERSION` in `hazma/__init__.py` per `PLAN.md`'s
+  `version_bump:` frontmatter and adds a `CHANGELOG.md` entry naming
+  this project slug, with the aggregated drift table. See
+  [`../../../docs/versioning.md`](../../../docs/versioning.md).
+
+## Inputs Reviewed
+
+- `../PLAN.md`, both `../references/*.md`, `../rules.md` — project
+  contract and grounded facts.
+- August 2026 analysis session: every `.pyx`/`.pxd` read in full by
+  five parallel passes; findings distilled into the references.
+- rust-cyphus crates (cloned + test-run 2026-08-03, rustc 1.96):
+  results in `../references/numerics-replacements.md`.
+
+## Findings
+
+- The five-pass audit's load-bearing facts (dead-code evidence, entry
+  points, cimport DAG, quad call sites, bugs) are **already promoted**
+  into `../references/` — consult those, not this section, and
+  re-verify line numbers at execution time (snapshot of 2.1.0).
+- Test-infra fact agents keep tripping on: bare `pytest` collects only
+  `hazma/**` (`setup.cfg` `testpaths`), while preflight runs
+  `pytest -q test` — two disjoint suites until Phase 01 Task 1.3 merges
+  them. Zero compiled-layer pinned tests run anywhere today.
+- Local env fact: nothing is prebuilt on a fresh clone — build with uv
+  (`uv venv`, `uv pip install -e .`) before preflight; expect preflight
+  red on a clean tree otherwise.
+- cyphus-diffeq (Hairer ODE ports) noted as possible future interest if
+  relic density ever moves to Rust — out of scope here, candidate
+  follow-up seed at close.
+
+## Numerical impact so far
+
+_No public code paths touched yet._ (Per-function drift lines land here
+as Phase 04–06 swaps merge; the Phase 07 CHANGELOG is assembled from
+this section — do not reconstruct it from memory.)
+
+## Decisions and Implementation Notes
+
+- Rust + PyO3 + maturin over pybind11; single abi3 `hazma._core`;
+  setuptools-rust coexistence during migration → ADR-0001 (Accepted).
+- No GSL-derived (GPL-3) code in tree or dependency graph; cephes
+  lineage (`spec_math`) for specfun; netlib-QUADPACK translation for
+  the integrator; cyphus crates as out-of-repo oracles only →
+  ADR-0002 (**Proposed**).
+- Capi-survivor exception: four spectra Cython extensions outlive their
+  Phase 04 swap until Phase 06 Task 6.4, because the mediator spectrum
+  `.pyx` cimport their `__pyx_capi__` symbols — recorded in the
+  Phase 04 file's Goal block.
+- Constants bit-parity before consolidation → `../rules.md` rule 4.
+
+## Files Changed
+
+_None yet — project scaffolding only (this PR)._
+
+## Verification
+
+- Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
+  changes).
+- Later: per-phase Verification sections in `phase-XX/README.md`.
+
+## Open Questions
+
+- **ADR-0002 sign-off** (Logan): accept the license-clean-numerics
+  decision, or deliberately take the GPL route? Gates Phase 03.
+- **Task 0.5**: `hazma.gamma_ray` — reimplement over `hazma.phase_space`
+  (keeps `minor`) or delete (raises to `major`, needs ADR-0003)?
+- Phase 05 parallelism: run 05 alongside 04 (no shared files) or keep
+  strictly serial? Decide when Phase 04 starts, based on who's driving.
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent starting any task in this project:**
+
+1. Read `../PLAN.md` end-to-end, then this file, then the active
+   phase's `phase-XX/README.md`.
+2. Load the reference file(s) the phase's Prerequisites name — the
+   references replace re-reading the Cython audit.
+3. Check Open Questions above; Phase 03 must not start Tasks 3.2/3.3
+   while ADR-0002 is unaccepted.
+
+**Currently safe to assume:**
+
+- The dead-code map and entry-point inventory were verified against
+  2.1.0 (Aug 2026); the tree is unchanged since.
+- `test/` is green post-PR #31 (51 passed / 20 skipped) — merging the
+  suites in Task 1.3 is safe.
+
+**Currently risky / unknown:**
+
+- `spec_math`'s `li2` argument convention vs scipy's `spence` is
+  unverified — Task 3.2 pins it before anything depends on it.
+- Whether the scalar/vector cross-section `.pyx` textually include any
+  `_utils` constants header was not conclusively established in the
+  audit — Task 0.1/6.4 must `rg` for `include` sites rather than trust
+  the inventory's include list.

--- a/projects/cython-to-rust/task-notes/_template.md
+++ b/projects/cython-to-rust/task-notes/_template.md
@@ -1,0 +1,71 @@
+# Task <N>: <Short Title>
+
+**Date:** <YYYY-MM-DD>
+**Project:** <project slug>
+**Status:** <In Progress | Complete | Blocked | Superseded>
+**Plan References:** <sections of `../PLAN.md`, a phase file, or `../rules.md`>
+**Related ADRs:** <none | ADR-XXXX (project-scoped) | ADR-XXXX (`docs/adrs/`)>
+**Depends On:** <none | Task N-1 | ADR-XXXX>
+
+## Objective
+
+<One or two sentences stating what this task accomplishes.>
+
+## Exit Criteria
+
+<Concrete, testable outcomes that define when this task is done. Fill this
+in at task start, before implementation — it's the gate you're working
+toward. "Verification" below captures retrospectively what you actually did
+to check these.>
+
+- <criterion 1>
+- <criterion 2>
+
+## Inputs Reviewed
+
+- <`../PLAN.md` sections consulted>
+- <Phase file, if phased project>
+- <`../rules.md` sections, if any>
+- <Existing code, docs, specs, external references>
+- <Prior task notes or ADRs consulted>
+
+## Findings
+
+- <Key fact or constraint discovered>
+- <Edge case, limitation, or interoperability note>
+
+## Decisions and Implementation Notes
+
+- <Decision made while implementing>
+- <Why that decision was taken over the obvious alternative>
+
+## Files Changed
+
+- <Path> — <purpose>
+
+## Verification
+
+- <Tests run, with command — e.g., `pytest test/spectra -q`>
+- <Manual checks or fixture validation>
+- <Anything intentionally deferred>
+
+## Open Questions
+
+- <Unresolved question, or `None`>
+
+## Plan Impact
+
+**Impact Level:** <None | Follow-up in learnings | Update phase file or
+`../rules.md` | ADR required | Both ADR and phase/rules update>
+
+<Describe whether this task changed canonical behavior, future task
+ordering, acceptance criteria, or internal contracts. If impact is
+"None", say so explicitly. For canonical changes, patch the affected
+`PLAN.md` / phase file / `rules.md`; promote to a repo-wide ADR under
+`docs/adrs/` if the decision has implications outside this project.>
+
+## Handoff to Next Task
+
+- <What the next agent should read first>
+- <What assumptions are now safe to make>
+- <What remains risky or incomplete>

--- a/projects/cython-to-rust/task-notes/phase-00/README.md
+++ b/projects/cython-to-rust/task-notes/phase-00/README.md
@@ -5,7 +5,7 @@
 **Phase:** 00
 **Status:** Not started
 **Plan References:** `../../phases/phase-00-dead-code-purge.md`
-**Related ADRs:** ADR-0003 (conditional — created by Task 0.5 if deletion chosen)
+**Related ADRs:** ADR-0003 (proposed — Task 0.5 ratifies; gates Task 0.2)
 **Depends On:** none
 
 ## Objective
@@ -18,10 +18,10 @@ purge.
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
 | 0.1 | Relocate legacy constants header | — | Not started | [task-0.1-relocate-constants.md](task-0.1-relocate-constants.md) |
-| 0.2 | Delete phase-space / gamma-ray slice | 0.1, 0.5 | Not started | [task-0.2-delete-mc-slice.md](task-0.2-delete-mc-slice.md) |
+| 0.2 | Delete phase-space / gamma-ray slice | 0.1, 0.5 (ADR-0003 accepted) | Not started | [task-0.2-delete-mc-slice.md](task-0.2-delete-mc-slice.md) |
 | 0.3 | Delete superseded kernels + helpers | 0.1 | Not started | [task-0.3-delete-superseded.md](task-0.3-delete-superseded.md) |
 | 0.4 | Prune build and packaging config | 0.2, 0.3 | Not started | [task-0.4-prune-build.md](task-0.4-prune-build.md) |
-| 0.5 | `hazma.gamma_ray` decision | — | Not started | [task-0.5-gamma-ray-decision.md](task-0.5-gamma-ray-decision.md) |
+| 0.5 | Ratify + execute ADR-0003 (`gamma_ray`) | — | Not started | [task-0.5-gamma-ray-decision.md](task-0.5-gamma-ray-decision.md) |
 
 ## Exit Criteria
 
@@ -52,7 +52,8 @@ _None yet — phase not started._
 
 ## Open Questions
 
-- Task 0.5 outcome (see project-level Open Questions).
+- ADR-0003 sign-off (see project-level Open Questions) — required
+  before Task 0.2 deletes anything.
 
 ## Plan Impact
 

--- a/projects/cython-to-rust/task-notes/phase-00/README.md
+++ b/projects/cython-to-rust/task-notes/phase-00/README.md
@@ -1,0 +1,72 @@
+# Working Memory: Phase 00 — Dead-code purge
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 00
+**Status:** Not started
+**Plan References:** `../../phases/phase-00-dead-code-purge.md`
+**Related ADRs:** ADR-0003 (conditional — created by Task 0.5 if deletion chosen)
+**Depends On:** none
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the dead-code
+purge.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 0.1 | Relocate legacy constants header | — | Not started | [task-0.1-relocate-constants.md](task-0.1-relocate-constants.md) |
+| 0.2 | Delete phase-space / gamma-ray slice | 0.1, 0.5 | Not started | [task-0.2-delete-mc-slice.md](task-0.2-delete-mc-slice.md) |
+| 0.3 | Delete superseded kernels + helpers | 0.1 | Not started | [task-0.3-delete-superseded.md](task-0.3-delete-superseded.md) |
+| 0.4 | Prune build and packaging config | 0.2, 0.3 | Not started | [task-0.4-prune-build.md](task-0.4-prune-build.md) |
+| 0.5 | `hazma.gamma_ray` decision | — | Not started | [task-0.5-gamma-ray-decision.md](task-0.5-gamma-ray-decision.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`.
+- Phase learnings at `../../learnings/phase-00-dead-code-purge.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-00-dead-code-purge.md`; `../README.md`;
+  `../../references/cython-inventory.md` (dead-code map).
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- Per task: importer re-check (`rg` the module path) quoted in PR body;
+  `pip install -e .` + import smoke + full preflight.
+
+## Open Questions
+
+- Task 0.5 outcome (see project-level Open Questions).
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 00:** read `../../PLAN.md`, then
+`../README.md`, then this file, then the phase file. Start with
+Task 0.5 (its decision gates 0.2) or Task 0.1 (independent).
+
+**Currently safe to assume:** the dead-code evidence table in the
+inventory reference was verified against 2.1.0.
+
+**Currently risky / unknown:** whether external user code imports the
+double-underscore legacy shims — the verify-before-delete check is the
+guard.

--- a/projects/cython-to-rust/task-notes/phase-01/README.md
+++ b/projects/cython-to-rust/task-notes/phase-01/README.md
@@ -1,0 +1,70 @@
+# Working Memory: Phase 01 — Golden parity corpus
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 01
+**Status:** Not started
+**Plan References:** `../../phases/phase-01-parity-corpus.md`
+**Related ADRs:** none
+**Depends On:** Phase 00 complete
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the parity
+corpus.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 1.1 | Corpus specification + generator | — | Not started | [task-1.1-corpus-generator.md](task-1.1-corpus-generator.md) |
+| 1.2 | Pytest runner + tolerance budgets | 1.1 | Not started | [task-1.2-parity-runner.md](task-1.2-parity-runner.md) |
+| 1.3 | Wire both suites into one gate | 1.2 | Not started | [task-1.3-test-wiring.md](task-1.3-test-wiring.md) |
+| 1.4 | Retire/regenerate legacy `.npy` suites | 1.2 | Not started | [task-1.4-legacy-npy.md](task-1.4-legacy-npy.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`.
+- Phase learnings at `../../learnings/phase-01-parity-corpus.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-01-parity-corpus.md`; `../README.md`;
+  `../../references/numerics-replacements.md` (tolerance table).
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- `python test/parity/generate.py --check` (hash verification);
+  bare `pytest` green incl. parity suite.
+
+## Open Questions
+
+_None yet._
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 01:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file. The corpus manifest
+must record the generating git SHA — rules.md rule 2.
+
+**Currently safe to assume:** `test/` is green post-PR #31; merging
+suites is safe.
+
+**Currently risky / unknown:** corpus grid density vs. repo-size
+budget (≤ ~10 MB) — measure before committing data.

--- a/projects/cython-to-rust/task-notes/phase-02/README.md
+++ b/projects/cython-to-rust/task-notes/phase-02/README.md
@@ -1,0 +1,70 @@
+# Working Memory: Phase 02 — Rust scaffold
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 02
+**Status:** Not started
+**Plan References:** `../../phases/phase-02-rust-scaffold.md`
+**Related ADRs:** ADR-0001 (accepted)
+**Depends On:** Phase 01 complete
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the Rust
+scaffold.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 2.1 | Crate + setuptools-rust integration | — | Not started | [task-2.1-crate-skeleton.md](task-2.1-crate-skeleton.md) |
+| 2.2 | CI, preflight, dev-loop docs | 2.1 | Not started | [task-2.2-ci-devloop.md](task-2.2-ci-devloop.md) |
+| 2.3 | Cross-language plumbing test | 2.1 | Not started | [task-2.3-plumbing-test.md](task-2.3-plumbing-test.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`.
+- Phase learnings at `../../learnings/phase-02-rust-scaffold.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-02-rust-scaffold.md`; `../README.md`;
+  `../../rules.md` rules 6–8.
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- `pip install -e .` builds hybrid; `python -c "import hazma._core"`;
+  wheel job produces abi3-tagged wheels; preflight incl. cargo gates.
+
+## Open Questions
+
+_None yet._
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 02:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file. The extension's import
+path is final from day one: `hazma._core`.
+
+**Currently safe to assume:** rustc/cargo 1.96 available locally
+(Homebrew); CI must install its own toolchain.
+
+**Currently risky / unknown:** setuptools-rust + editable-install
+rebuild ergonomics under uv — document whatever loop actually works in
+Task 2.2.

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -1,0 +1,72 @@
+# Working Memory: Phase 03 — Numerics foundation
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 03
+**Status:** Not started
+**Plan References:** `../../phases/phase-03-numerics-foundation.md`
+**Related ADRs:** ADR-0002 (**must be Accepted before Tasks 3.2/3.3**)
+**Depends On:** Phase 02 complete
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the numerics
+foundation.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 3.1 | Constants module | — | Not started | [task-3.1-constants.md](task-3.1-constants.md) |
+| 3.2 | Special functions | ADR-0002 | Not started | [task-3.2-specfun.md](task-3.2-specfun.md) |
+| 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | ADR-0002 | Not started | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
+| 3.4 | Interpolation + boost kernels | 3.1 | Not started | [task-3.4-interp-boost.md](task-3.4-interp-boost.md) |
+| 3.5 | Dispatch and error layer | — | Not started | [task-3.5-dispatch.md](task-3.5-dispatch.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`.
+- Phase learnings at `../../learnings/phase-03-numerics-foundation.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-03-numerics-foundation.md`; `../README.md`;
+  `../../references/numerics-replacements.md` (full).
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- `cargo test` (foundation units); scipy-comparison pytest suite green
+  in CI.
+
+## Open Questions
+
+- `spec_math::li2` convention vs `scipy.special.spence` — Task 3.2
+  resolves.
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 03:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file. Confirm ADR-0002 is
+Accepted before starting 3.2/3.3; 3.1/3.4/3.5 are unblocked regardless.
+
+**Currently safe to assume:** every live integral is finite-interval —
+`qagi` is out of scope.
+
+**Currently risky / unknown:** `qelg` Fortran→Rust translation is the
+fiddliest item in the project; budget review time accordingly.

--- a/projects/cython-to-rust/task-notes/phase-04/README.md
+++ b/projects/cython-to-rust/task-notes/phase-04/README.md
@@ -1,0 +1,76 @@
+# Working Memory: Phase 04 — Spectra kernels
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 04
+**Status:** Not started
+**Plan References:** `../../phases/phase-04-spectra-kernels.md`
+**Related ADRs:** ADR-0001, ADR-0002
+**Depends On:** Phase 03 complete
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the spectra
+kernel ports.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 4.1 | `_positron/_muon` (template swap) | — | Not started | [task-4.1-positron-muon.md](task-4.1-positron-muon.md) |
+| 4.2 | Photon table family (kaon + eta/omega/eta′/phi) | 4.1 | Not started | [task-4.2-photon-table-family.md](task-4.2-photon-table-family.md) |
+| 4.3 | `_photon/_muon` (spence) | 4.1 | Not started | [task-4.3-photon-muon.md](task-4.3-photon-muon.md) |
+| 4.4 | `_photon/_pion` | 4.3 | Not started | [task-4.4-photon-pion.md](task-4.4-photon-pion.md) |
+| 4.5 | `_photon/_rho` (nested quad) | 4.4 | Not started | [task-4.5-photon-rho.md](task-4.5-photon-rho.md) |
+| 4.6 | `_positron/_pion` + neutrino pair | 4.1, 4.3 | Not started | [task-4.6-positron-pion-neutrino.md](task-4.6-positron-pion-neutrino.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`.
+- Phase learnings at `../../learnings/phase-04-spectra-kernels.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-04-spectra-kernels.md` (incl. the capi-survivor
+  exception in its Goal); `../README.md`;
+  `../../references/cython-inventory.md` (cimport DAG).
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- Per task: corpus suite for the swapped entry points + full pytest +
+  import smoke (mediator modules must stay importable — capi survivors
+  intact).
+
+## Open Questions
+
+- Run Phase 05 in parallel once 4.1 lands? (Project-level question.)
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 04:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file — especially the
+capi-survivor exception; deleting `_photon/_muon`, `_photon/_pion`,
+`_positron/_muon`, or `_positron/_pion` extensions here breaks the
+mediator imports.
+
+**Currently safe to assume:** foundation (interp, boost, quad,
+dispatch) is unit-tested against scipy before this phase starts.
+
+**Currently risky / unknown:** nested-ρ drift (Task 4.5) is the
+project's numerical stress test — measure before adjusting any budget.

--- a/projects/cython-to-rust/task-notes/phase-05/README.md
+++ b/projects/cython-to-rust/task-notes/phase-05/README.md
@@ -1,0 +1,71 @@
+# Working Memory: Phase 05 — Mediator cross sections
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 05
+**Status:** Not started
+**Plan References:** `../../phases/phase-05-mediator-cross-sections.md`
+**Related ADRs:** ADR-0002
+**Depends On:** Phase 03 complete (may run parallel to Phase 04 — no
+shared files)
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the
+cross-section ports.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 5.1 | Vector cross sections (template) | — | Not started | [task-5.1-vector-xs.md](task-5.1-vector-xs.md) |
+| 5.2 | Scalar cross sections | 5.1 | Not started | [task-5.2-scalar-xs.md](task-5.2-scalar-xs.md) |
+| 5.3 | Thermal ⟨σv⟩ validation sweep | 5.1, 5.2 | Not started | [task-5.3-thermal-sweep.md](task-5.3-thermal-sweep.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`.
+- Phase learnings at `../../learnings/phase-05-mediator-cross-sections.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-05-mediator-cross-sections.md`; `../README.md`;
+  `../../references/cython-inventory.md` (three-tier structure, bug §2).
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- Corpus over the mediator parameter grid; relic-density end-to-end
+  check (Task 5.3); benchmark per rules.md rule 12.
+
+## Open Questions
+
+_None yet._
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 05:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file. Transliterate the
+Mathematica dumps mechanically — never retype a 90-line expression.
+
+**Currently safe to assume:** both `_c_*` modules cimport nothing from
+hazma — they are self-contained above the foundation.
+
+**Currently risky / unknown:** near-resonance corpus points are the
+most drift-sensitive for ⟨σv⟩ (integrand peaks at the `points=`
+breakpoints).

--- a/projects/cython-to-rust/task-notes/phase-06/README.md
+++ b/projects/cython-to-rust/task-notes/phase-06/README.md
@@ -1,0 +1,75 @@
+# Working Memory: Phase 06 — Mediator spectra
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 06
+**Status:** Not started
+**Plan References:** `../../phases/phase-06-mediator-spectra.md`
+**Related ADRs:** ADR-0001, ADR-0002
+**Depends On:** Phases 04 and 05 complete
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the mediator
+spectrum redesign — the last Cython.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 6.1 | Spectrum-table struct design | — | Not started | [task-6.1-table-struct.md](task-6.1-table-struct.md) |
+| 6.2 | Decay spectrum pair | 6.1 | Not started | [task-6.2-decay-spectra.md](task-6.2-decay-spectra.md) |
+| 6.3 | Positron spectrum pair | 6.1 | Not started | [task-6.3-positron-spectra.md](task-6.3-positron-spectra.md) |
+| 6.4 | Retire capi survivors + `_utils` headers | 6.2, 6.3 | Not started | [task-6.4-retire-survivors.md](task-6.4-retire-survivors.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`;
+  `find hazma -name "*.pyx" -o -name "*.pxd"` empty.
+- Phase learnings at `../../learnings/phase-06-mediator-spectra.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-06-mediator-spectra.md`; `../README.md`; both
+  references (8-symbol cimport list; dead-cache bug; dispatch
+  contract).
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- Corpus (quad budgets); benchmark vs pre-swap Cython (dead-cache fix
+  is the expected headline); import smoke after 6.4.
+
+## Open Questions
+
+_None yet._
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 06:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file. This is a redesign —
+review Task 6.1's design against all four modules before writing
+kernel code.
+
+**Currently safe to assume:** the Phase 04 kernel `fn`s are natively
+callable from Rust (rules.md rule 8 kept them PyO3-free).
+
+**Currently risky / unknown:** memoization keying (mediator mass +
+partial widths) must match how model classes mutate parameters —
+verify against `hazma/scalar_mediator/__init__.py` setter behavior
+before trusting the cache.

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -1,0 +1,77 @@
+# Working Memory: Phase 07 — Packaging cutover and close
+
+**Date:** 2026-08-03 (created)
+**Project:** cython-to-rust
+**Phase:** 07
+**Status:** Not started
+**Plan References:** `../../phases/phase-07-cutover.md`
+**Related ADRs:** ADR-0001
+**Depends On:** Phase 06 complete
+
+## Objective
+
+Track live per-task status and phase-scoped findings for the maturin
+cutover and project close.
+
+## Tasks
+
+| # | Task | Depends on | Status | Task Note |
+| --- | ------ | ------------ | -------- | ----------- |
+| 7.1 | Backend switch to maturin | — | Not started | [task-7.1-maturin-backend.md](task-7.1-maturin-backend.md) |
+| 7.2 | Release pipeline (abi3 wheels) | 7.1 | Not started | [task-7.2-release-pipeline.md](task-7.2-release-pipeline.md) |
+| 7.3 | Documentation sweep | 7.1 | Not started | [task-7.3-docs-sweep.md](task-7.3-docs-sweep.md) |
+| 7.4 | Close the project | 7.1–7.3 | Not started | [task-7.4-close.md](task-7.4-close.md) |
+
+## Exit Criteria
+
+- All rows Complete; phase file frontmatter `status: Complete`;
+  release candidate publishes from CI.
+- Phase learnings at `../../learnings/phase-07-cutover.md` and the
+  project retrospective at `../../learnings/project-retrospective.md`.
+
+## Inputs Reviewed
+
+- `../../phases/phase-07-cutover.md`; `../README.md`; the drift table
+  in `../README.md` ("Numerical impact so far") — input to the
+  CHANGELOG.
+
+## Findings
+
+_None yet._
+
+## Decisions and Implementation Notes
+
+_None yet._
+
+## Files Changed
+
+_None yet — phase not started._
+
+## Verification
+
+- Clean-clone `pip install .`; sdist content check; wheel abi3-tag +
+  import check on CPython 3.10 and newest; RTD/Sphinx build;
+  `scripts/agents/preflight.sh --closing`.
+
+## Open Questions
+
+- Add aarch64/Windows wheels now that they are cheap? (Task 7.2
+  records the call; default no.)
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent working in Phase 07:** read `../../PLAN.md`,
+`../README.md`, this file, then the phase file. Re-verify the
+"Prerequisites" packaging facts against the tree — they were recorded
+at plan time (2.1.0).
+
+**Currently safe to assume:** pytest config already lives in
+pyproject (moved in Phase 01 Task 1.3).
+
+**Currently risky / unknown:** `version = attr: hazma.VERSION` has
+tooling tendrils (`preflight.sh --closing`, release docs) — grep for
+every consumer before flipping the source of truth.


### PR DESCRIPTION
## Summary
- Scaffold `projects/cython-to-rust/`: a phased plan (8 phases, 33 tasks) to replace the Cython layer with Rust + PyO3 + maturin behind an unchanged public API — dead-code purge → golden parity corpus → abi3 `hazma._core` scaffold → numerics foundation → spectra/mediator ports → packaging cutover. Two references distill the Aug 2026 audit of all 77 Cython files (44 `.pyx` + 33 `.pxd`; 20 of 32 built extensions survive the purge — 19 kernel modules + the C-level `_utils.boost` — exposing 43 public defs of which 41 are consumed; dead-code evidence, cimport DAG, quad call-site table, and bug list recorded with file:line cites).
- Three ADRs: ADR-0001 (Accepted) fixes the framework choice and setuptools-rust coexistence; ADR-0002 (**Proposed — needs sign-off, gates Phase 03**) keeps GSL-derived GPL-3 code, including the rust-cyphus crates (assessed: integration 43/44 tests green after a one-line fix, specfun 99/102), out of the MIT tree — cephes-lineage `spec_math` + a netlib-QUADPACK port instead, with cyphus as out-of-repo oracles; ADR-0003 (**Proposed — needs sign-off, gates Phase 00 Task 0.2**) deletes the broken-on-import `hazma.gamma_ray` rather than offering an un-pinnable rebuild.
- `version_bump: major` — Phase 00 deletes `hazma/deprecated/rambo.py` (any `deprecated/` removal is major per `docs/versioning.md`) and `hazma.gamma_ray` per ADR-0003.
- File a follow-up (`docs/followups/todo/markdownlint-config-for-templates.md`): preflight's markdownlint defaults conflict with the canonical template shapes (MD025 frontmatter-title, MD033 placeholders); worked around here with scoped inline pragmas. The five `_template.md` files are byte-identical copies of `projects/_template/` (per workflow) and were deliberately excluded from the `--md` gate — they inherit the template's pre-existing MD025/MD033 conflicts that the follow-up addresses.
- Round 1 of plan review applied in `41b8da1` (all 7 findings): major bump, ADR-0003, extension-level-only abi3 claims during the hybrid build, source-re-derived counts (20 extensions / 43 defs / 41 consumed / 77 files), an empirically-pinned scipy `points=` preprocessing contract for `qagp`, and two class-shaped entries in `docs/agents/lessons.md`.

No code, tests, or packaging touched; no numerical impact.

## Project
`projects/cython-to-rust/` — project scaffolding (pre-Task 0.1).

See `projects/cython-to-rust/PLAN.md` (canonical shape) and `projects/cython-to-rust/task-notes/README.md` (live status; open questions: ADR-0002 and ADR-0003 sign-offs, Phase 04/05 parallelism).

## Test plan
- [x] `scripts/agents/preflight.sh --paths "projects docs/followups docs/agents" --tests "test" --md "<32 changed .md files>"` → `RESULT: PASS`, with `pytest  52 passed, 20 skipped in 248.59s (0:04:08)`, `import hazma  version 2.1.0`, markdownlint PASS over all authored files (run again after the review-fix commit).
- [x] `scripts/agents/check_pr_title.py` → `OK` for both commit headers.
- [x] Count re-derivations quoted in `projects/cython-to-rust/references/cython-inventory.md`: `find hazma -name "*.pyx" | wc -l` → 44; `-name "*.pxd"` → 33; scalar wrapper imports 12 symbols, vector 6; `rg sigma_xx_to_all` outside `_c_*` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)