### PR TITLE
feat(spectra): add msqrd-driven FSR photon spectrum generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,29 @@ signature did.
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **`hazma.spectra.dnde_photon_fsr` — exact FSR photon spectra from a
+  user-supplied squared matrix element.** The maintained replacement for
+  the removed `hazma.gamma_ray.gamma_ray_fsr` (cython-to-rust ADR-0003),
+  designed per [`docs/adrs/ADR-0001`](docs/adrs/ADR-0001-fsr-generator-takes-both-matrix-elements.md)
+  and resolving
+  [`docs/followups/done/msqrd-driven-fsr-generator.md`](docs/followups/done/msqrd-driven-fsr-generator.md).
+  The caller supplies the squared matrix elements of both the radiative
+  and the non-radiative process; every initial-state factor cancels in
+  the ratio, so there is no rate float, no `isp_masses`, and no
+  decay/annihilation branch. A two-body non-photon final state is
+  integrated by deterministic Dalitz-strip quadrature; higher
+  multiplicities run seeded RAMBO Monte Carlo at the reduced invariant
+  mass, built on `hazma.phase_space`. Returns the new
+  `hazma.spectra.FSRSpectrum` NamedTuple `(dnde, error)` in MeV⁻¹, with
+  the one-sigma integration error a first-class output. Validated in
+  `test/spectra/test_dnde_photon_fsr.py` against exact tree-level matrix
+  elements (numerical Dirac traces / scalar QED) pinned to the analytic
+  mediator-model spectra `dnde_xx_to_v_to_ffg`, `dnde_xx_to_s_to_ffg`,
+  and `dnde_xx_to_v_to_pipig` at `rtol=1e-5`, plus Ward-identity,
+  soft-photon, Altarelli-Parisi, and flat-matrix-element phase-space
+  checks.
 
 ## [2.1.0] — 2026-08-03
 

--- a/docs/adrs/ADR-0001-fsr-generator-takes-both-matrix-elements.md
+++ b/docs/adrs/ADR-0001-fsr-generator-takes-both-matrix-elements.md
@@ -1,0 +1,119 @@
+# ADR 0001: The FSR generator takes both matrix elements
+
+**Date:** 2026-08-04
+**Status:** Proposed (acceptance rides on the review of the PR that
+implements it)
+
+## Context
+
+ADR-0003 of `projects/cython-to-rust/` removes `hazma.gamma_ray` and
+with it `gamma_ray_fsr`, the Monte-Carlo photon spectrum from a
+user-supplied squared matrix element. The follow-up
+[`msqrd-driven-fsr-generator`](../followups/done/msqrd-driven-fsr-generator.md)
+asks for a maintained replacement inside `hazma.spectra`, and names one
+design question that must be settled before code is written: the old
+signature took the non-radiative rate as a bare float,
+
+```python
+gamma_ray_fsr(photon_energies, cme, isp_masses, fsp_masses,
+              non_rad, msqrd, nevents=1000)
+```
+
+which forces the caller to supply a width or cross section in exactly
+the units, spin-averaging, symmetry-factor, and coupling conventions
+that the Monte-Carlo numerator happens to use. Nothing checks the two
+agree; a mismatch rescales the whole spectrum silently. The same float
+is why the old function needed `isp_masses` at all — it had to
+reconstruct the flux (annihilation) or `1/2M` (decay) prefactor to make
+the numerator's units match the caller's rate.
+
+The physics does not require any of that. The observable is
+
+```text
+dN/dE = d\Gamma(X -> F + gamma)/dE / \Gamma(X -> F)
+```
+
+and every initial-state factor — flux, 1/(2M), spin averaging,
+couplings, propagators at fixed s, symmetry factors of F (the photon is
+distinct) — appears identically in numerator and denominator. In the
+ratio of bare phase-space integrals
+
+```text
+dN/dE = [ dI_rad/dE ] / I_0,     I[|M|^2] = \int |M|^2 d\Phi
+```
+
+everything cancels except the two squared matrix elements themselves.
+
+## Decision
+
+The replacement is `hazma.spectra.dnde_photon_fsr`, and its contract is:
+
+1. **Both matrix elements, no rate float.** The caller supplies
+   `msqrd` (radiative, photon momentum last) *and* `msqrd_nonrad`
+   (non-radiative) as callables. There is no `non_rad` float and no
+   `isp_masses` argument; decays and annihilations are the same call.
+   Consistency of conventions between numerator and denominator is
+   automatic because both come from the same Feynman rules — any common
+   constant factor cancels.
+2. **No `Theory` coupling.** The function does not accept a model
+   object. Models (layer 5) may call `hazma.spectra` (layer 3), never
+   the reverse, and the concrete mediator models already ship analytic
+   FSR. A convenience wrapper on `Theory` can be added later without
+   touching this surface.
+3. **Momentum convention.** `msqrd(momenta)` receives a NumPy array of
+   shape `(4, n_fsp[, batch])` — rows `(E, px, py, pz)` in MeV, one
+   column per final-state particle in the order of
+   `final_state_masses`, with the photon appended last for the
+   radiative call. Implementations written with `hazma.utils.ldot` /
+   `lnorm_sqr` handle both the batched and unbatched forms for free.
+4. **Final-state invariants only.** Momenta are generated in a frame
+   where the non-photon system is at rest (total invariant mass
+   `sqrt(s)` once the photon is included); no initial-state momenta are
+   provided. `msqrd` must therefore be a Lorentz-invariant function of
+   the final-state momenta alone: decays of unpolarized particles
+   always qualify, and annihilation matrix elements must already be
+   averaged over the beam direction (exact for s-channel processes).
+5. **The statistical error is part of the API.** The return value is a
+   `FSRSpectrum` NamedTuple `(dnde, error)`, both in MeV⁻¹ and shaped
+   like the input energies. `error` is the one-sigma Monte-Carlo
+   estimate (quadrature-error estimate on the deterministic path). A
+   caller who ignores it can unpack `dnde` explicitly; limit-setting
+   code that would silently fit MC noise now has the noise floor in
+   hand.
+6. **Deterministic quadrature where possible, RAMBO elsewhere.** For a
+   2-body non-radiative final state (the dominant use case) the fixed
+   photon energy reduces the radiative integral to one Dalitz-strip
+   quadrature and the result carries no MC noise; for three or more
+   final-state particles the generator runs RAMBO at the reduced
+   invariant mass `s' = s - 2*sqrt(s)*E` with the photon appended —
+   the same fixed-photon-energy estimator the removed kernel used
+   (evaluating dN/dE exactly at the requested energies, with no
+   histogram binning) — seeded via `seed=` for reproducibility.
+   `method="auto"` picks between them; both are built on
+   `hazma.phase_space`, not a private phase-space implementation.
+
+## Consequences
+
+- **Positive:** the silent-normalization trap is structurally gone; the
+  decay/annihilation branch and `isp_masses` disappear; spectra keep
+  their layer; MC noise is visible to callers; the 2-body case is
+  exact up to quadrature error and needs no seed.
+- **Negative:** callers who know the non-radiative width analytically
+  must still write `|M_0|^2` as a callable (for a 2-body final state
+  this is a one-liner) and pay a cheap quadrature for a number they
+  already had; beam-direction-dependent (t-channel annihilation)
+  matrix elements are out of scope; polarized initial states are out
+  of scope.
+- **Mitigation:** the t-channel restriction is documented on the
+  function and can be lifted compatibly later (boost the generated
+  events to the CM frame and document a beam axis — invariant-only
+  `msqrd` implementations are unaffected by that change). Validation
+  is pinned in `test/spectra/` against real theoretical calculations:
+  exact tree-level `|M|^2` for `x xbar -> V* -> l+ l- gamma`,
+  `x xbar -> S* -> l+ l- gamma`, and `x xbar -> V* -> pi+ pi- gamma`
+  are integrated by the generator and compared with the closed-form
+  spectra the mediator models already ship
+  (`dnde_xx_to_v_to_ffg`, `dnde_xx_to_s_to_ffg`,
+  `dnde_xx_to_v_to_pipig`), with the soft-photon limit, the
+  Altarelli–Parisi collinear limit, and Ward identities as
+  corpus-level cross-checks.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -45,5 +45,5 @@ Copy [`template.md`](template.md) and fill in the sections.
 ## Index
 
 | ADR | Title | Status | Date |
-|-----|-------|--------|------|
-| _none yet_ | | | |
+| --- | --- | --- | --- |
+| [ADR-0001](ADR-0001-fsr-generator-takes-both-matrix-elements.md) | The FSR generator takes both matrix elements | Proposed | 2026-08-04 |

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -95,3 +95,11 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   workflow file (PR #33: the matrix had gone 3.10–3.12 → 3.10–3.14 and
   `black --check` had been re-enabled, while three docs still said
   otherwise).
+- [degenerate-sample-count] An API whose contract includes a statistical
+  error estimate must validate its sample-count input at the public entry
+  point: a `ddof=1` sample deviation is undefined below two samples, and a
+  degenerate count otherwise flows to *every* internal consumer — the
+  per-energy numerator and the Monte-Carlo non-radiative denominator alike —
+  as a finite value with `error=nan` plus a warning nobody reads. Validate
+  the type too: a non-integral count otherwise dies deep inside NumPy with
+  a message that names neither the argument nor the fix (PR #41).

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -26,10 +26,10 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [markdownlint config for templates](todo/markdownlint-config-for-templates.md) | 2026-08-03 | cython-to-rust scaffolding | cross-cutting |
 | [`WIDTH_K`/`WIDTH_PI` exponent bug](todo/legacy-parameters-width-exponent-bug.md) | 2026-08-04 | cython-to-rust Task 0.1 | cross-cutting |
 | [`cross_section_prefactor` threshold cancellation](todo/cross-section-prefactor-threshold-cancellation.md) | 2026-08-04 | cython-to-rust Task 0.3 | cross-cutting |
-| [`msqrd`-driven Monte-Carlo FSR generator](todo/msqrd-driven-fsr-generator.md) | 2026-08-04 | cython-to-rust ADR-0003 | cross-cutting |
 
 ## Promoted / Done / Pruned
 
 | Item | Status | Resolution |
 | --- | --- | --- |
 | [`black` pin diverges between pyproject and CI](done/black-pin-divergence-pyproject-vs-ci.md) | done | [PR #40](https://github.com/LoganAMorrison/Hazma/pull/40) — pins moved to a single PEP 735 `lint` dependency group that CI installs; repo reformatted with black 26.x (33 files). |
+| [`msqrd`-driven Monte-Carlo FSR generator](done/msqrd-driven-fsr-generator.md) | done | `hazma.spectra.dnde_photon_fsr` (ADR-0001, [PR #41](https://github.com/LoganAMorrison/Hazma/pull/41)) |

--- a/docs/followups/done/msqrd-driven-fsr-generator.md
+++ b/docs/followups/done/msqrd-driven-fsr-generator.md
@@ -5,7 +5,9 @@
   (Accepted 2026-08-04) — the ADR removes `hazma.gamma_ray.gamma_ray_fsr`
   and names this follow-up as the only route back
 - **Scope:** cross-cutting
-- **Status:** open
+- **Status:** done — implemented ad-hoc as `hazma.spectra.dnde_photon_fsr`
+  (design: [`docs/adrs/ADR-0001`](../../adrs/ADR-0001-fsr-generator-takes-both-matrix-elements.md);
+  [PR #41](https://github.com/LoganAMorrison/Hazma/pull/41))
 - **Triggers / blockers:** ripens when a user (or a model in this repo)
   actually needs FSR from a general squared matrix element and the
   Altarelli–Parisi approximations are not good enough. Technically
@@ -115,3 +117,44 @@ resolution.
   instead take the non-radiative process itself, and whether it should
   accept a `Theory` model directly, is an open design question that
   should be settled before any code is written.
+
+## Resolution (2026-08-04)
+
+Implemented ad-hoc rather than promoted to a project
+([PR #41](https://github.com/LoganAMorrison/Hazma/pull/41)): one PR
+carries the design ADR, the implementation, the validation corpus, and
+the docs. How each item of **What** was settled:
+
+1. **Surface:** `hazma.spectra.dnde_photon_fsr(photon_energies, cme,
+   final_state_masses, msqrd, msqrd_nonrad, *, method, npts, seed,
+   epsabs, epsrel)` returning an `FSRSpectrum` NamedTuple
+   `(dnde, error)` in MeV⁻¹. The interface-drift question is answered
+   by repo-wide
+   [`ADR-0001`](../../adrs/ADR-0001-fsr-generator-takes-both-matrix-elements.md):
+   the non-radiative process is supplied as a *matrix element*, not a
+   rate float and not a `Theory` — every initial-state factor cancels
+   in the ratio of phase-space integrals, which also removes
+   `isp_masses` and the decay/annihilation branch.
+2. **Built on `hazma.phase_space`:** RAMBO at the reduced invariant
+   mass `s' = s - 2*sqrt(s)*E` with the photon appended (the removed
+   kernel's fixed-photon-energy estimator, re-derived), plus a
+   deterministic Dalitz-strip quadrature backend for the dominant
+   2-body-plus-photon case; `ThreeBody` quadrature for 3-body
+   non-radiative integrals. No private phase-space code.
+3. **Validation plan first:** written into ADR-0001 and executed in
+   `test/spectra/test_dnde_photon_fsr.py` over a corpus of exact
+   tree-level matrix elements (`test/spectra/msqrd_corpus.py`,
+   numerical Dirac traces and scalar QED, self-checked by Ward
+   identities, soft-photon factorization, and the models' analytic
+   cross sections). Oracle (a): pinned against the closed-form
+   `dnde_xx_to_v_to_ffg`, `dnde_xx_to_s_to_ffg`, and
+   `dnde_xx_to_v_to_pipig` at `rtol=1e-5` (quadrature) and at fixed
+   seed within Monte-Carlo pulls < 4 (rambo). Oracle (b): matches
+   2× `dnde_photon_ap_fermion` to 1e-4 for electrons. Oracle (c): the
+   corpus factorizes onto the eikonal factor as `E_gamma -> 0`.
+4. **Statistical error is part of the API:** the error estimate is a
+   field of the return value, never discarded.
+5. **Kinematic edges:** threshold raises `RamboCMETooSmall`; energies
+   outside `(0, e_max)` (including the endpoint and NaN) return zero;
+   equal-mass, unequal-mass, massless, and 4-body cases are pinned
+   against analytic phase-space formulas.

--- a/docs/source/spectra.rst
+++ b/docs/source/spectra.rst
@@ -11,7 +11,8 @@ The :mod:`hazma.spectra` module contains functions for:
 * Computing photon,positron and neutrino spectra from the decays of individual SM particles,
 * Computing spectra from an :math:`N`-body final state,
 * Boosting spectra into new frames,
-* Computing FSR spectra using Altarelli-Parisi splitting functions.
+* Computing FSR spectra using Altarelli-Parisi splitting functions,
+* Computing exact FSR spectra from a user-supplied squared matrix element.
 
 Below, we demonstrate how each of these actions can be easily performed in ``hazma``.
 
@@ -474,6 +475,101 @@ demonstrate how to use these:
    plt.legend()
    plt.show()
 
+Exact FSR from a Squared Matrix Element
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the Altarelli-Parisi approximation is not accurate enough — away from
+the collinear regime, or for masses that are not small compared to the
+center-of-mass energy — :py:meth:`dnde_photon_fsr` computes the photon
+spectrum exactly from the squared matrix elements of the radiative process
+:math:`X \to f_1 \cdots f_n \gamma` and its non-radiative counterpart
+:math:`X \to f_1 \cdots f_n`:
+
+.. math::
+
+   \dv{N}{E_\gamma} = \frac{\dd{\Gamma}(X \to F\gamma)/\dd{E_\gamma}}
+   {\Gamma(X \to F)}
+
+Both squared matrix elements are supplied as callables over the final-state
+four-momenta, and every initial-state factor (couplings, propagators, flux,
+spin averages) cancels in the ratio — only factors unique to the radiative
+process, such as the electric charge, must be kept. For a two-body
+non-radiative final state the spectrum is computed by deterministic
+quadrature; for more final-state particles it is computed by Monte-Carlo
+integration over the reduced phase space (pass ``seed`` for
+reproducibility), and the returned :py:class:`FSRSpectrum` carries the
+one-sigma integration error alongside the spectrum.
+
+Below we compute the exact FSR spectrum for
+:math:`\chi\bar{\chi} \to V^* \to \pi^+\pi^-\gamma` (scalar QED with the
+seagull vertex required by gauge invariance, contracted with the
+beam-averaged dark-matter current) and compare it with the
+Altarelli-Parisi approximation:
+
+.. plot::
+   :include-source: True
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+   from hazma import spectra
+   from hazma.parameters import charged_pion_mass as MPI
+   from hazma.parameters import qe
+   from hazma.utils import ldot, lnorm_sqr
+
+   cme = 1000.0  # MeV
+
+
+   def msqrd_pipi(momenta):
+       """chi chibar -> V* -> pi+ pi-, common couplings dropped."""
+       pp, pm = momenta[:, 0], momenta[:, 1]
+       P = pp + pm
+       s = lnorm_sqr(P)
+       cur = pp - pm
+       # pion current contracted with the transverse projector
+       # P^mu P^nu / s - g^{mu nu} of the beam-averaged DM tensor
+       return ldot(P, cur) ** 2 / s - lnorm_sqr(cur)
+
+
+   def msqrd_pipig(momenta):
+       """chi chibar -> V* -> pi+ pi- gamma in scalar QED."""
+       pp, pm, k = momenta[:, 0], momenta[:, 1], momenta[:, 2]
+       P = pp + pm + k
+       s = lnorm_sqr(P)
+       # emission off pi+ and pi-, plus the gauge-fixing seagull:
+       # M^{mu a} = c1^mu d1^a - c2^mu d2^a - 2 g^{mu a}
+       c1, d1 = pp + k - pm, (2 * pp + k) / (2 * ldot(pp, k))
+       c2, d2 = pp - pm - k, (2 * pm + k) / (2 * ldot(pm, k))
+
+       def proj(a, b):
+           return ldot(P, a) * ldot(P, b) / s - ldot(a, b)
+
+       # -g_{ab} M^{mu a} M^{nu b} contracted with the projector
+       return qe**2 * (
+           -ldot(d1, d1) * proj(c1, c1)
+           + 2 * ldot(d1, d2) * proj(c1, c2)
+           - ldot(d2, d2) * proj(c2, c2)
+           + 4 * proj(c1, d1)
+           - 4 * proj(c2, d2)
+           + 12.0
+       )
+
+
+   es = np.geomspace(1.0, 460.0, 100)
+   dnde, error = spectra.dnde_photon_fsr(
+       es, cme, [MPI, MPI], msqrd_pipig, msqrd_pipi
+   )
+   dnde_ap = 2.0 * spectra.dnde_photon_ap_scalar(es, cme**2, MPI)
+
+   plt.figure(dpi=150)
+   plt.plot(es, dnde, label="exact")
+   plt.plot(es, dnde_ap, ls="--", label="Altarelli-Parisi")
+   plt.yscale("log")
+   plt.xscale("log")
+   plt.ylabel(r"$\dv{N}{E} \ [\mathrm{MeV}^{-1}]$", fontdict=dict(size=16))
+   plt.xlabel(r"$E \ [\mathrm{MeV}]$", fontdict=dict(size=16))
+   plt.legend()
+   plt.show()
+
 API Reference
 -------------
 
@@ -496,6 +592,26 @@ Functions for compute FSR spectra using the Altarelli-Parisi splitting functions
 
 .. autofunction:: dnde_photon_ap_fermion
 .. autofunction:: dnde_photon_ap_scalar
+
+
+Final-state radiation
+~~~~~~~~~~~~~~~~~~~~~
+
+Exact FSR spectra from user-supplied squared matrix elements:
+
+.. list-table ::
+    :header-rows: 1
+
+    * - Function
+      - Description
+
+    * - :meth:`~hazma.spectra.dnde_photon_fsr`
+      - Photon spectrum from a radiative squared matrix element.
+    * - :class:`~hazma.spectra.FSRSpectrum`
+      - Return type of ``dnde_photon_fsr``: ``(dnde, error)``.
+
+.. autofunction:: dnde_photon_fsr
+.. autoclass:: FSRSpectrum
 
 
 Boost

--- a/hazma/spectra/__init__.py
+++ b/hazma/spectra/__init__.py
@@ -21,6 +21,17 @@ Altarelli-parisi
     dnde_photon_ap_scalar  -- Approximate FSR from scalar.
 
 
+Final-state radiation
+---------------------
+
+.. autosummary::
+    :toctree:
+
+    dnde_photon_fsr -- Photon spectrum from a user-supplied radiative
+                       squared matrix element.
+    FSRSpectrum     -- Return type of dnde_photon_fsr: (dnde, error).
+
+
 Boost
 -----
 
@@ -98,18 +109,21 @@ Neutrino
 
 """
 
-from .altarelli_parisi import dnde_photon_ap_fermion, dnde_photon_ap_scalar
-
-from ._nbody import dnde_photon, dnde_positron, dnde_neutrino
-
-from .boost import (
-    boost_delta_function,
-    double_boost_delta_function,
-    dnde_boost_array,
-    make_boost_function,
-    dnde_boost,
+from ._fsr import FSRSpectrum, dnde_photon_fsr
+from ._nbody import dnde_neutrino, dnde_photon, dnde_positron
+from ._neutrino import (
+    dnde_neutrino_charged_kaon,
+    dnde_neutrino_charged_pion,
+    dnde_neutrino_charged_rho,
+    dnde_neutrino_eta,
+    dnde_neutrino_eta_prime,
+    dnde_neutrino_long_kaon,
+    dnde_neutrino_muon,
+    dnde_neutrino_neutral_rho,
+    dnde_neutrino_omega,
+    dnde_neutrino_phi,
+    dnde_neutrino_short_kaon,
 )
-
 from ._photon import (
     dnde_photon_charged_kaon,
     dnde_photon_charged_pion,
@@ -124,33 +138,26 @@ from ._photon import (
     dnde_photon_phi,
     dnde_photon_short_kaon,
 )
-
 from ._positron import (
-    dnde_positron_charged_pion,
-    dnde_positron_muon,
     dnde_positron_charged_kaon,
-    dnde_positron_short_kaon,
-    dnde_positron_long_kaon,
-    dnde_positron_eta,
-    dnde_positron_omega,
-    dnde_positron_neutral_rho,
+    dnde_positron_charged_pion,
     dnde_positron_charged_rho,
+    dnde_positron_eta,
     dnde_positron_eta_prime,
+    dnde_positron_long_kaon,
+    dnde_positron_muon,
+    dnde_positron_neutral_rho,
+    dnde_positron_omega,
     dnde_positron_phi,
+    dnde_positron_short_kaon,
 )
-
-from ._neutrino import (
-    dnde_neutrino_charged_pion,
-    dnde_neutrino_muon,
-    dnde_neutrino_charged_kaon,
-    dnde_neutrino_long_kaon,
-    dnde_neutrino_short_kaon,
-    dnde_neutrino_eta,
-    dnde_neutrino_omega,
-    dnde_neutrino_eta_prime,
-    dnde_neutrino_charged_rho,
-    dnde_neutrino_neutral_rho,
-    dnde_neutrino_phi,
+from .altarelli_parisi import dnde_photon_ap_fermion, dnde_photon_ap_scalar
+from .boost import (
+    boost_delta_function,
+    dnde_boost,
+    dnde_boost_array,
+    double_boost_delta_function,
+    make_boost_function,
 )
 
 __all__ = [
@@ -198,6 +205,9 @@ __all__ = [
     "dnde_photon_ap_fermion",
     "dnde_photon_ap_scalar",
     "altarelli_parisi",
+    # Final-state radiation
+    "dnde_photon_fsr",
+    "FSRSpectrum",
     # Boost
     "boost_delta_function",
     "double_boost_delta_function",

--- a/hazma/spectra/_fsr.py
+++ b/hazma/spectra/_fsr.py
@@ -1,0 +1,450 @@
+r"""Photon spectra from a user-supplied radiative squared matrix element.
+
+This module implements the maintained replacement for the removed
+``hazma.gamma_ray.gamma_ray_fsr`` (see ``docs/adrs/ADR-0001``): a
+generator that turns the exact tree-level squared matrix elements of a
+radiative process ``X -> f1 ... fn + gamma`` and its non-radiative
+counterpart ``X -> f1 ... fn`` into the photon spectrum per
+non-radiative event,
+
+.. math::
+
+    \frac{dN}{dE_\gamma}
+    = \frac{d\Gamma(X \to F\gamma)/dE_\gamma}{\Gamma(X \to F)}
+    = \frac{dI_{\mathrm{rad}}/dE_\gamma}{I_0},
+    \qquad
+    I[|M|^2] = \int |M|^2 \, d\Phi.
+
+Every initial-state factor (flux or :math:`1/2M`, spin averaging,
+couplings, propagators at fixed :math:`s`, and symmetry factors of the
+non-photon final state) appears identically in numerator and
+denominator and cancels in the ratio, so the generator needs only the
+two squared matrix elements and the final-state masses.
+
+At a fixed photon energy :math:`E_\gamma` the radiative phase space
+factorizes into the photon and the non-photon system at reduced
+invariant mass squared :math:`s' = s - 2\sqrt{s}E_\gamma`:
+
+.. math::
+
+    \frac{dI_{\mathrm{rad}}}{dE_\gamma}
+    = \frac{E_\gamma}{4\pi^2}
+      \left\langle \int |M_{\mathrm{rad}}|^2 \,
+      d\Phi_n(s') \right\rangle_{\hat{k}},
+
+which this module evaluates by adaptive quadrature over the single
+remaining angle when ``n == 2`` and by RAMBO Monte-Carlo integration at
+the reduced energy otherwise — the spectrum is computed exactly at the
+requested energies, with no histogram binning.
+"""
+
+from collections.abc import Callable, Sequence
+from typing import NamedTuple
+
+import numpy as np
+from scipy import integrate
+
+from hazma.hazma_errors import RamboCMETooSmall
+from hazma.phase_space import Rambo, ThreeBody
+from hazma.utils import RealArray, RealOrRealArray, kallen_lambda
+
+SquaredMatrixElement = Callable[[RealArray], RealOrRealArray]
+
+# Adaptive-quadrature subdivision limit for the angular integrals. FSR
+# integrands peak sharply where the photon is collinear with a light
+# charged particle (the peak width in cos(theta) is ~ 2 m^2/E^2), so the
+# scipy default of 50 subintervals is too small for large hierarchies.
+_QUAD_LIMIT = 200
+
+# Final-state multiplicities with a dedicated deterministic backend.
+_TWO_BODY = 2
+_THREE_BODY = 3
+
+
+class FSRSpectrum(NamedTuple):
+    r"""Photon spectrum with its integration-error estimate.
+
+    Attributes
+    ----------
+    dnde: float or ndarray
+        Photon spectrum dN/dE in MeV⁻¹, shaped like the input energies.
+    error: float or ndarray
+        One-sigma error estimate on ``dnde`` in MeV⁻¹: statistical for
+        the Monte-Carlo backend, quadrature-error propagation for the
+        deterministic backend.
+    """
+
+    dnde: RealOrRealArray
+    error: RealOrRealArray
+
+
+def _dphi2(s: float, m1: float, m2: float) -> float:
+    r"""Total two-body phase-space volume \int d\Phi_2 = \sqrt{\lambda}/(8\pi s)."""
+    lam = kallen_lambda(s, m1**2, m2**2)
+    if lam <= 0.0:
+        return 0.0
+    return np.sqrt(lam) / (8.0 * np.pi * s)
+
+
+def _split_quad(
+    integrand: Callable[[float], float],
+    epsabs: float | None,
+    epsrel: float | None,
+) -> tuple[float, float]:
+    r"""Integrate over cos(theta) in [-1, 1], split at 0.
+
+    The collinear peaks of FSR integrands sit against the endpoints
+    cos(theta) -> ±1; splitting gives each QAGS call a single difficult
+    endpoint region.
+    """
+    # Matrix-element magnitudes are arbitrary (common constants cancel in
+    # the spectrum ratio), so an absolute tolerance is meaningless: the
+    # scipy default epsabs=1.49e-8 would stop the subdivision early — or
+    # report a uselessly conservative error — whenever the integrand
+    # happens to be numerically small. Default to purely relative
+    # convergence instead.
+    lo, err_lo = integrate.quad(
+        integrand,
+        -1.0,
+        0.0,
+        epsabs=0.0 if epsabs is None else epsabs,
+        epsrel=1.49e-8 if epsrel is None else epsrel,
+        limit=_QUAD_LIMIT,
+    )
+    hi, err_hi = integrate.quad(
+        integrand,
+        0.0,
+        1.0,
+        epsabs=0.0 if epsabs is None else epsabs,
+        epsrel=1.49e-8 if epsrel is None else epsrel,
+        limit=_QUAD_LIMIT,
+    )
+    return lo + hi, err_lo + err_hi
+
+
+def _two_body_momenta(cme: float, m1: float, m2: float, ct: float) -> RealArray:
+    r"""Back-to-back momenta of (m1, m2) at angle theta to the z-axis.
+
+    Constructed in the pair rest frame, with the momentum of particle 1
+    in the x-z plane.
+    """
+    e1 = (cme**2 + m1**2 - m2**2) / (2.0 * cme)
+    p = np.sqrt(max(e1**2 - m1**2, 0.0))
+    st = np.sqrt(max(1.0 - ct**2, 0.0))
+    return np.array(
+        [
+            [e1, cme - e1],
+            [p * st, -p * st],
+            [0.0, 0.0],
+            [p * ct, -p * ct],
+        ]
+    )
+
+
+def _nonrad_integral(  # noqa: PLR0913, PLR0917 — internal, mirrors the public signature
+    cme: float,
+    masses: RealArray,
+    msqrd_nonrad: SquaredMatrixElement,
+    npts: int,
+    seed_seq: np.random.SeedSequence,
+    epsabs: float | None,
+    epsrel: float | None,
+) -> tuple[float, float]:
+    r"""Compute I_0 = \int |M_0|^2 d\Phi_n at the full center-of-mass energy.
+
+    Deterministic for two- and three-body final states (angular
+    quadrature and Dalitz double-quadrature respectively), RAMBO
+    Monte-Carlo above that.
+    """
+    n = len(masses)
+
+    if n == _TWO_BODY:
+        m1, m2 = masses
+
+        def integrand(ct: float) -> float:
+            return float(msqrd_nonrad(_two_body_momenta(cme, m1, m2, ct)))
+
+        # I_0 = dPhi_2 * <|M_0|^2>, with <.> = (1/2) Integral d cos(theta)
+        angular, angular_err = _split_quad(integrand, epsabs, epsrel)
+        pre = 0.5 * _dphi2(cme**2, m1, m2)
+        return pre * angular, pre * angular_err
+
+    if n == _THREE_BODY:
+        three_body = ThreeBody(
+            cme, tuple(masses), msqrd=msqrd_nonrad, msqrd_signature="momenta"
+        )
+        # epsabs=0: purely relative convergence, as in _split_quad.
+        return three_body.integrate(
+            method="quad",
+            epsabs=0.0 if epsabs is None else epsabs,
+            epsrel=1.49e-8 if epsrel is None else epsrel,
+        )
+
+    phase_space = Rambo(cme, masses, msqrd=msqrd_nonrad)
+    return phase_space.integrate(n=npts, seed=seed_seq)  # type: ignore[arg-type]
+
+
+def _dnde_point_quad(  # noqa: PLR0913, PLR0917 — internal, mirrors the public signature
+    photon_energy: float,
+    cme: float,
+    masses: RealArray,
+    msqrd: SquaredMatrixElement,
+    epsabs: float | None,
+    epsrel: float | None,
+) -> tuple[float, float]:
+    r"""dI_rad/dE at one photon energy for a two-body non-photon system.
+
+    At fixed E the remaining integral is one-dimensional: the
+    orientation of the back-to-back pair relative to the photon in the
+    pair rest frame.
+    """
+    m1, m2 = masses
+    sp = cme * (cme - 2.0 * photon_energy)
+
+    if not (photon_energy > 0.0 and sp > (m1 + m2) ** 2):
+        return 0.0, 0.0
+
+    cme_rf = np.sqrt(sp)
+    # Photon energy in the rest frame of the massive pair.
+    eg_rf = photon_energy * cme / cme_rf
+
+    def integrand(ct: float) -> float:
+        pair = _two_body_momenta(cme_rf, m1, m2, ct)
+        photon = np.array([eg_rf, 0.0, 0.0, eg_rf])
+        momenta = np.concatenate((pair, photon[:, None]), axis=1)
+        return float(msqrd(momenta))
+
+    angular, angular_err = _split_quad(integrand, epsabs, epsrel)
+    pre = photon_energy / (4.0 * np.pi**2) * _dphi2(sp, m1, m2) * 0.5
+    return pre * angular, pre * angular_err
+
+
+def _dnde_point_rambo(  # noqa: PLR0913, PLR0917 — internal, mirrors the public signature
+    photon_energy: float,
+    cme: float,
+    masses: RealArray,
+    msqrd: SquaredMatrixElement,
+    npts: int,
+    seed_seq: np.random.SeedSequence,
+) -> tuple[float, float]:
+    r"""dI_rad/dE at one photon energy via RAMBO at the reduced energy.
+
+    The non-photon system is generated in its own rest frame at
+    invariant mass sqrt(s') and the photon appended along the z-axis
+    with the energy it has in that frame; because the RAMBO ensemble is
+    isotropic this samples the exact fixed-E phase-space measure for
+    any Lorentz-invariant integrand.
+    """
+    sp = cme * (cme - 2.0 * photon_energy)
+
+    if not (photon_energy > 0.0 and sp > np.sum(masses) ** 2):
+        return 0.0, 0.0
+
+    cme_rf = np.sqrt(sp)
+    eg_rf = photon_energy * cme / cme_rf
+
+    phase_space = Rambo(cme_rf, masses)
+    momenta, weights = phase_space.generate(npts, seed=seed_seq)  # type: ignore[arg-type]
+
+    photon = np.zeros((4, 1, npts))
+    photon[0] = eg_rf
+    photon[3] = eg_rf
+    momenta = np.concatenate((momenta, photon), axis=1)
+
+    integrands = weights * np.asarray(msqrd(momenta))
+    mean = np.nanmean(integrands)
+    std = np.nanstd(integrands, ddof=1) / np.sqrt(npts)
+
+    pre = photon_energy / (4.0 * np.pi**2)
+    return pre * mean, pre * std
+
+
+def dnde_photon_fsr(  # noqa: PLR0913 — the surface fixed by ADR-0001
+    photon_energies: RealOrRealArray,
+    cme: float,
+    final_state_masses: Sequence[float],
+    msqrd: SquaredMatrixElement,
+    msqrd_nonrad: SquaredMatrixElement,
+    *,
+    method: str = "auto",
+    npts: int = 1 << 14,
+    seed: int | None = None,
+    epsabs: float | None = None,
+    epsrel: float | None = None,
+) -> FSRSpectrum:
+    r"""Photon spectrum of a radiative process from its squared matrix element.
+
+    The spectrum, normalized per non-radiative event, is the ratio of
+    bare phase-space integrals
+
+    .. math::
+
+        \frac{dN}{dE_\gamma} =
+        \frac{d I_{\mathrm{rad}}/dE_\gamma}{I_0},
+        \qquad I[|M|^2] = \int |M|^2 \, d\Phi,
+
+    in which every initial-state prefactor (flux or :math:`1/2M`, spin
+    averaging, couplings and propagators at fixed center-of-mass
+    energy, and symmetry factors of the non-photon final state) cancels
+    between numerator and denominator. Decays and annihilations are
+    therefore the same call: for the decay ``X -> F + gamma`` pass the
+    decaying particle's mass as `cme`, and for the annihilation
+    ``x xbar -> F + gamma`` pass the center-of-mass energy.
+
+    Parameters
+    ----------
+    photon_energies: float or array-like
+        Photon energy (energies) in MeV where the spectrum is computed.
+        Energies outside the open interval ``(0, e_max)`` with
+        ``e_max = (cme**2 - sum(final_state_masses)**2) / (2 * cme)``
+        yield zero.
+    cme: float
+        Center-of-mass energy of the process in MeV (the mass of the
+        decaying particle for a decay). Must exceed the sum of the
+        final-state masses.
+    final_state_masses: sequence of float
+        Masses in MeV of the final-state particles excluding the
+        photon. At least two are required.
+    msqrd: callable
+        Spin-summed (and, for an annihilation, initial-spin-averaged
+        and beam-direction-averaged) squared matrix element of the
+        radiative process. Called as ``msqrd(momenta)`` with `momenta`
+        of shape ``(4, len(final_state_masses) + 1[, batch])``: rows
+        are ``(E, px, py, pz)`` in MeV, one column per particle in the
+        order of `final_state_masses` with the photon last. It must be
+        a Lorentz-invariant function of the final-state momenta only
+        (implementations built from ``hazma.utils.ldot`` /
+        ``lnorm_sqr`` handle the batched and unbatched forms for free);
+        the momenta are supplied in the rest frame of the non-photon
+        system, and no initial-state momenta are provided.
+    msqrd_nonrad: callable
+        Squared matrix element of the non-radiative process, in the
+        same conventions as `msqrd`. Called with `momenta` of shape
+        ``(4, len(final_state_masses)[, batch])``. Any multiplicative
+        constant common to `msqrd` and `msqrd_nonrad` cancels.
+    method: str, optional
+        Integration backend: ``"quad"`` (deterministic; only available
+        for a two-body non-photon final state, where the fixed-energy
+        integral is one-dimensional), ``"rambo"`` (Monte-Carlo at the
+        reduced invariant mass, any multiplicity), or ``"auto"`` (the
+        default: ``"quad"`` when possible, else ``"rambo"``).
+    npts: int, optional
+        Monte-Carlo phase-space points per photon energy (and for the
+        non-radiative integral when four or more final-state particles
+        make it Monte-Carlo too). Ignored by the quadrature backend.
+        Default is ``2**14``.
+    seed: int, optional
+        Seed for the Monte-Carlo backend. Each photon energy draws an
+        independent substream, so results are deterministic for a fixed
+        seed and grid. Ignored by the quadrature backend.
+    epsabs, epsrel: float, optional
+        Absolute and relative tolerances of the quadrature backend (and
+        of the deterministic non-radiative integral). Defaults are
+        ``epsabs=0`` — purely relative convergence, since the magnitude
+        of a squared matrix element is convention-dependent — and the
+        scipy default ``epsrel=1.49e-8``.
+
+    Returns
+    -------
+    spectrum: FSRSpectrum
+        NamedTuple ``(dnde, error)``, each a float for scalar input or
+        an ndarray shaped like `photon_energies`. ``dnde`` is the
+        photon spectrum dN/dE in MeV⁻¹ per non-radiative event;
+        ``error`` is its one-sigma integration-error estimate. The
+        Monte-Carlo error estimate assumes a finite-variance integrand;
+        it degrades for strongly collinear-peaked matrix elements
+        (light charged particles at large ``cme``), for which the
+        quadrature backend is preferred.
+
+    Raises
+    ------
+    RamboCMETooSmall
+        If `cme` is below the sum of `final_state_masses`.
+    ValueError
+        If fewer than two final-state masses are given, if `method` is
+        unknown or inapplicable, or if the non-radiative integral is
+        not positive.
+
+    Notes
+    -----
+    The photon spectrum diverges as :math:`1/E_\gamma` for
+    :math:`E_\gamma \to 0` (soft divergence); the returned values are
+    finite at every requested energy, but the total photon number is
+    not.
+
+    For internal consistency the non-radiative integral :math:`I_0` is
+    computed with the same machinery: deterministic quadrature for two-
+    and three-body final states, RAMBO above that (with its statistical
+    error propagated into `error`).
+
+    Examples
+    --------
+    Photon spectrum for a 3-body process with a constant radiative and
+    non-radiative matrix element (pure phase space):
+
+    >>> import numpy as np
+    >>> from hazma.spectra import dnde_photon_fsr
+    >>> def msqrd(momenta):
+    ...     return np.ones(momenta.shape[-1]) if momenta.ndim == 3 else 1.0
+    >>> es = np.array([10.0, 50.0, 100.0])
+    >>> dnde, error = dnde_photon_fsr(
+    ...     es, 300.0, [105.658, 105.658], msqrd, msqrd
+    ... )
+    """
+    masses = np.atleast_1d(np.asarray(final_state_masses, dtype=np.float64))
+
+    if len(masses) < _TWO_BODY:
+        raise ValueError(
+            "'final_state_masses' must contain at least two masses (the"
+            " non-radiative process needs a two-or-more-body final state);"
+            f" got {len(masses)}."
+        )
+    if cme <= np.sum(masses):
+        raise RamboCMETooSmall(
+            f"Center-of-mass energy {cme} is below the sum of the"
+            f" final-state masses {np.sum(masses)}."
+        )
+
+    if method == "auto":
+        method = "quad" if len(masses) == _TWO_BODY else "rambo"
+    if method == "quad" and len(masses) != _TWO_BODY:
+        raise ValueError(
+            "method='quad' requires exactly two final-state masses; use"
+            " method='rambo' (or 'auto') for higher multiplicities."
+        )
+    if method not in ("quad", "rambo"):
+        raise ValueError(f"Invalid method: {method}. Use 'auto', 'quad' or 'rambo'.")
+
+    single = np.isscalar(photon_energies)
+    energies = np.atleast_1d(np.asarray(photon_energies, dtype=np.float64))
+
+    # Independent, reproducible substreams: one per photon energy plus
+    # one for a Monte-Carlo non-radiative integral.
+    seed_seqs = np.random.SeedSequence(seed).spawn(len(energies) + 1)
+
+    nonrad, nonrad_err = _nonrad_integral(
+        cme, masses, msqrd_nonrad, npts, seed_seqs[-1], epsabs, epsrel
+    )
+    if not nonrad > 0.0:
+        raise ValueError(
+            "The non-radiative phase-space integral is not positive"
+            f" (got {nonrad}); check 'msqrd_nonrad'."
+        )
+
+    dnde = np.zeros_like(energies)
+    error = np.zeros_like(energies)
+
+    for i, energy in enumerate(energies):
+        if method == "quad":
+            num, num_err = _dnde_point_quad(energy, cme, masses, msqrd, epsabs, epsrel)
+        else:
+            num, num_err = _dnde_point_rambo(
+                energy, cme, masses, msqrd, npts, seed_seqs[i]
+            )
+        dnde[i] = num / nonrad
+        # Uncorrelated ratio propagation: sigma^2 = (dN/D)^2 + (N dD/D^2)^2.
+        error[i] = np.hypot(num_err / nonrad, num * nonrad_err / nonrad**2)
+
+    if single:
+        return FSRSpectrum(float(dnde[0]), float(error[0]))
+    return FSRSpectrum(dnde, error)

--- a/hazma/spectra/_fsr.py
+++ b/hazma/spectra/_fsr.py
@@ -60,6 +60,10 @@ _QUAD_LIMIT = 200
 _TWO_BODY = 2
 _THREE_BODY = 3
 
+# The one-sigma Monte-Carlo error is a ddof=1 sample estimate — undefined
+# for a single sample — so the rambo backend needs at least two points.
+_MIN_MC_NPTS = 2
+
 
 class FSRSpectrum(NamedTuple):
     r"""Photon spectrum with its integration-error estimate.
@@ -331,8 +335,10 @@ def dnde_photon_fsr(  # noqa: PLR0913 — the surface fixed by ADR-0001
     npts: int, optional
         Monte-Carlo phase-space points per photon energy (and for the
         non-radiative integral when four or more final-state particles
-        make it Monte-Carlo too). Ignored by the quadrature backend.
-        Default is ``2**14``.
+        make it Monte-Carlo too). Must be an integer of at least 2 —
+        the returned one-sigma error is a ``ddof=1`` sample estimate,
+        undefined for a single sample. Ignored by the quadrature
+        backend. Default is ``2**14``.
     seed: int, optional
         Seed for the Monte-Carlo backend. Each photon energy draws an
         independent substream, so results are deterministic for a fixed
@@ -362,8 +368,9 @@ def dnde_photon_fsr(  # noqa: PLR0913 — the surface fixed by ADR-0001
         If `cme` is below the sum of `final_state_masses`.
     ValueError
         If fewer than two final-state masses are given, if `method` is
-        unknown or inapplicable, or if the non-radiative integral is
-        not positive.
+        unknown or inapplicable, if the Monte-Carlo backend is selected
+        with a non-integral `npts` or ``npts < 2``, or if the
+        non-radiative integral is not positive.
 
     Notes
     -----
@@ -414,6 +421,16 @@ def dnde_photon_fsr(  # noqa: PLR0913 — the surface fixed by ADR-0001
         )
     if method not in ("quad", "rambo"):
         raise ValueError(f"Invalid method: {method}. Use 'auto', 'quad' or 'rambo'.")
+    if method == "rambo" and not (
+        isinstance(npts, (int, np.integer)) and npts >= _MIN_MC_NPTS
+    ):
+        # A single sample would yield a finite spectrum with error=nan,
+        # silently voiding the one-sigma contract of FSRSpectrum.error.
+        raise ValueError(
+            "The Monte-Carlo backend requires an integer 'npts' of at"
+            f" least {_MIN_MC_NPTS} (the one-sigma error is a ddof=1"
+            f" sample estimate); got npts={npts!r}."
+        )
 
     single = np.isscalar(photon_energies)
     energies = np.atleast_1d(np.asarray(photon_energies, dtype=np.float64))

--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -154,7 +154,7 @@ against the post-cutover plumbing). See
   `hazma.gamma_ray` module — Task 0.5 executes the remaining steps
   (replacement status recorded, docs repointed); the replacement-free
   `gamma_ray_fsr` case is tracked at
-  [`../../docs/followups/todo/msqrd-driven-fsr-generator.md`](../../docs/followups/todo/msqrd-driven-fsr-generator.md).
+  [`../../docs/followups/done/msqrd-driven-fsr-generator.md`](../../docs/followups/done/msqrd-driven-fsr-generator.md).
 - Possible: QUADPACK-port deviation record, if faithful translation
   proves impractical for `qelg` and a documented algorithmic
   substitution is made instead (would revise corpus budgets).

--- a/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
+++ b/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
@@ -40,7 +40,7 @@ a shim. The module's public API and its replacement status:
   nearest live equivalents are the Altarelli–Parisi approximations
   (`hazma.spectra.dnde_photon_ap_fermion` / `_ap_scalar`); a general
   `msqrd`-driven FSR generator would be a new feature, tracked at
-  [`docs/followups/todo/msqrd-driven-fsr-generator.md`](../../../docs/followups/todo/msqrd-driven-fsr-generator.md).
+  [`docs/followups/done/msqrd-driven-fsr-generator.md`](../../../docs/followups/done/msqrd-driven-fsr-generator.md).
 
 (`gamma`/`gamma_point` are the compiled `_gamma_ray` names the module
 wraps, not its public surface.) Docs that reference `hazma.gamma_ray`
@@ -62,5 +62,14 @@ are updated to point at `hazma.spectra`.
   `gamma_ray_fsr` → none; nearest: the Altarelli–Parisi
   approximations). If a maintained equivalent is ever wanted, it
   enters as a designed feature with its own validation plan —
-  [`docs/followups/todo/msqrd-driven-fsr-generator.md`](../../../docs/followups/todo/msqrd-driven-fsr-generator.md)
+  [`docs/followups/done/msqrd-driven-fsr-generator.md`](../../../docs/followups/done/msqrd-driven-fsr-generator.md)
   — not as part of this migration.
+
+## Addendum (2026-08-04)
+
+The follow-up above has since been implemented, ad-hoc and outside this
+migration exactly as prescribed: `hazma.spectra.dnde_photon_fsr`
+(repo-wide ADR-0001, with its own validation corpus). The Phase 00
+CHANGELOG entry for this removal should therefore name
+`hazma.spectra.dnde_photon_fsr` as `gamma_ray_fsr`'s replacement
+instead of "none". The decision recorded here is unchanged.

--- a/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
@@ -138,7 +138,7 @@ Everything else is behavior-invisible.
   2026-08-04.** A rebuild stays out of scope (a *new feature* with no
   numerical oracle, since the module cannot run to produce a baseline);
   it re-enters with its own validation plan via
-  [`../../../docs/followups/todo/msqrd-driven-fsr-generator.md`](../../../docs/followups/todo/msqrd-driven-fsr-generator.md),
+  [`../../../docs/followups/done/msqrd-driven-fsr-generator.md`](../../../docs/followups/done/msqrd-driven-fsr-generator.md),
   filed 2026-08-04.
 - Replacement status of the module's actual public API confirmed and
   recorded in the task note: `gamma_ray_decay` is superseded by

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -229,7 +229,7 @@ it from memory.)
   It was the last thing standing between Phase 00 and Phase 01; with
   Tasks 0.1 and 0.3 already done, **Tasks 0.2, 0.4, and 0.5 are all
   unblocked.** The replacement-free `gamma_ray_fsr` case is tracked at
-  [`../../../docs/followups/todo/msqrd-driven-fsr-generator.md`](../../../docs/followups/todo/msqrd-driven-fsr-generator.md).
+  [`../../../docs/followups/done/msqrd-driven-fsr-generator.md`](../../../docs/followups/done/msqrd-driven-fsr-generator.md).
 - `cross_section_prefactor`'s threshold cancellation (found in Task
   0.3, filed as a follow-up): fix it **after** the port rather than
   before, or Phase 01's corpus pins the cancelling values and the Rust

--- a/projects/cython-to-rust/task-notes/phase-00/README.md
+++ b/projects/cython-to-rust/task-notes/phase-00/README.md
@@ -166,7 +166,7 @@ purge.
   replacement status in the task note, repoint docs off
   `hazma.gamma_ray`). The replacement-free `gamma_ray_fsr` case now
   lives at
-  [`docs/followups/todo/msqrd-driven-fsr-generator.md`](../../../../docs/followups/todo/msqrd-driven-fsr-generator.md).
+  [`docs/followups/done/msqrd-driven-fsr-generator.md`](../../../../docs/followups/done/msqrd-driven-fsr-generator.md).
 - `WIDTH_K` / `WIDTH_PI` in the legacy tables are written with `**`
   where a decimal exponent was meant (no consumer today) — deferred to
   [`docs/followups/todo/legacy-parameters-width-exponent-bug.md`](../../../../docs/followups/todo/legacy-parameters-width-exponent-bug.md).

--- a/test/spectra/msqrd_corpus.py
+++ b/test/spectra/msqrd_corpus.py
@@ -1,0 +1,533 @@
+r"""Exact tree-level squared matrix elements for validating `dnde_photon_fsr`.
+
+This module is the *theoretical corpus* backing
+``test/spectra/test_dnde_photon_fsr.py``: real matrix elements, computed
+from the Feynman rules of the hazma mediator models, for the radiative
+annihilations
+
+* ``x xbar -> V* -> l+ l- (gamma)``  — Dirac dark matter, vector mediator
+  with vector couplings ``gvxx`` (DM) and ``gvll`` (leptons);
+* ``x xbar -> S* -> l+ l- (gamma)``  — Dirac dark matter, scalar mediator
+  with Yukawa couplings ``gsxx`` and ``gsll``;
+* ``x xbar -> V* -> pi+ pi- (gamma)`` — vector mediator coupled to the
+  charged-pion current (point-like scalar QED; a hadronic form factor is
+  a constant at fixed s and cancels in the FSR ratio).
+
+Rather than transcribing hand-simplified trace formulas (easy to typo,
+hard to review), the fermionic squared matrix elements are evaluated
+*numerically* from explicit Dirac matrices: the amplitude of each
+diagram is assembled from its propagators and vertices, spin sums become
+matrix traces, and the photon polarization sum uses
+:math:`\sum_\lambda \epsilon_\alpha \epsilon^*_\beta \to -g_{\alpha\beta}`
+(valid because the summed amplitude obeys the Ward identity — asserted
+numerically in the test suite, together with conservation of the
+mediator current and soft-photon factorization).
+
+Conventions
+-----------
+* Momenta arrays follow the ``dnde_photon_fsr`` contract: shape
+  ``(4, n_fsp[, batch])``, rows ``(E, px, py, pz)`` in MeV, metric
+  ``(+,-,-,-)``. Column order is ``(l-, l+, gamma)`` /
+  ``(pi+, pi-, gamma)`` with the photon last; the non-radiative
+  functions take the same layout without the photon column.
+* All returned values are spin-summed over final states, averaged over
+  the initial DM spins, and averaged over the beam direction. For the
+  s-channel processes here the beam average is exact: the DM tensor of
+  the vector current, averaged over beam directions at fixed total
+  momentum :math:`P`, is
+
+  .. math::
+
+      \langle L^{\mu\nu} \rangle = g_{V\chi}^2\,\frac{s + 2 m_\chi^2}{3}
+      \left( \frac{P^\mu P^\nu}{s} - g^{\mu\nu} \right),
+
+  (derived by averaging :math:`p_{1,2} = P/2 \pm q` over the directions
+  of the relative momentum :math:`q`), and the scalar-current DM factor
+  :math:`g_{S\chi}^2 (s/2 - 2 m_\chi^2)` carries no direction at all.
+* Couplings and propagators are kept explicitly — including the
+  :math:`1/[(s - m_{V,S}^2)^2 + (m\,\Gamma)^2]` of the off-shell
+  mediator — so the corpus doubles as a check that common factors
+  cancel in the ``dnde_photon_fsr`` ratio. The electric charge is
+  ``hazma.parameters.qe`` (:math:`e^2 = 4\pi\alpha`).
+"""
+
+import numpy as np
+
+from hazma.parameters import qe
+from hazma.utils import ComplexArray, RealArray, RealOrRealArray, ldot, lnorm_sqr
+
+# ===================================================================
+# ---- Numerical Dirac algebra --------------------------------------
+# ===================================================================
+
+_METRIC = np.array([1.0, -1.0, -1.0, -1.0])
+
+_SIGMA = [
+    np.array([[0, 1], [1, 0]], dtype=np.complex128),
+    np.array([[0, -1j], [1j, 0]], dtype=np.complex128),
+    np.array([[1, 0], [0, -1]], dtype=np.complex128),
+]
+
+_ZERO2 = np.zeros((2, 2), dtype=np.complex128)
+_ID2 = np.eye(2, dtype=np.complex128)
+
+# Dirac representation: g^0 = diag(1,1,-1,-1), g^i off-diagonal Pauli.
+_GAMMA = np.stack(
+    [np.block([[_ID2, _ZERO2], [_ZERO2, -_ID2]])]
+    + [np.block([[_ZERO2, s], [-s, _ZERO2]]) for s in _SIGMA]
+)
+_G0 = _GAMMA[0]
+_ID4 = np.eye(4, dtype=np.complex128)
+
+
+def _ensure_batched(momenta: RealArray) -> tuple[RealArray, bool]:
+    """Return (momenta with a batch axis, had_no_batch_axis)."""
+    momenta = np.asarray(momenta, dtype=np.float64)
+    if momenta.ndim == 2:  # noqa: PLR2004 — (4, n) without a batch axis
+        return momenta[:, :, None], True
+    return momenta, False
+
+
+def _slash(p: RealArray) -> ComplexArray:
+    r"""p-slash = p_mu gamma^mu for p of shape (4, batch) -> (4, 4, batch)."""
+    return np.einsum("m,mij,m...->ij...", _METRIC, _GAMMA, p, optimize=True)
+
+
+def _fermionic_emission_parts(
+    p: RealArray, pbar: RealArray, k: RealArray, mass: float
+) -> tuple[ComplexArray, ComplexArray]:
+    r"""Propagator-dressed pieces of photon emission off a fermion pair.
+
+    For ``current -> f(p) fbar(pbar) gamma(k)`` the two diagrams carry
+
+    .. math::
+
+        S_1 = \frac{\slashed{p} + \slashed{k} + m}{2 p \cdot k},
+        \qquad
+        S_2 = \frac{-\slashed{p}' - \slashed{k} + m}{2 p' \cdot k},
+
+    such that the amplitude is
+    ``ubar(p) [g^a S_1 V + V S_2 g^a] v(pbar)`` for a current vertex
+    matrix ``V`` (photon index ``a``).
+    """
+    s1 = (_slash(p + k) + mass * _ID4[:, :, None]) / (2.0 * ldot(p, k))
+    s2 = (-_slash(pbar + k) + mass * _ID4[:, :, None]) / (2.0 * ldot(pbar, k))
+    return s1, s2
+
+
+# ===================================================================
+# ---- Beam-averaged dark-matter factors ----------------------------
+# ===================================================================
+
+
+def _dm_vector_contract(
+    tensor: RealArray, total_p: RealArray, mx: float
+) -> RealOrRealArray:
+    r"""Contract a current tensor with the beam-averaged DM vector tensor.
+
+    The DM tensor, couplings excluded, is
+    <L>_{mu nu} / g^2 = (s + 2 mx^2)/3 * (P_mu P_nu / s - g_{mu nu}).
+    """
+    s = lnorm_sqr(total_p)
+    p_lower = _METRIC[:, None] * total_p
+    php = np.einsum("m...,mn...,n...->...", p_lower, tensor, p_lower, optimize=True)
+    gt = np.einsum("m,mm...->...", _METRIC, tensor, optimize=True)
+    return (s + 2.0 * mx**2) / 3.0 * (php / s - gt)
+
+
+def _propagator_den(s: RealOrRealArray, mmed: float, width: float) -> RealOrRealArray:
+    return (s - mmed**2) ** 2 + (mmed * width) ** 2
+
+
+# ===================================================================
+# ---- x xbar -> V* -> l+ l- (gamma) --------------------------------
+# ===================================================================
+
+
+def msqrd_xx_to_v_to_ff(  # noqa: PLR0913 — the physics parameters of the process
+    momenta: RealArray,
+    *,
+    mf: float,
+    mx: float,
+    mv: float,
+    gvxx: float,
+    gvff: float,
+    widthv: float = 0.0,
+) -> RealOrRealArray:
+    r"""|M|^2 for x xbar -> V* -> f fbar, spin- and beam-averaged.
+
+    Momenta columns: (f, fbar). Equals
+    ``gvxx^2 gvff^2 / D_V * (s + 2 mx^2)/3 * 4 s (1 + 2 mf^2/s)``;
+    evaluated here with the numerical trace machinery so radiative and
+    non-radiative corpus entries share one implementation.
+    """
+    momenta, single = _ensure_batched(momenta)
+    p, pbar = momenta[:, 0], momenta[:, 1]
+    total_p = p + pbar
+    s = lnorm_sqr(total_p)
+
+    m1 = _slash(p) + mf * _ID4[:, :, None]
+    m2 = _slash(pbar) - mf * _ID4[:, :, None]
+
+    # H0^{mu nu} = Tr[(pslash + m) g^mu (pbarslash - m) g^nu]
+    tensor = np.einsum(
+        "ij...,mjk...,kl...,nli...->mn...",
+        m1,
+        _GAMMA[:, :, :, None],
+        m2,
+        _GAMMA[:, :, :, None],
+        optimize=True,
+    ).real
+
+    result = (
+        gvxx**2
+        * gvff**2
+        / _propagator_den(s, mv, widthv)
+        * _dm_vector_contract(tensor, total_p, mx)
+    )
+    return result[0] if single else result
+
+
+def msqrd_xx_to_v_to_ffg(  # noqa: PLR0913 — the physics parameters of the process
+    momenta: RealArray,
+    *,
+    mf: float,
+    mx: float,
+    mv: float,
+    gvxx: float,
+    gvff: float,
+    widthv: float = 0.0,
+) -> RealOrRealArray:
+    r"""|M|^2 for x xbar -> V* -> f fbar gamma, spin- and beam-averaged.
+
+    Momenta columns: (f, fbar, gamma). Photon emission off both fermion
+    legs; polarization sum via -g_{alpha beta}.
+    """
+    momenta, single = _ensure_batched(momenta)
+    p, pbar, k = momenta[:, 0], momenta[:, 1], momenta[:, 2]
+    total_p = p + pbar + k
+    s = lnorm_sqr(total_p)
+
+    s1, s2 = _fermionic_emission_parts(p, pbar, k, mf)
+    m1 = _slash(p) + mf * _ID4[:, :, None]
+    m2 = _slash(pbar) - mf * _ID4[:, :, None]
+
+    gam = _GAMMA[:, :, :, None]
+    # A[a, mu] = g^a S1 g^mu + g^mu S2 g^a  (photon index a, V index mu)
+    amp = np.einsum(
+        "aij...,jk...,mkl...->amil...", gam, s1, gam, optimize=True
+    ) + np.einsum("mij...,jk...,akl...->amil...", gam, s2, gam, optimize=True)
+    amp_bar = np.einsum("ik,amlk...,lj->amij...", _G0, np.conj(amp), _G0, optimize=True)
+
+    # H^{mu nu} = -g_ab Tr[(pslash+m) A^{a mu} (pbarslash-m) Abar^{b nu}]
+    tensor = -np.einsum(
+        "a,ij...,amjk...,kl...,anli...->mn...",
+        _METRIC,
+        m1,
+        amp,
+        m2,
+        amp_bar,
+        optimize=True,
+    ).real
+
+    result = (
+        qe**2
+        * gvxx**2
+        * gvff**2
+        / _propagator_den(s, mv, widthv)
+        * _dm_vector_contract(tensor, total_p, mx)
+    )
+    return result[0] if single else result
+
+
+def photon_ward_violation_v(momenta: RealArray, *, mf: float) -> RealOrRealArray:
+    r"""Relative photon Ward-identity violation of the vector amplitude.
+
+    The polarization sum replaced by k_alpha k_beta must annihilate the
+    current tensor.
+    """
+    momenta, _ = _ensure_batched(momenta)
+    p, pbar, k = momenta[:, 0], momenta[:, 1], momenta[:, 2]
+
+    s1, s2 = _fermionic_emission_parts(p, pbar, k, mf)
+    m1 = _slash(p) + mf * _ID4[:, :, None]
+    m2 = _slash(pbar) - mf * _ID4[:, :, None]
+
+    gam = _GAMMA[:, :, :, None]
+    kslash = _slash(k)
+    # k_alpha A^{alpha mu} = kslash S1 g^mu + g^mu S2 kslash
+    amp_k = np.einsum(
+        "ij...,jk...,mkl...->mil...", kslash, s1, gam, optimize=True
+    ) + np.einsum("mij...,jk...,kl...->mil...", gam, s2, kslash, optimize=True)
+    amp_k_bar = np.einsum(
+        "ik,mlk...,lj->mij...", _G0, np.conj(amp_k), _G0, optimize=True
+    )
+
+    violation = np.einsum(
+        "m,ij...,mjk...,kl...,mli...->...",
+        _METRIC,
+        m1,
+        amp_k,
+        m2,
+        amp_k_bar,
+        optimize=True,
+    ).real
+
+    # Scale: the same contraction with the physical -g_ab polarization sum.
+    amp = np.einsum(
+        "aij...,jk...,mkl...->amil...", gam, s1, gam, optimize=True
+    ) + np.einsum("mij...,jk...,akl...->amil...", gam, s2, gam, optimize=True)
+    amp_bar = np.einsum("ik,amlk...,lj->amij...", _G0, np.conj(amp), _G0, optimize=True)
+    scale = -np.einsum(
+        "a,m,ij...,amjk...,kl...,amli...->...",
+        _METRIC,
+        _METRIC,
+        m1,
+        amp,
+        m2,
+        amp_bar,
+        optimize=True,
+    ).real
+
+    return np.abs(violation) / np.abs(scale)
+
+
+# ===================================================================
+# ---- x xbar -> S* -> l+ l- (gamma) --------------------------------
+# ===================================================================
+
+
+def _dm_scalar_factor(s: RealOrRealArray, mx: float) -> RealOrRealArray:
+    r"""Spin-averaged DM factor of the scalar current, couplings excluded.
+
+    (1/4) Tr[(p2slash - mx)(p1slash + mx)] = s/2 - 2 mx^2.
+    """
+    return 0.5 * s - 2.0 * mx**2
+
+
+def msqrd_xx_to_s_to_ff(  # noqa: PLR0913 — the physics parameters of the process
+    momenta: RealArray,
+    *,
+    mf: float,
+    mx: float,
+    ms: float,
+    gsxx: float,
+    gsff: float,
+    widths: float = 0.0,
+) -> RealOrRealArray:
+    r"""|M|^2 for x xbar -> S* -> f fbar, spin-averaged.
+
+    Momenta columns: (f, fbar). Fermionic factor
+    Tr[(pslash+m)(pbarslash-m)] = 4 (p.pbar - m^2) = 2 s (1 - 4 mf^2/s).
+    """
+    momenta, single = _ensure_batched(momenta)
+    p, pbar = momenta[:, 0], momenta[:, 1]
+    s = lnorm_sqr(p + pbar)
+
+    fermionic = 4.0 * (ldot(p, pbar) - mf**2)
+    result = (
+        gsxx**2
+        * gsff**2
+        / _propagator_den(s, ms, widths)
+        * _dm_scalar_factor(s, mx)
+        * fermionic
+    )
+    return result[0] if single else result
+
+
+def msqrd_xx_to_s_to_ffg(  # noqa: PLR0913 — the physics parameters of the process
+    momenta: RealArray,
+    *,
+    mf: float,
+    mx: float,
+    ms: float,
+    gsxx: float,
+    gsff: float,
+    widths: float = 0.0,
+) -> RealOrRealArray:
+    r"""|M|^2 for x xbar -> S* -> f fbar gamma, spin-averaged.
+
+    Momenta columns: (f, fbar, gamma). The scalar vertex matrix is the
+    identity; photon emission off both fermion legs.
+    """
+    momenta, single = _ensure_batched(momenta)
+    p, pbar, k = momenta[:, 0], momenta[:, 1], momenta[:, 2]
+    s = lnorm_sqr(p + pbar + k)
+
+    s1, s2 = _fermionic_emission_parts(p, pbar, k, mf)
+    m1 = _slash(p) + mf * _ID4[:, :, None]
+    m2 = _slash(pbar) - mf * _ID4[:, :, None]
+
+    gam = _GAMMA[:, :, :, None]
+    # A^a = g^a S1 + S2 g^a
+    amp = np.einsum("aij...,jk...->aik...", gam, s1, optimize=True) + np.einsum(
+        "ij...,ajk...->aik...", s2, gam, optimize=True
+    )
+    amp_bar = np.einsum("ik,alk...,lj->aij...", _G0, np.conj(amp), _G0, optimize=True)
+
+    fermionic = -np.einsum(
+        "a,ij...,ajk...,kl...,ali...->...", _METRIC, m1, amp, m2, amp_bar, optimize=True
+    ).real
+
+    result = (
+        qe**2
+        * gsxx**2
+        * gsff**2
+        / _propagator_den(s, ms, widths)
+        * _dm_scalar_factor(s, mx)
+        * fermionic
+    )
+    return result[0] if single else result
+
+
+# ===================================================================
+# ---- x xbar -> V* -> pi+ pi- (gamma), scalar QED ------------------
+# ===================================================================
+
+
+def msqrd_xx_to_v_to_pipi(  # noqa: PLR0913 — the physics parameters of the process
+    momenta: RealArray,
+    *,
+    mx: float,
+    mv: float,
+    gvxx: float,
+    gvpipi: float,
+    widthv: float = 0.0,
+) -> RealOrRealArray:
+    r"""|M|^2 for x xbar -> V* -> pi+ pi-, spin- and beam-averaged.
+
+    Momenta columns: (pi+, pi-). The pion current is
+    ``M0^mu = (p+ - p-)^mu``.
+    """
+    momenta, single = _ensure_batched(momenta)
+    pp, pm = momenta[:, 0], momenta[:, 1]
+    total_p = pp + pm
+    s = lnorm_sqr(total_p)
+
+    current = pp - pm
+    tensor = np.einsum("m...,n...->mn...", current, current, optimize=True)
+
+    result = (
+        gvxx**2
+        * gvpipi**2
+        / _propagator_den(s, mv, widthv)
+        * _dm_vector_contract(tensor, total_p, mx)
+    )
+    return result[0] if single else result
+
+
+def _pion_rad_amplitude(pp: RealArray, pm: RealArray, k: RealArray) -> RealArray:
+    r"""Scalar-QED radiative amplitude tensor M^{mu alpha}.
+
+    V index mu, photon index alpha, couplings excluded, for
+    V* -> pi+(pp) pi-(pm) gamma(k):
+
+    .. math::
+
+        M^{\mu\alpha}
+        = \frac{(2 p_+ + k)^\alpha (p_+ + k - p_-)^\mu}{2 p_+ \cdot k}
+        - \frac{(2 p_- + k)^\alpha (p_+ - p_- - k)^\mu}{2 p_- \cdot k}
+        - 2 g^{\mu\alpha}.
+
+    The seagull coefficient is fixed by the Ward identities
+    ``k_alpha M^{mu alpha} = 0`` and ``P_mu M^{mu alpha} = 0`` (both
+    hold exactly; asserted in the test suite).
+    """
+    batch_shape = pp.shape[1:]
+    metric_upper = np.broadcast_to(
+        np.diag(_METRIC)[(...,) + (None,) * len(batch_shape)],
+        (4, 4) + batch_shape,
+    )
+    return (
+        np.einsum("m...,a...->ma...", pp + k - pm, (2.0 * pp + k) / (2.0 * ldot(pp, k)))
+        - np.einsum(
+            "m...,a...->ma...", pp - pm - k, (2.0 * pm + k) / (2.0 * ldot(pm, k))
+        )
+        - 2.0 * metric_upper
+    )
+
+
+def msqrd_xx_to_v_to_pipig(  # noqa: PLR0913 — the physics parameters of the process
+    momenta: RealArray,
+    *,
+    mx: float,
+    mv: float,
+    gvxx: float,
+    gvpipi: float,
+    widthv: float = 0.0,
+) -> RealOrRealArray:
+    r"""|M|^2 for x xbar -> V* -> pi+ pi- gamma, spin- and beam-averaged.
+
+    Momenta columns: (pi+, pi-, gamma). Point-pion scalar QED with the
+    seagull required by gauge invariance.
+    """
+    momenta, single = _ensure_batched(momenta)
+    pp, pm, k = momenta[:, 0], momenta[:, 1], momenta[:, 2]
+    total_p = pp + pm + k
+    s = lnorm_sqr(total_p)
+
+    amp = _pion_rad_amplitude(pp, pm, k)
+    # H^{mu nu} = -g_ab M^{mu a} M^{nu b}
+    tensor = -np.einsum("a,ma...,na...->mn...", _METRIC, amp, amp, optimize=True)
+
+    result = (
+        qe**2
+        * gvxx**2
+        * gvpipi**2
+        / _propagator_den(s, mv, widthv)
+        * _dm_vector_contract(tensor, total_p, mx)
+    )
+    return result[0] if single else result
+
+
+def pion_ward_violations(
+    momenta: RealArray,
+) -> tuple[RealOrRealArray, RealOrRealArray]:
+    r"""Ward violations of the scalar-QED radiative amplitude.
+
+    Returns the relative photon-current and mediator-current violations;
+    both should vanish identically.
+    """
+    momenta, _ = _ensure_batched(momenta)
+    pp, pm, k = momenta[:, 0], momenta[:, 1], momenta[:, 2]
+    total_p = pp + pm + k
+
+    amp = _pion_rad_amplitude(pp, pm, k)
+    scale = np.sqrt(np.einsum("ma...,ma...->...", amp, amp, optimize=True))
+
+    photon = np.einsum("a,a...,ma...->m...", _METRIC, k, amp, optimize=True)
+    mediator = np.einsum("m,m...,ma...->a...", _METRIC, total_p, amp, optimize=True)
+
+    photon_violation = (
+        np.sqrt(np.einsum("m...,m...->...", photon, photon, optimize=True)) / scale
+    )
+    mediator_violation = (
+        np.sqrt(np.einsum("a...,a...->...", mediator, mediator, optimize=True)) / scale
+    )
+    return photon_violation, mediator_violation
+
+
+# ===================================================================
+# ---- Soft-photon (eikonal) factor ---------------------------------
+# ===================================================================
+
+
+def eikonal_factor(p: RealArray, pbar: RealArray, k: RealArray) -> RealOrRealArray:
+    r"""Leading soft-photon factor for emission off a charge +1/-1 pair.
+
+    Defined as
+
+    .. math::
+
+        e^2 \left[ \frac{2 p \cdot \bar{p}}{(p \cdot k)(\bar{p} \cdot k)}
+        - \frac{p^2}{(p \cdot k)^2}
+        - \frac{\bar{p}^2}{(\bar{p} \cdot k)^2} \right],
+
+    such that ``|M_rad|^2 -> eikonal_factor * |M_nonrad|^2`` as the
+    photon momentum ``k -> 0`` (universal for fermions and scalars).
+    """
+    return qe**2 * (
+        2.0 * ldot(p, pbar) / (ldot(p, k) * ldot(pbar, k))
+        - lnorm_sqr(p) / ldot(p, k) ** 2
+        - lnorm_sqr(pbar) / ldot(pbar, k) ** 2
+    )

--- a/test/spectra/test_dnde_photon_fsr.py
+++ b/test/spectra/test_dnde_photon_fsr.py
@@ -1,0 +1,546 @@
+r"""Validation of `hazma.spectra.dnde_photon_fsr` against real theory.
+
+The validation plan (docs/adrs/ADR-0001, and the follow-up that demanded
+it be written before the code):
+
+1. **Corpus self-consistency.** The squared matrix elements in
+   `msqrd_corpus` are validated on their own terms: the numerical Dirac
+   traces reproduce hand-derived closed forms for the non-radiative
+   processes; the radiative amplitudes satisfy the photon (and, where
+   applicable, mediator-current) Ward identities; the radiative matrix
+   elements factorize onto the eikonal soft-photon factor as
+   ``E_gamma -> 0``; and the corpus normalization reproduces the
+   annihilation cross sections shipped (and separately tested) in the
+   mediator models to machine precision.
+2. **Closed-form oracles.** The deterministic quadrature backend is
+   pinned against the analytic FSR spectra the mediator models provide
+   (``dnde_xx_to_v_to_ffg``, ``dnde_xx_to_s_to_ffg``,
+   ``dnde_xx_to_v_to_pipig``) at ``rtol=1e-5``. The backend converges
+   to ~4e-7 of the closed forms (limited by quadrature tolerance and
+   the oracles' own floating-point evaluation); 1e-5 leaves margin
+   without admitting any physics-level discrepancy.
+3. **Approximate oracles.** The exact electron spectrum matches twice
+   the single-particle Altarelli-Parisi formula to 1e-4 (the AP log
+   captures the full vector-current result up to O(m^2/s) ~ 1e-6
+   corrections for electrons), while for muons the deviation stays
+   below 10% (genuine mass corrections at m/sqrt(s) ~ 0.1 — this
+   bounds AP's validity rather than testing the generator).
+4. **Monte-Carlo backend.** Pinned with a fixed seed against the
+   quadrature backend and against analytic flat-matrix-element phase
+   space (including a four-body radiative final state), with
+   tolerances expressed as pulls against the returned one-sigma error
+   estimate (|pull| < 4, i.e. a ~1e-4 false-failure probability if the
+   error estimate is honest).
+5. **Kinematic edges and the public contract** — thresholds, the
+   photon endpoint, scalars vs arrays, determinism, and error paths.
+"""
+
+import functools as ft
+
+import msqrd_corpus as corpus
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from hazma.hazma_errors import RamboCMETooSmall
+from hazma.parameters import charged_pion_mass as mpi
+from hazma.parameters import electron_mass as me
+from hazma.parameters import muon_mass as mmu
+from hazma.parameters import vh
+from hazma.phase_space import Rambo, ThreeBody
+from hazma.scalar_mediator import ScalarMediator
+from hazma.spectra import FSRSpectrum, dnde_photon_ap_fermion, dnde_photon_fsr
+from hazma.utils import (
+    RealArray,
+    RealOrRealArray,
+    cross_section_prefactor,
+    kallen_lambda,
+)
+from hazma.vector_mediator import VectorMediator
+
+# One kinematic point for the whole suite: annihilation at 1 GeV with the
+# mediators far off shell. mx < Q/2 keeps the models' kinematic gates open.
+Q = 1000.0
+MX = 200.0
+MV = 3000.0
+MS = 2500.0
+GVXX, GVLL = 1.3, 0.72
+GSXX, GSFF_MODEL = 1.1, 0.4
+GVPIPI = 0.5
+SEED = 1234
+
+# Ward-identity violations are float noise (~1e-12 measured); a dropped
+# diagram or wrong seagull produces O(1). Bound with four orders of margin.
+WARD_BOUND = 1e-8
+# Residual muon-mass corrections to Altarelli-Parisi at m/sqrt(s) ~ 0.1,
+# measured up to ~8% at the hard end of the grid.
+AP_MUON_BOUND = 0.10
+
+# Photon-energy grids inside the endpoints e_max = (Q^2 - (2m)^2)/(2Q):
+# 477.7 MeV (mu), 500.0 MeV (e), 461.0 MeV (pi).
+ES_MU = np.array([1.0, 5.0, 25.0, 100.0, 250.0, 400.0, 470.0])
+ES_E = np.array([1.0, 25.0, 100.0, 250.0, 400.0, 490.0])
+ES_PI = np.array([1.0, 5.0, 25.0, 100.0, 250.0, 400.0, 455.0])
+
+V_MU = dict(mf=mmu, mx=MX, mv=MV, gvxx=GVXX, gvff=GVLL)
+V_E = dict(mf=me, mx=MX, mv=MV, gvxx=GVXX, gvff=GVLL)
+# The scalar model's Yukawa convention is gsff * mf / vh.
+S_MU = dict(mf=mmu, mx=MX, ms=MS, gsxx=GSXX, gsff=GSFF_MODEL * mmu / vh)
+PI = dict(mx=MX, mv=MV, gvxx=GVXX, gvpipi=GVPIPI)
+
+
+def _flat(momenta: RealArray) -> RealOrRealArray:
+    batched = momenta.ndim == 3  # noqa: PLR2004 — (4, n, batch) layout
+    return np.ones(momenta.shape[-1]) if batched else 1.0
+
+
+@pytest.fixture(scope="module")
+def vector_model() -> VectorMediator:
+    return VectorMediator(
+        mx=MX,
+        mv=MV,
+        gvxx=GVXX,
+        gvuu=0.0,
+        gvdd=0.0,
+        gvss=0.0,
+        gvee=GVLL,
+        gvmumu=GVLL,
+    )
+
+
+@pytest.fixture(scope="module")
+def scalar_model() -> ScalarMediator:
+    return ScalarMediator(
+        mx=MX, ms=MS, gsxx=GSXX, gsff=GSFF_MODEL, gsGG=0.0, gsFF=0.0, lam=vh
+    )
+
+
+@pytest.fixture(scope="module")
+def dnde_quad_mumu() -> FSRSpectrum:
+    return dnde_photon_fsr(
+        ES_MU,
+        Q,
+        [mmu, mmu],
+        ft.partial(corpus.msqrd_xx_to_v_to_ffg, **V_MU),
+        ft.partial(corpus.msqrd_xx_to_v_to_ff, **V_MU),
+        method="quad",
+    )
+
+
+# ===================================================================
+# ---- 1. Corpus self-consistency -----------------------------------
+# ===================================================================
+
+
+class TestCorpusSelfConsistency:
+    def test_nonradiative_traces_match_hand_formulas(self) -> None:
+        """The numerical Dirac traces equal the textbook closed forms.
+
+        Pure floating-point identity between two exact expressions:
+        rtol 5e-12.
+        """
+        s = Q**2
+        momenta, _ = Rambo(Q, [mmu, mmu]).generate(8, seed=SEED)
+
+        num = corpus.msqrd_xx_to_v_to_ff(momenta, **V_MU)
+        hand = (
+            GVXX**2
+            * GVLL**2
+            / (s - MV**2) ** 2
+            * (s + 2 * MX**2)
+            / 3.0
+            * 4.0
+            * s
+            * (1.0 + 2.0 * mmu**2 / s)
+        )
+        assert_allclose(num, hand, rtol=5e-12)
+
+        num = corpus.msqrd_xx_to_s_to_ff(momenta, **S_MU)
+        hand = (
+            GSXX**2
+            * S_MU["gsff"] ** 2
+            / (s - MS**2) ** 2
+            * (0.5 * s - 2.0 * MX**2)
+            * 2.0
+            * s
+            * (1.0 - 4.0 * mmu**2 / s)
+        )
+        assert_allclose(num, hand, rtol=5e-12)
+
+        momenta, _ = Rambo(Q, [mpi, mpi]).generate(8, seed=SEED)
+        num = corpus.msqrd_xx_to_v_to_pipi(momenta, **PI)
+        hand = (
+            GVXX**2
+            * GVPIPI**2
+            / (s - MV**2) ** 2
+            * (s + 2 * MX**2)
+            / 3.0
+            * (s - 4.0 * mpi**2)
+        )
+        assert_allclose(num, hand, rtol=5e-12)
+
+    def test_ward_identities(self) -> None:
+        """Ward identities annihilate the radiative amplitudes.
+
+        Contracting with the photon momentum (and, for the pion current,
+        the mediator momentum) leaves pure float noise; see WARD_BOUND.
+        """
+        momenta, _ = Rambo(Q, [mmu, mmu, 0.0]).generate(8, seed=SEED)
+        assert np.all(corpus.photon_ward_violation_v(momenta, mf=mmu) < WARD_BOUND)
+
+        momenta, _ = Rambo(Q, [mpi, mpi, 0.0]).generate(8, seed=SEED)
+        photon, mediator = corpus.pion_ward_violations(momenta)
+        assert np.all(photon < WARD_BOUND)
+        assert np.all(mediator < WARD_BOUND)
+
+    @pytest.mark.parametrize(
+        ("egam", "rtol"),
+        [
+            # Soft-theorem corrections are O(E_gamma * d log|M0|^2 / dE):
+            # measured deviations 5e-5 and 5e-7; bounds carry a 10x margin
+            # and still verify the linear-in-E approach to factorization.
+            (1e-2, 5e-4),
+            (1e-4, 5e-6),
+        ],
+    )
+    def test_soft_photon_factorization(self, egam: float, rtol: float) -> None:
+        """|M_rad|^2 factorizes onto the eikonal factor as E_gamma -> 0.
+
+        Checked for all three corpus processes (fermionic vector,
+        fermionic scalar, and scalar QED).
+        """
+        sp = Q * (Q - 2.0 * egam)
+        cme_rf = np.sqrt(sp)
+        eg_rf = egam * Q / cme_rf
+        photon = np.zeros((4, 1, 4))
+        photon[0], photon[3] = eg_rf, eg_rf
+
+        pair, _ = Rambo(cme_rf, [mmu, mmu]).generate(4, seed=SEED)
+        momenta = np.concatenate((pair, photon), axis=1)
+        eik = corpus.eikonal_factor(pair[:, 0], pair[:, 1], momenta[:, 2])
+
+        rad = corpus.msqrd_xx_to_v_to_ffg(momenta, **V_MU)
+        nonrad = corpus.msqrd_xx_to_v_to_ff(pair, **V_MU)
+        assert_allclose(rad, eik * nonrad, rtol=rtol)
+
+        rad = corpus.msqrd_xx_to_s_to_ffg(momenta, **S_MU)
+        nonrad = corpus.msqrd_xx_to_s_to_ff(pair, **S_MU)
+        assert_allclose(rad, eik * nonrad, rtol=rtol)
+
+        pair, _ = Rambo(cme_rf, [mpi, mpi]).generate(4, seed=SEED)
+        momenta = np.concatenate((pair, photon), axis=1)
+        eik = corpus.eikonal_factor(pair[:, 0], pair[:, 1], momenta[:, 2])
+        rad = corpus.msqrd_xx_to_v_to_pipig(momenta, **PI)
+        nonrad = corpus.msqrd_xx_to_v_to_pipi(pair, **PI)
+        assert_allclose(rad, eik * nonrad, rtol=rtol)
+
+    def test_corpus_normalization_matches_model_cross_sections(
+        self, vector_model: VectorMediator, scalar_model: ScalarMediator
+    ) -> None:
+        """Corpus normalization reproduces the models' cross sections.
+
+        sigma = flux x dPhi_2 x |M0|^2 built from the corpus matrix
+        elements equals the models' analytic annihilation cross sections
+        (independently pinned in test/{vector,scalar}_mediator): an
+        exact algebraic identity, rtol 1e-11.
+        """
+        s = Q**2
+        e1 = Q / 2.0
+        p = np.sqrt(e1**2 - mmu**2)
+        momenta = np.array([[e1, e1], [0.0, 0.0], [0.0, 0.0], [p, -p]])
+        flux = cross_section_prefactor(MX, MX, Q)
+        dphi2 = np.sqrt(kallen_lambda(s, mmu**2, mmu**2)) / (8.0 * np.pi * s)
+
+        # Beam-averaged |M0|^2 is angle-independent: one point suffices.
+        sigma = (
+            flux
+            * dphi2
+            * corpus.msqrd_xx_to_v_to_ff(
+                momenta, **{**V_MU, "widthv": vector_model.width_v}
+            )
+        )
+        assert_allclose(sigma, vector_model.sigma_xx_to_v_to_ff(Q, "mu"), rtol=1e-11)
+
+        sigma = (
+            flux
+            * dphi2
+            * corpus.msqrd_xx_to_s_to_ff(
+                momenta, **{**S_MU, "widths": scalar_model.width_s}
+            )
+        )
+        assert_allclose(sigma, scalar_model.sigma_xx_to_s_to_ff(Q, "mu"), rtol=1e-11)
+
+
+# ===================================================================
+# ---- 2./3. Oracles: closed forms and Altarelli-Parisi -------------
+# ===================================================================
+
+
+class TestQuadBackendOracles:
+    # Quadrature converges to ~4e-7 of the closed forms (epsrel 1.49e-8
+    # per angular integral, plus the oracles' own complex-log float
+    # noise); rtol 1e-5 has ~25x margin yet fails on any physics-level
+    # discrepancy, which for a wrong diagram/normalization is O(1).
+    ORACLE_RTOL = 1e-5
+
+    def test_v_to_mumug(
+        self, vector_model: VectorMediator, dnde_quad_mumu: FSRSpectrum
+    ) -> None:
+        oracle = vector_model.dnde_xx_to_v_to_ffg(ES_MU, Q, "mu")
+        assert_allclose(dnde_quad_mumu.dnde, oracle, rtol=self.ORACLE_RTOL)
+        # The quadrature-error estimate must reflect that convergence.
+        assert np.all(dnde_quad_mumu.error < 1e-4 * dnde_quad_mumu.dnde)
+
+    def test_v_to_eeg(self, vector_model: VectorMediator) -> None:
+        """Electron final state: the hardest quadrature case.
+
+        The collinear peaks have width ~ 2 me^2/s ~ 5e-7 in cos(theta).
+        """
+        result = dnde_photon_fsr(
+            ES_E,
+            Q,
+            [me, me],
+            ft.partial(corpus.msqrd_xx_to_v_to_ffg, **V_E),
+            ft.partial(corpus.msqrd_xx_to_v_to_ff, **V_E),
+            method="quad",
+        )
+        oracle = vector_model.dnde_xx_to_v_to_ffg(ES_E, Q, "e")
+        assert_allclose(result.dnde, oracle, rtol=self.ORACLE_RTOL)
+
+    def test_s_to_mumug(self, scalar_model: ScalarMediator) -> None:
+        result = dnde_photon_fsr(
+            ES_MU,
+            Q,
+            [mmu, mmu],
+            ft.partial(corpus.msqrd_xx_to_s_to_ffg, **S_MU),
+            ft.partial(corpus.msqrd_xx_to_s_to_ff, **S_MU),
+            method="quad",
+        )
+        oracle = scalar_model.dnde_xx_to_s_to_ffg(ES_MU, Q, mmu)
+        assert_allclose(result.dnde, oracle, rtol=self.ORACLE_RTOL)
+
+    def test_v_to_pipig(self, vector_model: VectorMediator) -> None:
+        result = dnde_photon_fsr(
+            ES_PI,
+            Q,
+            [mpi, mpi],
+            ft.partial(corpus.msqrd_xx_to_v_to_pipig, **PI),
+            ft.partial(corpus.msqrd_xx_to_v_to_pipi, **PI),
+            method="quad",
+        )
+        oracle = vector_model.dnde_xx_to_v_to_pipig(ES_PI, Q)
+        assert_allclose(result.dnde, oracle, rtol=self.ORACLE_RTOL)
+
+    def test_altarelli_parisi_collinear_limit(
+        self, vector_model: VectorMediator
+    ) -> None:
+        """Against 2x the single-particle AP spectrum (both legs radiate).
+
+        For electrons the AP log expression is the complete massless
+        limit of the vector-current spectrum — measured agreement 1e-6,
+        asserted at 1e-4. For muons the residual is a genuine
+        O(m/sqrt(s)) mass correction, measured up to ~8% at the hard
+        end of the grid; the 10% bound documents where AP stops being
+        trustworthy rather than testing the generator.
+        """
+        es = np.array([50.0, 150.0, 250.0, 350.0, 450.0])
+        result = dnde_photon_fsr(
+            es,
+            Q,
+            [me, me],
+            ft.partial(corpus.msqrd_xx_to_v_to_ffg, **V_E),
+            ft.partial(corpus.msqrd_xx_to_v_to_ff, **V_E),
+            method="quad",
+        )
+        ap = 2.0 * dnde_photon_ap_fermion(es, Q**2, me)
+        assert_allclose(result.dnde, ap, rtol=1e-4)
+
+        result = dnde_photon_fsr(
+            es,
+            Q,
+            [mmu, mmu],
+            ft.partial(corpus.msqrd_xx_to_v_to_ffg, **V_MU),
+            ft.partial(corpus.msqrd_xx_to_v_to_ff, **V_MU),
+            method="quad",
+        )
+        ap = 2.0 * dnde_photon_ap_fermion(es, Q**2, mmu)
+        assert np.all(np.abs(result.dnde / ap - 1.0) < AP_MUON_BOUND)
+
+
+# ===================================================================
+# ---- 4. Monte-Carlo backend ---------------------------------------
+# ===================================================================
+
+
+class TestRamboBackend:
+    # A |pull| < 4 bound on a fixed seed fails with probability ~1e-4
+    # per point if the returned one-sigma error estimate is honest, and
+    # catches both bias (wrong prefactor/frame) and a broken estimate.
+    MAX_PULL = 4.0
+
+    def test_pion_mc_matches_closed_form(self, vector_model: VectorMediator) -> None:
+        result = dnde_photon_fsr(
+            ES_PI,
+            Q,
+            [mpi, mpi],
+            ft.partial(corpus.msqrd_xx_to_v_to_pipig, **PI),
+            ft.partial(corpus.msqrd_xx_to_v_to_pipi, **PI),
+            method="rambo",
+            npts=1 << 14,
+            seed=SEED,
+        )
+        oracle = vector_model.dnde_xx_to_v_to_pipig(ES_PI, Q)
+        pulls = (result.dnde - oracle) / result.error
+        assert np.all(np.abs(pulls) < self.MAX_PULL)
+        # Noise-floor sanity: ~1% relative error at 2^14 points.
+        assert np.all(result.error < 0.02 * result.dnde)
+
+    def test_fermionic_mc_matches_quad(self, dnde_quad_mumu: FSRSpectrum) -> None:
+        es = ES_MU[[1, 3, 5]]
+        result = dnde_photon_fsr(
+            es,
+            Q,
+            [mmu, mmu],
+            ft.partial(corpus.msqrd_xx_to_v_to_ffg, **V_MU),
+            ft.partial(corpus.msqrd_xx_to_v_to_ff, **V_MU),
+            method="rambo",
+            npts=1 << 12,
+            seed=SEED,
+        )
+        quad = dnde_quad_mumu.dnde[[1, 3, 5]]
+        pulls = (result.dnde - quad) / result.error
+        assert np.all(np.abs(pulls) < self.MAX_PULL)
+
+    def test_four_body_flat_massless_phase_space(self) -> None:
+        """Four-body flat massless phase space has a closed form.
+
+        Three massless particles + photon with flat matrix elements:
+        dN/dE = E s'/(4 pi^2 s) exactly, from Phi_3(s) = s/(256 pi^3).
+
+        Exercises the >= 3-body Monte-Carlo numerator and the ThreeBody
+        quadrature denominator in one pin. Massless RAMBO weights are
+        constant, so the Monte-Carlo mean is deterministic up to float
+        noise: rtol 1e-6.
+        """
+        es = np.array([1.0, 100.0, 300.0, 499.0])
+        result = dnde_photon_fsr(
+            es, Q, [0.0, 0.0, 0.0], _flat, _flat, npts=1 << 12, seed=SEED
+        )
+        sp = Q * (Q - 2.0 * es)
+        assert_allclose(result.dnde, es * sp / (4.0 * np.pi**2 * Q**2), rtol=1e-6)
+
+    def test_massive_three_body_flat_vs_threebody_quad(self) -> None:
+        """The MC numerator agrees with independent ThreeBody quadrature.
+
+        Massive 3-body + photon, flat matrix elements: the numerator must
+        reproduce E/(4 pi^2) x Phi_3(s')/Phi_3(s) with Phi_3 computed by
+        ThreeBody quadrature.
+        """
+        masses = (200.0, 150.0, 100.0)
+        es = np.array([20.0, 120.0, 240.0])
+        result = dnde_photon_fsr(es, Q, masses, _flat, _flat, npts=1 << 14, seed=SEED)
+        phi3_s = ThreeBody(Q, masses).integrate(epsabs=0.0)[0]
+        expected = np.array(
+            [
+                e
+                / (4.0 * np.pi**2)
+                * ThreeBody(np.sqrt(Q * (Q - 2.0 * e)), masses).integrate(epsabs=0.0)[0]
+                / phi3_s
+                for e in es
+            ]
+        )
+        pulls = (result.dnde - expected) / result.error
+        assert np.all(np.abs(pulls) < self.MAX_PULL)
+
+    def test_seed_determinism(self) -> None:
+        args = (ES_PI[:3], Q, [mpi, mpi], _flat, _flat)
+        kwargs = dict(method="rambo", npts=2000)
+        first = dnde_photon_fsr(*args, seed=SEED, **kwargs)
+        second = dnde_photon_fsr(*args, seed=SEED, **kwargs)
+        third = dnde_photon_fsr(*args, seed=SEED + 1, **kwargs)
+        assert np.array_equal(first.dnde, second.dnde)
+        assert np.array_equal(first.error, second.error)
+        assert not np.array_equal(first.dnde, third.dnde)
+
+
+# ===================================================================
+# ---- 5. Kinematic edges and the public contract -------------------
+# ===================================================================
+
+
+class TestContract:
+    def test_flat_massless_two_body_is_exact(self) -> None:
+        """Massless flat two-body spectra are exactly E/(4 pi^2).
+
+        dPhi_2 is independent of s', so dN/dE = E/(4 pi^2) — every
+        prefactor in the quadrature backend, with zero physics input.
+        rtol 1e-10 (quad of a constant is exact to roundoff).
+        """
+        es = np.array([1.0, 100.0, 300.0, 499.0])
+        result = dnde_photon_fsr(es, Q, [0.0, 0.0], _flat, _flat, method="quad")
+        assert_allclose(result.dnde, es / (4.0 * np.pi**2), rtol=1e-10)
+
+    @pytest.mark.parametrize("method", ["quad", "rambo"])
+    def test_unequal_masses_flat(self, method: str) -> None:
+        """Unequal masses with flat matrix elements match the Kallen form.
+
+        dN/dE = E/(4 pi^2) x dPhi_2(s')/dPhi_2(s) analytically (Kallen
+        square roots). Deterministic for quad (rtol 1e-8); the rambo
+        backend is exact here too because two-body RAMBO weights are
+        constant (rtol 1e-8).
+        """
+        m1, m2 = 300.0, 50.0
+        es = np.array([1.0, 100.0, 300.0])
+
+        def dphi2(s: RealOrRealArray) -> RealOrRealArray:
+            return np.sqrt(kallen_lambda(s, m1**2, m2**2)) / (8.0 * np.pi * s)
+
+        sp = Q * (Q - 2.0 * es)
+        expected = es / (4.0 * np.pi**2) * dphi2(sp) / dphi2(Q**2)
+        result = dnde_photon_fsr(
+            es, Q, [m1, m2], _flat, _flat, method=method, npts=1 << 12, seed=SEED
+        )
+        assert_allclose(result.dnde, expected, rtol=1e-8)
+
+    def test_out_of_range_energies_are_zero(self) -> None:
+        """Out-of-range energies give (0, 0).
+
+        Below zero, at zero, at/beyond the endpoint, and NaN — rather
+        than NaN or negative phase space.
+        """
+        e_max = (Q**2 - (2.0 * mmu) ** 2) / (2.0 * Q)
+        es = np.array([-5.0, 0.0, e_max, e_max + 10.0, np.nan])
+        result = dnde_photon_fsr(es, Q, [mmu, mmu], _flat, _flat, method="quad")
+        assert np.array_equal(result.dnde, np.zeros(5))
+        assert np.array_equal(result.error, np.zeros(5))
+        # ... while just inside the endpoint the spectrum is positive.
+        inside = dnde_photon_fsr(e_max - 1.0, Q, [mmu, mmu], _flat, _flat)
+        assert inside.dnde > 0.0
+
+    def test_scalar_and_array_contract(self, dnde_quad_mumu: FSRSpectrum) -> None:
+        result = dnde_photon_fsr(100.0, Q, [mmu, mmu], _flat, _flat)
+        assert isinstance(result, FSRSpectrum)
+        assert isinstance(result.dnde, float)
+        assert isinstance(result.error, float)
+
+        assert isinstance(dnde_quad_mumu, FSRSpectrum)
+        assert dnde_quad_mumu.dnde.shape == ES_MU.shape
+        assert dnde_quad_mumu.error.shape == ES_MU.shape
+        # NamedTuple unpacking is part of the public contract.
+        dnde, error = dnde_quad_mumu
+        assert dnde is dnde_quad_mumu.dnde and error is dnde_quad_mumu.error
+        # In range, the error field is a positive, small fraction.
+        inside = slice(0, len(ES_MU))
+        assert np.all(dnde_quad_mumu.error[inside] > 0.0)
+
+    def test_raises(self) -> None:
+        with pytest.raises(RamboCMETooSmall):
+            dnde_photon_fsr(10.0, 100.0, [mmu, mmu], _flat, _flat)
+        with pytest.raises(ValueError, match="at least two"):
+            dnde_photon_fsr(10.0, Q, [mmu], _flat, _flat)
+        with pytest.raises(ValueError, match="method='quad'"):
+            dnde_photon_fsr(10.0, Q, [1.0, 1.0, 1.0], _flat, _flat, method="quad")
+        with pytest.raises(ValueError, match="Invalid method"):
+            dnde_photon_fsr(10.0, Q, [mmu, mmu], _flat, _flat, method="bogus")
+        with pytest.raises(ValueError, match="not positive"):
+            dnde_photon_fsr(10.0, Q, [mmu, mmu], _flat, lambda m: 0.0)

--- a/test/spectra/test_dnde_photon_fsr.py
+++ b/test/spectra/test_dnde_photon_fsr.py
@@ -544,3 +544,35 @@ class TestContract:
             dnde_photon_fsr(10.0, Q, [mmu, mmu], _flat, _flat, method="bogus")
         with pytest.raises(ValueError, match="not positive"):
             dnde_photon_fsr(10.0, Q, [mmu, mmu], _flat, lambda m: 0.0)
+
+    @pytest.mark.parametrize("npts", [1, 0, -3, 2.5, True])
+    def test_rambo_rejects_degenerate_npts(self, npts: object) -> None:
+        """The Monte-Carlo backend rejects npts < 2 and non-integral npts.
+
+        A single sample would return a finite spectrum with
+        ``error=nan`` (``ddof=1`` is undefined for one sample), silently
+        voiding the one-sigma contract of ``FSRSpectrum.error``; the
+        same validation guards the Monte-Carlo non-radiative integral of
+        four-or-more-body final states. Regression test for PR #41
+        review round 1.
+        """
+        with pytest.raises(ValueError, match="npts"):
+            dnde_photon_fsr(
+                10.0, Q, [mmu, mmu], _flat, _flat, method="rambo", npts=npts
+            )
+        with pytest.raises(ValueError, match="npts"):
+            dnde_photon_fsr(
+                10.0, Q, [0.0, 0.0, 0.0], _flat, _flat, method="rambo", npts=npts
+            )
+
+    def test_quad_ignores_npts(self) -> None:
+        """A value the Monte-Carlo backend rejects is accepted by quad.
+
+        npts is documented as ignored by the quadrature backend, and the
+        error field stays finite.
+        """
+        result = dnde_photon_fsr(
+            10.0, Q, [mmu, mmu], _flat, _flat, method="quad", npts=1
+        )
+        assert np.isfinite(result.dnde)
+        assert np.isfinite(result.error)


### PR DESCRIPTION
## Summary

- Implements the [`msqrd-driven-fsr-generator`](docs/followups/done/msqrd-driven-fsr-generator.md)
  follow-up: `hazma.spectra.dnde_photon_fsr`, a maintained, validated
  replacement for the capability lost when cython-to-rust ADR-0003 removed
  `hazma.gamma_ray.gamma_ray_fsr` — the photon spectrum of a radiative
  process computed from a user-supplied squared matrix element.
- The interface question the follow-up flagged is settled by repo-wide
  [ADR-0001](docs/adrs/ADR-0001-fsr-generator-takes-both-matrix-elements.md):
  the caller supplies **both** matrix elements (radiative and
  non-radiative) and the spectrum is the ratio of bare phase-space
  integrals — every initial-state factor (flux/`1/2M`, spin averages,
  couplings, propagators, symmetry factors) cancels, eliminating the old
  `non_rad` float units trap, `isp_masses`, and the decay/annihilation
  branch. Statistical error is part of the API: the return type is a new
  `FSRSpectrum` NamedTuple `(dnde, error)`, both MeV⁻¹.
- Two backends, both on `hazma.phase_space` (no private phase-space code):
  deterministic Dalitz-strip quadrature for a 2-body non-photon final
  state (defaults to purely relative quad tolerance, since matrix-element
  magnitudes are convention-dependent), and seeded RAMBO at the reduced
  invariant mass `s' = s − 2√s·Eγ` for higher multiplicities — the removed
  kernel's fixed-photon-energy estimator, independently re-derived
  (prefactor `Eγ/4π²`), evaluating the spectrum exactly at the requested
  energies with no histogram binning.
- Validation corpus of **real theoretical calculations**
  (`test/spectra/msqrd_corpus.py`): exact tree-level `|M|²` for
  `χχ̄ → V* → ℓ⁺ℓ⁻(γ)`, `χχ̄ → S* → ℓ⁺ℓ⁻(γ)` (numerical Dirac traces
  assembled from Feynman rules) and `χχ̄ → V* → π⁺π⁻(γ)` (scalar QED with
  the gauge-invariance seagull), with the beam-averaged DM tensor derived
  in the module docstring. The corpus is self-checked (Ward identities,
  soft-photon factorization, non-radiative traces vs closed forms, σ vs
  the shipped model cross sections to 1e-11) and then pins the generator
  against the models' analytic FSR spectra `dnde_xx_to_v_to_ffg`,
  `dnde_xx_to_s_to_ffg`, `dnde_xx_to_v_to_pipig` at `rtol=1e-5` (quad)
  and within Monte-Carlo pulls < 4σ at fixed seed (rambo), plus the
  Altarelli–Parisi collinear limit and analytic flat-matrix-element
  phase-space pins (including a 4-body radiative final state and the
  kinematic edges the follow-up lists).
- Docs: usage + API sections in `docs/source/spectra.rst` (with a worked
  scalar-QED example verified against the corpus), CHANGELOG entry under
  `[Unreleased]` (additive; `minor` when released), follow-up moved to
  `done/` with its resolution recorded, all inbound links repointed, and
  an addendum on ADR-0003 so the eventual Phase 00 CHANGELOG names the
  replacement.

**No existing numbers move.** The change is purely additive; no shipped
spectrum, width, or cross section is touched.

**Review round 1** (blocking finding, fixed in the second commit): the
Monte-Carlo backend accepted `npts=1` and returned a finite spectrum
with `error=nan` (ddof=1 is undefined for one sample). `npts` is now
validated at the entry point as an integer ≥ 2 whenever the rambo
backend is selected — covering the per-energy numerator, the ≥4-body
Monte-Carlo denominator, and the previously cryptic non-integral-npts
TypeError — with regression tests for all three and for quad's
documented indifference to `npts`. A `[degenerate-sample-count]` entry
was added to `docs/agents/lessons.md`.

**Rebased on master @ 42cb0b5** (post PR #39/#40): one conflict in
`docs/followups/README.md` (both PRs moved different rows to done/),
resolved by keeping both; the tree passes CI's re-enabled
`black --check hazma test` at the unified pin (black 26.5.1, 227 files
unchanged), and CI's critical-ruff findings are the two pre-existing
`hazma/experimental/` F821s, identical on master.

## Test plan

- [x] `pytest test/spectra/test_dnde_photon_fsr.py` — 27 passed in 7.25s
  (on the rebased tree)
- [x] Full suite `pytest test` — 95 passed, 20 skipped in 4:17 on the
  rebased tree (master baseline: 68 passed, 20 skipped; the +27 are the
  new file, no new failures)
- [x] `black --check` / `isort --check-only` / `ruff check` clean on all
  four touched Python files (`hazma/spectra/_fsr.py`,
  `hazma/spectra/__init__.py`, `test/spectra/msqrd_corpus.py`,
  `test/spectra/test_dnde_photon_fsr.py`; `__init__.py` retains 3
  pre-existing findings, down from 4 on the base)
- [x] `markdownlint --dot` clean on all 11 changed markdown files
- [x] Import smoke: `python -c "import hazma; import hazma.spectra"`
- [x] Forbidden-token scan of the diff: clean
- [x] `scripts/agents/check_pr_title.py` on the PR title: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
