### PR TITLE
build(packaging): reconcile the build config and close phase 00

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -89,7 +89,7 @@ no import-order or configured-rule check) — this gate catches more than
 CI will. A non-zero exit is
 a blocked commit; a `WARN` row is an unrun gate, not a pass.
 
-If the diff touched `.pyx` / `.pxd` / `_build.py`, rebuild
+If the diff touched `.pyx` / `.pxd` / `setup.py`, rebuild
 (`pip install -e .`) **before** the gate, not after.
 
 ### Step 5: Stage and commit

--- a/.claude/skills/execute-single-task/SKILL.md
+++ b/.claude/skills/execute-single-task/SKILL.md
@@ -99,7 +99,7 @@ All edits and gates happen inside the worktree. The Bash-tool cwd can
 reset between calls — use `git -C <worktree>` with absolute paths (see
 [`environment.md`](../../../docs/agents/environment.md)).
 
-**If the task touches Cython** (`.pyx`, `.pxd`, `_build.py`), rebuild in
+**If the task touches Cython** (`.pyx`, `.pxd`, `setup.py`), rebuild in
 the worktree before running anything: `pip install -e .`, then confirm
 `python -c "import hazma; print(hazma.__file__)"` points inside the
 worktree. A stale extension makes every later result meaningless.

--- a/.claude/skills/review-cycle/SKILL.md
+++ b/.claude/skills/review-cycle/SKILL.md
@@ -177,7 +177,7 @@ Agent(
 > append when a finding is class-shaped.
 >
 > **You MUST commit and push.** Stage only files you intentionally
-> changed. Rebuild first if you touched `.pyx` / `.pxd` / `_build.py`.
+> changed. Rebuild first if you touched `.pyx` / `.pxd` / `setup.py`.
 > Run the preflight gate (`docs/agents/preflight.md`) before staging;
 > assert a real `N passed` count. Commit with a Conventional Commits
 > message (validate with `scripts/agents/check_pr_title.py`) and

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -130,7 +130,7 @@ not hunt outside your area — that is another reviewer's job.
   README snippet, or claims a user-visible behavior, RUN it and paste the
   output. Static review does not catch a wrong number.
 - **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` /
-  `_build.py`, confirm the cited results came from a rebuilt tree.
+  `setup.py`, confirm the cited results came from a rebuilt tree.
 
 The full baseline duties and the **per-lens FOCUS rubric** for your lens
 live in [`review-lenses.md`](../../../docs/agents/review-lenses.md) —

--- a/.claude/skills/review-respond/SKILL.md
+++ b/.claude/skills/review-respond/SKILL.md
@@ -117,7 +117,7 @@ in the response.
   re-check the PR body against the post-fix diff — a stale body is a
   blocking finding.
 - **Rebuild before gating** if you touched `.pyx` / `.pxd` /
-  `_build.py`: `pip install -e .`.
+  `setup.py`: `pip install -e .`.
 - **Run the preflight gate.** `scripts/agents/preflight.sh --paths
   "<touched>" --tests "<targets>"` (or the manual list in
   [`preflight.md`](../../../docs/agents/preflight.md)). Read the pytest

--- a/.claude/skills/task-pipeline/SKILL.md
+++ b/.claude/skills/task-pipeline/SKILL.md
@@ -71,7 +71,7 @@ and `<BRANCH>` from Phase A.
 > by the pipeline orchestrator.
 >
 > Hazma ships Cython extensions. If your work touches `.pyx`, `.pxd`, or
-> `_build.py`, run `pip install -e .` inside this worktree before running
+> `setup.py`, run `pip install -e .` inside this worktree before running
 > tests, and confirm `python -c "import hazma; print(hazma.__file__)"`
 > resolves inside `<WT_PATH>` — otherwise every result you report comes
 > from a different tree.

--- a/.codex/skills/execute-single-task/SKILL.md
+++ b/.codex/skills/execute-single-task/SKILL.md
@@ -29,7 +29,7 @@ change directly, then use `$commit-and-pr` when it is ready to ship.
    Run all later commands in the reported `wt_path`, preferably as
    `git -C <wt_path> ...`. If a pipeline already supplied its managed
    worktree, skip this creation step and use that exact path.
-4. If the task edits `.pyx`, `.pxd`, or `_build.py`, rebuild inside that
+4. If the task edits `.pyx`, `.pxd`, or `setup.py`, rebuild inside that
    worktree and confirm `python -c "import hazma; print(hazma.__file__)"`
    resolves there before trusting any result.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ the tree you edited, not an installed copy.
   there is a user-facing break — see `docs/versioning.md`. The package is
   empty today (its last module went in cython-to-rust Task 0.2), so the
   rule binds the next module parked there.
-- **Never commit generated C/C++.** `_build.py` cythonizes on build; the
+- **Never commit generated C/C++.** `setup.py` cythonizes on build; the
   `.c` / `.cpp` output is not the source of truth.
 - **No `breakpoint()`, `pdb`, or stray `print()` in library code.** Use
   the returned value or a logger.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,15 @@
 global-include *.txt *.rst *.pyx *.pxd *.c *.md
 include MANIFEST.in
+
+# The global-include above is a repo-wide sweep, so it also picks up the
+# agent-workflow scaffolding: `.claude/` and `.codex/` skills, and the
+# `projects/` plans, task notes and ADRs. None of that belongs in a
+# published sdist. (The wheel is already clean — see
+# [tool.setuptools.packages.find] in pyproject.toml.)
+prune .claude
+prune .codex
+prune projects
+
 include hazma/gamma_ray_data/*.dat
 include hazma/gamma_ray_data/A_eff/*.dat
 include hazma/gamma_ray_data/bg_model/*.dat

--- a/docs/PR_GUIDELINES.md
+++ b/docs/PR_GUIDELINES.md
@@ -45,7 +45,7 @@ Use the most specific scope that applies. Common scopes (non-exhaustive):
 | `form`      | `hazma/form_factors/`                                        |
 | `params`    | `hazma/parameters.py`, `gamma_ray_parameters.py`             |
 | `utils`     | `hazma/utils.py`, `hazma/_utils/` Cython helpers             |
-| `packaging` | `_build.py`, Cython build wiring, `pyproject.toml`           |
+| `packaging` | `setup.py`, Cython build wiring, `pyproject.toml`            |
 | `actions`   | `.github/workflows/` — CI and release automation             |
 | `sphinx`    | `docs/source/` — the published docs and their build          |
 | `readme`    | `README.md` and other top-level prose                        |

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -36,7 +36,7 @@ file.** Edit the marked region by hand, then confirm zero markers remain
 ## Build and imports
 
 **Editing a `.pyx` / `.pxd` and re-running pytest tests the OLD kernel.**
-Cython sources are compiled at build time by `_build.py`. Until you
+Cython sources are compiled at build time by `setup.py`. Until you
 rebuild (`pip install -e .`), every import resolves the previously-built
 extension — so a change can look like it had no effect, or a bug can look
 fixed when it isn't. Rebuild, then confirm.
@@ -56,6 +56,24 @@ builds as C only.)
 
 **Never hand-edit generated `.c` / `.cpp`.** They are cythonize output.
 Edit the `.pyx` and rebuild.
+
+**A clean wheel is not evidence of a clean sdist.** They are built by
+different machinery and neither fix reaches the other: the wheel's
+contents come from `[tool.setuptools.packages.find]` in
+`pyproject.toml`, the sdist's from `MANIFEST.in`. `MANIFEST.in`'s
+`global-include` is a **repo-wide** sweep, so it happily picks up
+`.claude/`, `.codex/` and `projects/` — it did, unnoticed, for four
+months, because no one ran `build --sdist` (cython-to-rust Task 0.4).
+Check the artifact you actually changed. And when probing a `tar tzf`
+listing for paths that should be absent, **anchor the pattern** (`^…$`):
+an unanchored `_positron` or `gamma_ray` matches dozens of live paths
+and buries the real hit.
+
+**A path probe is not a build.** A tarball can list exactly the right
+files and still fail to install. The gate is
+`uv pip install --no-binary hazma dist/*.tar.gz` into a *fresh* venv,
+then import-smoke from outside the repo — `cd /tmp` first, or you will
+import the checkout instead of the installed package.
 
 ## Linters
 

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -55,6 +55,26 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   plan drifted (32→"19" survivors vs 20 actual; "43" corpus entry points vs
   41 consumed; "44 .pyx/.pxd" conflating 44 .pyx + 33 .pxd), and each read
   as authoritative until review recounted (PR #35).
+- [measurement-taken-before-the-task-ended] A number measured *correctly*,
+  with a real command, still goes stale if the task's own later output
+  changes what the command measures. Re-run every measurement against the
+  final tree before handing off, and measure both halves of a before/after
+  pair on the *same* tree — taking "before" early and "after" late compares
+  two different trees while looking rigorous. Watch for the self-referential
+  case in particular (PR #49: an sdist file count of `498 → 397` was taken
+  right after the `MANIFEST.in` fix, but the follow-up documenting the sdist
+  payload then landed under the un-pruned `docs/` and became part of that
+  payload; the true figures on the final tree were `501 → 398`). Distinct
+  from [derived-count-not-rederived] above, which is about numbers never
+  derived at all; this one is about a derivation that expired.
+- [artifact-inventory-depends-on-cwd-state] Any claim about what a built
+  artifact *contains* must state that it came from a clean tree. A
+  filesystem-walking packager (setuptools' sdist, Docker build context)
+  ships untracked junk that `.gitignore` hides from `git status`, so the
+  same commit yields different artifacts depending on what the working
+  directory has accumulated (PR #49: an identical tree produced 400 files
+  dirty and 398 clean, the difference being `.pytest_cache/README.md`
+  swept in by `global-include *.md` despite `.gitignore:526`).
 - [wheel-tag-vs-extension-abi] A wheel's tag is per-distribution, not
   per-extension: while any version-specific extension (e.g. Cython) remains
   in the package, wheels stay CPython-tagged no matter how many extensions

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -31,7 +31,7 @@ before you stage anything.
    a different interpreter, produces a tree that lints and formats
    cleanly and fails at import. Run this after any change under
    `_utils/`, or to the `.pyx` in `spectra/`, `scalar_mediator/`,
-   `vector_mediator/`, and after any `_build.py` change.
+   `vector_mediator/`, and after any `setup.py` change.
 6. **`markdownlint --dot <changed .md files>`** — when curated docs
    changed. Word-diff after any `--fix`: it can corrupt code spans.
    Run it from the repo root: the committed

--- a/docs/agents/review-lenses.md
+++ b/docs/agents/review-lenses.md
@@ -132,7 +132,7 @@ These apply regardless of lens.
 - **Empirical execution.** When the diff adds or edits a docstring
   example, a README snippet, or claims a user-visible behavior, RUN it
   and paste the output. Static review does not catch a wrong number.
-- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` / `_build.py`,
+- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` / `setup.py`,
   confirm the cited test results came from a tree that was rebuilt. A
   green run against a stale extension proves nothing.
 - **Read [`lessons.md`](lessons.md) first**, then check the diff against

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -28,6 +28,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [redundant `hazma.utils` helpers kept out of the public surface](todo/utils-public-surface-redundant-helpers.md) | 2026-08-05 | docs audit of `utils.rst` | cross-cutting |
 | [`preflight.sh` isort/ruff gates are red on the trunk](todo/preflight-isort-ruff-red-on-trunk.md) | 2026-08-05 | cython-to-rust Task 0.5 | cross-cutting |
 | [markdownlint was never run over `.claude/skills/`](todo/markdownlint-skips-skill-file-shapes.md) | 2026-08-06 | PR #48 review round 1 | cross-cutting |
+| [sdist ships cythonized `*.c`, `docs/`, `test/`](todo/sdist-ships-generated-c-and-docs.md) | 2026-08-06 | cython-to-rust Task 0.4 | cross-cutting |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/preflight-isort-ruff-red-on-trunk.md
+++ b/docs/followups/todo/preflight-isort-ruff-red-on-trunk.md
@@ -64,6 +64,20 @@ Pick one of three, and record which in this file:
 Option 2 is the cheapest and is probably the right first move; option 1
 is the durable end state.
 
+**Add a fourth thing regardless of which is chosen: a way to say "this
+diff has no Python."** `preflight.sh:81` defaults `PATHS` to
+`hazma test` when `--paths` is empty, so a *docs-only* run silently
+widens from "nothing to check" to "check the two reddest paths in the
+repo" and reports `FAIL`. There is no flag that means no-Python — the
+only workaround is to pass some unrelated-but-clean file, which is
+exactly the kind of gaming that erodes a gate's meaning. cython-to-rust
+Task 0.4 hit this on a two-file markdown commit (the diff touched
+nothing under `hazma/` or `test/` at all, making the red rows provably
+pure trunk state) and had to re-run scoped to `setup.py` to get an
+honest green. An explicit `--no-python`, or treating an empty `--paths`
+as "skip gates 1–3" rather than as a wildcard, would remove the
+temptation.
+
 ## Entry points
 
 - `scripts/agents/preflight.sh` — gates 2 and 3.
@@ -77,6 +91,8 @@ is the durable end state.
   standing "ruff is red on the trunk and does not block CI" note.
 - `projects/cython-to-rust/task-notes/phase-00/task-0.5-gamma-ray-decision.md`
   §"Preflight disposition" — a worked example of the per-task cost.
+- `scripts/agents/preflight.sh:81` — the `PATHS="hazma test"` default
+  that turns a docs-only run into a trunk-wide lint run.
 
 ## Risks / open questions
 

--- a/docs/followups/todo/sdist-ships-generated-c-and-docs.md
+++ b/docs/followups/todo/sdist-ships-generated-c-and-docs.md
@@ -13,11 +13,12 @@
 ## Why
 
 Task 0.4 pruned `.claude/`, `.codex/` and `projects/` out of the sdist —
-101 files of agent scaffolding that `MANIFEST.in`'s repo-wide
-`global-include *.md` was sweeping into a publishable tarball. That was
-unambiguous. Three payload questions surfaced in the same run and are
-**not** unambiguous, so they were left alone rather than decided inside a
-dead-code-purge task:
+103 files of agent scaffolding that `MANIFEST.in`'s repo-wide
+`global-include *.md` was sweeping into a publishable tarball, taking it
+from 501 files to 398. That was unambiguous. Four payload questions
+surfaced in the same run (the last during PR #49's review) and are
+**not** unambiguous, so they were left alone rather than decided inside
+a dead-code-purge task:
 
 1. **20 cythonized `*.c` files** (`global-include *.c`). They are never
    used: `cython` is in `[build-system] requires` and `setup.py` calls
@@ -27,10 +28,22 @@ dead-code-purge task:
    `AGENTS.md` says generated C is never the source of truth. (The
    observed count is stable at 20 only because the isolated sdist build
    itself runs `cythonize()` first.)
-2. **`docs/` (46 files), `test/` (12) and `notebooks/` (2).** Shipping
+2. **`docs/` (47 files), `test/` (12) and `notebooks/` (2).** Shipping
    tests in an sdist is a defensible convention; shipping the Sphinx
    sources is more marginal. Neither is a defect, just unexamined.
-3. **`[tool.setuptools.package-data]`'s `"hazma"` entry lists `*.pyd`,
+3. **The sweep reaches untracked, `.gitignore`d junk.** setuptools'
+   sdist walks the *filesystem*, not the git index, so anything matching
+   `global-include` that happens to be lying around is shipped. A tree
+   that has run `pytest` grows `.pytest_cache/README.md`, and
+   `global-include *.md` duly puts it in the tarball — despite
+   `.gitignore:526` listing `.pytest_cache/`. Observed while re-deriving
+   this task's counts in review: the same tree gave 400 files dirty and
+   398 clean. This is the sharp edge of item 1: the sdist's contents are
+   a function of the working directory's state, so two people building
+   "the same" release can ship different tarballs. Whatever replaces
+   `global-include`, it should enumerate what belongs rather than sweep
+   and subtract.
+4. **`[tool.setuptools.package-data]`'s `"hazma"` entry lists `*.pyd`,
    not `*.pxd`** (`pyproject.toml`). `.pyd` is the Windows extension-
    binary suffix, which setuptools adds on its own; the Cython headers
    the neighbouring `*.pyx` glob implies are spelled `.pxd`. Almost
@@ -49,16 +62,23 @@ Decide, and encode the decision in whichever backend is live at the time:
 - Keep or drop `docs/` and `notebooks/`; state which and why in a
   comment, so the next reader does not re-litigate it.
 - Fix or delete the `*.pyd` package-data entry.
+- Make the tarball independent of working-directory state — either
+  enumerate includes explicitly instead of `global-include`, or `prune`
+  the known artifact directories (`.pytest_cache`, `.ruff_cache`,
+  `.venv`, `htmlcov`). Reconciling `MANIFEST.in` against `.gitignore`
+  would catch the whole class at once.
 
 Verify the same way Task 0.4 did: `uv build --sdist`, then install the
 tarball into a fresh venv with `--no-binary hazma` and import-smoke the
 public entry points. A source install that stops working is the failure
-mode that matters.
+mode that matters. **Build from a clean tree**, and say so when quoting
+a file count — item 3 makes the number depend on it.
 
 ## Entry points
 
 - `MANIFEST.in` (the `global-include` line and the `prune` block Task
-  0.4 added)
+  0.4 added); `.gitignore:526` (`.pytest_cache/`), which the sdist
+  sweep does not consult
 - `pyproject.toml` — `[tool.setuptools.package-data]`,
   `[tool.setuptools.packages.find]`
 - `projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md`

--- a/docs/followups/todo/sdist-ships-generated-c-and-docs.md
+++ b/docs/followups/todo/sdist-ships-generated-c-and-docs.md
@@ -1,0 +1,76 @@
+# The sdist ships cythonized `*.c`, `docs/`, `test/` and `notebooks/`
+
+- **Added:** 2026-08-06
+- **Source:** cython-to-rust Task 0.4 — the first `uv build --sdist` run
+  in the project's history
+- **Scope:** cross-cutting (packaging)
+- **Status:** open
+- **Triggers / blockers:** decide before Phase 07 Task 7.1 rewrites the
+  build backend on maturin — maturin's sdist is `Cargo.toml`-driven and
+  will not read `MANIFEST.in`, so whatever is decided here has to be
+  re-expressed there rather than carried over.
+
+## Why
+
+Task 0.4 pruned `.claude/`, `.codex/` and `projects/` out of the sdist —
+101 files of agent scaffolding that `MANIFEST.in`'s repo-wide
+`global-include *.md` was sweeping into a publishable tarball. That was
+unambiguous. Three payload questions surfaced in the same run and are
+**not** unambiguous, so they were left alone rather than decided inside a
+dead-code-purge task:
+
+1. **20 cythonized `*.c` files** (`global-include *.c`). They are never
+   used: `cython` is in `[build-system] requires` and `setup.py` calls
+   `cythonize()` unconditionally on the `.pyx`, so a source install
+   regenerates them. Worse, they are *build-state dependent* — the sdist
+   sweeps whatever the source tree happens to have lying around, and
+   `AGENTS.md` says generated C is never the source of truth. (The
+   observed count is stable at 20 only because the isolated sdist build
+   itself runs `cythonize()` first.)
+2. **`docs/` (46 files), `test/` (12) and `notebooks/` (2).** Shipping
+   tests in an sdist is a defensible convention; shipping the Sphinx
+   sources is more marginal. Neither is a defect, just unexamined.
+3. **`[tool.setuptools.package-data]`'s `"hazma"` entry lists `*.pyd`,
+   not `*.pxd`** (`pyproject.toml`). `.pyd` is the Windows extension-
+   binary suffix, which setuptools adds on its own; the Cython headers
+   the neighbouring `*.pyx` glob implies are spelled `.pxd`. Almost
+   certainly a typo. It is currently harmless — the wheel ships all 17
+   `.pxd` anyway (via `MANIFEST.in` + `zip-safe = false`) and nothing
+   downstream cimports hazma's headers — which is exactly why it has
+   survived unnoticed.
+
+## What
+
+Decide, and encode the decision in whichever backend is live at the time:
+
+- Drop `*.c` from `MANIFEST.in`'s `global-include`, unless there is a
+  deliberate reason to ship pre-cythonized sources (there is not, while
+  `cython` stays a hard build requirement).
+- Keep or drop `docs/` and `notebooks/`; state which and why in a
+  comment, so the next reader does not re-litigate it.
+- Fix or delete the `*.pyd` package-data entry.
+
+Verify the same way Task 0.4 did: `uv build --sdist`, then install the
+tarball into a fresh venv with `--no-binary hazma` and import-smoke the
+public entry points. A source install that stops working is the failure
+mode that matters.
+
+## Entry points
+
+- `MANIFEST.in` (the `global-include` line and the `prune` block Task
+  0.4 added)
+- `pyproject.toml` — `[tool.setuptools.package-data]`,
+  `[tool.setuptools.packages.find]`
+- `projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md`
+  — the measured before/after sdist inventories
+- `projects/cython-to-rust/phases/phase-07-cutover.md` Task 7.1 (maturin
+  backend) and Task 7.3 (stale `requirements.txt` / `Dockerfile`, which
+  are already assigned there and deliberately untouched by Task 0.4)
+
+## Risks / open questions
+
+Sequencing is the whole risk. If this lands before Phase 07 it is two
+lines of `MANIFEST.in`; if it lands after, `MANIFEST.in` is gone and the
+same decisions have to be expressed through maturin's include/exclude
+rules instead. Cheapest window is now; the honest alternative is to fold
+it into Task 7.1 rather than leave it drifting between the two.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -9,17 +9,13 @@ touch.
 
 ```python
 # hazma/__init__.py
-VERSION: Final[str] = "2.0.2"
+VERSION: Final[str] = "2.1.0"
 __version__ = VERSION
 ```
 
 `pyproject.toml` reads it dynamically (`version = { attr =
 "hazma.VERSION" }`), so there is exactly one number to edit. Do not add a
 second copy.
-
-> `_build.py` carries an unrelated, stale `VERSION` constant that is not
-> the package version and is not read by the build metadata. Leave it
-> alone; it is not part of a version bump.
 
 ## The public surface
 

--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -90,7 +90,7 @@ total landed at 21–32 days across ~33 tasks.
 
 | # | Phase | File | Days | Delivers |
 | --- | ------- | ------ | ------ | ---------- |
-| 00 | Dead-code purge | [`phases/phase-00-dead-code-purge.md`](phases/phase-00-dead-code-purge.md) | 1–2 | −6,500 lines, 32→20 extensions, zero C++, `gamma_ray` removal (ADR-0003) |
+| 00 | Dead-code purge | [`phases/phase-00-dead-code-purge.md`](phases/phase-00-dead-code-purge.md) | 1–2 | **Complete (2026-08-06)** — 32→20 extensions, zero C++, `gamma_ray` removal (ADR-0003); [learnings](learnings/phase-00-dead-code-purge.md) |
 | 01 | Golden parity corpus | [`phases/phase-01-parity-corpus.md`](phases/phase-01-parity-corpus.md) | 2–3 | Pinned reference arrays for all 41 consumed entry points, one pytest gate |
 | 02 | Rust scaffold | [`phases/phase-02-rust-scaffold.md`](phases/phase-02-rust-scaffold.md) | 1–2 | `hazma._core` (abi3) building beside Cython via setuptools-rust |
 | 03 | Numerics foundation | [`phases/phase-03-numerics-foundation.md`](phases/phase-03-numerics-foundation.md) | 3–5 | constants, spence/K-Bessels, QUADPACK port, interp, boost, dispatch |

--- a/projects/cython-to-rust/learnings/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/learnings/phase-00-dead-code-purge.md
@@ -1,0 +1,209 @@
+# Phase 00 Learnings: Dead-code purge
+
+Synthesized at phase close (2026-08-06) from the five task notes in
+`../task-notes/phase-00/`. Durable memory for Phases 01–07 and for
+anyone who later deletes code in this repo — not a status log.
+
+## 1. Implementation Reality Check
+
+The phase delivered its headline target exactly: **32 extensions → 20**,
+zero C++, no `.pyx` outside the live surface, and roughly −33,000 lines
+across `hazma/` and `test/`. The 20 survivors are 8 `spectra/_photon` +
+2 `spectra/_positron` + 3 `spectra/_neutrino` + 6 mediator +
+`_utils/boost`, and `setup.py`'s declared list, the `.pyx` on disk and
+the `.so` from a clean build are now a verified set equality, not three
+numbers that happen to agree.
+
+Where execution diverged from the plan:
+
+- **Task ordering was not the numbered ordering.** The plan implied
+  0.1 → 0.2 → 0.3 → 0.4 with 0.5 as a decision gate. What actually ran
+  was 0.1 → 0.3 → 0.5 → 0.2 → 0.4, because ADR-0003's sign-off gated
+  0.2's deletion while 0.3 had no such dependency. Phased plans should
+  expect the sign-off-gated task to float.
+- **Three of five tasks patched canonical criteria.** Task 0.1 corrected
+  its own (four include sites → five built + two unbuilt), Task 0.2
+  rewrote **Task 0.4's**, and Task 0.4 amended its own twice. This is the
+  phase's most transferable process result: *the criteria written before
+  a deletion are routinely wrong about what the deletion strands*, and
+  patching them in the same PR is cheaper and more honest than absorbing
+  the difference into the diff.
+- **Task 0.4 was smaller than written and wider than written at once.**
+  The extension-list reconciliation it was assigned turned out to be a
+  no-op (Tasks 0.2/0.3 had already dropped every group, because a
+  deletion task *cannot* defer its own `setup.py` edit — the build fails
+  immediately on an `Extension` whose source is gone). But the sdist it
+  was assigned to run — the first in the project's history — surfaced two
+  defects the criteria never anticipated.
+
+ADRs: **ADR-0003** (remove `hazma.gamma_ray`) was accepted 2026-08-04
+with an Addendum the same day, and is **fully discharged** — non-deletion
+steps in Task 0.5, the deletion in Task 0.2. ADR-0001 and ADR-0002 were
+accepted before the phase and were not touched. Repo-wide ADR-0001
+(FSR generator) flipped Proposed → Accepted in Task 0.5 as a side effect
+of PR #41 merging.
+
+## 2. Critical Context for Future Work
+
+- **The live surface is 20 extensions; re-derive, do not quote.** Every
+  count in this project's docs is a snapshot. The recipe is: clean
+  (`find hazma -name '*.c' -o -name '*.cpp' -o -name '*.so' | xargs -r rm -f`),
+  `pip install -e .`, then compare the *sets* — declared in `setup.py`,
+  `.pyx` on disk, `.so` built. Comparing counts hides a stale `.so` that
+  makes a wrong list look right.
+- **`setup.py`, not `_build.py`, is the build entry point.** `_build.py`
+  was deleted in `7a817f9` (2026-08-02), before this project began, but
+  thirteen durable docs still named it until Task 0.4 swept them —
+  twelve by rename, and `docs/versioning.md` by deleting a blockquote
+  whose whole subject was a stale `VERSION` inside the vanished file. If
+  you see `_build.py` referenced outside this project's dated records
+  again, it is rot.
+- **`hazma.utils` is the single home for `cross_section_prefactor` and
+  `minkowski_dot`**; the legacy constants table is
+  `hazma/_utils/legacy_parameters.pxd` and is now its only copy, kept
+  deliberately divergent from `_utils/constants.pxd` per `../rules.md`
+  rule 4.
+- **`hazma/deprecated/` no longer exists as a package.** Removing
+  `rambo.py` removed the directory with it, since there was no
+  `__init__.py`. `AGENTS.md` and `docs/versioning.md` §6 were rescoped
+  from "it stays importable" (a claim about the tree) to a policy about
+  whatever is parked there next.
+- **Four spectra extensions and the `_utils` headers are capi
+  survivors.** They outlive their Phase 04 swap because the mediator
+  spectrum `.pyx` cimport their `__pyx_capi__` symbols; Phase 06 Task 6.4
+  is the only place they die. Task 0.3 also kept `boost_jac` /
+  `boost_eng` in `_utils/boost.pyx` on that basis — they have zero
+  cimporters but *are* declared in `boost.pxd`, i.e. published C-level
+  API. That is a 6.4 call, not a 0.x one.
+- **The public compiled surface did not move in this phase.** Two
+  declared drifts exist, both in the Cython → pure-Python helper swap,
+  both recorded in `../task-notes/README.md`. Separately, the
+  `two_body_momentum` repair landed out-of-band before Phase 01, so
+  **the corpus must pin the post-fix values.**
+
+## 3. Quirk Log & Edge Cases
+
+The five that cost real time, in the order a future deleter will hit
+them:
+
+- **Stale generated `.c`/`.cpp` silently poisons the build.** A worktree
+  can inherit them from another environment; their mtimes suppress
+  re-cythonization and the build dies deep inside generated code with a
+  misleading error (Task 0.1 saw `no member named 'subarray' in
+  '_PyArray_Descr'` from a `.cpp` generated against an older NumPy).
+  Clean before every rebuild. This is the single most-repeated lesson of
+  the phase.
+- **`git rm -r` on a package leaves it importable.** An untracked
+  `__pycache__` keeps the directory alive, and an empty directory on
+  `sys.path` is a *namespace package* — `import
+  hazma.field_theory_helper_functions` still succeeded right after the
+  `git rm` (Task 0.3). `rm -rf` too, then re-run the negative import
+  check. Any verify-after-delete that only reads the git index misses
+  this.
+- **A `git stash` round-trip un-stages a deletion** (Task 0.2). Stashing
+  to baseline the linters against the trunk and popping restores removals
+  as *unstaged*, so `git ls-files` still lists deleted paths and
+  `scripts/agents/check_doc_citations.py` tracebacks with
+  `FileNotFoundError`. `git add -A` after every pop. This bites precisely
+  when following the documented recipe for proving preflight redness is
+  pre-existing.
+- **A clean wheel is not evidence of a clean sdist** (Task 0.4). The two
+  are built by different machinery: `[tool.setuptools.packages.find]`
+  scoped the wheel to `hazma*` back in `7a817f9`, but `MANIFEST.in`'s
+  `global-include *.md` kept sweeping `.claude/`, `.codex/` and
+  `projects/` — 101 files of agent scaffolding — into the tarball.
+  Nobody noticed for four months because nobody ran `build --sdist`.
+- **An unanchored path probe over a tarball listing is useless.** Task
+  0.4's first pass matched `_positron`, `rambo` and `gamma_ray` as bare
+  substrings and produced 70+ hits, every one a live path
+  (`hazma/spectra/_positron/`, `hazma/phase_space/_rambo.py`,
+  `hazma/theory/_theory_gamma_ray_limits.py`). Anchor with `^` and `$`.
+  A probe that cries wolf gets ignored, which is worse than no probe.
+
+Two more worth carrying:
+
+- **Deleting a `.pyx` forces the matching `setup.py` edit in the same
+  task** — a deletion task cannot hand its extension groups to a later
+  cleanup task. `test/conftest.py` had the same property for
+  `test/decay/`: its `iterdir()` was unconditional and raised at
+  *collection*, taking the whole suite down.
+- **`docs/source/` has orphan pages no toctree reaches** (nine documents
+  from `index.rst`, plus four nested). Sphinx still builds an orphan, so
+  "unlinked" is not "not shipped" — but deleting one breaks no
+  navigation. Precedent set in Task 0.5 and reused in 0.2: an orphan page
+  whose entire subject is being removed is deleted, not converted into a
+  stub Sphinx cannot redirect from.
+
+## 4. Test Infrastructure State
+
+- **`test/conftest.py` now skips no test module at all.** Its
+  `collect_ignore` holds only the repo's `setup.py`. Both entries that
+  used to hide part of the suite went with the code they covered
+  (`test/decay/` in 0.3, `test/test_gamma_ray.py` in 0.2). **This makes
+  Phase 01 Task 1.3's suite merge simpler than planned.**
+- **Two disjoint suites remain, for one unrelated reason.**
+  `pytest -q test` → `244 passed, 20 skipped`; bare `pytest -q` →
+  `57 passed, 10 skipped`, because `setup.cfg`'s `testpaths = hazma`
+  keeps a bare run inside the package. Cite the command, never "the full
+  suite". **Zero compiled-layer pinned tests run anywhere** — that gap is
+  exactly what Phase 01 exists to close.
+- **The phase's own regression harness is the before/after grid**, and it
+  should be reused verbatim in Phases 04–06. Dump every compiled-backed
+  public entry point over `np.logspace(-2, 3, 200)` MeV at three parent
+  energies / three mediator masses, `git stash`, clean, rebuild, dump
+  again, diff. Task 0.3 ran 171 arrays, Task 0.2 159, Task 0.4 213; all
+  bit-for-bit identical. It caught nothing in this phase, which is the
+  point — it is what licenses "no public value changes" as a *measured*
+  claim rather than an assertion.
+- **`test/test_utils.py`** (16 pinned cases) was added by Task 0.3 when
+  `cross_section_prefactor` and `minkowski_dot` moved to pure Python. It
+  is the pattern for pinning a relocated numeric helper.
+- **New in this phase and worth keeping: install the sdist and run it.**
+  `uv build --sdist`, then `uv pip install --no-binary hazma
+  dist/*.tar.gz` into a *fresh* venv and import-smoke from outside the
+  repo. A tarball can pass every path probe and still fail to build.
+  Phase 07 Task 7.1 should re-run this against maturin.
+- **`preflight.sh` cannot return zero for a file under `hazma/`** on the
+  trunk (gates 2 and 3), while CI enforces only `black` plus
+  `ruff --isolated --select E9,F63,F7,F82`. Every task in this phase
+  inherited the two red rows and had to prove they were pre-existing.
+  Tracked in
+  [`../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md).
+
+## 5. Follow-on seeds
+
+- **The sdist payload is unexamined.** Beyond the scaffolding Task 0.4
+  pruned, the tarball still ships 20 cythonized `*.c` (never used — the
+  build always re-cythonizes, and their presence makes the sdist
+  build-output rather than source), `docs/` (46 files), `test/` (12) and
+  `notebooks/` (2), and `pyproject.toml`'s package-data lists `*.pyd`
+  where `*.pxd` was surely meant. Each is a judgment call rather than a
+  defect, which is why a dead-code task did not settle them. **Trigger:
+  before Phase 07 Task 7.1** — maturin does not read `MANIFEST.in`, so
+  after the cutover the same decisions cost more to express. Filed as
+  [`../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md).
+- **`requirements.txt` and `Dockerfile` contradict `pyproject.toml`**
+  (`numpy>=1.16.2` against `numpy>=2.0`; a dev toolchain of flake8 and
+  jupyter that the PEP 735 groups replaced). Deliberately untouched by
+  Task 0.4 because `phases/phase-07-cutover.md` Task 7.3 already owns
+  them. Noted here so the next reader does not re-derive that they are
+  stale.
+- **The constants tables are still deliberately divergent.**
+  `_utils/legacy_parameters.pxd` versus `_utils/constants.pxd`, preserved
+  bit-for-bit per `../rules.md` rule 4. Consolidation is a *declared
+  numerical change* for after the port, and is already named in
+  `PLAN.md` §Scope as out of scope. It remains the most obvious
+  post-project cleanup.
+- **The remaining `sqrt(kallen_lambda(...))` call sites** carved out of
+  the `cross_section_prefactor` repair —
+  [`../../../docs/followups/todo/kallen-under-sqrt-remaining-call-sites.md`](../../../docs/followups/todo/kallen-under-sqrt-remaining-call-sites.md).
+  Phase 01 pins whatever these currently return, so fixing one afterwards
+  means regenerating corpus entries. Worth resolving early or accepting
+  consciously.
+- **`hazma/experimental/axial_vector_mediator/__init__.py` is broken on
+  the trunk** (`from hazma.theory import Theory`, but `hazma.theory`
+  exports `TheoryAnn` / `TheoryDec`). Pre-existing, out of every lint
+  gate, and excluded from import smoke throughout this phase. No
+  follow-up filed — `experimental/` is explicitly not a public surface —
+  but it will keep tripping import sweeps until someone deletes or fixes
+  it.

--- a/projects/cython-to-rust/learnings/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/learnings/phase-00-dead-code-purge.md
@@ -111,7 +111,7 @@ them:
   are built by different machinery: `[tool.setuptools.packages.find]`
   scoped the wheel to `hazma*` back in `7a817f9`, but `MANIFEST.in`'s
   `global-include *.md` kept sweeping `.claude/`, `.codex/` and
-  `projects/` — 101 files of agent scaffolding — into the tarball.
+  `projects/` — 103 files of agent scaffolding — into the tarball.
   Nobody noticed for four months because nobody ran `build --sdist`.
 - **An unanchored path probe over a tarball listing is useless.** Task
   0.4's first pass matched `_positron`, `rambo` and `gamma_ray` as bare

--- a/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
@@ -1,7 +1,7 @@
 ---
 phase: 00
 title: Dead-code purge
-status: In Progress
+status: Complete
 ---
 
 # Phase 00: Dead-code purge
@@ -143,6 +143,24 @@ Everything else is behavior-invisible.
   deleted directories; sdist builds and contains no deleted paths.
   (Task 0.3 already removed the `hazma._decay.interpolation_data.*`
   entries; this task confirms nothing else dangles and runs the sdist.)
+  The first sdist run in the project's history turned up a defect the
+  deletions did not cause and this criterion did not anticipate:
+  `MANIFEST.in`'s `global-include *.md` is a repo-wide sweep, so the
+  tarball shipped `.claude/`, `.codex/` and `projects/` — 101 files of
+  agent scaffolding. `prune`d here rather than deferred, on the Task 0.2
+  precedent (widen the task, amend the criterion in the same PR). The
+  wheel was already clean; `test/`, `docs/` and the cythonized `*.c`
+  stay, and the case for dropping them is
+  [`../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md).
+- `_build.py` no longer exists — it was replaced by `setup.py` in
+  `7a817f9` (2026-08-02), *before* this project began, and thirteen
+  durable docs still named it as the build entry point (`AGENTS.md`,
+  four `docs/`, six `.claude/skills/`, one `.codex/skills/`, plus a
+  `docs/versioning.md` note warning about a stale `VERSION` constant
+  that died with the file). Swept here: this is the task that owns the
+  build entry point, and Phase 07 Task 7.3 — which nominally covers
+  these files — is six phases away, so the false statement would have
+  misled every agent in between.
 - CI green on the full matrix.
 
 ### Task 0.5: Execute ADR-0003 (`hazma.gamma_ray` removal)

--- a/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/phases/phase-00-dead-code-purge.md
@@ -146,9 +146,11 @@ Everything else is behavior-invisible.
   The first sdist run in the project's history turned up a defect the
   deletions did not cause and this criterion did not anticipate:
   `MANIFEST.in`'s `global-include *.md` is a repo-wide sweep, so the
-  tarball shipped `.claude/`, `.codex/` and `projects/` — 101 files of
-  agent scaffolding. `prune`d here rather than deferred, on the Task 0.2
-  precedent (widen the task, amend the criterion in the same PR). The
+  tarball shipped `.claude/`, `.codex/` and `projects/` — 103 files of
+  agent scaffolding (501 → 398 files, measured with and without the
+  `prune` lines on the same tree). `prune`d here rather than deferred,
+  on the Task 0.2 precedent (widen the task, amend the criterion in the
+  same PR). The
   wheel was already clean; `test/`, `docs/` and the cythonized `*.c`
   stay, and the case for dropping them is
   [`../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md).

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -21,8 +21,8 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 
 | # | Phase | Phase file | Working memory | Status |
 | --- | ------- | ----------- | ---------------- | -------- |
-| 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | In Progress (0.1, 0.2, 0.3, 0.5 done — every deletion has landed; only 0.4, build/packaging reconciliation, remains) |
-| 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | Not started |
+| 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | **Complete (2026-08-06)** — all five tasks done; [learnings](../learnings/phase-00-dead-code-purge.md) |
+| 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | Not started — **next**; unblocked by Phase 00 |
 | 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | Not started |
 | 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | Not started |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
@@ -87,8 +87,10 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   [`../../../docs/followups/done/black-pin-divergence-pyproject-vs-ci.md`](../../../docs/followups/done/black-pin-divergence-pyproject-vs-ci.md).
   The class is `[unpinned-formatter-version]` in
   `docs/agents/lessons.md`.
-- **`ruff check hazma test` really is red on the trunk (6844 findings),
-  and that does not block CI.** CI's ruff step is
+- **`ruff check hazma test` really is red on the trunk (6298 findings
+  under ruff 0.16.1; 6844 was the count under the version current at
+  Task 0.1 — the number tracks the linter, so re-measure rather than
+  quote), and that does not block CI.** CI's ruff step is
   `ruff check --isolated --select E9,F63,F7,F82`, which deliberately
   ignores `pyproject.toml`'s much stricter config. Judge the configured
   form as a delta against the trunk; run the `--isolated` form to
@@ -139,6 +141,26 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   body still reads "no direct replacement" by design — it is a dated
   record amended by its Addendum, and the forward-looking gate text was
   patched instead.
+- **A clean wheel is not evidence of a clean sdist** (Task 0.4). Wheel
+  contents come from `[tool.setuptools.packages.find]`, sdist contents
+  from `MANIFEST.in`, and fixing one has never fixed the other. The
+  sdist was shipping `.claude/`, `.codex/` and `projects/` — 101 files —
+  because `global-include *.md` is a repo-wide sweep. Pruned. **Phase 07
+  Task 7.1 inherits the general lesson:** maturin has its own
+  include/exclude machinery and reads neither of these files, so verify
+  the tarball's contents directly after the cutover instead of assuming
+  the wheel's cleanliness carries over.
+- **The sdist install-and-run check is the real packaging gate** (Task
+  0.4, new to this project): `uv build --sdist`, then
+  `uv pip install --no-binary hazma dist/*.tar.gz` into a fresh venv and
+  import-smoke from outside the repo. A path probe over `tar tzf` proves
+  nothing dangles by *name*; only a source install proves the build
+  works. Reuse it in Phase 07.
+- **`_build.py` does not exist and has not since 2026-08-02** (`7a817f9`
+  replaced it with `setup.py`). Thirteen durable docs still named it —
+  including `AGENTS.md` and the rebuild-awareness rules every review
+  skill points at — until Task 0.4 swept them. If a doc, skill or plan
+  mentions it again, that text predates the sweep.
 - **Sphinx orphan pages are a live doc-sweep hazard** (Task 0.5).
   `docs/source/index.rst` reaches nine documents; `limits.rst` and
   `models.rst` nest four more. Every other `docs/source/*.rst` is in no
@@ -220,6 +242,22 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   non-drop-in replacement) and `hazma.deprecated.rambo` are gone, and the
   `### Removed` block under `CHANGELOG.md`'s `[Unreleased]` is the
   settled wording for the Phase 07 aggregate.
+
+- **Task 0.4 (prune build and packaging config): no public value
+  changes.** 213 arrays — 12 `dnde_photon_*`, 12 `dnde_positron_*` and
+  12 `dnde_neutrino_*` over `np.logspace(-2, 3, 200)` MeV at parent
+  energies 150 / 500 / 1500 MeV, plus both models' `spectra()`,
+  `positron_spectra()`, `annihilation_cross_sections()` and
+  `thermal_cross_section()` at mediator masses 200 / 550 / 1200 MeV —
+  **bit-for-bit identical** across the change and a clean rebuild (max
+  relative deviation 0.000e+00). Expected, and the mechanism is
+  checkable rather than merely plausible: the only executable change is
+  the removal of an `if cpp:` branch no call site reaches, so every
+  `Extension` object `setup.py` builds is unchanged and the compiled
+  artifacts are identical. **Phase 00 therefore closes with the public
+  compiled surface exactly where it started**; the only declared drifts
+  in the whole phase are Task 0.3's two pure-Python helper swaps and the
+  out-of-band `two_body_momentum` repair, both above.
 
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
@@ -303,6 +341,20 @@ it from memory.)
   (+816 / −4,413); under `hazma/` and `test/` alone, 25 files and
   **−4,023 lines against +6**. Full list in
   [`phase-00/README.md`](phase-00/README.md).
+- **Task 0.4** — build/packaging reconciliation, closing the phase.
+  `setup.py`'s `make_extension` lost its unreachable C++ branch (and,
+  on the same signature, `List[str]` → `list[str]` plus a return type,
+  taking the file from 5 configured-`ruff` findings to 0); `MANIFEST.in`
+  gained `prune .claude` / `.codex` / `projects`, which took the sdist
+  from 498 to 397 files; `pyproject.toml` audited and unchanged.
+  The thirteen durable docs that still named `_build.py` were swept —
+  twelve by rename, plus `docs/versioning.md`, whose sole occurrence sat
+  inside an obsolete blockquote that was deleted outright (its `VERSION`
+  snippet was re-derived at the same time). One follow-up filed
+  ([sdist payload](../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md)).
+  Phase closed: learnings written, phase frontmatter
+  `status: Complete`, `PLAN.md` Phases row updated. Full list in
+  [`phase-00/README.md`](phase-00/README.md).
 - **Task 0.5** — docs repointed off `hazma.gamma_ray` ahead of the
   delete: `docs/source/gamma_ray.rst` deleted (orphan page),
   `hazma/spectra/_photon/__init__.py`'s `electron` docstring repointed,
@@ -316,7 +368,13 @@ it from memory.)
 
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
-- Later: per-phase Verification sections in `phase-XX/README.md`.
+- Per-phase Verification sections live in `phase-XX/README.md`.
+- **Phase 00 closing state (2026-08-06):** 20 `.pyx` ↔ 20 declared
+  `Extension`s ↔ 20 `.so`, verified as a set equality; zero C++;
+  `pytest -q test` → `244 passed, 20 skipped`, bare `pytest -q` →
+  `57 passed, 10 skipped`; sdist and wheel both build, and the sdist
+  installs and runs in a fresh venv from outside the repo. The public
+  compiled surface is unchanged from where the phase started.
 
 ## Open Questions
 
@@ -332,7 +390,7 @@ it from memory.)
   discharged.** Accepted 2026-08-04; non-deletion steps executed in
   Task 0.5 on 2026-08-05 (replacement status recorded, docs repointed);
   the deletion itself executed in Task 0.2 on 2026-08-06, with its
-  CHANGELOG entry. **Only Task 0.4 remains in Phase 00.**
+  CHANGELOG entry. **Phase 00 closed the same day.**
   `gamma_ray_fsr`'s successor, `hazma.spectra.dnde_photon_fsr`, shipped
   via
   [`../../../docs/followups/done/msqrd-driven-fsr-generator.md`](../../../docs/followups/done/msqrd-driven-fsr-generator.md).
@@ -344,6 +402,14 @@ it from memory.)
   The question is moot; the corpus will pin the fixed values.
 - Phase 05 parallelism: run 05 alongside 04 (no shared files) or keep
   strictly serial? Decide when Phase 04 starts, based on who's driving.
+- **The sdist payload** (opened by Task 0.4, the first task in the
+  project to build one): the tarball still ships 20 cythonized `*.c`,
+  `docs/`, `test/` and `notebooks/`, and `pyproject.toml`'s package-data
+  says `*.pyd` where `*.pxd` was surely meant. Deferred deliberately —
+  judgment calls, not defects — but **time-boxed to before Phase 07 Task
+  7.1**, because maturin does not read `MANIFEST.in` and the same
+  decisions cost more to express afterwards. Filed as
+  [`../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md).
 - ~~Whether the mediator cross-section `.pyx` include a constants
   header~~ — **closed by Task 0.1: they contain no `include` directive
   at all.**
@@ -375,10 +441,24 @@ it from memory.)
   `rh_neutrino/_rh_neutrino_fsr_four_body.pyx`. Read that file for the
   **live surface** and the cimport DAG, which Phases 04–06 still need;
   read its headline counts as history.
-- **20 extensions, 20 `.pyx`, 17 `.pxd`, zero C++** as of Task 0.2 —
-  re-derive with `find hazma -name '*.so' | wc -l` rather than quoting
-  this. That is the Phase 00 target the phase Exit Criteria name, hit
-  before Task 0.4 runs.
+- **20 extensions, 20 `.pyx`, 17 `.pxd`, zero C++**, and as of Task 0.4
+  `setup.py`'s declared list is *verified* to be that same set, not
+  merely the same size. Re-derive with the clean-then-rebuild recipe
+  rather than quoting this; a stale `.so` makes a wrong list look right.
+- **Phase 00 is Complete (2026-08-06).** Read
+  [`../learnings/phase-00-dead-code-purge.md`](../learnings/phase-00-dead-code-purge.md)
+  rather than its five task notes — it is the distillation, they are
+  history. Phase 01 is next and carries no decision gate.
+- **The build entry point is `setup.py`.** `_build.py` was deleted in
+  `7a817f9` (2026-08-02) and Task 0.4 swept the thirteen durable docs
+  that still named it, so `AGENTS.md`, `docs/`, the skills, `.github/`
+  and the build config are all clean. The name still appears under
+  `projects/` — that is this phase's own record of the sweep, not a live
+  reference.
+- **The sdist and wheel both build, and the sdist installs and runs** in
+  a fresh venv from outside the repo (recipe in Task 0.4's note; reuse
+  it in Phase 07). Neither ships a deleted path; neither ships the agent
+  scaffolding any more.
 - `test/` is green (244 passed / 20 skipped as of Task 0.2, 2026-08-06;
   68/20 at Task 0.3; 52/20 at Task 0.1) — merging the suites in Task 1.3
   is safe, and simpler than planned: `test/conftest.py` now skips **no**

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -144,8 +144,9 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 - **A clean wheel is not evidence of a clean sdist** (Task 0.4). Wheel
   contents come from `[tool.setuptools.packages.find]`, sdist contents
   from `MANIFEST.in`, and fixing one has never fixed the other. The
-  sdist was shipping `.claude/`, `.codex/` and `projects/` — 101 files —
-  because `global-include *.md` is a repo-wide sweep. Pruned. **Phase 07
+  sdist was shipping `.claude/`, `.codex/` and `projects/` — 103 files
+  on this branch's final tree — because `global-include *.md` is a
+  repo-wide sweep. Pruned: 501 → 398 files. **Phase 07
   Task 7.1 inherits the general lesson:** maturin has its own
   include/exclude machinery and reads neither of these files, so verify
   the tarball's contents directly after the cutover instead of assuming
@@ -346,7 +347,7 @@ it from memory.)
   on the same signature, `List[str]` → `list[str]` plus a return type,
   taking the file from 5 configured-`ruff` findings to 0); `MANIFEST.in`
   gained `prune .claude` / `.codex` / `projects`, which took the sdist
-  from 498 to 397 files; `pyproject.toml` audited and unchanged.
+  from 501 to 398 files; `pyproject.toml` audited and unchanged.
   The thirteen durable docs that still named `_build.py` were swept —
   twelve by rename, plus `docs/versioning.md`, whose sole occurrence sat
   inside an obsolete blockquote that was deleted outright (its `VERSION`

--- a/projects/cython-to-rust/task-notes/phase-00/README.md
+++ b/projects/cython-to-rust/task-notes/phase-00/README.md
@@ -3,8 +3,9 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 00
-**Status:** In Progress (Tasks 0.1, 0.2, 0.3, 0.5 Complete; only 0.4
-remains)
+**Status:** Complete (2026-08-06) — all five tasks Complete; phase
+learnings written to
+[`../../learnings/phase-00-dead-code-purge.md`](../../learnings/phase-00-dead-code-purge.md)
 **Plan References:** `../../phases/phase-00-dead-code-purge.md`
 **Related ADRs:** ADR-0003 (accepted 2026-08-04, with an Addendum the
 same day; Task 0.5 executed its non-deletion steps 2026-08-05 and Task
@@ -23,13 +24,21 @@ purge.
 | 0.1 | Relocate legacy constants header | — | Complete | [task-0.1-relocate-constants.md](task-0.1-relocate-constants.md) |
 | 0.2 | Delete phase-space / gamma-ray slice | 0.1 (ADR-0003 accepted 2026-08-04) | Complete | [task-0.2-delete-mc-slice.md](task-0.2-delete-mc-slice.md) |
 | 0.3 | Delete superseded kernels + helpers | 0.1 | Complete | [task-0.3-delete-superseded.md](task-0.3-delete-superseded.md) |
-| 0.4 | Prune build and packaging config | 0.2, 0.3 | Not started | [task-0.4-prune-build.md](task-0.4-prune-build.md) |
+| 0.4 | Prune build and packaging config | 0.2, 0.3 | Complete | [task-0.4-prune-build.md](task-0.4-prune-build.md) |
 | 0.5 | Execute ADR-0003 (`gamma_ray`) — ratified 2026-08-04 | — | Complete | [task-0.5-gamma-ray-decision.md](task-0.5-gamma-ray-decision.md) |
 
 ## Exit Criteria
 
-- All rows Complete; phase file frontmatter `status: Complete`.
-- Phase learnings at `../../learnings/phase-00-dead-code-purge.md`.
+- ~~All rows Complete; phase file frontmatter `status: Complete`.~~ —
+  **met 2026-08-06** by Task 0.4.
+- ~~Phase learnings at `../../learnings/phase-00-dead-code-purge.md`.~~ —
+  **written.**
+- The phase-file Exit Criteria are met too, all measured rather than
+  asserted: 20 `.pyx` ↔ 20 declared `Extension`s ↔ 20 `.so` as a set
+  equality; `git grep -l "std::" -- hazma/` empty; no `language="c++"`
+  anywhere in the build config. The one criterion that cannot close from
+  a worktree is **CI green on the full matrix** — local verification was
+  CPython 3.12 / macOS arm64 only.
 
 ## Inputs Reviewed
 
@@ -124,6 +133,34 @@ purge.
   (`AGENTS.md`, `docs/versioning.md` §6) asserted "it stays importable"
   as a fact about the tree rather than as a policy about whatever lives
   there; both were rescoped rather than dropped.
+- **A clean wheel is not evidence of a clean sdist** (Task 0.4). The two
+  are produced by different machinery: `7a817f9` scoped the *wheel* to
+  `hazma*` via `[tool.setuptools.packages.find]`, but `MANIFEST.in`'s
+  `global-include *.md` is a repo-wide sweep and kept putting `.claude/`
+  (18 files), `.codex/` (18) and `projects/` (65) into the *sdist*.
+  Nobody noticed for four months because no task had run
+  `build --sdist`. Task 0.4 was the first, and it is the only check in
+  Phase 00 that could have caught this.
+- **The extension list needs a set comparison, not a count** (Task 0.4).
+  A stale `.so` surviving from an earlier build inflates
+  `find hazma -name '*.so' | wc -l` until it matches a declared list that
+  is wrong. Clean first, then compare declared-in-`setup.py` vs `.pyx`
+  on disk vs `.so` built, in both directions. All three are the same
+  20-element set today.
+- **An unanchored path probe over a tarball listing is worse than none**
+  (Task 0.4). Matching `_positron`, `rambo` or `gamma_ray` as bare
+  substrings returned 70+ hits, every one a live path
+  (`hazma/spectra/_positron/`, `hazma/phase_space/_rambo.py`,
+  `hazma/theory/_theory_gamma_ray_limits.py`). Anchor with `^` / `$`.
+- **`_build.py` has not existed since `7a817f9` (2026-08-02)** — it was
+  replaced by `setup.py` in the commit that fixed `py3-none-any`
+  mistagging, *before* this project started. Thirteen durable docs still
+  named it as the build entry point until Task 0.4 swept them, including
+  `AGENTS.md` and the rebuild-awareness rule in
+  `docs/agents/environment.md`. `docs/versioning.md` also warned readers
+  off a stale `VERSION = "2.0.0-rc1"` that died with the file
+  (`git show 7a817f9^:_build.py`); that blockquote was deleted rather
+  than renamed, since `setup.py` has no `VERSION` at all.
 - **`docs/source/` has orphan pages that no toctree reaches** — checked
   in Task 0.5: `index.rst` lists nine documents, `limits.rst` nests
   `gamma_ray_limits` + `cmb`, `models.rst` nests the two mediators.
@@ -185,6 +222,29 @@ purge.
   defer its own groups. What is left for 0.4 is the survivor-count
   reconciliation, the sdist, and `make_extension`'s now-unreachable
   `cpp=True` branch.
+- Task 0.4 found **nothing left to remove** from `setup.py`'s extension
+  list — Tasks 0.2 and 0.3 had already dropped every group, exactly as
+  the phase file predicted. The deliverable there is the *measurement*
+  (a set equality across three sources), not an edit.
+- Task 0.4 pruned `.claude/`, `.codex/` and `projects/` from the sdist
+  but deliberately left the cythonized `*.c`, `docs/`, `test/`,
+  `notebooks/` and the `*.pyd`-for-`*.pxd` package-data entry alone.
+  The first is not distribution content under any reading; the rest are
+  judgment calls that a dead-code-purge task is the wrong place to
+  settle. Filed as
+  [`../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md)
+  with a deadline of **before Phase 07 Task 7.1**, after which
+  `MANIFEST.in` no longer exists to fix.
+- Task 0.4 left `requirements.txt` and `Dockerfile` untouched even though
+  both contradict `pyproject.toml` today: `phases/phase-07-cutover.md`
+  Task 7.3 already owns them. Widening into another task's named scope
+  is theft, not initiative — the distinction that separates it from the
+  two widenings 0.4 *did* take.
+- Task 0.4 swept `_build.py` → `setup.py` across all thirteen docs rather
+  than deferring to Phase 07 Task 7.3, which nominally covers those files
+  but is six phases away and is scoped to the *Rust* rewrite. A wrong
+  filename in the tie-breaker doc would have misled every agent in
+  Phases 01–06, and a partial sweep is worse than none.
 - Task 0.2 landed the `### Removed` CHANGELOG block under `[Unreleased]`
   instead of deferring it to Phase 07: the replacement wording was
   already settled by ADR-0003's Addendum, and `../README.md` forbids
@@ -266,6 +326,31 @@ purge.
 - `projects/cython-to-rust/task-notes/phase-00/task-0.5-gamma-ray-decision.md`
   added. Full list in the task note.
 
+### Task 0.4
+
+- `setup.py` — `make_extension` loses the `cpp` parameter and the
+  `language="c++"` / `-std=c++11` branch; annotations modernised to
+  builtin generics (`from typing import List` dropped with them).
+  Extension list unchanged: it was already exact.
+- `MANIFEST.in` — `prune .claude` / `.codex` / `projects`, with a comment
+  on why the `global-include` above them reaches that far.
+  `pyproject.toml` audited and **unchanged**.
+- Thirteen durable docs named `_build.py`; twelve got the rename to
+  `setup.py` (`AGENTS.md`, `docs/PR_GUIDELINES.md`,
+  `docs/agents/{environment,preflight,review-lenses}.md`, six
+  `.claude/skills/*/SKILL.md`, one
+  `.codex/skills/execute-single-task/SKILL.md`). The thirteenth,
+  `docs/versioning.md`, had its only occurrence inside a blockquote
+  warning about a stale `VERSION` constant that died with the file — the
+  blockquote was deleted rather than renamed, and the
+  `hazma/__init__.py` snippet three lines above it re-derived
+  (`2.0.2` → `2.1.0`).
+- `docs/followups/todo/sdist-ships-generated-c-and-docs.md` (new) + index
+  row. Phase file: Task 0.4 exit criteria amended, frontmatter
+  `status: Complete`. `PLAN.md` Phases row 00.
+  `learnings/phase-00-dead-code-purge.md` (new). Full list in the task
+  note.
+
 ## Verification
 
 - Per task: importer re-check (`rg` the module path) quoted in PR body;
@@ -288,6 +373,20 @@ purge.
   20 the phase Exit Criteria name); 26 `.pyx` / 19 `.pxd` remain; the
   171-array public compiled surface bit-for-bit unchanged. Details in
   the task note.
+- Task 0.4: `pytest -q test` → `244 passed, 20 skipped`; bare `pytest -q`
+  → `57 passed, 10 skipped` — unchanged from Task 0.2, as expected for a
+  diff that touches no library code. Extension reconciliation is a
+  verified **set equality**: 20 declared in `setup.py`, 20 `.pyx` on
+  disk, 20 `.so` from a clean `pip install -e .`, all four symmetric
+  differences empty; `git grep -l 'std::' -- hazma/` empty; no
+  `language=` / `c++` token anywhere in the build config. sdist 498 → 397
+  files (the 101 scaffolding files gone), **and it installs**: a fresh
+  venv with `uv pip install --no-binary hazma dist/hazma-2.1.0.tar.gz`
+  imports every public entry point from outside the repo and reproduces
+  the expected spectra. Wheel: 311 files, `hazma/` + dist-info only, 20
+  `.so`, `Tag: cp312-cp312-macosx_11_0_arm64`, `Root-Is-Purelib: false`.
+  213-array public compiled surface bit-for-bit unchanged
+  (`0.000e+00`). Details in the task note.
 - Task 0.5: docs-only, so no build and no test-count change — the diff's
   single file under `hazma/` is a docstring hunk in
   `hazma/spectra/_photon/__init__.py`. Checks run instead: no toctree
@@ -327,8 +426,25 @@ purge.
   file: `hazma/spectra/_photon/__init__.py` was the only file under
   `hazma/` it edited, so its import block was sorted in-task and that
   gate now passes. The `ruff` row stays red — those findings are `UP006`
-  / `ANN001` in `setup.py` and the test files, out of any single task's
-  scope.
+  / `ANN001` in the test files, out of any single task's scope.
+  **Task 0.4 narrowed it again:** `setup.py` was the other named
+  offender, and rewriting `make_extension` took it from 5 configured
+  findings to **0** (`UP006` fixed by `list[str]`, `ANN201` by the
+  `-> list[Extension]` return type, the rest by deleting the C++
+  branch). `ruff check hazma test` is unchanged at 6298 both ways —
+  `setup.py` sits at the repo root and is outside those two paths, so it
+  never contributed to that number. `black --check hazma test` and the
+  CI-form `ruff --isolated` both pass.
+- **The sdist payload is unexamined** (opened by Task 0.4, the first
+  task to build one). Beyond the agent scaffolding it pruned, the tarball
+  still ships 20 cythonized `*.c` (regenerated by the sdist build itself,
+  so they are build output rather than source), `docs/`, `test/`,
+  `notebooks/`, and `pyproject.toml` lists `*.pyd` where `*.pxd` was
+  surely meant. Deferred deliberately — each is a judgment call, not a
+  defect. Filed as
+  [`docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md),
+  **time-boxed to before Phase 07 Task 7.1**, after which `MANIFEST.in`
+  no longer exists to fix.
 - ~~`cross_section_prefactor`'s threshold cancellation — deferred;
   sequencing matters, because if Phase 01 captures the corpus first the
   Rust port inherits the cancelling values~~ — **closed: repaired
@@ -341,54 +457,74 @@ purge.
 ## Plan Impact
 
 **Impact Level:** None (this file is metadata, not a canonical change).
-Tasks 0.1, 0.2, 0.3, and 0.5 each patched canonical files; those patches
-are recorded in their own task notes' Plan Impact sections (0.5 also
-patched `../../PLAN.md`; 0.2 rewrote **Task 0.4's** exit criteria as well
-as its own).
+All five tasks patched canonical files; those patches are recorded in
+their own task notes' Plan Impact sections. 0.5 also patched
+`../../PLAN.md`; 0.2 rewrote **Task 0.4's** exit criteria as well as its
+own; 0.4 amended its own twice (the sdist prune, the `_build.py` sweep),
+flipped the phase file to `status: Complete`, and updated `PLAN.md`'s
+Phases row. Patching a criterion in the same PR that outgrows it is now
+this phase's established precedent, used three times.
 
 ## Handoff to Next Task
 
-**For the next agent working in Phase 00:** read `../../PLAN.md`, then
-`../README.md`, then this file, then the phase file. **Tasks 0.1, 0.2,
-0.3 and 0.5 are done — Task 0.4 is all that remains, and it closes the
-phase.** No sign-off is outstanding anywhere in this phase; all three
-project ADRs are Accepted and ADR-0003 is fully discharged.
+**Phase 00 is closed (2026-08-06).** There is no next task *in this
+phase*. The next agent starts **Phase 01 — golden parity corpus**: read
+`../../PLAN.md`, then `../README.md`, then
+[`../../learnings/phase-00-dead-code-purge.md`](../../learnings/phase-00-dead-code-purge.md),
+then `../../phases/phase-01-parity-corpus.md`. Prefer the learnings file
+over this one and over the five task notes — those are history, it is the
+distillation. No sign-off is outstanding anywhere; all three project ADRs
+are Accepted and ADR-0003 is fully discharged.
 
-**Every deletion in this phase has landed.** Task 0.4 is build and
-packaging reconciliation only, and it is smaller than the original phase
-text implied — Task 0.2 rewrote its exit criteria, so read them from the
-phase file rather than from memory. What is left:
+**Currently safe to assume:**
 
-1. reconcile `setup.py`'s extension list against the survivor count
-   (20 `.so` from a clean `pip install -e .`);
-2. delete `make_extension`'s now-unreachable `cpp=True` parameter and
-   `language="c++"` branch (`setup.py:18,28-35`) — no caller passes it;
-3. confirm `pyproject.toml` package-data and `MANIFEST.in` dangle
-   nothing, and **run the sdist** — Task 0.2 did not, `build` was not in
-   the venv;
-4. write `../../learnings/phase-00-dead-code-purge.md` and flip the phase
-   file frontmatter to `status: Complete`.
+- **20 extensions, 20 `.pyx`, 17 `.pxd`, zero C++**, and the build config
+  is reconciled against them as a verified set equality rather than a
+  count. Re-derive with the clean-then-rebuild recipe (see Findings)
+  rather than quoting these numbers.
+- The **sdist and wheel both build, and the sdist installs and runs** in
+  a fresh venv from outside the repo. Neither ships a deleted path, and
+  neither ships the agent scaffolding any more. The wheel is 311 files,
+  `hazma/` + dist-info only, correctly platform-tagged.
+- Every durable doc names **`setup.py`**, not `_build.py`, as the build
+  entry point — the rebuild-awareness rules in the skills and in
+  `docs/agents/review-lenses.md` are actionable again.
+- `test/conftest.py` skips no test module; `collect_ignore` holds only
+  the repo's `setup.py`. `pytest -q test` → `244 passed, 20 skipped`;
+  bare `pytest -q` → `57 passed, 10 skipped`.
+- `hazma/deprecated/` no longer exists. `hazma.gamma_ray`,
+  `hazma._gamma_ray`, `hazma._phase_space` and
+  `hazma.rh_neutrino._rh_neutrino_spectra` all raise
+  `ModuleNotFoundError`. `hazma.utils` is the single home for
+  `cross_section_prefactor` and `minkowski_dot`. `CHANGELOG.md`'s
+  `[Unreleased]` already carries the `### Removed` block for both
+  `major` removals with their settled replacement wording — Phase 07
+  aggregates it, it does not rewrite it.
+- The **public compiled surface never moved in this phase** (64 / 171 /
+  159 / 213 arrays bit-for-bit identical across Tasks 0.1 / 0.3 / 0.2 /
+  0.4). The two declared drifts are pure-Python helper swaps, recorded
+  in `../README.md`.
+- Working habits that cost this phase real time: clean stale
+  `.c`/`.cpp`/`.so` before every rebuild, `rm -rf` a package directory
+  after `git rm -r`, `git add -A` after any `git stash pop`, and anchor
+  path probes with `^`/`$`.
 
-**Currently safe to assume:** the tree carries **20 extensions, 20
-`.pyx`, 17 `.pxd`**, zero C++ (`git grep -l 'std::' -- hazma/` is empty),
-and no `.pyx` outside the live surface — re-derive with
-`find hazma -name '*.so' | wc -l` rather than quoting this.
-`test/conftest.py` skips no test module at all; `collect_ignore` holds
-only the repo's `setup.py`. `hazma/deprecated/` no longer exists.
-`hazma.gamma_ray`, `hazma._gamma_ray`, `hazma._phase_space` and
-`hazma.rh_neutrino._rh_neutrino_spectra` all raise `ModuleNotFoundError`.
-`hazma.utils` is the single home for `cross_section_prefactor` and
-`minkowski_dot`. `CHANGELOG.md`'s `[Unreleased]` already carries the
-`### Removed` block for both `major` removals with their replacement
-wording — Phase 07 aggregates it, it does not rewrite it. Clean stale
-`.c`/`.cpp`/`.so` before every rebuild, `rm -rf` a package directory
-after `git rm -r`, and `git add -A` after any `git stash pop`
-(see Findings).
+**Currently risky / unknown:**
 
-**Currently risky / unknown:** the sdist has not been built since the
-deletions — Task 0.4 owes it. And whether external user code imported
-the removed public names (`hazma.gamma_ray`, `hazma.deprecated.rambo`,
-the double-underscore legacy shims) is unknowable in-repo: the
-verify-before-delete checks found no in-repo importer that was not itself
-being deleted, but they cannot see downstream users. That is exactly what
-the project's `version_bump: major` is for.
+- **CI has not run Task 0.4's diff.** Local verification was CPython 3.12
+  on macOS arm64; the matrix is 3.10–3.14 on Linux plus macOS 3.14. "CI
+  green on the full matrix" is the one phase Exit Criterion that closes
+  on the PR, not in the worktree.
+- The **sdist payload** question is open and time-boxed to before Task
+  7.1 (see Open Questions).
+- Whether external user code imported the removed public names
+  (`hazma.gamma_ray`, `hazma.deprecated.rambo`, the double-underscore
+  legacy shims) is unknowable in-repo. The verify-before-delete checks
+  found no in-repo importer that was not itself being deleted, but they
+  cannot see downstream users — which is what `version_bump: major` is
+  for.
+- **Phase 01 inherits one hard obligation** from this phase's numerics:
+  the corpus must pin the **post-`two_body_momentum`-fix** values, not
+  the pre-fix ones, and the remaining `sqrt(kallen_lambda(...))` sites
+  are still unfixed — pinning them freezes their current behavior. See
+  `../README.md` §"Numerical impact so far".

--- a/projects/cython-to-rust/task-notes/phase-00/README.md
+++ b/projects/cython-to-rust/task-notes/phase-00/README.md
@@ -140,7 +140,7 @@ purge.
   are produced by different machinery: `7a817f9` scoped the *wheel* to
   `hazma*` via `[tool.setuptools.packages.find]`, but `MANIFEST.in`'s
   `global-include *.md` is a repo-wide sweep and kept putting `.claude/`
-  (18 files), `.codex/` (18) and `projects/` (65) into the *sdist*.
+  (18 files), `.codex/` (18) and `projects/` (67) into the *sdist*.
   Nobody noticed for four months because no task had run
   `build --sdist`. Task 0.4 was the first, and it is the only check in
   Phase 00 that could have caught this.
@@ -382,8 +382,10 @@ purge.
   verified **set equality**: 20 declared in `setup.py`, 20 `.pyx` on
   disk, 20 `.so` from a clean `pip install -e .`, all four symmetric
   differences empty; `git grep -l 'std::' -- hazma/` empty; no
-  `language=` / `c++` token anywhere in the build config. sdist 498 → 397
-  files (the 101 scaffolding files gone), **and it installs**: a fresh
+  `language=` / `c++` token anywhere in the build config. sdist
+  501 → 398 files with and without the `prune` lines, both measured on
+  the final tree (the 103 scaffolding files gone), **and it installs**:
+  a fresh
   venv with `uv pip install --no-binary hazma dist/hazma-2.1.0.tar.gz`
   imports every public entry point from outside the repo and reproduces
   the expected spectra. Wheel: 311 files, `hazma/` + dist-info only, 20

--- a/projects/cython-to-rust/task-notes/phase-00/README.md
+++ b/projects/cython-to-rust/task-notes/phase-00/README.md
@@ -36,9 +36,12 @@ purge.
 - The phase-file Exit Criteria are met too, all measured rather than
   asserted: 20 `.pyx` ↔ 20 declared `Extension`s ↔ 20 `.so` as a set
   equality; `git grep -l "std::" -- hazma/` empty; no `language="c++"`
-  anywhere in the build config. The one criterion that cannot close from
-  a worktree is **CI green on the full matrix** — local verification was
-  CPython 3.12 / macOS arm64 only.
+  anywhere in the build config.
+- **CI green on the full matrix** — the one criterion that could not
+  close from a worktree, closed on
+  [PR #49](https://github.com/LoganAMorrison/Hazma/pull/49) (run
+  31151019771): Lint plus ubuntu-latest py3.10–3.14 and macos-latest
+  py3.14, all passing.
 
 ## Inputs Reviewed
 

--- a/projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md
+++ b/projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md
@@ -74,11 +74,12 @@ last two bullets were added *by* this task and are flagged as such.
   (`find hazma -name '*.c' -o -name '*.cpp' -o -name '*.so' | xargs rm -f`)
   first, then compare the three sets, not the three counts.
 - **`MANIFEST.in`'s `global-include` is repo-wide, and nothing scoped
-  it.** The pre-task sdist carried 498 files, of which 101 were
-  `.claude/` (18), `.codex/` (18) and `projects/` (65) — the agent
-  skills, and this project's own plans, ADRs and task notes, inside a
-  publishable tarball. The wheel has been clean since `7a817f9`
-  restricted `[tool.setuptools.packages.find]` to `hazma*`; that fix
+  it.** Without the `prune` lines this task added, the sdist carries
+  **501** files, of which **103** are `.claude/` (18), `.codex/` (18)
+  and `projects/` (67) — the agent skills, and this project's own plans,
+  ADRs and task notes, inside a publishable tarball. The wheel has been
+  clean since `7a817f9` restricted
+  `[tool.setuptools.packages.find]` to `hazma*`; that fix
   never reached the sdist, because the two are built by different
   machinery. **A clean wheel is not evidence of a clean sdist.**
 - **The sdist had never been built in this project.** Task 0.2's handoff
@@ -137,6 +138,20 @@ last two bullets were added *by* this task and are flagged as such.
   dead-code-purge task is the wrong place to settle packaging policy.
   Follow-up filed with the measured inventories and a stated deadline —
   before Task 7.1, because maturin will not read `MANIFEST.in`.
+- **Review round 1 (PR #49) — the recorded sdist counts were stale.**
+  `498 → 397` was measured mid-task, before this task's own task note,
+  learnings file and follow-up existed; the follow-up lands under
+  `docs/`, which is not pruned, so it changed the very number it
+  documents. Re-derived both halves on the final tree with and without
+  the `prune` lines: **501 → 398**, 103 scaffolding files. The reviewer
+  cited three occurrences; the §11 sweep found **six** files carrying
+  the stale figures (`101`, `498`, `397`, plus the `projects/ (65)` and
+  `docs/ (46)` sub-counts), and all six were fixed together. Rebuilding
+  also exposed that a dirty tree yields **400** — setuptools' sdist
+  walks the filesystem, not the git index, so `.pytest_cache/README.md`
+  ships despite `.gitignore:526`. Added to the sdist follow-up as its
+  own item, since it is the mechanism behind the drift rather than a
+  separate defect.
 - **Left `requirements.txt` and `Dockerfile` alone** even though both
   contradict `pyproject.toml` today (`numpy>=1.16.2` vs `numpy>=2.0`).
   `phase-07-cutover.md` Task 7.3 already names both. Touching them here
@@ -246,11 +261,30 @@ That is the 20 the phase Exit Criteria name: 8 `spectra/_photon` + 2
 
 **sdist** (`uv build --sdist`), before and after the `MANIFEST.in` prune:
 
-| | before | after |
+Both columns are measured on **this branch's final tree** (`b193c22`,
+clean of build artifacts), by building the sdist with and without the
+three `prune` lines. An earlier draft of this table read `498 → 397`
+from a mid-task measurement and was **wrong by construction** — see the
+note below it.
+
+| | without `prune` | with `prune` |
 | --- | --- | --- |
-| files in tarball | 498 | 397 |
-| `.claude/` + `.codex/` + `projects/` | 101 | 0 |
+| files in tarball | 501 | 398 |
+| `.claude/` + `.codex/` + `projects/` | 103 (18 + 18 + 67) | 0 |
+| `docs/` | 47 | 47 |
 | deleted Phase-00 paths | 0 | 0 |
+
+**Why the first numbers were wrong, and why it matters beyond a typo.**
+The original `498 → 397` was taken right after the `MANIFEST.in` edit,
+*before* this task had written its own task note, its learnings file and
+`docs/followups/todo/sdist-ships-generated-c-and-docs.md`. Those three
+files then landed in the tree — two under the now-pruned `projects/`,
+but the follow-up under `docs/`, which is **not** pruned. So the
+follow-up documenting the sdist payload became part of the sdist
+payload, and the recorded "after" count was stale the moment it was
+written. A before/after pair is only meaningful when both halves are
+measured on the same tree; taking "before" early and "after" late
+silently compares two different trees. Caught in review.
 
 The deleted-path probe is an anchored alternation over every path Phase
 00 removed (`^hazma/_decay/`, `^hazma/_gamma_ray/`, `^hazma/_phase_space/`,

--- a/projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md
+++ b/projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md
@@ -35,9 +35,12 @@ last two bullets were added *by* this task and are flagged as such.
 - [x] Phase closure: `../../learnings/phase-00-dead-code-purge.md`
   written, phase file frontmatter `status: Complete`, `PLAN.md` Phases
   table row updated.
-- [ ] CI green on the full matrix — cannot be checked pre-PR; verified
-  locally on CPython 3.12 (build, sdist, wheel, both suites) and left to
-  the PR run.
+- [x] CI green on the full matrix — **closed on
+  [PR #49](https://github.com/LoganAMorrison/Hazma/pull/49)** (run
+  31151019771): Lint plus all six test legs (ubuntu-latest py3.10–3.14,
+  macos-latest py3.14). This was the one criterion that could not close
+  from a worktree; local verification was CPython 3.12 / macOS arm64
+  only (build, sdist, wheel, both suites).
 
 ## Inputs Reviewed
 

--- a/projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md
+++ b/projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md
@@ -1,0 +1,421 @@
+# Task 0.4: Prune build and packaging config
+
+**Date:** 2026-08-06
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-00-dead-code-purge.md` (Task 0.4
+and phase Exit Criteria); `../../PLAN.md` §Scope, §Numerical impact
+**Related ADRs:** none directly (ADR-0003 was fully discharged by Tasks
+0.5 and 0.2)
+**Depends On:** Tasks 0.2, 0.3 — both Complete
+
+## Objective
+
+Close Phase 00 by reconciling the build and packaging config against the
+surviving Cython surface: prove `setup.py`'s extension list is exactly
+the survivors, delete the `make_extension` C++ branch that no caller can
+reach any more, and run the sdist that no task in this phase had yet run.
+
+## Exit Criteria
+
+Copied from the phase file's Task 0.4 block before implementation; the
+last two bullets were added *by* this task and are flagged as such.
+
+- [x] `setup.py`'s extension list matches the survivors exactly, counted
+  against the `.so` from a fresh `pip install -e .`.
+- [x] `make_extension`'s now-unreachable `cpp=True` parameter and
+  `language="c++"` branch removed — no caller has passed it since Task
+  0.2.
+- [x] `pyproject.toml` package-data globs and `MANIFEST.in` ship no
+  deleted directory; **the sdist builds and contains no deleted path.**
+- [x] *(scope addition, criterion amended in this PR)* the sdist ships no
+  agent scaffolding.
+- [x] *(scope addition, criterion amended in this PR)* no durable doc
+  names `_build.py` as the build entry point.
+- [x] Phase closure: `../../learnings/phase-00-dead-code-purge.md`
+  written, phase file frontmatter `status: Complete`, `PLAN.md` Phases
+  table row updated.
+- [ ] CI green on the full matrix — cannot be checked pre-PR; verified
+  locally on CPython 3.12 (build, sdist, wheel, both suites) and left to
+  the PR run.
+
+## Inputs Reviewed
+
+- `../../PLAN.md` (all sections), `../README.md`, `README.md` (phase-00
+  working memory), `../../phases/phase-00-dead-code-purge.md`,
+  `../../rules.md`.
+- `../../phases/phase-07-cutover.md` Tasks 7.1/7.3 — checked for overlap
+  before widening scope. It already owns `requirements.txt` and
+  `Dockerfile`, so this task left both alone.
+- `docs/agents/environment.md`, `docs/agents/preflight.md`,
+  `docs/agents/doc-consistency.md`, `docs/agents/lessons.md`.
+- `setup.py`, `pyproject.toml`, `MANIFEST.in`, `setup.cfg`,
+  `requirements.txt`, `Dockerfile`, `.github/workflows/ci.yml`.
+- `git show 7a817f9` — the commit that deleted `_build.py` and added
+  `setup.py`.
+
+## Findings
+
+- **The extension list was already correct; the reconciliation is the
+  deliverable, not a fix.** Declared-in-`setup.py`, `.pyx`-on-disk and
+  `.so`-built are the same 20-element set, with empty symmetric
+  differences in both directions. Tasks 0.2 and 0.3 each dropped their
+  own groups as they deleted sources — as the phase file predicted, a
+  deletion task cannot defer them — so Task 0.4 found nothing left to
+  remove. Recorded here because "no change" is a result that has to be
+  *measured*: the criterion is a set equality, not an eyeball count of a
+  literal list.
+- **The `.so` count is not by itself evidence of reconciliation.** A
+  stale `.so` from a prior build survives `pip install -e .` and inflates
+  the count to match a list that is wrong. Clean
+  (`find hazma -name '*.c' -o -name '*.cpp' -o -name '*.so' | xargs rm -f`)
+  first, then compare the three sets, not the three counts.
+- **`MANIFEST.in`'s `global-include` is repo-wide, and nothing scoped
+  it.** The pre-task sdist carried 498 files, of which 101 were
+  `.claude/` (18), `.codex/` (18) and `projects/` (65) — the agent
+  skills, and this project's own plans, ADRs and task notes, inside a
+  publishable tarball. The wheel has been clean since `7a817f9`
+  restricted `[tool.setuptools.packages.find]` to `hazma*`; that fix
+  never reached the sdist, because the two are built by different
+  machinery. **A clean wheel is not evidence of a clean sdist.**
+- **The sdist had never been built in this project.** Task 0.2's handoff
+  says so explicitly (`build` was not in its venv). It is the only check
+  in Phase 00 that could have caught the above, and it was the last one
+  to run.
+- **`_build.py` has not existed since 2026-08-02** — commit `7a817f9`
+  deleted it and added `setup.py` in the same change, to fix wheels
+  being mistagged `py3-none-any`. That predates this project. Thirteen
+  durable docs still named it as the build entry point, including
+  `AGENTS.md` (the tie-breaker) and `docs/agents/environment.md`'s
+  **Build and imports** section — i.e. the exact sentence every agent
+  reads before deciding whether a rebuild is required. `docs/versioning.md`
+  additionally warned readers to leave alone a stale `VERSION` constant
+  (`VERSION = "2.0.0-rc1"`, retrievable at `git show 7a817f9^:_build.py`)
+  in a file that no longer exists.
+- **The sdist regenerates the `.c` it ships.** Deleting every `.c` from
+  the tree and rebuilding the sdist still produced 20 of them: the
+  isolated sdist build runs `setup.py`, which calls `cythonize()`
+  unconditionally, writing `.c` next to each `.pyx` before `global-include
+  *.c` sweeps them in. So the tarball's contents are stable, but they are
+  build-output rather than source. Deferred, with the `docs/`, `test/`
+  and `*.pyd` questions, to
+  [`../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md).
+- **The preflight `isort`/`ruff` rows behave as Task 0.5 predicted**, and
+  this task narrowed the `ruff` debt: `setup.py` was one of the files
+  carrying `UP006` (`List[str]` where `list[str]` works on Python ≥3.10).
+  Modernising the annotation on the signature line this task was already
+  rewriting dropped the `from typing import List` import with it.
+
+## Decisions and Implementation Notes
+
+- **Removed the C++ branch rather than keeping it "in case".** No caller
+  passes `cpp`, `git grep -l 'std::' -- hazma/` is empty, and the phase
+  Exit Criteria require no `language="c++"` extension to remain. The
+  docstring records *why* it went (the C++ extensions left with
+  `_gamma_ray/` and `_phase_space/` in Task 0.2) so the next reader does
+  not reintroduce it. The docstring deliberately does not spell the
+  literal `language="c++"` — a future `grep` for that string should
+  return nothing, and a prose mention would be a false positive.
+- **Modernised `List[str]` → `list[str]` in the same signature.** Two
+  tokens on a line the task was rewriting anyway, on a repo whose floor
+  is Python 3.10; it removes a configured-`ruff` finding rather than
+  leaving one behind in a file this task owns. Not a behavior change —
+  `setup.py` runs only at build time and the build was re-run after.
+- **Pruned the agent scaffolding out of the sdist (scope addition).**
+  `.claude/`, `.codex/` and `projects/` are not distribution content
+  under any reading, the fix is three `prune` lines, and it was found by
+  the sdist run this task was assigned to perform. Widened here and the
+  criterion amended in the same PR, on **Task 0.2's precedent** — the
+  alternative was to file a follow-up against a `MANIFEST.in` that Phase
+  07 Task 7.1 deletes, which would have quietly dropped it.
+- **Did not prune `docs/`, `test/`, `notebooks/` or the cythonized
+  `*.c`.** Each is a judgment call with a real argument on both sides
+  (shipping tests in an sdist is a convention, not a defect), and a
+  dead-code-purge task is the wrong place to settle packaging policy.
+  Follow-up filed with the measured inventories and a stated deadline —
+  before Task 7.1, because maturin will not read `MANIFEST.in`.
+- **Left `requirements.txt` and `Dockerfile` alone** even though both
+  contradict `pyproject.toml` today (`numpy>=1.16.2` vs `numpy>=2.0`).
+  `phase-07-cutover.md` Task 7.3 already names both. Touching them here
+  would have been scope theft, not scope addition.
+- **Swept all thirteen docs that named `_build.py` (scope addition)** —
+  twelve by rename, one by deletion; see Files Changed. Phase 07 Task
+  7.3 nominally covers `AGENTS.md`,
+  `docs/agents/` and the skills — but it covers them for *Rust*, and it
+  is six phases out. A wrong filename in the tie-breaker doc and in the
+  rebuild-awareness rule would have misled every agent in Phases 01–06.
+  A partial fix would have been worse than none, so the sweep is
+  exhaustive over the *durable-doc surface* — `AGENTS.md`, `docs/`,
+  `.claude/`, `.codex/`, `.github/` and the build config all come back
+  empty. The name still appears 21 times under `projects/`, entirely in
+  this task's own records describing the rename; those are dated history,
+  not live references, and are deliberately left as written.
+- **Deleted `docs/versioning.md`'s stale-`VERSION` blockquote instead of
+  rewriting it.** A mechanical rename would have turned a true warning
+  about `_build.py` into a false claim about `setup.py`, which has no
+  `VERSION` at all. Same §11 stale-sibling pass caught the illustrative
+  snippet three lines above it still reading `"2.0.2"` against the live
+  `"2.1.0"`.
+
+## Files Changed
+
+### Build and packaging
+
+- `setup.py` — `make_extension` loses the `cpp` parameter, the
+  `language="c++"` / `-std=c++11` branch, and the now-single-use
+  `include_dirs` local; annotations modernised to builtin generics, so
+  `from typing import List` goes too. Docstring records why no C++ branch
+  remains. Extension list untouched (it was already exact).
+- `MANIFEST.in` — `prune .claude`, `prune .codex`, `prune projects`, with
+  a comment explaining that the `global-include` above them is a
+  repo-wide sweep and that the wheel is clean by a different mechanism.
+- `pyproject.toml` — **unchanged.** Audited, nothing dangles; the one
+  suspect entry (`*.pyd`) went to the follow-up.
+
+### Durable docs
+
+Thirteen files named `_build.py`
+(`grep -rl '_build\.py' --include='*.md' .` outside `projects/`).
+Twelve took the rename:
+
+- `AGENTS.md`, `docs/PR_GUIDELINES.md`, `docs/agents/environment.md`,
+  `docs/agents/preflight.md`, `docs/agents/review-lenses.md`,
+  `.claude/skills/{commit-and-pr,execute-single-task,review-cycle,
+  review-pr,review-respond,task-pipeline}/SKILL.md`,
+  `.codex/skills/execute-single-task/SKILL.md` — `_build.py` →
+  `setup.py` (one token each). `docs/PR_GUIDELINES.md` also had its
+  table row re-padded, since the replacement is a character shorter.
+
+The thirteenth is the exception the rename would have broken:
+
+- `docs/versioning.md` — its only occurrence was the blockquote warning
+  readers off a stale `VERSION`, so renaming would have produced a false
+  claim about `setup.py`. Blockquote deleted; the `hazma/__init__.py`
+  snippet three lines above it re-derived from the live file
+  (`2.0.2` → `2.1.0`).
+- `docs/agents/environment.md` additionally gained two new **Build and
+  imports** entries — the wheel-is-not-sdist trap and the
+  path-probe-is-not-a-build rule — per that file's own standing
+  instruction to record a new trap in the same commit. (`lessons.md`
+  was deliberately not touched: its format requires a merged PR
+  citation, and it says to put an uncitable class in a `docs/agents/`
+  checklist instead.)
+- `docs/followups/todo/sdist-ships-generated-c-and-docs.md` (new) +
+  an Open row in `docs/followups/README.md`.
+
+### Project bookkeeping
+
+- `projects/cython-to-rust/phases/phase-00-dead-code-purge.md` — Task 0.4
+  exit criteria amended for the two scope additions; frontmatter
+  `status: In Progress` → `Complete`.
+- `projects/cython-to-rust/PLAN.md` — Phases-table row 00.
+- `projects/cython-to-rust/learnings/phase-00-dead-code-purge.md` (new).
+- `projects/cython-to-rust/task-notes/README.md` and
+  `task-notes/phase-00/README.md` — status, findings, files-changed
+  roll-up, handoff.
+- This note.
+
+## Verification
+
+Environment: `uv venv --python 3.12` inside the task worktree; hazma
+built with `uv pip install --python .venv/bin/python -e .` after
+`find hazma -name '*.c' -o -name '*.cpp' -o -name '*.so' | xargs -r rm -f`.
+`python -c "import hazma; print(hazma.__file__)"` resolves inside the
+worktree, not to an installed copy.
+
+**Extension reconciliation** — the three sets compared programmatically
+(`setup.py` imported with a stubbed `setup()`; `.pyx` globbed; `.so`
+globbed), not counted by eye:
+
+```text
+declared in setup.py : 20
+.pyx sources on disk : 20
+.so built in place   : 20
+declared - pyx : none      pyx - declared : none
+declared - so  : none      so - declared  : none
+RECONCILED
+git grep -l 'std::' -- hazma/ : empty
+```
+
+That is the 20 the phase Exit Criteria name: 8 `spectra/_photon` + 2
+`spectra/_positron` + 3 `spectra/_neutrino` + 6 mediator +
+`_utils/boost`.
+
+**sdist** (`uv build --sdist`), before and after the `MANIFEST.in` prune:
+
+| | before | after |
+| --- | --- | --- |
+| files in tarball | 498 | 397 |
+| `.claude/` + `.codex/` + `projects/` | 101 | 0 |
+| deleted Phase-00 paths | 0 | 0 |
+
+The deleted-path probe is an anchored alternation over every path Phase
+00 removed (`^hazma/_decay/`, `^hazma/_gamma_ray/`, `^hazma/_phase_space/`,
+`^hazma/_positron/`, `^hazma/_neutrino/`,
+`^hazma/field_theory_helper_functions/`, `^hazma/deprecated/`,
+`^hazma/gamma_ray\.py$`, the three `hazma/__*.py` shims,
+`^hazma/spectra/_positron/_kaon\.pyx$`, `_rh_neutrino_fsr_four_body`,
+`_rh_neutrino_spectra\.py`, `^test/test_gamma_ray\.py$`, `^test/decay/`,
+`^docs/source/(gamma_ray|rambo)\.rst$`) — no hits either way. An earlier
+unanchored probe produced 70+ false positives on live paths
+(`hazma/spectra/_positron/`, `hazma/phase_space/_rambo.py`,
+`hazma/theory/_theory_gamma_ray_limits.py`); anchoring is load-bearing
+for this check, not cosmetic.
+
+**The sdist installs and runs.** Installed into a *fresh* venv with
+`uv pip install --no-binary hazma dist/hazma-2.1.0.tar.gz`, then
+imported and evaluated from outside the repo:
+
+```text
+dnde_photon_muon([1,10,50], 200 MeV) : [0.01769967 0.00142339 0.00012374]
+dnde_positron_muon([1,10,50], 200)   : [6.42823262e-05 5.41334191e-03 8.67582062e-03]
+ScalarMediator.total_spectrum(E, 550): [0.03022713 0.00252758 0.00531033]
+```
+
+`hazma.{theory,limits,cmb,pbh,utils,spectra,phase_space,relic_density}`,
+both mediator packages and `hazma.spectra._photon._muon` all import. This
+is the check that actually proves nothing dangles — a tarball can pass a
+path probe and still fail to build.
+
+**wheel** (`uv build --wheel`): 311 files, `hazma/` + `.dist-info` only,
+20 `.so`, `Tag: cp312-cp312-macosx_11_0_arm64` and
+`Root-Is-Purelib: false` (the mistagging `7a817f9` fixed has not
+regressed). No deleted path.
+
+**Tests**, both against the rebuilt worktree:
+
+```text
+$ .venv/bin/python -m pytest -q test
+244 passed, 20 skipped in 291.62s (0:04:51)
+
+$ .venv/bin/python -m pytest -q
+57 passed, 10 skipped in 0.45s
+```
+
+Identical to Task 0.2's counts, which is the expected result for a diff
+that changes no library code. The two commands are two *different*
+suites, not a subset and a superset: `setup.cfg`'s `testpaths = hazma`
+means a bare `pytest` collects only the in-package `*_test.py` modules
+(`hazma/form_factors/`, `hazma/phase_space/`) and never enters `test/`.
+Neither exited 5, and both summary lines are quoted above rather than
+inferred from the exit status. What they cover: the 244 are the
+spectra/mediator/positron/rh-neutrino suites plus `test/test_utils.py`'s
+16 pinned `hazma.utils` cases; the 57 are form-factor and phase-space
+unit tests. Note that **neither suite exercises the packaging change** —
+no test imports `setup.py` or inspects a built distribution, which is
+why the sdist install-and-run check above is the real gate here.
+
+**Numerical impact: none.** See below.
+
+## Numerical impact
+
+**No public value changes.** 213 arrays — every compiled-backed public
+entry point over `np.logspace(-2, 3, 200)` MeV (12 `dnde_photon_*`, 12
+`dnde_positron_*`, 12 `dnde_neutrino_*`, each at parent energies 150 /
+500 / 1500 MeV, plus both models' `spectra()`, `positron_spectra()`,
+`annihilation_cross_sections()` and `thermal_cross_section()` at mediator
+masses 200 / 550 / 1200 MeV) — **bit-for-bit identical** across the
+change, max relative deviation `0.000e+00`, measured by dumping the grid,
+`git stash`ing the diff, cleaning and rebuilding, dumping again, and
+comparing:
+
+```text
+arrays compared       : 213
+bit-for-bit identical : 213
+max relative deviation: 0.000e+00
+```
+
+Expected, and the mechanism is worth stating rather than asserting: the
+only executable change is the deletion of an `if cpp:` branch no call
+site reaches, so every `Extension` object `setup.py` constructs is
+identical to before and the compiled artifacts are the same. Everything
+else in the diff is `MANIFEST.in` and prose.
+
+Per the recipe in `../README.md`, `git add -A` was run after the
+`git stash pop` so the staged tree matches the working tree.
+
+## Open Questions
+
+- **The sdist payload** — cythonized `*.c`, `docs/`, `test/`,
+  `notebooks/`, and the `*.pyd`-for-`*.pxd` package-data entry. Filed as
+  [`../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md),
+  deliberately deferred, with a stated deadline of Phase 07 Task 7.1
+  (after which `MANIFEST.in` no longer exists to fix).
+- **`preflight.sh` `isort`/`ruff` on the trunk** — still red for reasons
+  unrelated to any single task, per
+  [`../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md).
+  This task's delta is recorded under Verification in `../README.md`.
+- **CI on the full matrix** is the one exit criterion that cannot be
+  closed from a local worktree. Everything CI runs was run here on
+  CPython 3.12; the 3.10–3.14 sweep and the Linux legs are the PR's job.
+
+## Plan Impact
+
+**Impact Level:** Update phase file (no ADR).
+
+- `phases/phase-00-dead-code-purge.md` Task 0.4 exit criteria amended to
+  name the two scope additions (the sdist prune, the `_build.py` doc
+  sweep), rather than absorbing them silently into the diff — Task 0.2's
+  precedent, now applied twice in this phase.
+- Same file's frontmatter flipped to `status: Complete`; `PLAN.md`'s
+  Phases table row 00 updated to match. No task ordering, interface,
+  unit or normalization convention changed, so no ADR.
+- Phase 07 Task 7.3's criteria were **not** patched. It still owes the
+  Rust-facing rewrite of `AGENTS.md` and `docs/agents/`; this task only
+  corrected a filename that was wrong independently of Rust.
+
+## Stale-state sweep
+
+Run against `claude/cython-to-rust/task-0.4-prune-build` at the end of
+the task.
+
+| Check | Command | Result |
+| --- | --- | --- |
+| No `_build.py` in the durable-doc surface | same grep over `AGENTS.md CLAUDE.md docs/ .claude/ .codex/ .github/ setup.py pyproject.toml MANIFEST.in setup.cfg` | no occurrences |
+| `_build.py` survives only as history | `grep -rn '_build\.py' projects/ \| wc -l` | 21 — all in this task's own note, the phase README, the learnings and the amended criterion, each describing the rename. Dated records, not live references; a repo-wide grep therefore does **not** come back empty, and a sweep row claiming it does would be wrong. |
+| No C++ wiring in build config | `grep -rn 'language\s*=\|c++\|std::' setup.py pyproject.toml MANIFEST.in` | no occurrences |
+| No C++ in the package | `git grep -l 'std::' -- hazma/` | empty |
+| Extension sets agree | reconcile script (above) | `RECONCILED`, 20/20/20 |
+| sdist ships no deleted path | anchored probe over `tar tzf` listing | no occurrences |
+| sdist ships no scaffolding | `cut -d/ -f1` on the listing | `.claude`/`.codex`/`projects` absent |
+| `VERSION` claim re-derived | `grep -n VERSION hazma/__init__.py` vs `docs/versioning.md` | both `2.1.0` |
+| Extension count claims | `find hazma -name '*.so' \| wc -l` | 20, matching every doc that states it |
+| Task-0.4 row vs `**Status:**` vs phase frontmatter | read all three | all `Complete` |
+| Forbidden tokens | `git diff origin/master -- '*.py'` for `breakpoint()`/`pdb`/`print()` | none added |
+| **Numerical-impact statement** | 213-array before/after diff | **none** — bit-for-bit identical, `0.000e+00` |
+
+## Handoff to Next Task
+
+**Phase 00 is closed.** The next agent starts Phase 01 (golden parity
+corpus) — read `../../PLAN.md`, then `../README.md`, then
+`../../learnings/phase-00-dead-code-purge.md`, then
+`../../phases/phase-01-parity-corpus.md`. Phase 00's per-task notes are
+history; the learnings file is the distillation.
+
+**Currently safe to assume:**
+
+- The build is reconciled and reproducible: 20 `.pyx` → 20 declared
+  `Extension`s → 20 `.so`, zero C++, no dangling package-data or
+  `MANIFEST.in` entry. Re-derive with the clean-then-count recipe rather
+  than quoting the number.
+- The sdist and the wheel both build, and the sdist *installs and runs*
+  in a fresh venv from outside the repo. That check now exists as a
+  recipe in this note; Phase 07 Task 7.1 should re-run it against
+  maturin.
+- Every durable doc names `setup.py`, not `_build.py`, as the build
+  entry point. The rebuild-awareness rules in the skills and in
+  `docs/agents/review-lenses.md` are now actionable.
+- The public compiled surface has not moved anywhere in Phase 00, with
+  the two declared pure-Python helper drifts recorded in `../README.md`
+  §"Numerical impact so far". **Phase 01's corpus pins the current
+  values** — including the out-of-band `two_body_momentum` repair — and
+  the Rust port must reproduce those.
+
+**Currently risky / unknown:**
+
+- CI has not run this diff. Local verification was CPython 3.12 on macOS
+  arm64 only; the matrix is 3.10–3.14 on Linux plus macOS 3.14.
+- The sdist payload question is open and time-boxed to before Task 7.1
+  (see Open Questions). It is the only packaging item Phase 00
+  deliberately left on the table besides `requirements.txt` /
+  `Dockerfile`, which belong to Task 7.3.

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,18 @@ wheel tags — otherwise wheels come out mistagged as py3-none-any.
 
 # pylint: disable=invalid-name
 
-from typing import List
-
 import numpy
 from Cython.Build import cythonize
 from setuptools import Extension, setup
 
 
-def make_extension(module: List[str], sources: List[str], cpp=False):
-    """Build a Cython extension module."""
+def make_extension(module: list[str], sources: list[str]) -> list[Extension]:
+    """Build a Cython extension module.
+
+    Every surviving extension compiles as C. The C++ ones went with
+    ``_gamma_ray/`` and ``_phase_space/`` in cython-to-rust Task 0.2, so
+    this helper no longer carries a C++ branch.
+    """
     package = ".".join(["hazma", *module])
     path = "/".join(["hazma", *module])
 
@@ -24,17 +27,7 @@ def make_extension(module: List[str], sources: List[str], cpp=False):
     for src in sources:
         m = package + "." + src
         p = [path + "/" + src + ".pyx"]
-        include_dirs = [numpy.get_include()]
-        if cpp:
-            exts = Extension(
-                m,
-                p,
-                extra_compile_args=["-std=c++11"],
-                language="c++",
-                include_dirs=include_dirs,
-            )
-        else:
-            exts = Extension(m, p, include_dirs=include_dirs)
+        exts = Extension(m, p, include_dirs=[numpy.get_include()])
         for ext in cythonize(exts):
             extensions.append(ext)
     return extensions


### PR DESCRIPTION
## Summary

Closes **Phase 00** of `cython-to-rust` — Task 0.4, build and packaging
reconciliation. Three commits: the build-config change, a doc sweep it
forced, and the phase-closure bookkeeping.

- **`setup.py`** — `make_extension`'s `cpp=True` parameter and
  `language="c++"` branch have been unreachable since Task 0.2 removed the
  last C++ extensions; no caller ever passed the flag and
  `git grep -l 'std::' -- hazma/` is empty. Removing it also lets the
  signature drop `typing.List` for builtin generics and gain a return type,
  taking the file from 5 configured-`ruff` findings to **0**. The extension
  **list** needed no edit — declared-in-`setup.py`, `.pyx`-on-disk and
  `.so`-built are the same 20-element set, all four symmetric differences
  empty. That reconciliation *is* the deliverable; Tasks 0.2/0.3 had already
  dropped their own groups, since a deletion task cannot defer them.

- **`MANIFEST.in`** — its `global-include` is a repo-wide sweep, so the sdist
  was shipping `.claude/` (18 files), `.codex/` (18) and `projects/` (65)
  into a publishable tarball. The **wheel** has been clean since `7a817f9`
  scoped `packages.find` to `hazma*`; that fix never reached the sdist
  because the two are built by different machinery. Pruned: **501 → 398**
  files, removing 103 scaffolding files (`.claude/` 18 + `.codex/` 18 +
  `projects/` 67). Both halves are measured on the branch's final tree, with
  and without the three `prune` lines. This is a scope addition — found by
  the sdist run this task was assigned to perform, and the canonical
  criterion is amended in the same PR on Task 0.2's precedent.

- **13 durable docs** named `_build.py`, which has not existed since
  `7a817f9` (2026-08-02) — including `AGENTS.md` and the rebuild-awareness
  rule in `docs/agents/environment.md`. Twelve take the rename to `setup.py`.
  The thirteenth, `docs/versioning.md`, had its only occurrence inside a
  blockquote warning about a stale `VERSION` that died with the file, so
  renaming would have produced a *false* claim; the blockquote is deleted and
  the adjacent snippet re-derived (`2.0.2` → `2.1.0`).

- **No public value changes.** 213 arrays over the compiled-backed public
  surface are bit-for-bit identical across the change and a clean rebuild,
  max relative deviation `0.000e+00`. Expected: every `Extension` object
  `setup.py` constructs is unchanged, so the compiled artifacts are the same.

- **Not a project-closing PR.** `PLAN.md` `status:` stays `In Progress` and
  `VERSION` stays `2.1.0`; only the *phase* closes. Phase 00's two `major`
  removals already carry their `### Removed` block under `CHANGELOG.md`'s
  `[Unreleased]` from Task 0.2.

Deliberately **not** done: the rest of the sdist payload (20 cythonized
`*.c`, `docs/`, `test/`, `notebooks/`, and a `*.pyd`-for-`*.pxd` typo in
package-data) — judgment calls, not defects, filed as
`docs/followups/todo/sdist-ships-generated-c-and-docs.md` and time-boxed to
before Phase 07 Task 7.1, after which maturin replaces `MANIFEST.in`.
`requirements.txt` and `Dockerfile` are left alone despite contradicting
`pyproject.toml`: `phase-07-cutover.md` Task 7.3 already owns them.

## Project

`projects/cython-to-rust/` — Task 0.4: Prune build and packaging config
(closes Phase 00).

See `projects/cython-to-rust/task-notes/phase-00/task-0.4-prune-build.md` for
detail, and `projects/cython-to-rust/learnings/phase-00-dead-code-purge.md`
for what carries into Phase 01.

## Test plan

- [x] `scripts/agents/preflight.sh --paths setup.py --tests test --md <14 changed docs>` → `RESULT: PASS`, every row green:

```text
PASS   black --check           setup.py
PASS   isort --check-only      setup.py
PASS   ruff check              setup.py
PASS   pytest                  244 passed, 20 skipped in 256.98s (0:04:16)
PASS   import hazma            version 2.1.0
PASS   markdownlint            AGENTS.md docs/PR_GUIDELINES.md ... (14 files)
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
```

- [x] Bare `pytest -q` (the other, disjoint suite — `setup.cfg`'s `testpaths` keeps it inside `hazma/`) → `57 passed, 10 skipped in 0.45s`

- [x] Extension reconciliation as a **set equality**, not a count (a stale `.so` makes a wrong list look right):

```text
declared in setup.py : 20
.pyx sources on disk : 20
.so built in place   : 20
declared - pyx : none      pyx - declared : none
declared - so  : none      so - declared  : none
RECONCILED
git grep -l 'std::' -- hazma/ : empty
```

- [x] **sdist installs and runs** — a path probe proves nothing dangles by *name*; only a source install proves the build works. `uv build --sdist`, then into a fresh venv with `uv pip install --no-binary hazma dist/hazma-2.1.0.tar.gz`, imported from outside the repo:

```text
dnde_photon_muon([1,10,50], 200 MeV) : [0.01769967 0.00142339 0.00012374]
dnde_positron_muon([1,10,50], 200)   : [6.42823262e-05 5.41334191e-03 8.67582062e-03]
ScalarMediator.total_spectrum(E, 550): [0.03022713 0.00252758 0.00531033]
```

- [x] Anchored deleted-path probe over the tarball listing (every path Phase 00 removed) → no hits, before and after the prune. An earlier *unanchored* probe returned 70+ false positives on live paths, so the anchoring is load-bearing.

- [x] **Review round 1 fix** — the sdist counts were re-derived at HEAD from a clean tree. `498 → 397` was measured mid-task, before this PR's own follow-up file landed under the un-pruned `docs/`; the follow-up documenting the sdist payload became part of that payload. Corrected to `501 → 398` (103 scaffolding files) across all six documents carrying the stale figures. Rebuilding also showed the tarball is sensitive to working-directory state — `.pytest_cache/README.md` ships despite `.gitignore:526`, giving 400 dirty vs 398 clean — recorded as a fourth item on the sdist follow-up.

- [x] Wheel: 311 files, `hazma/` + dist-info only, 20 `.so`, `Tag: cp312-cp312-macosx_11_0_arm64`, `Root-Is-Purelib: false` — the mistagging `7a817f9` fixed has not regressed.

- [x] Numerical impact: 213 arrays dumped, `git stash`, clean rebuild, re-dump, diff → `213 bit-for-bit identical, max relative deviation 0.000e+00`.

Local verification was CPython 3.12 on macOS arm64; the 3.10–3.14 Linux legs
and macOS 3.14 are this PR's CI run. Pre-existing and unrelated:
`markdownlint` fails on `.claude/skills/task-pipeline/SKILL.md` at lines
14/21/318/336+ (none touched here) — tracked in
`docs/followups/todo/markdownlint-skips-skill-file-shapes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
