### PR TITLE
build(packaging): unify linter pins, reformat with black 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,14 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install linters
-        run: python -m pip install "black>=23.3,<25.0" ruff
+        # The pins live in pyproject.toml's [dependency-groups] `lint`
+        # group, never here. A literal pin in this file is what drifted
+        # from the pyproject one and made Lint reject a locally-clean
+        # tree. `--group` needs pip >= 25.1 and installs only the group,
+        # so this job still does not build the Cython extensions.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --group lint
       - name: Check formatting with black
         run: black --check --diff hazma test
       - name: Lint with ruff (critical errors only)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ implementation*. Public callers go through `hazma.spectra`,
 
 ```sh
 pip install -e .          # build the Cython extensions in place
+pip install --group dev   # black, isort, ruff, pytest at their pinned versions
 pytest                    # full suite
 pytest test/spectra -q    # one area
 black hazma test          # format
@@ -112,7 +113,10 @@ the tree you edited, not an installed copy.
   annotations is supported (`runtime-typing = true`), so do not stringify
   annotations that users may resolve.
 - **Formatting is black (88 cols) + isort (black profile).** Do not
-  hand-format around them.
+  hand-format around them, and do not install them by hand — the pins
+  live once, in `pyproject.toml`'s `[dependency-groups]`, and CI
+  installs that same `lint` group. A version pinned in two places drifts
+  and turns CI red on lines nobody touched.
 - **Naming:** modules and functions `snake_case`, classes `UpperCamel`,
   constants `SCREAMING_SNAKE`. Physics symbols keep their conventional
   spelling in docstrings (`dN/dE`, `⟨σv⟩`), not in identifiers.

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -57,28 +57,30 @@ Edit the `.pyx` and rebuild.
 
 ## Linters
 
-**`black` is pinned differently in `pyproject.toml` and in CI, and the
-difference changes formatting.** `pyproject.toml`'s `dev` extra allows
-`black>=23.3,<27.0`; `.github/workflows/ci.yml`'s Lint job installs
-`black>=23.3,<25.0`. Black's style changed across that boundary (a sole
-multiline string argument is "hugged" in 26.x, exploded in 24.x), so
-`pip install -e '.[dev]'` gives you a formatter that reformats files
-into a style CI rejects. Symptom: `black --check` clean locally, Lint
-red on the PR, on lines you never touched.
-
-Install CI's version before trusting any black result:
+**Install the linters from the `lint` dependency group, not by hand.**
+`pyproject.toml`'s `[dependency-groups]` is the only place the `black`,
+`isort`, and `ruff` pins live, and CI's Lint job installs that same
+group. Anything else risks a formatter that disagrees with CI:
 
 ```sh
-uv pip install "black>=23.3,<25.0"
+uv pip install --group lint     # or: pip install --group lint
 ```
 
-Corollary: **`black --check hazma test` is clean on `master`.** A run
-claiming it wants to reformat dozens of files is measuring a newer
-black, not a property of the repo — measured at `cd0be2b`, black 24.10.0
-reports `249 files would be left unchanged` while black 26.5.1 wants 34.
-`preflight.sh` invokes whatever is on `PATH`, so it inherits whichever
-you installed. Tracked in
-[`../followups/todo/black-pin-divergence-pyproject-vs-ci.md`](../followups/todo/black-pin-divergence-pyproject-vs-ci.md).
+`--group dev` adds `pytest` on top, for the full preflight toolchain.
+Note these are PEP 735 groups, **not** extras — the old
+`pip install -e '.[dev]'` no longer resolves, and `--group` needs
+pip >= 25.1.
+
+This used to be a live trap and is worth knowing about because
+`preflight.sh` invokes whatever `black` is on `PATH`: until 2026-08-04
+the pin was written out twice, `black>=23.3,<27.0` in `pyproject.toml`
+against `black>=23.3,<25.0` in `.github/workflows/ci.yml`. Black's style
+changed across that boundary (a sole multiline string argument is
+"hugged" in 26.x, exploded in 24.x), so the documented dev setup
+installed a formatter whose output CI rejected — `black --check` clean
+locally, Lint red on the PR, on lines nobody touched. The repo is now
+formatted with black 26.x and the workflow carries no literal pin. Do
+not reintroduce one.
 
 **CI's ruff step is not the configured one.** Lint runs
 `ruff check --isolated --select E9,F63,F7,F82 --exclude hazma/experimental

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -72,15 +72,19 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   defects, "gamma ray" prose in the positron module and a
   `hazma.phase_space_generator.rambo` path that never existed).
 - [unpinned-formatter-version] A formatter gate is only meaningful at the
-  version CI runs. `preflight.sh` invokes whatever `black` is on `PATH`, and
-  `pyproject.toml`'s dev extra (`<27.0`) admits a newer major than the Lint
-  job pins (`<25.0`) — so a locally-clean `black --check` can still fail CI,
-  on lines you never meant to touch, and a locally-red one can be a phantom.
-  Check the workflow's pin before trusting or reporting any black/ruff/isort
-  result, and reproduce a lint failure with CI's exact version before
-  "fixing" it (PR #37: black 26.5.1 reformatted a `warnings.warn` into a
-  style black 24.10.0 rejects; the same skew had earlier been recorded as
-  "preflight is red on master", which CI's black says it is not).
+  version CI runs, and `preflight.sh` invokes whatever `black` is on `PATH`.
+  A pin written down in two places will drift, and the drift is invisible:
+  `pyproject.toml`'s dev extra (`<27.0`) once admitted a newer major than
+  the Lint job's own literal pin (`<25.0`), so a locally-clean
+  `black --check` still failed CI on lines nobody meant to touch, and a
+  locally-red one could be a phantom (PR #37: black 26.5.1 reformatted a
+  `warnings.warn` into a style black 24.10.0 rejects; the same skew had
+  earlier been recorded as "preflight is red on master", which it was not).
+  Fixed by deleting the duplicate rather than syncing it — the pins live
+  only in `pyproject.toml`'s `[dependency-groups]`, and both CI and you
+  install `--group lint`. The lesson generalizes past black: a version a
+  gate depends on belongs in exactly one file, and a workflow that
+  re-states it is the bug.
 - [stale-ci-capability-claim] A change to `.github/workflows/` silently
   falsifies every prose description of what CI does. Those descriptions
   live in `docs/agents/` and the skills, not next to the workflow, so

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -113,5 +113,8 @@ per gate and exits non-zero on the first hard failure. A non-zero exit is
 a blocked commit — fix and re-run; do not commit around a red gate.
 
 A `WARN` row means a tool is not installed and its gate did **not** run —
-it is a hole in your coverage, not a pass. Install the tool
-(`pip install ruff isort`) rather than shipping on an unchecked gate.
+it is a hole in your coverage, not a pass. Install the toolchain
+(`pip install --group dev`, which pulls black, isort, ruff, and pytest at
+the versions CI uses) rather than shipping on an unchecked gate. Do not
+`pip install black` on its own: this script runs whatever is on `PATH`,
+so a hand-picked version silently formats the tree differently from CI.

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -32,4 +32,4 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 
 | Item | Status | Resolution |
 | --- | --- | --- |
-| [`black` pin diverges between pyproject and CI](done/black-pin-divergence-pyproject-vs-ci.md) | done | Pins moved to a single PEP 735 `lint` dependency group that CI installs; repo reformatted with black 26.x (33 files). |
+| [`black` pin diverges between pyproject and CI](done/black-pin-divergence-pyproject-vs-ci.md) | done | [PR #40](https://github.com/LoganAMorrison/Hazma/pull/40) — pins moved to a single PEP 735 `lint` dependency group that CI installs; repo reformatted with black 26.x (33 files). |

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -26,11 +26,10 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [markdownlint config for templates](todo/markdownlint-config-for-templates.md) | 2026-08-03 | cython-to-rust scaffolding | cross-cutting |
 | [`WIDTH_K`/`WIDTH_PI` exponent bug](todo/legacy-parameters-width-exponent-bug.md) | 2026-08-04 | cython-to-rust Task 0.1 | cross-cutting |
 | [`cross_section_prefactor` threshold cancellation](todo/cross-section-prefactor-threshold-cancellation.md) | 2026-08-04 | cython-to-rust Task 0.3 | cross-cutting |
-| [`black` pin diverges between pyproject and CI](todo/black-pin-divergence-pyproject-vs-ci.md) | 2026-08-04 | cython-to-rust Task 0.3 (PR #37) | cross-cutting |
 | [`msqrd`-driven Monte-Carlo FSR generator](todo/msqrd-driven-fsr-generator.md) | 2026-08-04 | cython-to-rust ADR-0003 | cross-cutting |
 
 ## Promoted / Done / Pruned
 
 | Item | Status | Resolution |
 | --- | --- | --- |
-| _none yet_ | | |
+| [`black` pin diverges between pyproject and CI](done/black-pin-divergence-pyproject-vs-ci.md) | done | Pins moved to a single PEP 735 `lint` dependency group that CI installs; repo reformatted with black 26.x (33 files). |

--- a/docs/followups/done/black-pin-divergence-pyproject-vs-ci.md
+++ b/docs/followups/done/black-pin-divergence-pyproject-vs-ci.md
@@ -4,7 +4,9 @@
 - **Source:** cython-to-rust Task 0.3 (PR #37 — CI Lint went red on a
   locally-black-clean tree)
 - **Scope:** cross-cutting
-- **Status:** open
+- **Status:** done — resolved 2026-08-04 on
+  `claude/black-pin-divergence-pyproject-ci-4f5f38` (direction 2, see
+  [Resolution](#resolution)).
 - **Triggers / blockers:** none — but it silently breaks contributors
   today, so it ripens now.
 
@@ -84,3 +86,60 @@ rule that updates the workflow pin alongside the pyproject one.
   fast-moving. The same class of drift applies to it, and CI's ruff step
   is `--isolated --select E9,F63,F7,F82`, so it is much less exposed —
   worth confirming rather than assuming while fixing this.
+
+## Resolution
+
+**Direction 2**, maintainer's call: CI moves to modern black and the
+repo is reformatted to match.
+
+The pins now live in exactly one place —
+`pyproject.toml`'s PEP 735 `[dependency-groups]`:
+
+<!-- markdownlint-disable MD013 -- pin strings -->
+```toml
+[dependency-groups]
+lint = ["black>=23.3,<27.0", "isort>=5.12,<9.0", "ruff>=0.1,<1.0"]
+dev = [{ include-group = "lint" }, "pytest>=7.0"]
+```
+<!-- markdownlint-enable MD013 -->
+
+and `.github/workflows/ci.yml`'s Lint job installs that group
+(`python -m pip install --group lint`) instead of repeating a literal
+version. A group, not the `dev` extra: `--group` installs only those
+packages, so the Lint job still does not build the Cython extensions —
+`pip install -e '.[dev]'` would have made a formatting check compile 32
+extension modules. The old `[project.optional-dependencies] dev` extra
+is gone; the documented dev setup is now `pip install -e . --group dev`
+(pip >= 25.1), which also brings `pytest` for the preflight gate.
+
+`black hazma test` under black 26.5.1 then reformatted **33 files, +59
+/ −109 lines** — all formatting: `(a, b) = f()` → `a, b = f()`,
+`# type:ignore` → `# type: ignore`, one-line docstring collapse, blank
+lines after imports, and the "hug" of a sole multiline string argument
+that started this. Verified against the same tree, same commands:
+
+<!-- markdownlint-disable MD013 -- measurement table -->
+| Gate | Before | After |
+| --- | --- | --- |
+| `black --check hazma test` (26.5.1) | 33 reformat / 191 clean | **224 clean** |
+| `ruff check --isolated --select E9,F63,F7,F82` (CI's form) | passes | passes |
+| `isort --check-only hazma test` | 141 error lines | 134 |
+| `ruff check hazma test` (configured) | 6619 | 6611 |
+| `pytest` | 68 passed / 20 skipped | 68 passed / 20 skipped |
+<!-- markdownlint-enable MD013 -->
+
+isort and configured-ruff both improved because black collapsed
+constructs they were flagging; neither is a gate CI runs.
+
+Two things deliberately **not** done:
+
+- No `.github/dependabot.yml` `ignore` rule. Dependabot's unrestricted
+  `pip` rule is what widened the pyproject pin in PR #27, but with the
+  workflow no longer carrying a second pin there is nothing left to
+  desync — a future widening PR just moves the one pin, and its CI run
+  is an honest test of whether the new major reformats the repo.
+  Whether Dependabot reads PEP 735 groups at all is untested here; if it
+  stops proposing black bumps, that is a downgrade in nagging, not in
+  correctness.
+- No `CHANGELOG.md` entry. Nothing on the public Python API moved —
+  this is formatting and dev tooling only.

--- a/docs/followups/done/black-pin-divergence-pyproject-vs-ci.md
+++ b/docs/followups/done/black-pin-divergence-pyproject-vs-ci.md
@@ -4,9 +4,9 @@
 - **Source:** cython-to-rust Task 0.3 (PR #37 — CI Lint went red on a
   locally-black-clean tree)
 - **Scope:** cross-cutting
-- **Status:** done — resolved 2026-08-04 on
-  `claude/black-pin-divergence-pyproject-ci-4f5f38` (direction 2, see
-  [Resolution](#resolution)).
+- **Status:** done — resolved 2026-08-04 by
+  [PR #40](https://github.com/LoganAMorrison/Hazma/pull/40) (direction 2,
+  see [Resolution](#resolution)).
 - **Triggers / blockers:** none — but it silently breaks contributors
   today, so it ripens now.
 

--- a/hazma/deprecated/rambo.py
+++ b/hazma/deprecated/rambo.py
@@ -140,13 +140,9 @@ def generate_phase_space(
             num_cpus = num_ps_pts
         if num_cpus > mp.cpu_count():
             num_cpus = int(np.floor(mp.cpu_count() * 0.75))
-            warnings.warn(
-                """You only have {} cpus.
+            warnings.warn("""You only have {} cpus.
                           Using {} cpus instead.
-                          """.format(
-                    mp.cpu_count(), num_cpus
-                )
-            )
+                          """.format(mp.cpu_count(), num_cpus))
     else:
         # Use 75% of the cpu power.
         num_cpus = int(np.floor(mp.cpu_count() * 0.75))

--- a/hazma/form_factors/vector/_utils.py
+++ b/hazma/form_factors/vector/_utils.py
@@ -277,7 +277,7 @@ def gamma_p(
     if hasattr(s, "__len__") and reshape:
         rp = np.sqrt(
             np.clip(
-                v2[:, np.newaxis] / vr2,  # type:ignore
+                v2[:, np.newaxis] / vr2,  # type: ignore
                 0.0,
                 None,
             )
@@ -402,10 +402,10 @@ def breit_wigner_pwave(
             - ss[:, np.newaxis]
             - 1j
             * np.sqrt(ss)[:, np.newaxis]
-            * gamma_p(ss, mres, gamma, m1, m2, reshape=True)  # type:ignore
+            * gamma_p(ss, mres, gamma, m1, m2, reshape=True)  # type: ignore
         )
     return mr2 / (
-        mr2 - s - 1j * np.sqrt(s) * gamma_p(s, mres, gamma, m1, m2)  # type:ignore
+        mr2 - s - 1j * np.sqrt(s) * gamma_p(s, mres, gamma, m1, m2)  # type: ignore
     )
 
 

--- a/hazma/limits/_cmb.py
+++ b/hazma/limits/_cmb.py
@@ -8,7 +8,6 @@ from hazma.parameters import temp_cmb_formation
 
 from ._abstract import AbstractLimit
 
-
 """
 Functions required for computing CMB limits and related quantities.
 """

--- a/hazma/pbh.py
+++ b/hazma/pbh.py
@@ -83,7 +83,7 @@ class PBH(TheoryDec):
         # GeV -> MeV
         self._e_gams = data[:, 0] * 1e3
         # 1/GeV -> 1/MeV
-        self._d2n_dedt = data[:, 1:] * 1e-3  # type:ignore
+        self._d2n_dedt = data[:, 1:] * 1e-3  # type: ignore
 
     @property
     def bh_secondary(self):

--- a/hazma/relic_density/_diffeq.py
+++ b/hazma/relic_density/_diffeq.py
@@ -11,7 +11,6 @@ from ._thermal_functions import weq
 from ._thermal_functions import sm_sqrt_gstar
 from ._thermal_functions import thermal_cross_section
 
-
 # ----------------------------------------------- #
 # Functions for solving the Bolzmann equation     #
 # see arXiv:1204.3622v3 for detailed explaination #

--- a/hazma/rh_neutrino/_rh_neutrino_widths.py
+++ b/hazma/rh_neutrino/_rh_neutrino_widths.py
@@ -23,7 +23,6 @@ from hazma.parameters import (
     lepton_masses,
 )
 
-
 # =======================
 # ---- 2-Body Widths ----
 # =======================

--- a/hazma/rh_neutrino/_spectra.py
+++ b/hazma/rh_neutrino/_spectra.py
@@ -14,7 +14,6 @@ from hazma.parameters import standard_model_masses as sm_masses
 from ._proto import SingleRhNeutrinoModel, Generation
 from . import _widths as rhn_widths
 
-
 _LEPTON_STRS = ["e", "mu", "tau"]
 _NEUTRINO_STRS = ["ve", "vm", "vt"]
 

--- a/hazma/rh_neutrino/_widths.py
+++ b/hazma/rh_neutrino/_widths.py
@@ -1,5 +1,4 @@
-"""Partial decay widths of a RH-neutrino.
-"""
+"""Partial decay widths of a RH-neutrino."""
 
 from typing import Optional, Tuple, NamedTuple
 

--- a/hazma/scalar_mediator/_scalar_mediator_spectra.py
+++ b/hazma/scalar_mediator/_scalar_mediator_spectra.py
@@ -8,7 +8,6 @@ from hazma.scalar_mediator.scalar_mediator_decay_spectrum import (
     scalar_mediator_decay_spectrum,
 )
 
-
 SM_DECAY_MODES = ["pi pi", "mu mu", "pi0 pi0", "g g", "e e g", "pi pi g", "mu mu g"]
 
 
@@ -20,12 +19,8 @@ def dnde_ee(self, e_gams, e_cm, spectrum_type="all"):
     elif spectrum_type == "decay":
         return np.array([0.0 for _ in range(len(e_gams))])
     else:
-        raise ValueError(
-            "Type {} is invalid. Use 'all', 'fsr' or \
-                            'decay'".format(
-                spectrum_type
-            )
-        )
+        raise ValueError("Type {} is invalid. Use 'all', 'fsr' or \
+                            'decay'".format(spectrum_type))
 
 
 def dnde_mumu(self, e_gams, e_cm, spectrum_type="all"):
@@ -38,12 +33,8 @@ def dnde_mumu(self, e_gams, e_cm, spectrum_type="all"):
     elif spectrum_type == "decay":
         return 2.0 * spectra.dnde_photon_muon(e_gams, e_cm / 2.0)
     else:
-        raise ValueError(
-            "Type {} is invalid. Use 'all', 'fsr' or \
-                            'decay'".format(
-                spectrum_type
-            )
-        )
+        raise ValueError("Type {} is invalid. Use 'all', 'fsr' or \
+                            'decay'".format(spectrum_type))
 
 
 def dnde_pi0pi0(self, e_gams, e_cm, spectrum_type="all"):
@@ -56,12 +47,8 @@ def dnde_pi0pi0(self, e_gams, e_cm, spectrum_type="all"):
     if spectrum_type == "decay":
         return 2.0 * spectra.dnde_photon_neutral_pion(e_gams, e_cm / 2.0)
     else:
-        raise ValueError(
-            "Type {} is invalid. Use 'all', 'fsr' or \
-                            'decay'".format(
-                spectrum_type
-            )
-        )
+        raise ValueError("Type {} is invalid. Use 'all', 'fsr' or \
+                            'decay'".format(spectrum_type))
 
 
 def dnde_pipi(self, e_gams, e_cm, spectrum_type="all"):
@@ -74,12 +61,8 @@ def dnde_pipi(self, e_gams, e_cm, spectrum_type="all"):
     elif spectrum_type == "decay":
         return 2.0 * spectra.dnde_photon_charged_pion(e_gams, e_cm / 2.0)
     else:
-        raise ValueError(
-            "Type {} is invalid. Use 'all', 'fsr' or \
-                            'decay'".format(
-                spectrum_type
-            )
-        )
+        raise ValueError("Type {} is invalid. Use 'all', 'fsr' or \
+                            'decay'".format(spectrum_type))
 
 
 def dnde_ss(self, e_gams, e_cm, modes=SM_DECAY_MODES):

--- a/hazma/spectra/_nbody.py
+++ b/hazma/spectra/_nbody.py
@@ -20,7 +20,6 @@ from .altarelli_parisi import (
     dnde_photon_ap_fermion as _ap_fermion,
 )
 
-
 MSqrd = Union[Callable[[Any], Any], Callable[[Any, Any], Any]]
 
 # Currently implemented backend integrators

--- a/hazma/spectra/_neutrino/__init__.py
+++ b/hazma/spectra/_neutrino/__init__.py
@@ -17,7 +17,6 @@ from ._utils import (
     dnde_neutrino as _dnde_neutrino,
 )
 
-
 _eta_interp_e = _load_interp("eta_neutrino_e.csv")
 _eta_interp_mu = _load_interp("eta_neutrino_mu.csv")
 _charged_kaon_integrand_interp_e = _load_interp("charged_kaon_neutrino_e.csv")

--- a/hazma/vector_mediator/_gev/cross_sections.py
+++ b/hazma/vector_mediator/_gev/cross_sections.py
@@ -6,7 +6,6 @@ from hazma import parameters
 from hazma.utils import RealArray
 import hazma.form_factors.vector as vff
 
-
 ME = parameters.electron_mass
 MMU = parameters.muon_mass
 MPI0 = parameters.neutral_pion_mass

--- a/hazma/vector_mediator/_gev/model.py
+++ b/hazma/vector_mediator/_gev/model.py
@@ -1148,11 +1148,9 @@ class KineticMixingGeV(VectorMediatorGeV):
         self.gvmumu = -Qe * eps * qe
 
     def __cannot_set_error(self, param: str) -> AttributeError:
-        return AttributeError(
-            f"""
+        return AttributeError(f"""
         Cannot set {param}. Instead set 'eps' or use the 'VectorMediatorGeV'
-        for more a general coupling structure."""
-        )
+        for more a general coupling structure.""")
 
     # Hide underlying properties' setters
     @VectorMediatorGeV.gvuu.setter
@@ -1238,11 +1236,9 @@ class BLGeV(VectorMediatorGeV):
         """
 
     def __cannot_set_error(self, param: str) -> AttributeError:
-        return AttributeError(
-            f"""
+        return AttributeError(f"""
         Cannot set {param}. Instead use the 'VectorMediatorGeV'
-        for more a general coupling structure."""
-        )
+        for more a general coupling structure.""")
 
     def _update_charges(self) -> None:
         gq = 1.0 / 3.0

--- a/hazma/vector_mediator/form_factors/kk.py
+++ b/hazma/vector_mediator/form_factors/kk.py
@@ -6,7 +6,7 @@ from dataclasses import InitVar, dataclass, field
 from typing import NamedTuple, Optional, Tuple, Union
 
 import numpy as np
-from scipy.special import gamma  # type:ignore
+from scipy.special import gamma  # type: ignore
 
 from hazma import parameters
 

--- a/hazma/vector_mediator/form_factors/pipi.py
+++ b/hazma/vector_mediator/form_factors/pipi.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Union
 
 import numpy as np
-from scipy.special import gamma  # type:ignore
+from scipy.special import gamma  # type: ignore
 
 from hazma import parameters
 

--- a/hazma/vector_mediator/form_factors/utils.py
+++ b/hazma/vector_mediator/form_factors/utils.py
@@ -2,7 +2,7 @@ from typing import Generator, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
-from scipy.special import gamma  # type:ignore
+from scipy.special import gamma  # type: ignore
 from scipy import special
 
 from hazma import parameters
@@ -61,7 +61,7 @@ def beta2(
     """
     return np.clip(
         (1.0 - (m1 + m2) ** 2 / s) * (1.0 - (m1 - m2) ** 2 / s), 0.0, None
-    )  # type:ignore
+    )  # type: ignore
 
 
 def beta(
@@ -281,7 +281,7 @@ def gamma_p(
     if hasattr(s, "__len__") and reshape:
         rp = np.sqrt(
             np.clip(
-                v2[:, np.newaxis] / vr2,  # type:ignore
+                v2[:, np.newaxis] / vr2,  # type: ignore
                 0.0,
                 None,
             )
@@ -406,10 +406,10 @@ def breit_wigner_pwave(
             - ss[:, np.newaxis]
             - 1j
             * np.sqrt(ss)[:, np.newaxis]
-            * gamma_p(ss, mres, gamma, m1, m2, reshape=True)  # type:ignore
+            * gamma_p(ss, mres, gamma, m1, m2, reshape=True)  # type: ignore
         )
     return mr2 / (
-        mr2 - s - 1j * np.sqrt(s) * gamma_p(s, mres, gamma, m1, m2)  # type:ignore
+        mr2 - s - 1j * np.sqrt(s) * gamma_p(s, mres, gamma, m1, m2)  # type: ignore
     )
 
 

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -72,18 +72,19 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   the build dies inside generated code with a misleading error
   (Task 0.1). Clean, the tree builds on Cython 3.2.9 / NumPy 2.5.1.
 - **Preflight's black/isort verdict on `origin/master` — corrected in
-  Task 0.3.** Task 0.1 recorded "black wants to reformat 34 files, isort
-  errors on several `test/` files" as a property of the trunk. **It is
-  not.** That was an unpinned newer black: CI pins
-  `black>=23.3,<25.0` while `pyproject.toml`'s dev extra allows
-  `<27.0`, and the two majors format differently. At `cd0be2b`, black
-  **24.10.0** reports `249 files would be left unchanged` — CI's Lint
-  job is green on the trunk, and a reformat made with black 26 turns it
-  red (PR #37). Install CI's version
-  (`uv pip install "black>=23.3,<25.0"`) before trusting any black
-  result. Tracked in
-  [`../../../docs/followups/todo/black-pin-divergence-pyproject-vs-ci.md`](../../../docs/followups/todo/black-pin-divergence-pyproject-vs-ci.md);
-  the class is `[unpinned-formatter-version]` in `docs/agents/lessons.md`.
+  Task 0.3, then resolved.** Task 0.1 recorded "black wants to reformat
+  34 files, isort errors on several `test/` files" as a property of the
+  trunk. **It was not.** That was an unpinned newer black: CI pinned
+  `black>=23.3,<25.0` while `pyproject.toml`'s dev extra allowed
+  `<27.0`, and the two majors format differently, so at `cd0be2b` black
+  24.10.0 called the trunk clean while black 26 wanted 33 files
+  (PR #37). The divergence is now fixed — one pin, in
+  `pyproject.toml`'s `[dependency-groups]` `lint` group, installed by CI
+  and by you (`pip install --group lint`), with the repo reformatted to
+  black 26.x. Install that group rather than a hand-picked version; see
+  [`../../../docs/followups/done/black-pin-divergence-pyproject-vs-ci.md`](../../../docs/followups/done/black-pin-divergence-pyproject-vs-ci.md).
+  The class is `[unpinned-formatter-version]` in
+  `docs/agents/lessons.md`.
 - **`ruff check hazma test` really is red on the trunk (6844 findings),
   and that does not block CI.** CI's ruff step is
   `ruff check --isolated --select E9,F63,F7,F82`, which deliberately

--- a/projects/cython-to-rust/task-notes/phase-00/task-0.3-delete-superseded.md
+++ b/projects/cython-to-rust/task-notes/phase-00/task-0.3-delete-superseded.md
@@ -497,10 +497,14 @@ local venv repinned to `black>=23.3,<25.0`. This also **corrects a Task
 0.1 finding** that had entered `../README.md` as fact — "black wants to
 reformat 34 files on `origin/master`" was that same version skew; CI's
 black reports the trunk clean. Root cause filed as
-[`docs/followups/todo/black-pin-divergence-pyproject-vs-ci.md`](../../../../docs/followups/todo/black-pin-divergence-pyproject-vs-ci.md),
+[`docs/followups/done/black-pin-divergence-pyproject-vs-ci.md`](../../../../docs/followups/done/black-pin-divergence-pyproject-vs-ci.md),
 class added to `docs/agents/lessons.md` as
 `[unpinned-formatter-version]`, trap documented in
-`docs/agents/environment.md`.
+`docs/agents/environment.md`. **Since resolved** (2026-08-04): the pin
+lives once, in `pyproject.toml`'s `[dependency-groups]` `lint` group,
+and the repo was reformatted to black 26.x — so the workaround recorded
+above (repin the local venv to `<25.0`) is obsolete. Install
+`--group lint`.
 
 isort was brought to green because every remaining complaint sat in a
 file this task already edits. Per-file ruff, branch vs trunk:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,22 @@ dependencies = [
 Repository = "https://github.com/LoganAMorrison/Hazma"
 Documentation = "http://hazma.readthedocs.io"
 
-[project.optional-dependencies]
-dev = ["black>=23.3,<27.0"]
+# PEP 735 dependency groups. These are the single source of truth for the
+# tooling pins — CI installs `--group lint` instead of repeating literal
+# versions in .github/workflows/ci.yml. Repeating them is how black ended
+# up pinned <27.0 here and <25.0 in CI, so the documented dev setup
+# reformatted files into a style CI rejected.
+#
+# `pip install --group lint` (pip >= 25.1) installs only these packages, so
+# the Lint job never builds the Cython extensions.
+#
+# The caps are major-version caps, not exact pins: a formatter major bump
+# reformats the whole repo, so it should land as a deliberate PR rather
+# than arrive silently in a CI run. `ruff` is capped the same way even
+# though CI only runs its `--isolated --select E9,F63,F7,F82` subset.
+[dependency-groups]
+lint = ["black>=23.3,<27.0", "isort>=5.12,<9.0", "ruff>=0.1,<1.0"]
+dev = [{ include-group = "lint" }, "pytest>=7.0"]
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/test/vector_mediator/herwig4dm/3pi.py
+++ b/test/vector_mediator/herwig4dm/3pi.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 
 from . import F3pi
 
-
 ii = complex(0.0, 1.0)
 # from GeV to nb units for data comparison
 gev2nb = 389379.3656

--- a/test/vector_mediator/herwig4dm/4pi.py
+++ b/test/vector_mediator/herwig4dm/4pi.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 
 from . import F4pi
 
-
 br_omega_pi_gamma = 0.084
 
 F4pi.readHadronic_Current()

--- a/test/vector_mediator/herwig4dm/EtaOmega.py
+++ b/test/vector_mediator/herwig4dm/EtaOmega.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 
 from . import FEtaOmega
 
-
 # set DM parameters
 # DM to mediator coupling
 gDM = 1.0

--- a/test/vector_mediator/herwig4dm/EtaPhi.py
+++ b/test/vector_mediator/herwig4dm/EtaPhi.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 
 from . import FEtaPhi
 
-
 # set DM parameters
 # DM to mediator coupling
 gDM = 1.0

--- a/test/vector_mediator/herwig4dm/EtaPrimePiPi.py
+++ b/test/vector_mediator/herwig4dm/EtaPrimePiPi.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 
 from . import FEtaPrimePiPi
 
-
 xSM = []
 ySM = []
 xDP = []

--- a/test/vector_mediator/herwig4dm/F3pi.py
+++ b/test/vector_mediator/herwig4dm/F3pi.py
@@ -6,7 +6,6 @@ from scipy import integrate
 from . import Resonance
 from . import alpha
 
-
 ii = complex(0.0, 1.0)
 gev2nb = 389379.3656
 

--- a/test/vector_mediator/herwig4dm/F4pi.py
+++ b/test/vector_mediator/herwig4dm/F4pi.py
@@ -10,7 +10,6 @@ from scipy.interpolate import interp1d
 from . import Resonance
 from . import alpha
 
-
 """
 Parametrization taken from 0804.0359 with new fit values
 """
@@ -152,9 +151,9 @@ def phaseSpace1(m0, m1, m2, m3, m4, M12, G12, M34, G34):
         rho = rhomin + rhomax * random.random()
         m122 = max(m12min**2, min(m12max**2, M12**2 + M12 * G12 * math.tan(rho)))
         m12 = math.sqrt(m122)
-    (q1, q2) = twoBodyDecay(numpy.array([m0, 0.0, 0.0, 0.0]), m0, m12, m34)
-    (p1, p2) = twoBodyDecay(q1, m12, m1, m2)
-    (p3, p4) = twoBodyDecay(q2, m34, m3, m4)
+    q1, q2 = twoBodyDecay(numpy.array([m0, 0.0, 0.0, 0.0]), m0, m12, m34)
+    p1, p2 = twoBodyDecay(q1, m12, m1, m2)
+    p3, p4 = twoBodyDecay(q2, m34, m3, m4)
     return (p1, p2, p3, p4)
 
 
@@ -198,7 +197,7 @@ def phaseSpace2(m0, m1, m2, m3, m4, M234, G234, M34, G34):
     rho = rhomin + rhomax * random.random()
     m2342 = max(m234min**2, min(m234max**2, M234**2 + M234 * G234 * math.tan(rho)))
     m234 = math.sqrt(m2342)
-    (p1, q234) = twoBodyDecay(numpy.array([m0, 0.0, 0.0, 0.0]), m0, m1, m234)
+    p1, q234 = twoBodyDecay(numpy.array([m0, 0.0, 0.0, 0.0]), m0, m1, m234)
     m34min = m3 + m4
     m34max = m234 - m2
     rhomin = math.atan2(m34min**2 - M34**2, M34 * G34)
@@ -206,8 +205,8 @@ def phaseSpace2(m0, m1, m2, m3, m4, M234, G234, M34, G34):
     rho = rhomin + rhomax * random.random()
     m342 = max(m34min**2, min(m34max**2, M34**2 + M34 * G34 * math.tan(rho)))
     m34 = math.sqrt(m342)
-    (p2, q34) = twoBodyDecay(q234, m234, m2, m34)
-    (p3, p4) = twoBodyDecay(q34, m34, m3, m4)
+    p2, q34 = twoBodyDecay(q234, m234, m2, m34)
+    p3, p4 = twoBodyDecay(q34, m34, m3, m4)
     return (p1, p2, p3, p4)
 
 
@@ -434,61 +433,61 @@ functions for phase space calculation
 def generatepm00(rootS):
     rnd = random.random()
     if rnd < 0.25:
-        (p01, p02, pp, pm) = phaseSpace1(
+        p01, p02, pp, pm = phaseSpace1(
             rootS, mpi0, mpi0, mpip, mpip, mf0, gf0, mRho, gRho
         )
     elif rnd < 0.5:
         rnd = 4.0 * rnd - 1.0
         if rnd < 0.25:
-            (pm, p02, p01, pp) = phaseSpace2(
+            pm, p02, p01, pp = phaseSpace2(
                 rootS, mpip, mpi0, mpi0, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.5:
-            (pm, p01, p02, pp) = phaseSpace2(
+            pm, p01, p02, pp = phaseSpace2(
                 rootS, mpip, mpi0, mpi0, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.75:
-            (pp, p02, p01, pm) = phaseSpace2(
+            pp, p02, p01, pm = phaseSpace2(
                 rootS, mpip, mpi0, mpi0, mpip, ma1, ga1, mRho, gRho
             )
         else:
-            (pp, p01, p02, pm) = phaseSpace2(
+            pp, p01, p02, pm = phaseSpace2(
                 rootS, mpip, mpi0, mpi0, mpip, ma1, ga1, mRho, gRho
             )
     elif rnd < 0.75:
         rnd = 4.0 * rnd - 2.0
         if rnd < 0.5:
-            (p01, pm, p02, pp) = phaseSpace1(
+            p01, pm, p02, pp = phaseSpace1(
                 rootS, mpi0, mpip, mpi0, mpip, mRho, gRho, mRho, gRho
             )
         else:
-            (p02, pm, p01, pp) = phaseSpace1(
+            p02, pm, p01, pp = phaseSpace1(
                 rootS, mpi0, mpip, mpi0, mpip, mRho, gRho, mRho, gRho
             )
     else:
         rnd = 4.0 * rnd - 3.0
         if rnd < 1.0 / 6.0:
-            (p01, p02, pp, pm) = phaseSpace2(
+            p01, p02, pp, pm = phaseSpace2(
                 rootS, mpi0, mpi0, mpip, mpip, mOmega, gOmega, mRho, gRho
             )
         elif rnd < 1.0 / 3.0:
-            (p02, p01, pp, pm) = phaseSpace2(
+            p02, p01, pp, pm = phaseSpace2(
                 rootS, mpi0, mpi0, mpip, mpip, mOmega, gOmega, mRho, gRho
             )
         elif rnd < 0.5:
-            (p01, pp, p02, pm) = phaseSpace2(
+            p01, pp, p02, pm = phaseSpace2(
                 rootS, mpi0, mpip, mpi0, mpip, mOmega, gOmega, mRho, gRho
             )
         elif rnd < 2.0 / 3.0:
-            (p02, pp, p01, pm) = phaseSpace2(
+            p02, pp, p01, pm = phaseSpace2(
                 rootS, mpi0, mpip, mpi0, mpip, mOmega, gOmega, mRho, gRho
             )
         elif rnd < 5.0 / 6.0:
-            (p01, pm, p02, pp) = phaseSpace2(
+            p01, pm, p02, pp = phaseSpace2(
                 rootS, mpi0, mpip, mpi0, mpip, mOmega, gOmega, mRho, gRho
             )
         else:
-            (p02, pm, p01, pp) = phaseSpace2(
+            p02, pm, p01, pp = phaseSpace2(
                 rootS, mpi0, mpip, mpi0, mpip, mOmega, gOmega, mRho, gRho
             )
 
@@ -688,53 +687,53 @@ def generatepmpm(rootS):
     if rnd < 0.5:
         rnd *= 2.0
         if rnd < 0.25:
-            (pp1, pm1, pp2, pm2) = phaseSpace1(
+            pp1, pm1, pp2, pm2 = phaseSpace1(
                 rootS, mpip, mpip, mpip, mpip, mf0, gf0, mRho, gRho
             )
         elif rnd < 0.5:
-            (pp1, pm2, pp2, pm1) = phaseSpace1(
+            pp1, pm2, pp2, pm1 = phaseSpace1(
                 rootS, mpip, mpip, mpip, mpip, mf0, gf0, mRho, gRho
             )
         elif rnd < 0.75:
-            (pp2, pm1, pp1, pm2) = phaseSpace1(
+            pp2, pm1, pp1, pm2 = phaseSpace1(
                 rootS, mpip, mpip, mpip, mpip, mf0, gf0, mRho, gRho
             )
         else:
-            (pp2, pm2, pp1, pm1) = phaseSpace1(
+            pp2, pm2, pp1, pm1 = phaseSpace1(
                 rootS, mpip, mpip, mpip, mpip, mf0, gf0, mRho, gRho
             )
     else:
         rnd = 2.0 * rnd - 1.0
         if rnd < 0.125:
-            (pp1, pm1, pp2, pm2) = phaseSpace2(
+            pp1, pm1, pp2, pm2 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.25:
-            (pp1, pm2, pp2, pm1) = phaseSpace2(
+            pp1, pm2, pp2, pm1 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.375:
-            (pp2, pm1, pp1, pm2) = phaseSpace2(
+            pp2, pm1, pp1, pm2 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.5:
-            (pp2, pm2, pp1, pm1) = phaseSpace2(
+            pp2, pm2, pp1, pm1 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.625:
-            (pm1, pp1, pm2, pp2) = phaseSpace2(
+            pm1, pp1, pm2, pp2 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.75:
-            (pm1, pp2, pm2, pp1) = phaseSpace2(
+            pm1, pp2, pm2, pp1 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         elif rnd < 0.875:
-            (pm2, pp1, pm1, pp2) = phaseSpace2(
+            pm2, pp1, pm1, pp2 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
         else:
-            (pm2, pp2, pm1, pp1) = phaseSpace2(
+            pm2, pp2, pm1, pp1 = phaseSpace2(
                 rootS, mpip, mpip, mpip, mpip, ma1, ga1, mRho, gRho
             )
     wgt = 0.125 * (
@@ -1018,7 +1017,7 @@ def readHadronic_Current():
         en = key
         s = en**2
         x.append(en)
-        (npoints, wgt, wgt2) = val
+        npoints, wgt, wgt2 = val
         hadcurr, hadcurr_err = hadronic_current(s, npoints, wgt, wgt2, omegaOnly=False)
         y.append(abs(hadcurr))
     hadronic_interpolator_n = interp1d(x, y, kind="cubic", fill_value=(0.0, 0.0))
@@ -1029,7 +1028,7 @@ def readHadronic_Current():
         en = key
         s = en**2
         x.append(en)
-        (npoints, wgt, wgt2) = val
+        npoints, wgt, wgt2 = val
         hadcurr, hadcurr_err = hadronic_current(s, npoints, wgt, wgt2, omegaOnly=False)
         y.append(abs(hadcurr))
     hadronic_interpolator_c = interp1d(x, y, kind="cubic", fill_value=(0.0, 0.0))

--- a/test/vector_mediator/herwig4dm/FEtaGamma.py
+++ b/test/vector_mediator/herwig4dm/FEtaGamma.py
@@ -6,7 +6,6 @@ import cmath
 from . import Resonance
 from . import alpha
 
-
 # parametrization based on hep-ex/0605109
 
 # set of parameters

--- a/test/vector_mediator/herwig4dm/FEtaPiPi.py
+++ b/test/vector_mediator/herwig4dm/FEtaPiPi.py
@@ -9,7 +9,6 @@ from . import Resonance
 from . import alpha
 from .masses import mpi, meta, fpi
 
-
 ii = complex(0.0, 1.0)
 
 # parametrization taken from arXiv:1306.1985 with own fit values

--- a/test/vector_mediator/herwig4dm/FEtaPrimePiPi.py
+++ b/test/vector_mediator/herwig4dm/FEtaPrimePiPi.py
@@ -9,7 +9,6 @@ from . import Resonance
 from . import alpha
 from .masses import mpi, metap, fpi
 
-
 ii = complex(0.0, 1.0)
 gev2nb = 389379.3656
 

--- a/test/vector_mediator/herwig4dm/FKKpi.py
+++ b/test/vector_mediator/herwig4dm/FKKpi.py
@@ -10,7 +10,6 @@ import numpy as np
 from . import Resonance
 from . import alpha
 
-
 # masses and width from PDG
 mKp = 0.493677  # charged Kaon
 mK0 = 0.497648  # neutral Kaon

--- a/test/vector_mediator/herwig4dm/FOmegaPiPi.py
+++ b/test/vector_mediator/herwig4dm/FOmegaPiPi.py
@@ -6,7 +6,6 @@ import scipy.integrate
 
 from . import alpha
 
-
 ii = complex(0.0, 1.0)
 gev2nb = 389379.3656
 cF0_ = [0.165, 0.695]

--- a/test/vector_mediator/herwig4dm/FPiGamma.py
+++ b/test/vector_mediator/herwig4dm/FPiGamma.py
@@ -5,7 +5,6 @@ import cmath
 from . import Resonance
 from . import alpha
 
-
 # parametrization based on arXiv: 1601.08061
 
 # Set of parameters obtained from the fit

--- a/test/vector_mediator/herwig4dm/FPiGamma_new.py
+++ b/test/vector_mediator/herwig4dm/FPiGamma_new.py
@@ -4,7 +4,6 @@ import math
 from . import Resonance
 from . import alpha
 
-
 # parametrization losely based on https://arxiv.org/pdf/1711.00820.pdf
 
 # fpi_= 0.092663579634360449

--- a/test/vector_mediator/herwig4dm/KK.py
+++ b/test/vector_mediator/herwig4dm/KK.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 
 from . import FK
 
-
 # energy range SM
 low_lim = 2.0 * FK.mK0
 upp_lim = 2.0

--- a/test/vector_mediator/herwig4dm/OmegaPion.py
+++ b/test/vector_mediator/herwig4dm/OmegaPion.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 
 from . import FOmegaPion
 
-
 # set DM parameters
 # DM to mediator coupling
 gDM = 1.0

--- a/test/vector_mediator/herwig4dm/PhiPi.py
+++ b/test/vector_mediator/herwig4dm/PhiPi.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 
 from . import FPhiPi
 
-
 # set DM parameters
 # DM to mediator coupling
 gDM = 1.0


### PR DESCRIPTION
## Summary

- **The `black` pin lived in two files and they disagreed.**
  `pyproject.toml`'s `dev` extra allowed `black>=23.3,<27.0` while
  `.github/workflows/ci.yml`'s Lint job installed `black>=23.3,<25.0`.
  Black's style changed across that boundary, so `pip install -e '.[dev]'`
  — the documented dev setup — gave you a formatter whose output CI
  rejected: `black --check` clean locally, Lint red on the PR, on lines
  nobody touched (this is what bit #37). Fixed by deleting the duplicate
  rather than syncing it: the pins now live only in `pyproject.toml`'s
  PEP 735 `[dependency-groups]`, and the Lint job installs that group.

  ```toml
  [dependency-groups]
  lint = ["black>=23.3,<27.0", "isort>=5.12,<9.0", "ruff>=0.1,<1.0"]
  dev = [{ include-group = "lint" }, "pytest>=7.0"]
  ```

  A dependency group rather than the `dev` extra because
  `pip install --group lint` installs *only* those packages — installing
  the extra would make a formatting check compile 32 Cython extensions.
  **The `[project.optional-dependencies] dev` extra is gone**, so
  `pip install -e '.[dev]'` no longer resolves; the dev setup is now
  `pip install -e . --group dev`, which needs pip >= 25.1. Every doc that
  named the old command was updated.

- **CI moves to modern black, so the repo was reformatted** — `black hazma
  test` under 26.5.1 touched 33 files, +59/−109. Formatting only:
  `(a, b) = f()` → `a, b = f()`, `# type:ignore` → `# type: ignore`,
  one-line docstring collapse, blank lines after imports, and the "hug" of
  a sole multiline string argument that started this. **No returned value
  moves** — no expression, literal, or control flow changed, and pytest is
  identical before and after (68 passed / 20 skipped). No `CHANGELOG.md`
  entry for the same reason: nothing on the public Python API moved.

- **Resolves the follow-up**, moved
  `todo/black-pin-divergence-pyproject-vs-ci.md` → `done/` with a
  Resolution section recording the measurements and the two deliberate
  omissions. No `.github/dependabot.yml` `ignore` rule: Dependabot's `pip`
  rule is what widened the pyproject pin in #27, but with the workflow no
  longer carrying a second pin there is nothing left to desync — a future
  widening PR just moves the one pin, and its own CI run is an honest test
  of whether the new major reformats the repo. Docs updated to match:
  `AGENTS.md`, `docs/agents/{environment,lessons,preflight}.md`, and the
  two cython-to-rust task notes that recorded the now-obsolete workaround
  ("repin your local venv to `<25.0`").

## Test plan

- [x] `pip install --group lint` resolves as CI will run it, and installs
      no project build (pip 26.2.1):

  ```text
  Would install black-26.5.1 click-8.4.2 isort-8.0.1 mypy_extensions-1.1.0
  packaging-26.3 pathspec-1.1.1 platformdirs-4.11.0 pytokens-0.4.1 ruff-0.16.1
  ```

- [x] `scripts/agents/preflight.sh --paths "hazma test" --tests "test"`
      (with the 8 changed `.md` files):

  ```text
  PASS   black --check           hazma test
  FAIL   isort --check-only      run `isort hazma test` and re-check
  FAIL   ruff check              see output below
  PASS   pytest                  68 passed, 20 skipped in 279.57s (0:04:39)
  PASS   import hazma            version 2.1.0
  PASS   markdownlint            <the 8 changed docs>
  SKIP   version bump            not a closing PR (pass --closing)
  PASS   forbidden tokens        none added
  ```

  `black --check` was FAIL on this tree before the reformat and is now
  PASS. The two red gates are the repo's known pre-existing debt, not
  CI gates, and both counts *dropped* over the reformat — isort 141 → 134
  error lines, configured ruff 6619 → 6611 — because black collapsed
  constructs they were flagging. Nothing here added to either.

- [x] CI's own lint form, before and after the reformat — unchanged:

  ```text
  $ ruff check --isolated --select E9,F63,F7,F82 \
        --exclude hazma/experimental --exclude notebooks .
  All checks passed!
  ```

- [x] `black --check hazma test` under 26.5.1: `33 files would be
      reformatted, 191 files would be left unchanged` → after:
      `224 files would be left unchanged`.

- [x] Package metadata still builds from the edited `pyproject.toml`, with
      the extra gone and runtime deps untouched:

  ```text
  Name: hazma | Version: 2.1.0
  Provides-Extra: none
  Requires-Dist: ['numpy>=2.0', 'scipy>=1.13', 'matplotlib>=2.2.3', 'scikit-image']
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
