### PR TITLE
docs(projects): accept ADR-0002 and lift the phase 03 gate

### DIFF
--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -77,7 +77,7 @@ the closing CHANGELOG aggregates it per function.
 | [`references/cython-inventory.md`](references/cython-inventory.md) | Dead-code map with evidence, live surface + entry-point tables, C-level dependency DAG, data files, audit bug list |
 | [`references/numerics-replacements.md`](references/numerics-replacements.md) | quad call-site/tolerance table, specfun facts + conventions, `np.interp`/boost-integral specs, cyphus-crate assessment, dispatch contract |
 | [`adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md`](adrs/ADR-0001-rust-pyo3-maturin-over-pybind11.md) | Framework choice (Accepted) |
-| [`adrs/ADR-0002-license-clean-numerics.md`](adrs/ADR-0002-license-clean-numerics.md) | GSL/GPL boundary, cephes + netlib-QUADPACK provenance (**Proposed — sign-off gates Phase 03**) |
+| [`adrs/ADR-0002-license-clean-numerics.md`](adrs/ADR-0002-license-clean-numerics.md) | GSL/GPL boundary, cephes + netlib-QUADPACK provenance (Accepted 2026-08-04 — Phase 03 Tasks 3.2/3.3 unblocked) |
 | [`adrs/ADR-0003-remove-gamma-ray-module.md`](adrs/ADR-0003-remove-gamma-ray-module.md) | Remove broken `hazma.gamma_ray` (Accepted 2026-08-04 — Task 0.2 unblocked) |
 | [`rules.md`](rules.md) | Parity discipline, constants bit-parity, licensing, Rust conventions |
 
@@ -114,8 +114,8 @@ task blocks here.
 
 ## Dependencies
 
-- Requires: nothing upstream. ADR-0002 acceptance gates Phase 03
-  Tasks 3.2/3.3.
+- Requires: nothing upstream. ADR-0002 was accepted 2026-08-04, so
+  Phase 03 Tasks 3.2/3.3 carry no license gate.
 - External facts this plan leans on (re-verify if stale): `spec_math`
   0.1.6 (MIT OR Apache-2.0) provides `bessel_k1`/`bessel_kn`/`li2`;
   PyO3 abi3-py310 wheels cover CPython ≥3.10; the rust-cyphus crates
@@ -132,10 +132,10 @@ task blocks here.
 
 See [`../../docs/workflow.md#adr-placement`](../../docs/workflow.md#adr-placement)
 for when to write an ADR and where it lives. Patch the affected
-`PLAN.md` / phase file / `rules.md` when canonical behavior changes —
-known pending: the status flip of ADR-0002 (license-clean numerics),
-still Proposed and awaiting sign-off. ADR-0003 (`hazma.gamma_ray`
-removal) was accepted 2026-08-04.
+`PLAN.md` / phase file / `rules.md` when canonical behavior changes.
+All three project ADRs are Accepted: ADR-0001 (framework), ADR-0002
+(license-clean numerics, 2026-08-04) and ADR-0003 (`hazma.gamma_ray`
+removal, 2026-08-04). Nothing in this plan is awaiting a sign-off.
 
 ## Closing this project
 

--- a/projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md
+++ b/projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md
@@ -1,8 +1,8 @@
 # ADR 0002: License-clean numerics — cephes in-tree, GSL-derived code out
 
 **Date:** 2026-08-03
-**Status:** Proposed (needs Logan's sign-off — it forecloses the
-"relicense Hazma to GPL" alternative)
+**Status:** Accepted (signed off by Logan 2026-08-04 — Hazma stays MIT;
+no GPL-3 crates)
 **Scope:** Project-scoped (applies only within `projects/cython-to-rust/`).
 
 ## Context
@@ -64,8 +64,9 @@ to the upstream QUADPACK sources or the published algorithms.
   zero live callers); the corpus and per-integrand scipy comparisons
   catch translation faults; cyphus-integration's passing test suite
   demonstrates the job is bounded and was done once by the same author.
-- **Foreclosed alternative (why sign-off is needed):** accepting GPL-3
+- **Foreclosed alternative (settled by the sign-off):** accepting GPL-3
   for the wheels and depending on modernized cyphus crates directly.
-  Rejected by default because it changes Hazma's license terms for
-  every downstream user and requires co-author agreement, to save at
-  most a few days of foundation work.
+  Rejected because it changes Hazma's license terms for every
+  downstream user and requires co-author agreement, to save at most a
+  few days of foundation work. Hazma stays MIT; revisiting this needs a
+  new ADR superseding this one, not a judgment call inside a task.

--- a/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
@@ -18,8 +18,9 @@ uses it.
 
 ## Prerequisites
 
-- Phase 02 complete; **ADR-0002 accepted** (gates Tasks 3.2/3.3 —
-  confirm status before starting them).
+- Phase 02 complete. **ADR-0002 is Accepted (2026-08-04)** — Tasks
+  3.2/3.3 are ungated, and their source provenance is fixed by it:
+  cephes lineage and netlib QUADPACK only, nothing GSL-derived.
 - Read `../references/numerics-replacements.md` in full.
 
 ## Tasks

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -4,8 +4,8 @@
 **Project:** cython-to-rust
 **Status:** In Progress
 **Plan References:** `../PLAN.md` (all sections)
-**Related ADRs:** ADR-0001 (accepted), ADR-0002 (**proposed — needs
-Logan's sign-off before Phase 03 Tasks 3.2/3.3**), ADR-0003 (accepted
+**Related ADRs:** ADR-0001 (accepted), ADR-0002 (accepted 2026-08-04 —
+Phase 03 Tasks 3.2/3.3 no longer gated), ADR-0003 (accepted
 2026-08-04 — Task 0.2 no longer blocked on sign-off)
 **Depends On:** none
 
@@ -38,7 +38,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 - All eight phases Complete; zero `.pyx`/`.pxd` in the tree; all 41
   consumed entry points served by `hazma._core` (the 2 unconsumed
   `sigma_xx_to_all` exports dropped in Phase 05); maturin backend live.
-- ADR-0002 accepted (or superseded); ADR-0003 accepted 2026-08-04.
+- ADR-0002 and ADR-0003 both accepted 2026-08-04.
 - Closing PR bumps `VERSION` in `hazma/__init__.py` per `PLAN.md`'s
   `version_bump:` frontmatter and adds a `CHANGELOG.md` entry naming
   this project slug, with the aggregated drift table. See
@@ -151,7 +151,7 @@ it from memory.)
 - No GSL-derived (GPL-3) code in tree or dependency graph; cephes
   lineage (`spec_math`) for specfun; netlib-QUADPACK translation for
   the integrator; cyphus crates as out-of-repo oracles only →
-  ADR-0002 (**Proposed**).
+  ADR-0002 (Accepted 2026-08-04 — Hazma stays MIT).
 - Capi-survivor exception: four spectra Cython extensions outlive their
   Phase 04 swap until Phase 06 Task 6.4, because the mediator spectrum
   `.pyx` cimport their `__pyx_capi__` symbols — recorded in the
@@ -216,9 +216,13 @@ it from memory.)
 
 ## Open Questions
 
-- **ADR-0002 sign-off** (Logan): accept the license-clean-numerics
-  decision, or deliberately take the GPL route? Gates Phase 03
-  Tasks 3.2/3.3.
+- ~~**ADR-0002 sign-off** (Logan): accept the license-clean-numerics
+  decision, or deliberately take the GPL route?~~ — **closed
+  2026-08-04: accepted.** Hazma stays MIT and no GPL-3 crate enters the
+  tree or the dependency graph, so **Phase 03 Tasks 3.2/3.3 are
+  unblocked**: `spec_math` (cephes lineage) for specfun, a fresh
+  netlib-QUADPACK translation for the integrator, cyphus as an
+  out-of-repo oracle only.
 - ~~**ADR-0003 sign-off** (Logan): confirm deletion of the
   broken-on-import `hazma.gamma_ray`~~ — **closed 2026-08-04: accepted.**
   It was the last thing standing between Phase 00 and Phase 01; with
@@ -247,8 +251,8 @@ it from memory.)
    phase's `phase-XX/README.md`.
 2. Load the reference file(s) the phase's Prerequisites name — the
    references replace re-reading the Cython audit.
-3. Check Open Questions above; Phase 03 must not start Tasks 3.2/3.3
-   while ADR-0002 is unaccepted.
+3. Check Open Questions above. No ADR sign-off is outstanding — all
+   three project ADRs are Accepted, so no phase carries a decision gate.
 
 **Currently safe to assume:**
 

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -5,7 +5,8 @@
 **Phase:** 03
 **Status:** Not started
 **Plan References:** `../../phases/phase-03-numerics-foundation.md`
-**Related ADRs:** ADR-0002 (**must be Accepted before Tasks 3.2/3.3**)
+**Related ADRs:** ADR-0002 (Accepted 2026-08-04 — governs the
+provenance of Tasks 3.2/3.3, no longer gates them)
 **Depends On:** Phase 02 complete
 
 ## Objective
@@ -18,8 +19,8 @@ foundation.
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
 | 3.1 | Constants module | — | Not started | [task-3.1-constants.md](task-3.1-constants.md) |
-| 3.2 | Special functions | ADR-0002 | Not started | [task-3.2-specfun.md](task-3.2-specfun.md) |
-| 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | ADR-0002 | Not started | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
+| 3.2 | Special functions | — (ADR-0002 accepted) | Not started | [task-3.2-specfun.md](task-3.2-specfun.md) |
+| 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | — (ADR-0002 accepted) | Not started | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
 | 3.4 | Interpolation + boost kernels | 3.1 | Not started | [task-3.4-interp-boost.md](task-3.4-interp-boost.md) |
 | 3.5 | Dispatch and error layer | — | Not started | [task-3.5-dispatch.md](task-3.5-dispatch.md) |
 
@@ -62,8 +63,10 @@ _None yet — phase not started._
 ## Handoff to Next Task
 
 **For the next agent working in Phase 03:** read `../../PLAN.md`,
-`../README.md`, this file, then the phase file. Confirm ADR-0002 is
-Accepted before starting 3.2/3.3; 3.1/3.4/3.5 are unblocked regardless.
+`../README.md`, this file, then the phase file. Every task in this
+phase is unblocked — ADR-0002 was accepted 2026-08-04 — but 3.2/3.3
+must honor its provenance rule: cephes lineage and netlib QUADPACK
+only, nothing GSL-derived in the tree or the dependency graph.
 
 **Currently safe to assume:** every live integral is finite-interval —
 `qagi` is out of scope.


### PR DESCRIPTION
## Summary

- **ADR-0002 (license-clean numerics) → Accepted 2026-08-04.** Hazma stays MIT; no GSL-derived/GPL-3 code enters the repo or its dependency graph. The Decision section needed no edits — its four rules are what was signed off. The foreclosed alternative (taking GPL-3 for the wheels to reuse the cyphus crates directly) is now recorded as *settled*: reopening it needs a superseding ADR, not a judgment call inside a task.
- **The Phase 03 gate is lifted.** Tasks 3.2 (special functions) and 3.3 (QUADPACK port) could not start while the license question was open. They are now unblocked, and ADR-0002's role narrows from a decision gate to a provenance constraint on how they are written: cephes lineage (`spec_math`) for specfun, a fresh netlib-QUADPACK translation for the integrator, cyphus as an out-of-repo dev-time oracle only. The `Depends on: ADR-0002` rows and the phase prerequisite are reworded to match — same treatment ADR-0003's acceptance gave Phase 00.
- **Citation sweep so nothing still reads as pending.** `PLAN.md` (orientation table, Dependencies, Change control — which now records all three project ADRs as Accepted and nothing awaiting sign-off), `task-notes/README.md` (header, Exit Criteria, Decisions note, Handoff step 3, and the Open Question struck through and closed), and both Phase 03 files. `rules.md` rule 1 and the two `references/numerics-replacements.md` mentions were already status-neutral and are untouched.

Docs only — five `.md` files under `projects/cython-to-rust/`. **No code changes; no library value moves.**

## Project

`projects/cython-to-rust/` — ADR-0002 acceptance (not a numbered plan task; the parallel to Task 0.5's ADR-0003 sign-off).

See `projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md` for the decision and `projects/cython-to-rust/task-notes/README.md` for the closed Open Question.

## Test plan

- [x] `scripts/agents/preflight.sh --md "<the 5 changed docs>"` — gates that can respond to this diff all pass:

```text
FAIL   black --check           run `black hazma test` and re-check
FAIL   isort --check-only      run `isort hazma test` and re-check
FAIL   ruff check              see output below
PASS   pytest                  68 passed, 20 skipped in 277.56s (0:04:37)
PASS   import hazma            version 2.1.0
PASS   markdownlint            projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md ...
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
```

- [x] The three red rows are **pre-existing tree-wide Python lint debt, not this diff.** `git diff --name-only -- '*.py' '*.pyx' '*.pxd'` returns zero files, and re-running the three gates with the change stashed gives identical counts:

```text
baseline (stashed):  33 files would be reformatted | 141 isort errors | Found 6619 errors.
with this change:    33 files would be reformatted | 141 isort errors | Found 6619 errors.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)