### PR TITLE
docs(followups): unpin the quoted boost.pyx citation example

### DIFF
--- a/docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md
+++ b/docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md
@@ -16,10 +16,11 @@ exists at all it reports EXTERNAL and **skips** — correct for a
 file the repo *used to have* is indistinguishable from one into a
 third-party library.
 
-That is the gap the PR #42 review exposed from the other side.
-`boost.pyx:427` failed loudly because `hazma/_utils/boost.pyx` still
-exists and merely got shorter. Had the purge deleted the file outright,
-the same rotten citation would have been skipped in silence.
+That is the gap the PR #42 review exposed from the other side. The
+citation to ``boost.pyx line 427 as of `e94fb21^` `` failed loudly
+because `hazma/_utils/boost.pyx` still exists and merely got shorter.
+Had the purge deleted the file outright, the same rotten citation would
+have been skipped in silence.
 
 The dead-code purge makes this concrete: as of PR #42 the checker skips
 **25** citations, and the majority are not third-party at all — they


### PR DESCRIPTION
## Summary

- `docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md` — the
  follow-up note that *proposes hardening* `check_doc_citations.py` quoted
  `boost.pyx:427` as its worked example. The checker's regex cannot tell a
  quoted example from a live pointer, so the note failed the very gate it
  argues for: `hazma/_utils/boost.pyx` is 241 lines since the purge. Pinned
  the number to a commit (``boost.pyx line 427 as of `e94fb21^` ``) — the
  convention the note itself prescribes four paragraphs further down, and the
  same treatment c4b268b applied to `references/cython-inventory.md` and
  8e78cd8 applied to the `[touched-doc-inherits-its-citations]` lessons entry.
- Third recurrence of one trap. The number and the argument are unchanged;
  only the notation moved out of the bounds-checked `file.pyx:N` form.
- Docs only — no library code, and no returned value moves.

Swept `docs/agents/` as well: it contains zero `file.py:N` citations of any
kind, so nothing there needed the same treatment. This note was the only
remaining offender in the repo.

## Test plan

- [x] The reported failure, reproduced on `origin/master` (1087ff3):

  ```text
  FAIL: 1 problem(s)
    docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md:20:
      OUT OF RANGE boost.pyx:427 — hazma/_utils/boost.pyx has 241 lines
  ```

- [x] Every tracked markdown file after the fix —
  `git ls-files '*.md' -z | xargs -0 scripts/agents/check_doc_citations.py`:

  ```text
  docs scanned: 84
  in-repo citations checked: 110
  out-of-range or ambiguous: NONE
  ```

- [x] `scripts/agents/check_doc_citations.py docs/agents/lessons.md` → exit 0
  (`in-repo citations checked: 0`; already pinned by 8e78cd8).

- [x] `scripts/agents/preflight.sh --md docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md`,
  run against a real build (venv + `-e .`) after rebasing onto PR #44:

  ```text
  PASS   black --check           hazma test
  FAIL   isort --check-only      run `isort hazma test` and re-check
  FAIL   ruff check              see output below
  PASS   pytest                  244 passed, 20 skipped in 249.92s (0:04:09)
  PASS   import hazma            version 2.1.0
  PASS   markdownlint            docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md
  PASS   forbidden tokens        none added
  ```

  The two red gates are the tree-wide debt present on a clean `master`, not
  this diff: `git diff origin/master --name-only -- '*.py' '*.pyx' '*.pxd'`
  returns **0 files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)