### PR TITLE
test(suite): run the parity corpus as a tolerance-budgeted gate

### DIFF
--- a/projects/cython-to-rust/learnings/phase-00-dead-code-purge.md
+++ b/projects/cython-to-rust/learnings/phase-00-dead-code-purge.md
@@ -147,6 +147,10 @@ Two more worth carrying:
   keeps a bare run inside the package. Cite the command, never "the full
   suite". **Zero compiled-layer pinned tests run anywhere** — that gap is
   exactly what Phase 01 exists to close.
+  _(Half-closed as of Phase 01 Task 1.2, 2026-08-07: `pytest test` now
+  runs `test/parity`'s 626 tests over all 41 compiled entry points, so
+  the figures above read `870 passed, 20 skipped`. Bare `pytest` — the
+  form CI runs — still collects neither, until Task 1.3.)_
 - **The phase's own regression harness is the before/after grid**, and it
   should be reused verbatim in Phases 04–06. Dump every compiled-backed
   public entry point over `np.logspace(-2, 3, 200)` MeV at three parent

--- a/projects/cython-to-rust/phases/phase-01-parity-corpus.md
+++ b/projects/cython-to-rust/phases/phase-01-parity-corpus.md
@@ -21,14 +21,16 @@ evidence `docs/versioning.md` requires for numerical changes.
 - Phase 00 complete (corpus covers survivors only).
 - Read `../references/numerics-replacements.md` (call-site tolerances)
   and `../rules.md` rules 1–3.
-- Context: today **zero** pinned-value tests over compiled code execute
-  anywhere — CI's `pytest` collects only `hazma/**` (setup.cfg
-  `testpaths = hazma`), and every `.npy`-backed suite under `test/` is
-  either skipped or never collected (`test/spectra/integration.py`
-  matches no pytest filename pattern; `test/positron/test_positron.py`
-  is 0 bytes). Task 1.1 added `test/parity/` but no pytest module, so
-  this still holds; `collect_ignore` is no longer part of it —
-  `test/conftest.py` has listed only the repo's `setup.py` since
+- Context: when this phase was drafted, **zero** pinned-value tests over
+  compiled code executed anywhere — CI's `pytest` collects only
+  `hazma/**` (setup.cfg `testpaths = hazma`), and every `.npy`-backed
+  suite under `test/` is either skipped or never collected
+  (`test/spectra/integration.py` matches no pytest filename pattern;
+  `test/positron/test_positron.py` is 0 bytes). Task 1.2 ended the first
+  half of that: `test/parity/test_parity.py` runs under `pytest test`.
+  **CI still does not reach it** — `testpaths` is unchanged, which is
+  exactly what Task 1.3 fixes. `collect_ignore` is not part of any of
+  this; `test/conftest.py` has listed only the repo's `setup.py` since
   Task 0.2.
 
 ## Tasks
@@ -90,10 +92,14 @@ evidence `docs/versioning.md` requires for numerical changes.
 
 - pytest config moved to `pyproject.toml`
   (`[tool.pytest.ini_options]`), collecting `hazma` **and** `test`
-  (the `test/` suite is green: `pytest -q test` → 244 passed /
-  20 skipped as of 2026-08-07. It was 51/20 when this phase was
-  drafted, before PR #41 and Task 0.3 added cases — re-derive rather
-  than quoting either figure.)
+  (the `test/` suite is green: `pytest -q test` → 870 passed /
+  20 skipped as of 2026-08-07, on the capturing environment. It was
+  51/20 when this phase was drafted, then 244/20 after PR #41 and
+  Task 0.3, then +626 when Task 1.2 landed the parity suite —
+  re-derive rather than quoting any of them. Expect 869/21 off the
+  capturing environment: the parity suite skips its
+  `test_running_on_the_capturing_tree` marker there and enforces the
+  declared budgets instead.)
 - `test/spectra/integration.py` renamed to be collected; its property
   assertions pass.
 - CI and `scripts/agents/preflight.sh` run the same collection;

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -22,7 +22,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | # | Phase | Phase file | Working memory | Status |
 | --- | ------- | ----------- | ---------------- | -------- |
 | 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | **Complete (2026-08-06)** — all five tasks done; [learnings](../learnings/phase-00-dead-code-purge.md) |
-| 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | **In Progress** — Task 1.1 complete (2026-08-07); 1.2 next |
+| 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | **In Progress** — Tasks 1.1–1.2 complete (2026-08-07); 1.3 next |
 | 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | Not started |
 | 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | Not started |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
@@ -64,7 +64,9 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 - Test-infra fact agents keep tripping on: bare `pytest` collects only
   `hazma/**` (`setup.cfg` `testpaths`), while preflight runs
   `pytest -q test` — two disjoint suites until Phase 01 Task 1.3 merges
-  them. Zero compiled-layer pinned tests run anywhere today.
+  them. Since Task 1.2 the compiled layer *is* pinned, but only in the
+  second of those suites: `pytest test` runs `test/parity` (626 tests),
+  bare `pytest` does not, and CI still runs the bare form.
 - Local env fact: nothing is prebuilt on a fresh clone — build with uv
   (`uv venv`, `uv pip install -e .`) before preflight; expect preflight
   red on a clean tree otherwise. **And clean stale build artifacts
@@ -310,6 +312,12 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   `x > 300` thermal divergence — are observations, not drifts, and are
   under Findings above.
 
+- **Tasks 1.1–1.2 (parity corpus and its runner): no public value
+  changes** — neither task touched `hazma/`. Task 1.2 additionally
+  *proves* it for the whole compiled surface: `pytest -q test/parity` →
+  `626 passed` with every one of the 41 entry points held to
+  bit-equality against the corpus, on the environment that captured it.
+
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
 it from memory.)
@@ -527,11 +535,14 @@ it from memory.)
   a fresh venv from outside the repo (recipe in Task 0.4's note; reuse
   it in Phase 07). Neither ships a deleted path; neither ships the agent
   scaffolding any more.
-- `test/` is green (244 passed / 20 skipped as of Task 0.2, 2026-08-06;
-  68/20 at Task 0.3; 52/20 at Task 0.1) — merging the suites in Task 1.3
-  is safe, and simpler than planned: `test/conftest.py` now skips **no**
-  test module. A bare `pytest` still differs from `pytest test`, but only
-  because `setup.cfg`'s `testpaths` is `hazma`.
+- `test/` is green (870 passed / 20 skipped as of Task 1.2, 2026-08-07,
+  which added `test/parity`'s 626; 244/20 at Task 0.2; 68/20 at Task 0.3;
+  52/20 at Task 0.1) — merging the suites in Task 1.3 is safe, and
+  simpler than planned: `test/conftest.py` now skips **no** test module.
+  A bare `pytest` still differs from `pytest test`, but only because
+  `setup.cfg`'s `testpaths` is `hazma`. Off the corpus's capturing
+  environment expect 869/21 — the parity suite reports budget mode by
+  skipping one test rather than by failing.
 - The legacy constants table lives at
   `hazma/_utils/legacy_parameters.pxd` and is now its **only** copy.
   `hazma.utils` is the only home for `cross_section_prefactor` and

--- a/projects/cython-to-rust/task-notes/phase-01/README.md
+++ b/projects/cython-to-rust/task-notes/phase-01/README.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 01
-**Status:** In Progress (Task 1.1 complete 2026-08-07)
+**Status:** In Progress (Tasks 1.1-1.2 complete 2026-08-07)
 **Plan References:** `../../phases/phase-01-parity-corpus.md`
 **Related ADRs:** none
 **Depends On:** Phase 00 complete
@@ -18,8 +18,8 @@ corpus.
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
 | 1.1 | Corpus specification + generator | — | **Complete (2026-08-07)** | [task-1.1-corpus-generator.md](task-1.1-corpus-generator.md) |
-| 1.2 | Pytest runner + tolerance budgets | 1.1 | Not started — **next** | [task-1.2-parity-runner.md](task-1.2-parity-runner.md) |
-| 1.3 | Wire both suites into one gate | 1.2 | Not started | [task-1.3-test-wiring.md](task-1.3-test-wiring.md) |
+| 1.2 | Pytest runner + tolerance budgets | 1.1 | **Complete (2026-08-07)** | [task-1.2-parity-runner.md](task-1.2-parity-runner.md) |
+| 1.3 | Wire both suites into one gate | 1.2 | Not started — **next** | [task-1.3-test-wiring.md](task-1.3-test-wiring.md) |
 | 1.4 | Retire/regenerate legacy `.npy` suites | 1.2 | Not started | [task-1.4-legacy-npy.md](task-1.4-legacy-npy.md) |
 
 ## Exit Criteria
@@ -75,6 +75,31 @@ corpus.
   outside `REPO_ROOT`, and the manifest records where `hazma` actually
   resolved from (`hazma_package`). Task 1.2's runner gets the guard for
   free — it goes through `resolve()`.
+- **Mechanism, not physics, sets a tolerance.** Task 1.2 classified all
+  41 entry points by reading the live `.pyx`: 19 closed-form (exact), 1
+  closed form through `spence` (1e-13), 7 tabulated boost integrals
+  (1e-12), 5 single-`quad` (1e-8), 9 nested-`quad` (1e-6) — counts
+  re-derived from `tolerances.BUDGETS`, not tallied by hand. Two of those
+  would have been misfiled from the import list alone —
+  `hazma/spectra/_photon/_muon.pyx` and
+  `hazma/spectra/_positron/_muon.pyx` both `import quad` and never call
+  it on the live path.
+- **The nested class is not just ρ.** All seven mediator-spectrum entry
+  points cimport a quad-backed pion kernel into a cos θ quad integrand,
+  so they share ρ's subdivision sensitivity and its 1e-6 budget.
+- **A budget is the wrong gate on the capturing tree.** There, the
+  corpus pins an implementation against itself, so any difference is a
+  regression and a 1e-8 budget would swallow it.
+  `tolerances.effective_budget` therefore demands bit-equality whenever
+  the kernel digest, toolchain and numerics libraries all match the
+  manifest, and falls back to the declared budgets otherwise — which is
+  also what keeps a Linux CI runner from failing an exactness claim it
+  was never positioned to meet.
+- **`spectra.photon.neutral_pion[rest]` has exactly one non-zero value
+  and it is `inf`** — the rest-frame two-body delta. Worth knowing
+  before using that block to check anything: a multiplicative
+  perturbation of `inf` is invisible (found while negative-testing the
+  runner, Task 1.2).
 
 ## Decisions and Implementation Notes
 
@@ -94,6 +119,27 @@ corpus.
 - Five parent energies per spectrum rather than the four required; the
   extra is `M·(1 + 1e-12)`, straddling the `E − M < DBL_EPSILON`
   rest-frame short-circuit — Task 1.1.
+- The runner evaluates through `generate.evaluate_block` — the same
+  function that produced the stored numbers — rather than its own loop,
+  so a harness difference cannot masquerade as an implementation
+  difference. The raise replay falls out of that: the function returns
+  the same `{"index", "argument", "type"}` records the manifest stores,
+  so one `==` catches both a swallowed raise and a new one — Task 1.2.
+- One test per block (623), not per case or per array: a block is one
+  grid at one fixed argument set, which is the granularity at which a
+  failure is diagnosable — Task 1.2.
+- `atol = 0.0` everywhere. One absolute floor cannot serve spectra at
+  ~1e-3 MeV⁻¹ and cross sections at ~1e-20 MeV⁻²; it is also
+  unnecessary, since the out-of-support regions return exactly `0.0`
+  — Task 1.2.
+- Abscissae (`grid`, `scalar_grid`) are compared exactly in **both**
+  modes. No tolerance on a value compensates for having moved where it
+  was measured — Task 1.2.
+- No measurement/reporting hook. `pytest_addoption` is only honored in
+  an *initial* conftest, which `test/parity/conftest.py` is not under
+  `pytest test`, and `assert_allclose` already prints the max relative
+  difference on breach — so Phase 03's tightening loop is "set the
+  budget you want and read the failure" — Task 1.2.
 
 ## Files Changed
 
@@ -112,6 +158,26 @@ corpus.
 
 Nothing under `hazma/` was touched.
 
+### Task 1.2
+
+- `test/parity/test_parity.py`, `test/parity/tolerances.py` — new.
+- `test/parity/cases.py` — `rust_core_available()` extracted from
+  `assert_no_rust_core`.
+- `test/parity/generate.py` — `load_manifest()` extracted from `check()`;
+  `_sweep_pointwise` now reports an all-points-raised block instead of
+  dying in `np.concatenate`.
+- `test/parity/README.md` — the runner and its two comparison modes.
+- `../../phases/phase-01-parity-corpus.md` — the Prerequisites context
+  bullet and Task 1.3's `pytest -q test` figure re-derived.
+- `task-1.1-corpus-generator.md` and
+  `../../learnings/phase-00-dead-code-purge.md` — one forward-looking
+  and one present-tense claim each, both falsified by this task,
+  annotated in place.
+- This file, `../README.md` and `task-1.2-parity-runner.md` — status
+  bookkeeping.
+
+Nothing under `hazma/` was touched.
+
 ## Verification
 
 - Task 1.1: `python test/parity/generate.py` → `41 cases / 623 blocks /
@@ -119,14 +185,29 @@ Nothing under `hazma/` was touched.
   existing suites unchanged from the Phase 00 baseline (`pytest -q` →
   `57 passed, 10 skipped`; `pytest -q test` → `244 passed, 20 skipped`).
   Full command log and the guard negative-tests are in the task note.
-- Remaining: bare `pytest` green incl. the parity suite (Tasks 1.2/1.3).
+- Task 1.2: `pytest -q test/parity` → `626 passed`, all in exact
+  (bit-equality) mode — the phase file's "running against unmodified
+  Cython passes bit-exact" criterion, now a standing gate rather than an
+  observation. Nine negative scenarios (behind three baselines) confirm
+  each assertion fires: swallowed raise, wholesale raise, single-point
+  raise, value shifts against both modes, grid drift, and the three
+  budget-table guards. Command log in the task note. Suites on the final
+  tree: `pytest -q test` → `870 passed, 20 skipped` (244 + 626, the
+  pre-existing suite untouched); bare `pytest -q` → `57 passed, 10
+  skipped`, unchanged because `testpaths = hazma` still scopes it.
+- Remaining: bare `pytest` green incl. the parity suite (Task 1.3).
 
 ## Open Questions
 
 - Whether every stored value is bit-reproducible on the Linux CI matrix
-  is **unverified** — the corpus was captured on macOS/arm64. Task 1.2
-  answers it when it sets per-function budgets, which is the right place
-  for the answer.
+  is still **unmeasured** — the corpus was captured on macOS/arm64 and
+  Task 1.2 had no Linux runner to answer on. It is no longer a *risk*,
+  though: a runner whose platform differs from the manifest drops to
+  budget mode by construction, so CI is gated on the declared budgets
+  rather than on an exactness claim nobody has evidence for. Task 1.3
+  wires CI and produces the first Linux numbers; the plausible outcome
+  is that the transcendental-libm kernels (`exp`/`log`/`spence`) differ
+  in the last ulp, well inside every declared budget.
 - Task 1.4's scope narrowed but is not decided: the 90 `.npy` arrays
   the two skipped mediator classes read overlap the cross-section and
   mediator-spectrum cases now pinned here, so the
@@ -138,37 +219,54 @@ Nothing under `hazma/` was touched.
 
 ## Plan Impact
 
-**Impact Level:** Update phase file (Task 1.1).
+**Impact Level:** Update phase file (Tasks 1.1 and 1.2).
 
-`../../phases/phase-01-parity-corpus.md`'s Task 1.2 exit criteria gained
-a bullet requiring the runner to replay the manifest's `raises` records
-rather than compare the stored `nan`. Patched in the task that found the
-need. Nothing else canonical moved.
+- Task 1.1: `../../phases/phase-01-parity-corpus.md`'s Task 1.2 exit
+  criteria gained a bullet requiring the runner to replay the manifest's
+  `raises` records rather than compare the stored `nan`.
+- Task 1.2: the same file's Prerequisites context bullet said "zero
+  pinned-value tests over compiled code execute anywhere ... Task 1.1
+  added `test/parity/` but no pytest module, so this still holds". Half
+  of that is now false — `pytest test` reaches the parity suite; CI does
+  not, which is Task 1.3's job. Re-derived along with Task 1.3's
+  `pytest -q test` figure, which this task moved.
+
+No ADR: nothing about the port's architecture, interfaces or ordering
+changed. The tolerance table is a new contract, but the phase file
+already specified it.
 
 ## Handoff to Next Task
 
-**For the next agent working in Phase 01 (Task 1.2):** read
-`test/parity/README.md`, then `test/parity/cases.py`'s module docstring,
-then `task-1.1-corpus-generator.md`'s Findings and Handoff. The corpus
-manifest records the generating git SHA — rules.md rule 2 — and the
-`kernel_digest` that actually identifies the kernels.
+**For the next agent working in Phase 01 (Task 1.3):** read
+`test/parity/README.md` (now covers the runner and its two comparison
+modes), then `tolerances.py`'s module docstring, then
+`task-1.2-parity-runner.md`'s Findings and Handoff.
 
 **Currently safe to assume:**
 
-- `test/` is green post-PR #31 and unchanged by Task 1.1; merging the
-  suites in Task 1.3 is safe.
+- The corpus reproduces bit-exactly on the capturing environment:
+  `pytest -q test/parity` → `626 passed`, exact mode. Task 1.3 is
+  wiring, not repair.
 - Coverage of the 41 entry points does not need re-deriving —
-  `assert_full_coverage` does it on every generation.
-- `cases.py` is the single source of the call convention. Re-evaluate
-  `block.array_call` / `block.scalar_call` against the live
-  implementation rather than rebuilding argument tuples.
+  `assert_full_coverage` does it on every generation, and
+  `test_every_corpus_case_has_a_budget` does the same for the tolerance
+  table.
+- `cases.py` is the single source of the call convention, and
+  `generate.evaluate_block` the single source of the evaluation path.
+  Both are already reused by the runner; do not fork either.
 - The corpus pins the **post-fix** `two_body_momentum` values.
+- Widening a budget is a declared act, not a fix: `tolerances.py`'s
+  module docstring states rules 2 and 3 at the point of use.
 
 **Currently risky / unknown:**
 
-- Task 1.2 must replay the three `raises` blocks, now an exit criterion.
+- The parity suite costs ~4.6 min. Task 1.3 puts that on every CI matrix
+  entry; if that is unacceptable, the decision (marker, split job) is
+  Task 1.3's to make and to record — Task 1.2 deliberately did not
+  invent a policy.
 - Do not hoist `cases.py`'s deferred model imports.
 - Corpus grid density vs. repo-size budget is **settled**: 2.9 MiB
   against a ~10 MB ceiling, with `MAX_TOTAL_BYTES` failing generation
   above it.
-- Cross-platform bit-reproducibility, per Open Questions.
+- Cross-platform behavior, per Open Questions — expect budget mode and a
+  skipped `test_running_on_the_capturing_tree` on CI, not a failure.

--- a/projects/cython-to-rust/task-notes/phase-01/task-1.1-corpus-generator.md
+++ b/projects/cython-to-rust/task-notes/phase-01/task-1.1-corpus-generator.md
@@ -562,3 +562,9 @@ module docstring (grid design), then this note's Findings.
   Task 1.2 will find out when it sets tolerances, and that is the right
   place for the answer, since it is exactly what the budget per function
   has to absorb.
+  _(Task 1.2, 2026-08-07: it did not — no Linux runner was available.
+  What it did instead is make the question harmless: the runner demands
+  bit-equality only when the manifest's platform, toolchain and kernel
+  digest all match, and enforces the declared budgets otherwise, so a
+  Linux runner cannot fail an exactness claim nobody has evidence for.
+  The measurement itself moves to Task 1.3, which wires CI.)_

--- a/projects/cython-to-rust/task-notes/phase-01/task-1.2-parity-runner.md
+++ b/projects/cython-to-rust/task-notes/phase-01/task-1.2-parity-runner.md
@@ -1,0 +1,546 @@
+# Task 1.2: Pytest runner and tolerance budgets
+
+**Date:** 2026-08-07
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-01-parity-corpus.md` (Task 1.2);
+`../../rules.md` rules 1–3 (parity discipline);
+`../../references/numerics-replacements.md` (quad call-site table,
+special-function parity figures)
+**Related ADRs:** ADR-0002 (license-clean numerics — sets what the
+replacement implementations will be, and therefore what the budgets have
+to absorb)
+**Depends On:** Task 1.1
+
+## Objective
+
+Turn the Task 1.1 corpus into a running pytest gate: re-evaluate every
+pinned entry point against the live implementation, compare within a
+declared per-function tolerance budget, and replay the exceptions the
+corpus recorded rather than comparing the `nan` that stands in for them.
+
+## Exit Criteria
+
+From `../../phases/phase-01-parity-corpus.md`, Task 1.2:
+
+- `test/parity/test_parity.py` parametrizes over the manifest and
+  compares live imports against stored arrays.
+- Per-function budgets live in `test/parity/tolerances.py` with a
+  one-line justification each: exact (bit-equal) for pure closed-form
+  kernels against the capturing commit, documented budgets for
+  quad-backed kernels (start 1e-8 rel, tighten after Phase 03
+  measurement; nested-ρ gets its own line).
+- The manifest's per-block `raises` records are replayed, not skipped:
+  where the corpus says an entry point raised, the runner asserts the
+  live implementation raises the same exception type at the same
+  argument.
+- Running against unmodified Cython passes bit-exact.
+
+## Inputs Reviewed
+
+- `../../PLAN.md` (Numerical impact; Phase table ordering).
+- `../../phases/phase-01-parity-corpus.md` — Task 1.2 block and the
+  phase Prerequisites.
+- `../../rules.md` — rules 1–3 (corpus gates every swap; corpus is
+  generated only from pre-port Cython; every numerical shift declared).
+- `../../references/numerics-replacements.md` — the `quad` call-site
+  table with each site's `epsabs`/`epsrel`, the `spec_math` parity
+  figure (≤1e-13 relative), and the `boost_integrate_linear_interp`
+  description.
+- `../README.md` and `task-1.1-corpus-generator.md` — Findings and
+  Handoff.
+- `test/parity/README.md`, `test/parity/cases.py`,
+  `test/parity/generate.py`.
+- `docs/agents/lessons.md`, `docs/agents/environment.md`.
+- The surviving `.pyx` sources, to classify each entry point by
+  mechanism rather than by name (see Findings).
+
+## Findings
+
+- **Every entry point falls into one of five mechanism classes**, and
+  the class — not the physics — is what sets its budget. Derived by
+  reading the live sources rather than the inventory:
+
+  | Class | rtol | Cases |
+  | --- | --- | --- |
+  | closed form | 0 (exact) | 19 — neutral pion, positron/neutrino muon, and all 16 non-thermal cross sections |
+  | closed form + `spence` | 1e-13 | 1 — `spectra.photon.muon` |
+  | tabulated boost integral | 1e-12 | 7 — 3 kaons, eta, eta', omega, phi |
+  | one `quad` | 1e-8 | 5 — charged pion (photon/positron/neutrino), both `thermal_cross_section` |
+  | nested `quad` | 1e-6 | 9 — both rho, all 7 mediator spectra |
+
+  Counts re-derived from the table itself, not by hand — an earlier
+  hand-count of this row said 16 and was wrong:
+
+  ```python
+  collections.Counter(b.rtol for b in tolerances.BUDGETS.values())
+  # {0.0: 19, 1e-13: 1, 1e-12: 7, 1e-08: 5, 1e-06: 9}  -> 41
+  ```
+
+- **The nested class is larger than "the ρ integrals".** All seven
+  mediator-spectrum entry points cimport a quad-backed pion kernel into
+  a cos θ quad integrand
+  (`hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx:2-3,184`
+  and the three siblings), so they share ρ's failure mode. The phase
+  file asks for ρ to get its own line, which it has; the mechanism is
+  what put the other seven beside it.
+- **`hazma/spectra/_photon/_muon.pyx` and
+  `hazma/spectra/_positron/_muon.pyx` import `quad` but never call it**
+  on the live path (`hazma/spectra/_positron/_muon.pyx:134` is commented
+  out; `hazma/spectra/_photon/_muon.pyx:113` reaches `spence` and no
+  further). Classifying from the import list rather than the call sites
+  would have put two exact kernels in the 1e-8 bucket.
+- **The declared budgets are not the gate on the capturing tree.** The
+  corpus was captured from these exact kernels in this exact
+  environment, so on that tree any difference at all is a regression and
+  a 1e-8 budget would hide it. `tolerances.effective_budget` therefore
+  demands bit-equality whenever the kernel digest, the toolchain and the
+  numerics libraries all match the manifest, and falls back to the
+  declared budgets otherwise. This is what makes "Running against
+  unmodified Cython passes bit-exact" a standing gate rather than a
+  one-off observation.
+- **Cross-platform bit-reproducibility is still open, and now degrades
+  safely.** The corpus was captured on macOS/arm64 with numpy 2.5.1 /
+  scipy 1.18.0 / Cython 3.2.9. A Linux CI runner differs in `platform`
+  at minimum, so it lands in budget mode rather than failing an
+  exactness claim it was never in a position to meet. The `-rs` skip
+  reason on `test_running_on_the_capturing_tree` names exactly what
+  differed. Task 1.3 wires CI and is where the Linux numbers first get
+  measured.
+- **Reusing `generate.evaluate_block` is what makes the comparison
+  meaningful.** It owns the `IntegrationWarning` suppression and the
+  point-by-point recovery a batched call needs when one grid point
+  raises. A re-implementation in the runner would have made a harness
+  difference indistinguishable from an implementation difference — and
+  it is also how the raise replay comes for free: the function returns
+  the same `{"index", "argument", "type"}` records the manifest stores,
+  so `raised == manifest_block.get("raises", {})` catches a swallowed
+  raise *and* a new one.
+
+## Decisions and Implementation Notes
+
+- **One test per corpus block** (623), not per case (41) or per array
+  (1,580). A block is one grid at one fixed argument set, which is the
+  granularity at which a failure is diagnosable; the id is
+  `case[block-label]`, so a failure names the model point and parent
+  energy directly.
+- **The stored grid is asserted against the re-derived one before any
+  value is compared.** `cases.py` is re-evaluated live, so a change to
+  grid construction would otherwise move every abscissa and leave the
+  value comparison comparing two different samplings. The assertion is
+  exact and unconditional — grids are arithmetic on constants.
+- **Abscissae are compared exactly in both modes.** `grid` and
+  `scalar_grid` record *where* an entry point was sampled, not what it
+  returned; no tolerance on a value compensates for having moved the
+  point it was measured at, so the budget never reaches them.
+- **`atol = 0.0` for every case.** One absolute floor cannot serve
+  spectra at ~1e-3 MeV⁻¹ and cross sections at ~1e-20 MeV⁻²; it is also
+  unnecessary, since the sub-threshold and above-endpoint regions return
+  exactly `0.0` and `|0 − 0| ≤ rtol·0` holds. A port returning 1e-300
+  where the Cython returned zero fails, which is the intended answer.
+- **No measurement/reporting hook.** An earlier draft added a
+  `--parity-report` pytest option; dropped for two reasons.
+  `pytest_addoption` is only honored in an *initial* conftest, which
+  `test/parity/conftest.py` is not under `pytest test`, and
+  `numpy.testing.assert_allclose` already prints the max relative
+  difference on breach. Phase 03's tightening loop is therefore "set the
+  budget to the value you want and read what the failure reports", with
+  no extra machinery to keep working.
+- **Three small changes to Task 1.1's modules rather than duplicates
+  here:** `cases.rust_core_available()` (the predicate
+  `assert_no_rust_core` already needed, now also read by
+  `tolerances.provenance`), `generate.load_manifest()` (one spelling of
+  where the manifest lives, shared with `check()`), and the
+  all-points-raised guard in `generate._sweep_pointwise` (see
+  Verification).
+- **`hazma`'s own version is excluded from the provenance comparison.**
+  Phase 07 bumps it without touching a number; letting a version bump
+  silently drop the gate out of exact mode would be the wrong trade.
+
+## Files Changed
+
+- `test/parity/test_parity.py` — new. 623 block tests plus three
+  guards (capturing-tree report, budget-table coverage, budget
+  justification).
+- `test/parity/tolerances.py` — new. `Budget`, `Provenance`, the 41-entry
+  budget table, `budget_for`, `provenance`, `effective_budget`.
+- `test/parity/cases.py` — `rust_core_available()` extracted from
+  `assert_no_rust_core`.
+- `test/parity/generate.py` — `load_manifest()` extracted from `check()`;
+  `_sweep_pointwise` now raises a `RuntimeError` naming an
+  all-points-raised block instead of dying inside `np.concatenate`.
+- `test/parity/README.md` — the runner and the two comparison modes
+  documented alongside the generator.
+- `../../phases/phase-01-parity-corpus.md` — Prerequisites context bullet
+  and Task 1.3's `pytest -q test` figure, both falsified by this task.
+- `task-1.1-corpus-generator.md` — one forward-looking claim about what
+  Task 1.2 would find out, annotated with what it actually did.
+- `../../learnings/phase-00-dead-code-purge.md` — its present-tense
+  "zero compiled-layer pinned tests run anywhere" annotated as
+  half-closed, with the new suite figures.
+- `README.md`, `../README.md`, this file — status bookkeeping.
+
+Nothing under `hazma/` was touched.
+
+## Verification
+
+Environment: a scratchpad venv on Python 3.12.12, numpy 2.5.1, scipy
+1.18.0, macOS-26.5.2-arm64 — the same tuple the manifest records, and
+the kernel digest matches (`f5e6e269be47`), so the runs below are in
+**exact** mode.
+
+### The gate itself
+
+```text
+$ pytest -q test/parity -rs
+626 passed in 278.83s (0:04:38)
+```
+
+626 = 623 corpus blocks + `test_running_on_the_capturing_tree` (passed,
+i.e. exact mode was active and not silently skipped) +
+`test_every_corpus_case_has_a_budget` + `test_every_budget_states_a_reason`.
+This is the phase file's "Running against unmodified Cython passes
+bit-exact" criterion: every one of the 41 entry points reproduced its
+pinned values with `rtol=0, atol=0`.
+
+Collection sanity (pytest exits 5 on zero collected — it did not):
+
+```text
+$ pytest test/parity --collect-only -q | tail -n 1
+626 tests collected in 4.47s
+```
+
+Corpus integrity is unaffected by this task's edits to `generate.py`:
+
+```text
+$ python test/parity/generate.py --check
+corpus OK: 41 cases / 1580 arrays match the manifest
+(generated at 010747c6125d, kernel digest f5e6e269be47)
+```
+
+### Test validity (stash-proof)
+
+A parity gate that passes is uninformative unless its assertions fire on
+a broken implementation, and the production code here is Cython that
+cannot be stashed. Each scenario instead patches `Case.resolve` (or the
+specification) to break exactly one thing, then runs the real test
+function. Baselines are run first, on the very blocks the scenarios
+break, so a failure proves the scenario and not the block.
+
+```text
+$ python negative_tests.py
+raising block: cross_sections.vector.sigma_xx_to_v_to_pipi[1]
+PASS  baseline raising block: clean
+PASS  baseline closed-form block: clean
+PASS  baseline quad-backed block: clean
+PASS  raise swallowed -> returns nan: raised AssertionError -- ...exceptions changed.
+PASS  new raise where corpus has none: raised RuntimeError -- every one of the 250 grid
+      points raised (TypeError); the entry point is broken, not merely singular at an edge
+PASS  new raise at one grid point: raised AssertionError -- ...exceptions changed.
+PASS  closed form shifted by 1e-15 rel: raised AssertionError -- Not equal to tolerance
+      rtol=0, atol=0
+PASS  quad kernel shifted by 1e-6 rel against a 1e-8 budget: raised AssertionError --
+      Not equal to tolerance rtol=1e-08, atol=0
+PASS  cases.py grid drifted: raised AssertionError -- Arrays are not equal
+PASS  case with no declared budget: raised AssertionError -- ...disagree.
+PASS  budget with no corpus case: raised AssertionError -- ...disagree.
+PASS  budget with a blank reason: raised AssertionError -- budgets with no justification:
+      ['spectra.positron.muon']
+
+all negative tests fired as expected
+```
+
+What each one covers, against the Exit Criteria:
+
+- **Raise replay** (the criterion the phase file added in Task 1.1) —
+  scenarios 1, 2, 2b: an implementation that swallows the pinned
+  `TypeError` and returns `nan` fails; one that raises everywhere fails;
+  one that starts raising at a single new point fails. Scenario 1 is
+  precisely the failure a `nan`-only comparison would miss.
+- **Budgets bite in both modes** — scenarios 3 and 4: a 1e-15 relative
+  shift fails on the capturing tree, and a 1e-6 shift fails against a
+  1e-8 budget with the exact-mode override disabled. Without scenario 4
+  the declared budgets would be untested until Phase 04.
+- **Grid drift** — scenario 5: perturbing `cases.ANCHOR_OFFSETS` fails
+  before any value is compared.
+- **Table guards** — scenarios 6 and 7: a corpus case with no budget, a
+  budget with no case, and a blank justification each fail.
+
+The script lives in the session scratchpad rather than the repo: it
+mutates module state globally (patching `Case.resolve`, swapping
+`tolerances.BUDGETS`), which is fine for a one-shot proof and would be a
+liability inside a suite that also runs the real gate.
+
+### Two negative results worth recording
+
+- **`spectra.photon.neutral_pion[rest]` is unusable as a perturbation
+  target.** It has exactly one non-zero value and that value is `inf`
+  (the rest-frame two-body delta), so `inf * (1 + 1e-15)` is still
+  `inf`. Scenario 3 silently passed against a "broken" implementation
+  until the case was switched to `spectra.positron.muon`. Recorded in
+  the phase README's Findings — the same trap awaits anyone spot-checking
+  a port against that block.
+- **`generate._sweep_pointwise` had no answer for a block where every
+  point raises.** The fill shape is read off a successful result; with
+  none, `shape` fell back to `()` and `np.concatenate` died with
+  `ValueError: zero-dimensional arrays cannot be concatenated`. The gate
+  still failed, but on a message that names numpy rather than the
+  kernel. Now a `RuntimeError` saying so. Unreachable during generation
+  (no corpus block raises everywhere) and reachable in Phase 04 the
+  first time a port breaks a kernel outright, which is why it was worth
+  fixing here rather than filing.
+
+### Numerical impact
+
+**No public value changes (verified: `pytest -q test/parity` → 626
+passed in exact mode; `git diff origin/master --name-only -- 'hazma/*'`
+→ empty).** Nothing under `hazma/` is touched; the whole diff is
+`test/parity/` plus project bookkeeping. The parity run is itself the
+strongest available statement of no-change: all 41 compiled entry points
+reproduce their pinned values bit-for-bit.
+
+### Suites
+
+Both re-run on the final tree, after every code edit:
+
+```text
+$ pytest -q test -rs
+870 passed, 20 skipped in 527.17s (0:08:47)
+
+$ pytest -q
+57 passed, 10 skipped in 0.42s
+```
+
+### Preflight gate
+
+```text
+$ scripts/agents/preflight.sh \
+    --paths "test/parity/cases.py test/parity/generate.py \
+             test/parity/test_parity.py test/parity/tolerances.py" \
+    --tests "test" --md "<the seven markdown files above>"
+PASS   black --check
+PASS   isort --check-only
+PASS   ruff check
+PASS   pytest                  870 passed, 20 skipped in 535.60s (0:08:55)
+PASS   import hazma            version 2.1.0
+PASS   markdownlint
+SKIP   version bump            not a closing PR (pass --closing)
+PASS   forbidden tokens        none added
+RESULT: PASS
+```
+
+No WARN rows: every gate ran. `--paths` names the four `.py` files
+rather than the `test/parity` directory, per the project README's note
+that a directory drags in unrelated unformatted files.
+
+`pytest -q test` is 244 + 626: the pre-existing suite is untouched and
+the parity gate is additive. The 20 skips are the pre-existing ones (9 +
+8 "Needs to be updated" mediator classes, 3 form-factor cases) — Task 1.4
+owns the first two groups. Bare `pytest` is unchanged at 57/10 because
+`setup.cfg`'s `testpaths = hazma` still keeps it inside the package; CI
+runs that form, which is exactly the gap Task 1.3 closes.
+
+## Open Questions
+
+- **Cross-platform bit-reproducibility is measured by nobody yet.** The
+  corpus was captured on macOS/arm64; no Linux runner was available
+  here. This is no longer a risk to the gate — a differing `platform`
+  puts the run in budget mode by construction — but the actual Linux
+  numbers are unknown, and Task 1.3 is where they first appear. The
+  plausible outcome is last-ulp differences in the transcendental-libm
+  kernels (`exp`, `log`, `spence`), which every declared budget absorbs
+  with room to spare. If any case *fails* its declared budget on Linux,
+  that is a genuine finding about the tolerance, not about the harness.
+- **The parity suite costs ~4.6 minutes.** Task 1.3 puts it on the CI
+  matrix. Whether that warrants a marker or a separate job is a policy
+  call that belongs to the task doing the wiring; Task 1.2 deliberately
+  did not invent one, and registered no new markers.
+
+## Plan Impact
+
+**Impact Level:** Update phase file.
+
+`../../phases/phase-01-parity-corpus.md` changed in two places, both
+because this task falsified them:
+
+1. The Prerequisites "Context" bullet said pinned-value tests over
+   compiled code execute **nowhere**, and that Task 1.1 "added
+   `test/parity/` but no pytest module, so this still holds". Half of
+   that is now false: `pytest test` reaches the parity suite. The other
+   half is not — `setup.cfg`'s `testpaths = hazma` still keeps CI out of
+   it, which is exactly Task 1.3's job. Reworded to say which half moved.
+2. Task 1.3's exit criteria quote `pytest -q test` → 244 passed / 20
+   skipped "as of 2026-08-07". This task adds 626 tests to that
+   collection. Re-derived rather than left to rot, per the phase file's
+   own instruction to re-derive rather than quote.
+
+No ADR. Nothing about the port's architecture, interfaces, units or task
+ordering moved. The tolerance table is a new contract, but the phase file
+already specified that it would exist and what shape it would take.
+
+## Stale-state sweep
+
+### Identifier sweep
+
+New/changed names: `test_parity`, `tolerances`, `Budget`, `Provenance`,
+`BUDGETS`, `budget_for`, `provenance`, `effective_budget`,
+`rust_core_available`, `load_manifest`, `ABSCISSAE`.
+
+```text
+$ rg -n 'effective_budget|budget_for|rust_core_available|load_manifest|test_parity|tolerances' \
+    projects/ docs/ README.md hazma/ test/ | grep -v '^test/parity/'
+projects/cython-to-rust/phases/phase-01-parity-corpus.md:22   ...numerics-replacements.md` (call-site tolerances)   KEPT (unrelated word)
+projects/cython-to-rust/phases/phase-01-parity-corpus.md:30   `test/parity/test_parity.py` runs under `pytest test`   EDITED (this task)
+projects/cython-to-rust/phases/phase-01-parity-corpus.md:69   exit criterion naming test_parity.py                    KEPT (the spec; satisfied)
+projects/cython-to-rust/phases/phase-01-parity-corpus.md:71   "test/parity/tolerances.py (or `.toml`)"                KEPT (spec permitted either; `.py` chosen)
+projects/cython-to-rust/rules.md:12                           "test/parity/tolerances.*"                          KEPT (glob covers the `.py` that now exists)
+hazma/spectra/_fsr.py:347                                     "Absolute and relative tolerances"                  KEPT (unrelated word)
+docs/workflow.md:178                                          "not tolerances"                                    KEPT (unrelated word)
+projects/cython-to-rust/references/numerics-replacements.md:3,58                                                  KEPT (unrelated word)
+projects/cython-to-rust/task-notes/phase-01/task-1.2-parity-runner.md:*                                            KEPT (this note)
+```
+
+No file outside `test/parity/` names a symbol this task added, so there
+was nothing to repoint.
+
+### Line-number citation sweep
+
+Every markdown file this task touched, on the final tree:
+
+```text
+$ python3 scripts/agents/check_doc_citations.py \
+    projects/cython-to-rust/task-notes/phase-01/task-1.2-parity-runner.md \
+    projects/cython-to-rust/task-notes/phase-01/README.md \
+    projects/cython-to-rust/task-notes/README.md \
+    projects/cython-to-rust/phases/phase-01-parity-corpus.md \
+    projects/cython-to-rust/task-notes/phase-01/task-1.1-corpus-generator.md \
+    projects/cython-to-rust/learnings/phase-00-dead-code-purge.md \
+    test/parity/README.md
+docs scanned: 7
+in-repo citations checked: 11
+  resolved by exact: 11
+external citations skipped: 0
+out-of-range or ambiguous: NONE
+```
+
+An earlier run of the same command reported one **suffix** resolution —
+a basename-only citation of the positron muon kernel in this note —
+EDITED to the full repo-relative path
+(`hazma/spectra/_positron/_muon.pyx:134`) per the `elided-doc-paths`
+lesson, which is why the final run is 11/11 exact. The checker does not
+scan `.py`, so `tolerances.py`'s citations were swept by hand for the
+same class; two basename-only `_rho.pyx` citations were EDITED to full
+paths there.
+
+### Forward-looking phrase sweep
+
+```text
+$ rg -n '(Task [0-9.]+ will|will be added|still pending|today: ?stub)' \
+    projects/cython-to-rust/ test/parity/
+phase-00/task-0.1-relocate-constants.md:414    the sweep command, quoted            KEPT
+phase-01/task-1.1-corpus-generator.md:452      the sweep's own null result, quoted  KEPT
+phase-01/task-1.1-corpus-generator.md:562      "Task 1.2 will find out when it
+                                                sets tolerances"                    EDITED
+phase-01/task-1.2-parity-runner.md:411         this block, quoting the hit above    KEPT
+```
+
+Task 1.1's claim was falsified by this task — 1.2 set the tolerances but
+did not find out, because no Linux runner was available. Annotated in
+place with what actually happened and where the measurement moved
+(Task 1.3), rather than rewritten.
+
+A present-tense sibling of the same claim turned up outside the pattern,
+in `../../learnings/phase-00-dead-code-purge.md:148` ("**Zero
+compiled-layer pinned tests run anywhere**"). Found by grepping the
+claim's distinctive phrase rather than the forward-looking pattern —
+the `sibling-copies-of-a-fixed-claim` lesson — and annotated as
+half-closed with the new suite figures:
+
+```text
+$ rg -n "Zero compiled-layer pinned tests|zero pinned-value|no pinned-value" \
+    projects/ docs/ .claude/ .codex/
+projects/cython-to-rust/learnings/phase-00-dead-code-purge.md:148             EDITED
+projects/cython-to-rust/task-notes/README.md:67 ("Zero compiled-layer
+  pinned tests run anywhere today")                                          EDITED
+projects/cython-to-rust/phases/phase-01-parity-corpus.md:24 ("zero
+  pinned-value tests ... execute anywhere")                                  EDITED
+```
+
+### Count sweep
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| This note, class table (19/1/7/5/9) | `Counter(b.rtol for b in tolerances.BUDGETS.values())` | `{0.0: 19, 1e-13: 1, 1e-12: 7, 1e-08: 5, 1e-06: 9}` = 41 | **Corrected** — an earlier hand-count said 16 exact |
+| This note + phase README, "623 blocks / 626 tests" | `pytest test/parity --collect-only -q \| tail -1` | `626 tests collected` | OK |
+| This note, corpus size "41 cases / 1580 arrays" | `python test/parity/generate.py --check` | `41 cases / 1580 arrays` | OK |
+| Phase file Task 1.3, `pytest -q test` | `pytest -q test` | `870 passed, 20 skipped` | **Updated** from `244 / 20` — this task added 626 |
+| Phase file Task 1.3, off-capture figure `869/21` | not runnable here (no Linux runner) | — | **Derived, not measured** — stated as an expectation with its reason, not as a reading |
+| Project README handoff, bare-`pytest` figure | `pytest -q` | `57 passed, 10 skipped` | OK — unchanged, `testpaths = hazma` |
+| TABULATED budget rationale, "501 rows" | `wc -l hazma/spectra/_photon/data/*.csv` | 501 (six tables), 101 (eta) | OK |
+| Phase README, "~4.6 min" parity runtime | `pytest -q test/parity` | `278.83s (0:04:38)` | OK |
+
+### Numerical-impact statement
+
+**No public value changes.** Nothing under `hazma/` is in the diff
+(`git diff origin/master --name-only -- 'hazma/*'` → empty; `git status
+--short` lists only `test/parity/` and `projects/`). The grid is the
+corpus itself — all 41 consumed compiled entry points over 623 blocks /
+179,695 pinned values — and every value reproduced at `rtol=0, atol=0`
+(`pytest -q test/parity` → `626 passed`).
+
+### Exit Criteria → test mapping
+
+| Exit criterion | What satisfies it |
+| --- | --- |
+| Runner parametrizes over the manifest, compares live imports to stored arrays | `test/parity/test_parity.py::test_entry_point_matches_corpus`, 623 params built from `MANIFEST["cases"]` |
+| Per-function budgets with a one-line justification each | `test/parity/tolerances.py::BUDGETS` (41 entries); enforced by `test_every_corpus_case_has_a_budget` and `test_every_budget_states_a_reason` |
+| Exact for closed-form kernels against the capturing commit | `tolerances.effective_budget` + `tolerances.provenance`; asserted live by `test_running_on_the_capturing_tree` (passed, not skipped) |
+| Quad-backed budgets start 1e-8; nested-ρ its own line | `QUAD_RTOL = 1e-8` on 5 cases; `NESTED_RTOL = 1e-6` with explicit `spectra.photon.charged_rho` and `spectra.photon.neutral_rho` entries |
+| `raises` records replayed, not skipped | `assert raised == manifest_block.get("raises", {})`; negative scenarios 1, 2 and 2b prove it fires |
+| Running against unmodified Cython passes bit-exact | `pytest -q test/parity` → `626 passed` in exact mode |
+
+### Task-note self-consistency
+
+`**Status:** Complete` matches the phase README row and every Exit
+Criterion having a mapping row. Every symbol named in §Files Changed and
+§Decisions (`Budget`, `Provenance`, `BUDGETS`, `budget_for`,
+`provenance`, `effective_budget`, `rust_core_available`,
+`load_manifest`, `_sweep_pointwise`) appears in `git diff --stat
+origin/master --` or in a file this task created.
+
+## Handoff to Next Task
+
+**Read first:** `test/parity/README.md` ("What the gate compares" is
+new), then `test/parity/tolerances.py`'s module docstring, then this
+note's Findings.
+
+**Currently safe to assume:**
+
+- The corpus reproduces bit-exactly on the capturing environment, and
+  the gate proves it on every run rather than by report. Task 1.3 is
+  wiring, not repair.
+- The tolerance table cannot silently drift out of sync with the corpus:
+  `test_every_corpus_case_has_a_budget` fails in both directions.
+- The two comparison modes are not a hidden switch. `pytest
+  test/parity -rs` names the active one; a skipped
+  `test_running_on_the_capturing_tree` means budget mode and its reason
+  says what differed.
+- `generate.evaluate_block` is now shared between the generator and the
+  gate. Changing it changes both — which is the point, but it means a
+  change there needs a corpus `--check` *and* a parity run, not one of
+  the two.
+
+**Currently risky / unknown:**
+
+- Expect the parity suite to land in **budget mode** on CI, with one
+  extra skip. That is correct behavior, not a regression; a Task 1.3
+  agent who sees `625 passed, 1 skipped` where this note says `626
+  passed` is looking at a Linux runner, and `-rs` will say so.
+- The ~4.6-minute cost, per Open Questions.
+- Do not regenerate the corpus to make a failing case pass. `rules.md`
+  rule 2 and `tolerances.py`'s docstring both say so; the remedy is a
+  declared budget widening plus an entry in "Numerical impact so far".
+- Do not hoist `cases.py`'s deferred model imports — `generate.py
+  --check` still has to work on an unbuilt tree, and `tolerances.py`
+  imports `cases` at module scope now, so the runner shares that
+  constraint.

--- a/test/parity/README.md
+++ b/test/parity/README.md
@@ -10,10 +10,20 @@ function's budget.
 | --- | --- |
 | [`cases.py`](cases.py) | The specification — which entry points, on which grids, invoked how. No numbers. |
 | [`generate.py`](generate.py) | Evaluates the specification and writes `data/`; also verifies `data/` against its manifest. |
+| [`tolerances.py`](tolerances.py) | How far a replacement implementation may move each entry point, and why that far. |
+| [`test_parity.py`](test_parity.py) | The gate — re-evaluates every entry point and compares against `data/`. |
 | `data/*.npz` | One file per entry point. Reference arrays, stored exactly as the library returned them. |
 | `data/manifest.json` | Provenance and per-array hashes. |
 
 ## Commands
+
+Run the gate. One test per corpus block (623 of them) plus three guards;
+takes around five minutes, nearly all of it the nested adaptive
+quadrature in the rho and mediator-spectrum kernels:
+
+```bash
+pytest test/parity
+```
 
 Verify the committed data is intact and complete. Imports no kernel and
 evaluates nothing, so it is fast and works on an unbuilt tree:
@@ -22,8 +32,8 @@ evaluates nothing, so it is fast and works on an unbuilt tree:
 python test/parity/generate.py --check
 ```
 
-Regenerate everything. Takes a few minutes — most of it is the nested
-adaptive quadrature in the rho and mediator-spectrum kernels:
+Regenerate everything. Takes a few minutes, for the same reason the gate
+does:
 
 ```bash
 python test/parity/generate.py
@@ -58,6 +68,26 @@ including `nan`, `inf` and negative entries. Where an entry point
 `sigma_xx_to_v_to_pi0v` raise `TypeError` exactly at `e_cm = 2 mx`), the
 stored value is `nan` and the manifest's `raises` block records the
 index, the argument and the exception type.
+
+## What the gate compares
+
+Per block: the grid `cases.py` produces against the grid the values were
+captured on (exact, always); the values themselves against the budget
+[`tolerances.py`](tolerances.py) selects; and the manifest's `raises`
+records, **replayed** — the entry point must still raise the same type at
+the same argument, and must not raise anywhere new. Evaluation goes
+through `generate.evaluate_block`, the same function that produced the
+stored numbers, so the kernel is the only thing that can differ.
+
+The budget depends on which tree you are on. When the kernel digest, the
+toolchain and the numerics libraries all match what the manifest records,
+every case is held to **bit-equality** — the corpus pins that
+implementation against itself, so any difference is a regression. Once
+anything diverges (a ported kernel, a different platform, a newer scipy)
+the declared per-function budgets in `tolerances.py` take over, which is
+the situation they were written for. `pytest test/parity -rs` names the
+mode: a skipped `test_running_on_the_capturing_tree` means budget mode,
+and its reason says what differed.
 
 **Provenance.** The manifest carries the generating commit and whether
 that tree was dirty, the versions of numpy/scipy/cython/hazma, and

--- a/test/parity/cases.py
+++ b/test/parity/cases.py
@@ -1188,6 +1188,16 @@ def hazma_package_path() -> Path:
     return Path(hazma.__file__).resolve().parent
 
 
+def rust_core_available() -> bool:
+    """Whether this tree has a Rust extension, i.e. the port has started.
+
+    Used two ways: `assert_no_rust_core` refuses to regenerate the corpus
+    once it is true, and the parity runner stops demanding bit-equality
+    (`tolerances.provenance`).
+    """
+    return importlib.util.find_spec("hazma._core") is not None
+
+
 def assert_no_rust_core() -> None:
     """Refuse to touch the corpus if any kernel already runs on Rust.
 
@@ -1195,7 +1205,7 @@ def assert_no_rust_core() -> None:
     pre-port Cython. Once ``hazma._core`` exists, a regenerated corpus
     would pin the port against itself.
     """
-    if importlib.util.find_spec("hazma._core") is not None:
+    if rust_core_available():
         raise RuntimeError(
             "hazma._core is importable: this tree runs Rust kernels. "
             "The parity corpus must only ever be generated from pre-port "

--- a/test/parity/generate.py
+++ b/test/parity/generate.py
@@ -207,6 +207,14 @@ def _sweep_pointwise(
         exception *message* is deliberately not recorded — Cython rewords
         its errors between releases, and it is the fact of the raise and
         its type that a port has to reproduce.
+
+    Raises
+    ------
+    RuntimeError
+        If no point evaluated. The fill shape is read off a successful
+        result, so with none there is nothing to shape the ``nan`` to —
+        and a kernel that raises everywhere is a breakage to report, not
+        a block to record.
     """
     results: list[np.ndarray | None] = []
     raises: list[dict[str, Any]] = []
@@ -219,7 +227,15 @@ def _sweep_pointwise(
             )
             results.append(None)
 
-    shape = next((r.shape for r in results if r is not None), ())
+    if raises and len(raises) == len(results):
+        kinds = sorted({record["type"] for record in raises})
+        raise RuntimeError(
+            f"every one of the {len(results)} grid points raised "
+            f"({', '.join(kinds)}); the entry point is broken, not merely "
+            "singular at an edge"
+        )
+
+    shape = next(r.shape for r in results if r is not None)
     filled = [np.full(shape, np.nan) if r is None else r for r in results]
     return filled, raises
 
@@ -401,6 +417,15 @@ def _check_case(
     return failures, n_arrays
 
 
+def load_manifest() -> dict[str, Any]:
+    """Read the committed manifest.
+
+    Shared with the parity test suite so there is one spelling of where
+    the manifest lives and how it is parsed.
+    """
+    return json.loads(MANIFEST_PATH.read_text())
+
+
 def check() -> int:
     """Re-hash the stored corpus against the manifest. Returns an exit code.
 
@@ -412,7 +437,7 @@ def check() -> int:
         print(f"ERROR: no manifest at {MANIFEST_PATH}", file=sys.stderr)
         return 1
 
-    manifest = json.loads(MANIFEST_PATH.read_text())
+    manifest = load_manifest()
     if manifest.get("schema") != SCHEMA_VERSION:
         print(
             f"ERROR: manifest schema {manifest.get('schema')} != "

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -1,0 +1,219 @@
+"""The parity gate: re-evaluate every pinned entry point and compare.
+
+One test per corpus block (`cases.Block`) — 623 of them across the 41
+consumed compiled entry points. Each one re-derives the block from
+`cases`, re-evaluates the live implementation through the *generator's
+own* evaluation path, and compares against the arrays committed under
+``data/``.
+
+Why the generator's path
+------------------------
+`generate.evaluate_block` is what produced the stored numbers: it
+suppresses scipy's `IntegrationWarning` on the deliberately pathological
+grid points, and when a batched call raises it recovers the surviving
+points one at a time and records what raised. Re-implementing any of that
+here would let a difference in the harness masquerade as a difference in
+the implementation. Calling the same function leaves the kernel as the
+only variable.
+
+What is compared
+----------------
+For every block:
+
+1. **The abscissae the specification produces** — the swept grid and the
+   scalar probe drawn from it — against the ones stored in the corpus.
+   `cases` is re-evaluated live, so a change to grid construction would
+   otherwise silently move every sample point and leave the value
+   comparison comparing two differently-sampled functions. Exact in
+   either mode: grids are arithmetic on constants, and no tolerance on a
+   *value* can make up for having moved where it was measured.
+2. **The values**, array path and scalar path, within the budget
+   `tolerances.effective_budget` selects — bit-equality on the capturing
+   tree, the declared per-function budget anywhere else.
+3. **The raises**, replayed rather than skipped. Three blocks record a
+   `TypeError` at a kinematic edge (`sigma_xx_to_v_to_pipi` and
+   `sigma_xx_to_v_to_pi0v` at ``e_cm = 2 mx``). The stored value there is
+   `nan`, so a runner that only compared arrays would pass against an
+   implementation that quietly returned a number. Comparing the *records*
+   catches the reverse too — a new raise where the corpus has none.
+
+Reading a failure
+-----------------
+`numpy.testing.assert_allclose` prints the max relative difference it
+saw, which is the measurement a later phase needs in order to tighten a
+budget: set the budget to the value you want and read what the run
+reports.
+
+Runtime
+-------
+Around five minutes, nearly all of it nested adaptive quadrature in the
+rho and mediator-spectrum kernels. That is the cost of the gate, not
+overhead — it is the same work `generate.py` does.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cases as corpus  # (imported after the sys.path entry above)
+import generate as corpus_generate
+import tolerances
+
+MANIFEST = corpus_generate.load_manifest()
+
+#: The live specification. Built once at import: `pytest.mark.parametrize`
+#: needs the block list at collection time, and constructing the mediator
+#: models (which solve for `vs` and integrate partial widths) is not free.
+CASES = corpus.build_cases()
+
+#: Which tree we are running on, and therefore which budget applies.
+TREE = tolerances.provenance(MANIFEST)
+
+#: What the `stored_arrays` fixture hands back: case name -> npz contents.
+ArrayLoader = Callable[[str], dict[str, np.ndarray]]
+
+#: Block arrays that record *where* an entry point was sampled rather than
+#: what it returned. Always compared exactly, in either mode.
+ABSCISSAE = frozenset({"grid", "scalar_grid"})
+
+
+def _blocks() -> list[Any]:
+    """One `pytest.param` per corpus block, ided by case and block label."""
+    return [
+        pytest.param(name, index, id=f"{name}[{block['label']}]")
+        for name, case in MANIFEST["cases"].items()
+        for index, block in enumerate(case["blocks"])
+    ]
+
+
+@pytest.fixture(scope="session")
+def stored_arrays() -> ArrayLoader:
+    """Load a case's ``.npz`` once and hand out its arrays by key.
+
+    The whole corpus is ~180k float64 values, so holding every case in
+    memory for the session is cheaper than reopening an npz 623 times.
+    """
+    cache: dict[str, dict[str, np.ndarray]] = {}
+
+    def load(case_name: str) -> dict[str, np.ndarray]:
+        if case_name not in cache:
+            path = corpus_generate.DATA_DIR / MANIFEST["cases"][case_name]["file"]
+            with np.load(path) as npz:
+                cache[case_name] = {key: npz[key] for key in npz.files}
+        return cache[case_name]
+
+    return load
+
+
+@pytest.mark.parametrize(("case_name", "block_index"), _blocks())
+def test_entry_point_matches_corpus(
+    case_name: str, block_index: int, stored_arrays: ArrayLoader
+) -> None:
+    """One corpus block: same grid, same raises, same values."""
+    manifest_block = MANIFEST["cases"][case_name]["blocks"][block_index]
+    case = CASES[case_name]
+    block = case.blocks[block_index]
+    arrays = stored_arrays(case_name)
+    budget = tolerances.effective_budget(case_name, TREE)
+
+    assert block.label == manifest_block["label"], (
+        f"{case_name}: block {block_index} is {block.label!r} in cases.py but "
+        f"{manifest_block['label']!r} in the manifest — the specification and "
+        "the corpus have diverged; regenerate or revert."
+    )
+
+    # The specification must still produce the abscissae the values were
+    # captured at, or the comparison below is between two different
+    # functions sampled differently.
+    np.testing.assert_array_equal(
+        block.grid,
+        arrays[manifest_block["arrays"]["grid"]["key"]],
+        err_msg=f"{case_name}[{block.label}]: cases.py no longer produces the "
+        "grid the corpus was captured on",
+    )
+
+    actual, raised = corpus_generate.evaluate_block(case.resolve(), block)
+
+    # Replay, not skip: where the corpus says the entry point raised, the
+    # live one must raise the same type at the same argument, and where it
+    # says nothing raised, nothing may.
+    assert raised == manifest_block.get("raises", {}), (
+        f"{case_name}[{block.label}]: exceptions changed.\n"
+        f"  corpus: {manifest_block.get('raises', {})}\n"
+        f"  live:   {raised}"
+    )
+
+    # Both directions: a block that lost its scalar branch would otherwise
+    # fail as a KeyError below, and one that gained a branch the corpus
+    # never captured would pass without anyone checking it.
+    assert set(actual) == set(manifest_block["arrays"]), (
+        f"{case_name}[{block.label}]: the block produced "
+        f"{sorted(actual)} where the corpus holds "
+        f"{sorted(manifest_block['arrays'])}"
+    )
+
+    for suffix, entry in manifest_block["arrays"].items():
+        expected = arrays[entry["key"]]
+        where = f"{case_name}[{block.label}].{suffix}"
+        if suffix in ABSCISSAE:
+            # Where the values were sampled, not what came back. A budget
+            # would be meaningless here and actively harmful: comparing at
+            # drifted abscissae compares two different functions.
+            np.testing.assert_array_equal(
+                actual[suffix], expected, err_msg=f"{where} is not the pinned grid"
+            )
+            continue
+        np.testing.assert_allclose(
+            actual[suffix],
+            expected,
+            rtol=budget.rtol,
+            atol=budget.atol,
+            equal_nan=True,
+            err_msg=f"{where} moved beyond its budget ({budget.why})",
+        )
+
+
+def test_running_on_the_capturing_tree() -> None:
+    """Assert the gate is in bit-equality mode, or say why it is not.
+
+    The mode switch in `tolerances.effective_budget` is load-bearing — it
+    is the difference between catching a one-ulp regression and tolerating
+    1e-6 — so it is reported rather than left to be inferred. A skip here
+    (visible with ``-rs``) means the declared budgets are what is being
+    enforced, and its reason names what differs from the capture.
+    """
+    if not TREE.exact:
+        pytest.skip(f"declared budgets in force: {TREE.detail}")
+
+
+def test_every_corpus_case_has_a_budget() -> None:
+    """No entry point may run through the gate without a declared budget.
+
+    `tolerances.budget_for` raises on a missing case, but only for a case
+    something actually evaluates. This closes the other direction too: a
+    budget for a case the corpus no longer has is a leftover, and reading
+    it as coverage would overstate the gate.
+    """
+    corpus_cases = set(MANIFEST["cases"])
+    declared = set(tolerances.BUDGETS)
+    assert declared == corpus_cases, (
+        "tolerances.BUDGETS and the corpus manifest disagree.\n"
+        f"  cases with no budget: {sorted(corpus_cases - declared)}\n"
+        f"  budgets with no case: {sorted(declared - corpus_cases)}"
+    )
+
+
+def test_every_budget_states_a_reason() -> None:
+    """rules.md rule 2: a tolerance nobody justified cannot be argued with."""
+    unjustified = sorted(
+        name for name, budget in tolerances.BUDGETS.items() if not budget.why.strip()
+    )
+    assert not unjustified, f"budgets with no justification: {unjustified}"

--- a/test/parity/tolerances.py
+++ b/test/parity/tolerances.py
@@ -1,0 +1,521 @@
+"""Per-entry-point tolerance budgets for the golden parity corpus.
+
+The corpus (`cases`, `generate`) pins what the pre-port Cython returned.
+This module declares how far a *replacement* implementation is allowed to
+move each of those numbers, and `test_parity` enforces it.
+
+A budget is a contract, not a prediction. It says "a port that lands here
+is accepted without further argument"; it does not say the port will land
+here. Widening one is therefore a real decision:
+``projects/cython-to-rust/rules.md`` rule 2 requires a one-line
+justification in this file plus a note in the widening task's task note,
+and rule 3 requires any shift beyond 1e-12 relative to be declared in the
+PR body and the project's "Numerical impact so far" log even when the
+budget absorbs it.
+
+Budget classes
+--------------
+Every entry point falls into one of five classes, set by *what the
+implementation does* rather than by what it computes:
+
+``EXACT`` (rtol 0)
+    Closed-form arithmetic: `+ - * /`, `sqrt`, `pow`, `log`, `exp`,
+    `atan`, `atanh` and branch selection, nothing else — everything in
+    this class reaches only `libc.math`. The phase file asks for
+    bit-equality here against the capturing commit. Note this is strict
+    enough to catch a libm change — Rust's `f64::exp` need not agree with
+    the platform C library in the last ulp — which is deliberate: such a
+    shift should be measured and declared, not absorbed silently.
+``SPECFUN`` (rtol 1e-13)
+    Closed form apart from a special function. ADR-0002 replaces scipy's
+    cephes bindings with cephes-lineage Rust, which is
+    algorithm-for-algorithm parity rather than merely value parity; 1e-13
+    relative is the acceptance figure the numerics reference already sets
+    for that swap
+    (`projects/cython-to-rust/references/numerics-replacements.md`,
+    "Special functions", Task 3.2 check 2).
+``TABULATED`` (rtol 1e-12)
+    Driven by `boost_integrate_linear_interp` over a shipped CSV table:
+    `np.trapezoid` across interior cells, closed-form partial cells at
+    both edges, an analytic `1/E` tail below the table. A Rust rewrite
+    keeps the algorithm and changes the summation order, so the drift is
+    accumulated rounding, not method error: the tables are 101 rows (eta)
+    or 501 (the other six), and 501 · 2^-52 is ~1.1e-13, so 1e-12 leaves
+    roughly a decade of headroom over the worst case.
+``QUAD`` (rtol 1e-8)
+    One adaptive `scipy.integrate.quad` call. The numerics reference
+    expects a faithful netlib-QUADPACK port to reproduce these to ~1e-12
+    or better; the phase file sets the opening budget at 1e-8 and tightens
+    it once Phase 03 has measured the port.
+``NESTED`` (rtol 1e-6)
+    An adaptive quadrature whose integrand is itself an adaptive
+    quadrature. Subdivision is a discontinuous function of the integrand:
+    a last-ulp change inside can move an outer bisection decision, and the
+    outer call is then only as accurate as its own `epsrel`, which is
+    1e-5 at every live site. 1e-6 sits one decade inside that, so the
+    budget tracks the integrator's own accuracy claim rather than the
+    resolution of the arithmetic.
+
+`atol` is 0.0 everywhere
+------------------------
+An absolute floor is scale-dependent — spectra run to ~1e-3 MeV^-1 and
+cross sections to ~1e-20 MeV^-2 — so one floor either does nothing or
+hides a real shift in the smaller quantity. It is also unnecessary: the
+below-threshold and above-endpoint regions return exactly ``0.0``, and
+``|0 - 0| <= rtol * 0`` holds. A port that returns 1e-300 where the
+Cython returned zero therefore fails, which is the intended answer.
+
+Citations
+---------
+Every ``file:line`` below was read against the tree whose kernel digest is
+``f5e6e269be47`` — the digest the corpus manifest records. Phases 04-06
+delete the files they point into; the line numbers are evidence for the
+classification, not live references.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cases as corpus  # (imported after the sys.path entry above)
+import generate as corpus_generate
+
+#: Bit-equality against the capturing commit, in the sense
+#: `numpy.testing.assert_allclose` gives it: NaN matches NaN, infinities
+#: match in position and sign, and every other value must be equal as an
+#: IEEE double. Signed zeros and NaN payloads are not distinguished --
+#: byte-level identity of the *stored* corpus is what
+#: `generate.py --check` covers.
+EXACT_RTOL = 0.0
+SPECFUN_RTOL = 1e-13
+TABULATED_RTOL = 1e-12
+QUAD_RTOL = 1e-8
+NESTED_RTOL = 1e-6
+
+
+@dataclass(frozen=True)
+class Budget:
+    """How far one entry point's values may move, and why that far.
+
+    Parameters
+    ----------
+    rtol, atol : float
+        Passed straight to `numpy.testing.assert_allclose`.
+    why : str
+        One-line justification. Required: a tolerance without a stated
+        reason is one nobody can argue against later.
+    """
+
+    rtol: float
+    atol: float
+    why: str
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """Whether the live tree is the one the corpus was captured from.
+
+    Parameters
+    ----------
+    exact : bool
+        True when the kernels, the toolchain and the numerics libraries
+        all match what the manifest records.
+    detail : str
+        Empty when `exact`; otherwise a human-readable list of what
+        differs. Surfaced as the skip reason on
+        `test_parity.test_running_on_the_capturing_tree`, so the mode is
+        never something a reader has to infer.
+    """
+
+    exact: bool
+    detail: str
+
+
+# ===========================================================================
+# ---- The budget table -----------------------------------------------------
+# ===========================================================================
+
+#: Case name -> budget. Keys are `cases.build_cases()` names, which is
+#: also what the manifest is keyed by; `test_parity` asserts the two sets
+#: agree, so a corpus case can never quietly run without a declared budget.
+BUDGETS: dict[str, Budget] = {
+    # -- spectra: photon ----------------------------------------------------
+    "spectra.photon.muon": Budget(
+        rtol=SPECFUN_RTOL,
+        atol=0.0,
+        why="closed form apart from two `spence` calls "
+        "(hazma/spectra/_photon/_muon.pyx:113); the cephes-lineage "
+        "replacement is held to <=1e-13 relative by the numerics "
+        "reference's own Task 3.2 acceptance check.",
+    ),
+    "spectra.photon.charged_pion": Budget(
+        rtol=QUAD_RTOL,
+        atol=0.0,
+        why="one QAGP over cos(theta) "
+        "(hazma/spectra/_photon/_pion.pyx:123, epsabs=1e-10, epsrel=1e-5); "
+        "the integrand is the spence-bearing muon spectrum, whose 1e-13 "
+        "class sits well inside the quadrature budget.",
+    ),
+    "spectra.photon.neutral_pion": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form boosted box spectrum, arithmetic and branch "
+        "selection only (hazma/spectra/_photon/_pion.pyx:168-196).",
+    ),
+    "spectra.photon.charged_rho": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="quad at hazma/spectra/_photon/_rho.pyx:123 whose integrand "
+        "calls the charged- and neutral-pion point kernels "
+        "(hazma/spectra/_photon/_rho.pyx:10-11 and :95-96), the first of "
+        "which quads again — the nested case the phase file singles out.",
+    ),
+    "spectra.photon.neutral_rho": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="quad at hazma/spectra/_photon/_rho.pyx:52 over an integrand "
+        "that calls the quad-backed charged-pion point kernel "
+        "(hazma/spectra/_photon/_rho.pyx:26) — the second nested-rho "
+        "entry point.",
+    ),
+    "spectra.photon.charged_kaon": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over the shipped CSV table "
+        "(hazma/spectra/_photon/_kaon.pyx:57-58); drift is trapezoid "
+        "summation order, not method.",
+    ),
+    "spectra.photon.long_kaon": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over long_kaon_photon.csv, same mechanism as "
+        "the charged kaon (hazma/spectra/_photon/_kaon.pyx:57-58).",
+    ),
+    "spectra.photon.short_kaon": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over short_kaon_photon.csv, same mechanism as "
+        "the charged kaon (hazma/spectra/_photon/_kaon.pyx:57-58).",
+    ),
+    "spectra.photon.eta": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over eta_photon.csv "
+        "(hazma/spectra/_photon/_eta.pyx:98), no quadrature on the live "
+        "path.",
+    ),
+    "spectra.photon.eta_prime": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over eta_prime_photon.csv, same mechanism as "
+        "the eta (hazma/spectra/_photon/_eta_prime.pyx).",
+    ),
+    "spectra.photon.omega": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over omega_photon.csv, same mechanism as the "
+        "eta (hazma/spectra/_photon/_omega.pyx).",
+    ),
+    "spectra.photon.phi": Budget(
+        rtol=TABULATED_RTOL,
+        atol=0.0,
+        why="boost integral over phi_photon.csv, same mechanism as the eta "
+        "(hazma/spectra/_photon/_phi.pyx).",
+    ),
+    # -- spectra: positron --------------------------------------------------
+    "spectra.positron.muon": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="the boost integral is done analytically — closed-form "
+        "arithmetic only, no quad on the live path "
+        "(hazma/spectra/_positron/_muon.pyx:33-57).",
+    ),
+    "spectra.positron.charged_pion": Budget(
+        rtol=QUAD_RTOL,
+        atol=0.0,
+        why="one quad over cos(theta) "
+        "(hazma/spectra/_positron/_pion.pyx:58, epsabs=1e-10, "
+        "epsrel=1e-4) over the closed-form positron-muon spectrum.",
+    ),
+    # -- spectra: neutrino --------------------------------------------------
+    "spectra.neutrino.muon": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form per-flavor spectra, libc math only "
+        "(hazma/spectra/_neutrino/_muon.pyx:8).",
+    ),
+    "spectra.neutrino.charged_pion": Budget(
+        rtol=QUAD_RTOL,
+        atol=0.0,
+        why="two energy-space quads at scipy's default tolerances "
+        "(hazma/spectra/_neutrino/_pion.pyx:124,127) over the closed-form "
+        "neutrino-muon spectrum.",
+    ),
+    # -- scalar-mediator cross sections -------------------------------------
+    "cross_sections.scalar.sigma_xx_to_s_to_ff": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form s-channel cross section; arithmetic and the "
+        "below-threshold branch only.",
+    ),
+    "cross_sections.scalar.sigma_xx_to_s_to_gg": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form xx -> s* -> g g, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xx_to_s_to_pi0pi0": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form xx -> s* -> pi0 pi0, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xx_to_s_to_pipi": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form xx -> s* -> pi pi, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xx_to_ss": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form t/u-channel result, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_ss_to_xx": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form crossing of sigma_xx_to_ss, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xl_to_xl": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form elastic scattering; the negatives and infinities "
+        "the corpus stores are branch behavior, not integration noise.",
+    ),
+    "cross_sections.scalar.sigma_xpi_to_xpi": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form elastic scattering, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xpi0_to_xpi0": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form elastic scattering, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xg_to_xg": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form elastic scattering, arithmetic only.",
+    ),
+    "cross_sections.scalar.sigma_xs_to_xs": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form elastic scattering, arithmetic only.",
+    ),
+    "cross_sections.scalar.thermal_cross_section": Budget(
+        rtol=QUAD_RTOL,
+        atol=0.0,
+        why="QAGP over z with mediator breakpoints "
+        "(hazma/scalar_mediator/_c_scalar_mediator_cross_sections.pyx:1411) "
+        "and Bessel K1/K2 prefactors (:1361, :1404); the quadrature, not "
+        "the 1e-13 Bessel class, sets the budget.",
+    ),
+    # -- vector-mediator cross sections -------------------------------------
+    "cross_sections.vector.sigma_xx_to_v_to_ff": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form s-channel cross section, arithmetic only.",
+    ),
+    "cross_sections.vector.sigma_xx_to_v_to_pipi": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed form; the TypeError the corpus pins at e_cm = 2 mx is "
+        "a branch, replayed rather than tolerated.",
+    ),
+    "cross_sections.vector.sigma_xx_to_v_to_pi0g": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form xx -> v* -> pi0 gamma, arithmetic only.",
+    ),
+    "cross_sections.vector.sigma_xx_to_v_to_pi0v": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed form; like sigma_xx_to_v_to_pipi it raises at "
+        "e_cm = 2 mx, which the runner replays.",
+    ),
+    "cross_sections.vector.sigma_xx_to_vv": Budget(
+        rtol=EXACT_RTOL,
+        atol=0.0,
+        why="closed-form t/u-channel result, arithmetic only.",
+    ),
+    "cross_sections.vector.thermal_cross_section": Budget(
+        rtol=QUAD_RTOL,
+        atol=0.0,
+        why="QAGP over z with mediator breakpoints "
+        "(hazma/vector_mediator/_c_vector_mediator_cross_sections.pyx:656) "
+        "and Bessel K1/K2 prefactors (:606, :650); the x > 300 saturation "
+        "is a branch, not a tolerance question.",
+    ),
+    # -- mediator spectra ---------------------------------------------------
+    "mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="cos(theta) QAGP "
+        "(hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx:184) "
+        "over an integrand that calls the quad-backed charged-pion photon "
+        "kernel (:2-3).",
+    ),
+    "mediator_spectra.scalar.positron.dnde_decay_s": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="cos(theta) QAGP "
+        "(hazma/scalar_mediator/scalar_mediator_positron_spec.pyx:209) "
+        "over the quad-backed positron charged-pion kernel (:2).",
+    ),
+    "mediator_spectra.scalar.positron.dnde_decay_s_pt": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="scalar-argument twin of dnde_decay_s, same nested quadrature "
+        "(hazma/scalar_mediator/scalar_mediator_positron_spec.pyx:209).",
+    ),
+    "mediator_spectra.vector.photon.dnde_decay_v": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="cos(theta) QAGP "
+        "(hazma/vector_mediator/vector_mediator_decay_spectrum.pyx:219) "
+        "over an integrand that calls the quad-backed charged-pion photon "
+        "kernel (:10).",
+    ),
+    "mediator_spectra.vector.photon.dnde_decay_v_pt": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="scalar-argument twin of the vector photon dnde_decay_v, same "
+        "nested quadrature "
+        "(hazma/vector_mediator/vector_mediator_decay_spectrum.pyx:219).",
+    ),
+    "mediator_spectra.vector.positron.dnde_decay_v": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="cos(theta) QAGP "
+        "(hazma/vector_mediator/vector_mediator_positron_spec.pyx:210) "
+        "over the quad-backed positron charged-pion kernel (:10).",
+    ),
+    "mediator_spectra.vector.positron.dnde_decay_v_pt": Budget(
+        rtol=NESTED_RTOL,
+        atol=0.0,
+        why="scalar-argument twin of the vector positron dnde_decay_v, "
+        "same nested quadrature "
+        "(hazma/vector_mediator/vector_mediator_positron_spec.pyx:210).",
+    ),
+}
+
+
+def budget_for(case_name: str) -> Budget:
+    """The declared budget for one corpus case.
+
+    Raises
+    ------
+    KeyError
+        If the case has no declared budget. A corpus case without one is
+        a gap in the gate, not something to fall back from — the port
+        would then be free to move that entry point by any amount.
+    """
+    try:
+        return BUDGETS[case_name]
+    except KeyError:
+        raise KeyError(
+            f"no tolerance budget declared for corpus case {case_name!r}. "
+            "Add one to test/parity/tolerances.py with a one-line "
+            "justification (projects/cython-to-rust/rules.md, rule 2)."
+        ) from None
+
+
+# ===========================================================================
+# ---- Which budget actually applies ----------------------------------------
+# ===========================================================================
+
+#: Manifest environment keys that can move a captured value. `hazma`'s own
+#: version is deliberately absent: Phase 07 bumps it without touching a
+#: number, and a version bump must not silently relax the gate.
+_NUMERICS_ENVIRONMENT_KEYS = (
+    "python",
+    "numpy",
+    "scipy",
+    "cython",
+    "platform",
+    "machine",
+)
+
+
+def provenance(manifest: dict[str, Any]) -> Provenance:
+    """Decide whether this tree *is* the tree the corpus was captured from.
+
+    The comparison covers three things that can each move a value on their
+    own: the kernel sources (`generate.kernel_digest`), the toolchain and
+    numerics libraries the manifest records, and whether any kernel has
+    already been ported to Rust.
+
+    Parameters
+    ----------
+    manifest : dict
+        The parsed ``data/manifest.json``.
+
+    Returns
+    -------
+    Provenance
+        `exact` is True only when all three agree.
+    """
+    differences: list[str] = []
+
+    stored_env = manifest["environment"]
+    live_env = corpus_generate.environment()
+    differences.extend(
+        f"{key} {stored_env.get(key)!r} -> {live_env.get(key)!r}"
+        for key in _NUMERICS_ENVIRONMENT_KEYS
+        if stored_env.get(key) != live_env.get(key)
+    )
+
+    stored_digest = manifest["kernel_digest"]["sha256"]
+    live_digest = corpus_generate.kernel_digest()["sha256"]
+    if stored_digest != live_digest:
+        differences.append(f"kernel digest {stored_digest[:12]} -> {live_digest[:12]}")
+
+    if corpus.rust_core_available():
+        differences.append("hazma._core is importable")
+
+    return Provenance(exact=not differences, detail="; ".join(differences))
+
+
+def effective_budget(case_name: str, tree: Provenance) -> Budget:
+    """The budget the runner enforces, given what tree it is running on.
+
+    On the capturing tree the declared budgets are not the right gate.
+    The corpus was captured from these exact kernels in this exact
+    environment, so any difference at all is a regression somebody
+    introduced, and the phase file asks for bit-equality accordingly
+    ("Running against unmodified Cython passes bit-exact"). Once the tree
+    diverges — a ported kernel, a new scipy, a different platform — the
+    declared budget takes over, because that is precisely the situation it
+    was written for.
+
+    Parameters
+    ----------
+    case_name : str
+        A `cases.build_cases()` key.
+    tree : Provenance
+        From `provenance`.
+    """
+    # Looked up before the branch on purpose: a case with no declared
+    # budget must fail even on the capturing tree, where the override
+    # would otherwise never consult the table.
+    declared = budget_for(case_name)
+    if tree.exact:
+        return Budget(
+            rtol=EXACT_RTOL,
+            atol=0.0,
+            why="running on the capturing tree, where the corpus pins this "
+            "implementation against itself",
+        )
+    return declared


### PR DESCRIPTION
## Summary

- **`test/parity/test_parity.py` turns the Task 1.1 corpus into a gate.** 623 tests, one per corpus block, covering all 41 consumed compiled entry points, plus three guards. Evaluation goes through `generate.evaluate_block` — the same function that produced the stored numbers — so a difference in the harness cannot masquerade as a difference in the kernel.
- **The manifest's `raises` records are replayed, not skipped.** Three blocks record a `TypeError` at exactly `e_cm = 2·mx` (`sigma_xx_to_v_to_pipi`, `sigma_xx_to_v_to_pi0v`). The stored value there is `nan`, so an array-only comparison would pass against an implementation that quietly returned a number; comparing the records catches that *and* a new raise where the corpus has none.
- **`test/parity/tolerances.py` declares a budget per entry point**, classified by what the implementation does rather than what it computes — 19 closed form (exact), 1 through `spence` (1e-13), 7 tabulated boost integrals (1e-12), 5 single-`quad` (1e-8), 9 nested-`quad` (1e-6) — each with a one-line justification, as `rules.md` rule 2 requires of any later widening. Two kernels would have been misfiled from their import lists alone: `hazma/spectra/_photon/_muon.pyx` and `hazma/spectra/_positron/_muon.pyx` both `import quad` and never call it on the live path.
- **On the capturing tree the declared budgets are the wrong gate.** The corpus pins that implementation against itself, so a 1e-8 budget would swallow a real regression. `effective_budget` demands bit-equality whenever the kernel digest, toolchain and numerics libraries all match the manifest, and falls back to the declared budgets otherwise — which is also what keeps a Linux runner from failing an exactness claim nobody has evidence for. Expect `869 passed, 1 skipped` in CI where this ran `870 passed`; `-rs` names the mode.
- **Three small changes to Task 1.1's modules rather than duplicates:** `cases.rust_core_available()`, `generate.load_manifest()`, and a guard in `generate._sweep_pointwise` for a block where *every* point raises (previously an opaque `ValueError` out of `np.concatenate`; now a `RuntimeError` naming the kernel).
- **No returned value moves.** Nothing under `hazma/` is in the diff, and the parity run is itself the statement: all 41 entry points reproduce their pinned values bit-for-bit.
- Doc sweep: three durable docs claimed "zero pinned-value tests over compiled code execute anywhere". Half of that is now false — `pytest test` reaches the parity suite, CI still does not — so each was corrected or annotated in place rather than left to rot.

## Project

`projects/cython-to-rust/` — Task 1.2: Pytest runner and tolerance budgets.

See `projects/cython-to-rust/task-notes/phase-01/task-1.2-parity-runner.md` for implementation detail, decisions, and verification.

## Test plan

- [x] The gate itself, in exact (bit-equality) mode:

```text
$ pytest -q test/parity -rs
626 passed in 278.83s (0:04:38)
```

626 = 623 corpus blocks + `test_running_on_the_capturing_tree` (passed, so exact mode was active and not silently skipped) + the two budget-table guards.

- [x] Preflight gate, on the final tree:

```text
PASS   black --check
PASS   isort --check-only
PASS   ruff check
PASS   pytest                  870 passed, 20 skipped in 567.70s (0:09:27)
PASS   import hazma            version 2.1.0
PASS   markdownlint
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
RESULT: PASS
```

`pytest -q test` is 244 + 626: the pre-existing suite is untouched and the parity gate is additive. Bare `pytest -q` is unchanged at `57 passed, 10 skipped` — `setup.cfg`'s `testpaths = hazma` still scopes it, which is what Task 1.3 fixes.

- [x] Corpus integrity unaffected by the `generate.py` edits:

```text
$ python test/parity/generate.py --check
corpus OK: 41 cases / 1580 arrays match the manifest
(generated at 010747c6125d, kernel digest f5e6e269be47)
```

- [x] **Test validity.** The production code here is Cython that cannot be stashed, so nine negative scenarios (behind three baselines run on the very blocks they break) patch `Case.resolve` or the specification to break one thing each and confirm the assertion fires: swallowed raise, wholesale raise, single-point raise, a 1e-15 shift against exact mode, a 1e-6 shift against a 1e-8 budget, grid drift, and the three budget-table guards. Full output in the task note's `## Verification`.

Two of those found real problems, both fixed here: `_sweep_pointwise` had no answer for an all-points-raised block, and `spectra.photon.neutral_pion[rest]` turned out to be unusable as a perturbation target — its only non-zero value is the `inf` of the rest-frame delta, so `inf × (1+ε)` is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)