### PR TITLE
ci(actions): pin the rust toolchain in ci and the preflight gate

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -89,8 +89,10 @@ no import-order or configured-rule check) — this gate catches more than
 CI will. A non-zero exit is
 a blocked commit; a `WARN` row is an unrun gate, not a pass.
 
-If the diff touched `.pyx` / `.pxd` / `setup.py`, rebuild
-(`pip install -e .`) **before** the gate, not after.
+If the diff touched `.pyx` / `.pxd` / `rust/` / `setup.py`, rebuild
+(`pip install -e .`) **before** the gate, not after. `cargo build` is
+not that rebuild: it refreshes `rust/target/`, not the
+`hazma/_core.abi3.so` Python imports.
 
 ### Step 5: Stage and commit
 

--- a/.claude/skills/execute-single-task/SKILL.md
+++ b/.claude/skills/execute-single-task/SKILL.md
@@ -99,10 +99,13 @@ All edits and gates happen inside the worktree. The Bash-tool cwd can
 reset between calls — use `git -C <worktree>` with absolute paths (see
 [`environment.md`](../../../docs/agents/environment.md)).
 
-**If the task touches Cython** (`.pyx`, `.pxd`, `setup.py`), rebuild in
-the worktree before running anything: `pip install -e .`, then confirm
+**If the task touches compiled code** (`.pyx`, `.pxd`, `rust/`,
+`setup.py`), rebuild in the worktree before running anything:
+`pip install -e .`, then confirm
 `python -c "import hazma; print(hazma.__file__)"` points inside the
-worktree. A stale extension makes every later result meaningless.
+worktree. A stale extension makes every later result meaningless, and
+`cargo build` / `cargo test` do not count as the rebuild — they work out
+of `rust/target/`, which nothing Python imports.
 
 ### Step 4: Read only the required context
 

--- a/.claude/skills/review-cycle/SKILL.md
+++ b/.claude/skills/review-cycle/SKILL.md
@@ -177,7 +177,8 @@ Agent(
 > append when a finding is class-shaped.
 >
 > **You MUST commit and push.** Stage only files you intentionally
-> changed. Rebuild first if you touched `.pyx` / `.pxd` / `setup.py`.
+> changed. Rebuild first (`pip install -e .`, never `cargo build` alone)
+> if you touched `.pyx` / `.pxd` / `rust/` / `setup.py`.
 > Run the preflight gate (`docs/agents/preflight.md`) before staging;
 > assert a real `N passed` count. Commit with a Conventional Commits
 > message (validate with `scripts/agents/check_pr_title.py`) and

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -100,8 +100,8 @@ Common "diff omits" patterns in this repo:
 - A new final state / channel added to one dispatch table but not its
   siblings (photon but not positron; the function map but not the
   documented channel list).
-- A `.pyx` / `.pxd` change with no evidence of a rebuild, so the cited
-  test results came from the old extension.
+- A `.pyx` / `.pxd` / `rust/` change with no evidence of a rebuild, so
+  the cited test results came from the old extension.
 - A renamed or removed public object still referenced by `docs/source/`
   — the published Sphinx build breaks without any test failing.
 - Package data (`*.dat`, `*.csv`) added under `hazma/` but not registered
@@ -131,8 +131,9 @@ not hunt outside your area — that is another reviewer's job.
 - **Empirical execution.** When the diff edits a docstring example, a
   README snippet, or claims a user-visible behavior, RUN it and paste the
   output. Static review does not catch a wrong number.
-- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` /
-  `setup.py`, confirm the cited results came from a rebuilt tree.
+- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` / `rust/` /
+  `setup.py`, confirm the cited results came from a rebuilt tree —
+  including a `cargo`-only run cited as if it were a Python result.
 
 The full baseline duties and the **per-lens FOCUS rubric** for your lens
 live in [`review-lenses.md`](../../../docs/agents/review-lenses.md) —

--- a/.claude/skills/review-respond/SKILL.md
+++ b/.claude/skills/review-respond/SKILL.md
@@ -116,8 +116,9 @@ in the response.
   update the task note and (on a closing PR) `CHANGELOG.md`. Then
   re-check the PR body against the post-fix diff — a stale body is a
   blocking finding.
-- **Rebuild before gating** if you touched `.pyx` / `.pxd` /
-  `setup.py`: `pip install -e .`.
+- **Rebuild before gating** if you touched `.pyx` / `.pxd` / `rust/` /
+  `setup.py`: `pip install -e .` (a `cargo` run does not republish the
+  extension).
 - **Run the preflight gate.** `scripts/agents/preflight.sh --paths
   "<touched>"` — bare, so its pytest gate is the same collection CI runs
   (or the manual list in

--- a/.claude/skills/task-pipeline/SKILL.md
+++ b/.claude/skills/task-pipeline/SKILL.md
@@ -70,9 +70,10 @@ and `<BRANCH>` from Phase A.
 > on branch `<BRANCH>`, branched from the trunk. This worktree is managed
 > by the pipeline orchestrator.
 >
-> Hazma ships Cython extensions. If your work touches `.pyx`, `.pxd`, or
-> `setup.py`, run `pip install -e .` inside this worktree before running
-> tests, and confirm `python -c "import hazma; print(hazma.__file__)"`
+> Hazma ships Cython and Rust extensions. If your work touches `.pyx`,
+> `.pxd`, `rust/`, or `setup.py`, run `pip install -e .` inside this
+> worktree before running tests — `cargo build` alone publishes nothing
+> to Python — and confirm `python -c "import hazma; print(hazma.__file__)"`
 > resolves inside `<WT_PATH>` — otherwise every result you report comes
 > from a different tree.
 

--- a/.codex/skills/execute-single-task/SKILL.md
+++ b/.codex/skills/execute-single-task/SKILL.md
@@ -29,9 +29,11 @@ change directly, then use `$commit-and-pr` when it is ready to ship.
    Run all later commands in the reported `wt_path`, preferably as
    `git -C <wt_path> ...`. If a pipeline already supplied its managed
    worktree, skip this creation step and use that exact path.
-4. If the task edits `.pyx`, `.pxd`, or `setup.py`, rebuild inside that
-   worktree and confirm `python -c "import hazma; print(hazma.__file__)"`
-   resolves there before trusting any result.
+4. If the task edits `.pyx`, `.pxd`, `rust/`, or `setup.py`, rebuild
+   inside that worktree (`pip install -e .` — not `cargo build`, which
+   publishes nothing to Python) and confirm
+   `python -c "import hazma; print(hazma.__file__)"` resolves there
+   before trusting any result.
 
 ## Read the task context
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,31 @@ jobs:
           --exclude notebooks
           .
 
+  rust:
+    name: Rust (fmt, clippy, test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: actions/setup-python@v7
+        # Not for the build: `cargo test` links libpython for real. The
+        # crate's `extension-module` feature is what lets a *wheel* leave
+        # CPython's symbols undefined, and the test harness has no
+        # interpreter to resolve them — hence --no-default-features
+        # below, and hence a Python on PATH here.
+        with:
+          python-version: "3.12"
+      - name: Check formatting with rustfmt
+        run: cargo fmt --manifest-path rust/Cargo.toml --check
+      - name: Lint with clippy
+        run: >-
+          cargo clippy --manifest-path rust/Cargo.toml
+          --all-targets -- -D warnings
+      - name: Run the crate's unit tests
+        run: cargo test --manifest-path rust/Cargo.toml --no-default-features
+
   test:
     name: Test (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
@@ -60,6 +85,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
+      - uses: dtolnay/rust-toolchain@stable
+        # pyproject.toml's [build-system] requires setuptools-rust, which
+        # shells out to cargo — so from cython-to-rust Phase 02 on, no
+        # cargo means no build at all, on either OS. The GitHub-hosted
+        # images happened to ship one already (measured on PR #55: the
+        # whole matrix went green with no toolchain step), but nothing in
+        # this repo required them to keep doing so, and an image refresh
+        # that dropped Rust would have taken every entry down at once.
       - name: Build and install hazma
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        # macOS only in effect: cibuildwheel builds the macOS wheels on
+        # the runner itself, so the host toolchain is the one that builds
+        # hazma._core. The Linux wheels are built inside a manylinux
+        # container that cannot see this one — CIBW_BEFORE_ALL_LINUX
+        # below is their toolchain.
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.1
         env:
@@ -30,9 +36,47 @@ jobs:
           CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "arm64"
+          # setuptools-rust needs cargo inside the manylinux container.
+          # This is cibuildwheel's documented recipe for Rust projects;
+          # CIBW_ENVIRONMENT_LINUX is what puts the freshly-installed
+          # toolchain on PATH for the build step that follows.
+          CIBW_BEFORE_ALL_LINUX: >-
+            curl -sSf https://sh.rustup.rs
+            | sh -s -- -y --profile minimal --default-toolchain stable
+          CIBW_ENVIRONMENT_LINUX: 'PATH="$HOME/.cargo/bin:$PATH"'
           # Import a compiled extension module, not just the (pure-Python)
           # top-level package, so a mistagged or broken wheel fails the build.
-          CIBW_TEST_COMMAND: python -c "import hazma.spectra._photon._muon"
+          # Both toolchains are named: a Cython extension and the Rust one.
+          CIBW_TEST_COMMAND: >-
+            python -c "import hazma.spectra._photon._muon, hazma._core"
+      - name: Assert every wheel ships the Rust extension as abi3
+        # The wheels themselves stay CPython-tagged and will until the
+        # last Cython extension goes in Phase 06 — a wheel tag is a
+        # property of the distribution, not of one extension. What is
+        # checkable now is extension-level: PyO3's abi3-py310 feature
+        # makes setuptools-rust install the cdylib as `_core.abi3.so`,
+        # so that filename inside the archive *is* the limited-API
+        # assertion. A plain `_core.cpython-312-*.so` would mean the
+        # feature silently stopped applying.
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import pathlib, sys, zipfile
+
+          wheels = sorted(pathlib.Path("wheelhouse").glob("*.whl"))
+          if not wheels:
+              sys.exit("no wheels in wheelhouse/ — nothing was verified")
+          bad = []
+          for wheel in wheels:
+              names = zipfile.ZipFile(wheel).namelist()
+              ok = "hazma/_core.abi3.so" in names
+              print(f"{'ok  ' if ok else 'FAIL'} {wheel.name}")
+              if not ok:
+                  bad.append(wheel.name)
+          if bad:
+              sys.exit(f"missing hazma/_core.abi3.so in: {', '.join(bad)}")
+          print(f"{len(wheels)} wheel(s) carry hazma/_core.abi3.so")
+          PY
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,12 @@ Hazma computes indirect-detection observables for sub-GeV dark matter:
 gamma-ray, electron/positron, and neutrino spectra from dark matter
 annihilation; limits from existing gamma-ray data; discovery reach for
 future detectors; and CMB constraints. It is a scientific Python library
-with performance-critical inner loops written in Cython.
+with performance-critical inner loops in compiled code — historically
+Cython, currently mid-migration to a single Rust extension
+(`hazma._core`) under the `cython-to-rust` project. Both toolchains build
+in the same `pip install -e .` pass and both are gated by
+[`scripts/agents/preflight.sh`](scripts/agents/preflight.sh); until that
+project closes, expect to meet either one.
 
 The user-facing surface is the **public Python API** — module paths,
 function and class names, keyword arguments, return shapes and units, and
@@ -48,6 +53,8 @@ hazma/
 ├── cmb.py, pbh.py, parameters.py, utils.py
 ├── gamma_ray_data/     # detector response data (*.dat)
 └── experimental/       # excluded from lint gates; not a public surface
+rust/                   # the hazma._core crate (PyO3); src/kernels.rs is
+                        #   PyO3-free, src/dispatch.rs is the PyO3 boundary
 test/                   # pytest suite, mirrors the package tree
 docs/source/            # Sphinx documentation (the published docs)
 notebooks/              # exploratory notebooks + spectrum-generation scripts
@@ -58,9 +65,10 @@ examples/
 
 The dependency direction is one-way; do not invert it.
 
-1. **Cython kernels** (`_utils/` and the `.pyx` under `spectra/`,
-   `scalar_mediator/`, `vector_mediator/`) — numerics only. They import
-   nothing from the pure-Python layers above.
+1. **Compiled kernels** — the `.pyx` under `_utils/`, `spectra/`,
+   `scalar_mediator/` and `vector_mediator/`, plus the `rust/` crate that
+   is replacing them. Numerics only; they import nothing from the
+   pure-Python layers above.
 2. **Primitives** (`parameters.py`, `utils.py`, `form_factors/`,
    `phase_space/`) — physical constants, kinematics, shared helpers.
 3. **Spectra** (`spectra/`) — builds on 1 and 2. This is the layer most
@@ -79,7 +87,7 @@ A leading underscore on a package (`_utils`, `spectra/_photon`) means
 ## Commands
 
 ```sh
-pip install -e .          # build the Cython extensions in place
+pip install -e .          # build the Cython + Rust extensions in place
 pip install --group dev   # black, isort, ruff, pytest at their pinned versions
 pytest                    # full suite (hazma + test; minutes, not seconds)
 pytest test/spectra -q    # one area
@@ -88,6 +96,20 @@ isort hazma test          # import order
 ruff check hazma test     # lint
 pyright hazma             # types (advisory)
 ```
+
+The Rust crate has its own three, all run from the repo root against
+`rust/Cargo.toml` (`preflight.sh` runs exactly these):
+
+```sh
+cargo fmt --manifest-path rust/Cargo.toml --check
+cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
+cargo test --manifest-path rust/Cargo.toml --no-default-features
+```
+
+`--no-default-features` on the test command is load-bearing: the crate's
+default `extension-module` feature leaves CPython's symbols to be
+resolved by the interpreter that loads the shared object, and a test
+executable has no interpreter, so with it on the harness will not link.
 
 The one-command pre-commit gate is
 [`scripts/agents/preflight.sh`](scripts/agents/preflight.sh) — see
@@ -99,6 +121,21 @@ does not pick up Cython edits automatically on every setup — if a change
 to a kernel does not show up, rebuild explicitly and confirm with
 `python -c "import hazma; print(hazma.__file__)"` that you are importing
 the tree you edited, not an installed copy.
+
+**Editing a `.rs` requires the same rebuild, and `cargo build` is not
+it.** `cargo build` refreshes `rust/target/`, which nothing imports;
+`pip install -e .` is what re-links the crate into the tree as
+`hazma/_core.abi3.so`. So the loop is: iterate with
+`cargo test --no-default-features` (fast, needs no reinstall, and is
+where kernel unit tests belong), then re-run the editable install before
+any Python-side check — pytest, the parity corpus, an interactive
+`import hazma._core` — is worth believing. Confirm the same way as for
+Cython: `python -c "import hazma._core; print(hazma._core.__file__)"`
+must land inside your worktree.
+
+A source build now needs `cargo` on `PATH` at all: `pyproject.toml`'s
+`[build-system] requires` includes `setuptools-rust`, and pip cannot
+install a Rust toolchain for you.
 
 ## Conventions
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -25,7 +25,7 @@ than restating them.
 
 | File | Purpose |
 | --- | --- |
-| [`preflight.md`](preflight.md) | The before-every-commit / before-every-PR gate: format, lint, tests, import smoke, the sequential critical path. |
+| [`preflight.md`](preflight.md) | The before-every-commit / before-every-PR gate: format, lint, the cargo gates, tests, import smoke, the sequential critical path. |
 | [`doc-consistency.md`](doc-consistency.md) | The canonical doc-consistency checklist — implementers run it pre-PR, Reviewer D verifies it. |
 | [`review-lenses.md`](review-lenses.md) | Reviewer roster, per-lens rubrics, selection rules, and the verdict rule. |
 | [`environment.md`](environment.md) | Environment and test-infra gotchas (fish shell, cwd resets, Cython rebuilds, pytest collection traps). |

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -54,6 +54,32 @@ a clear "install Cython" message. (Every C++ extension went with
 `_gamma_ray/` and `_phase_space/` in cython-to-rust Task 0.2; the tree
 builds as C only.)
 
+**It also needs `cargo` on `PATH`, and pip cannot supply it.**
+`pyproject.toml`'s `[build-system] requires` carries `setuptools-rust`
+(cython-to-rust Phase 02), which shells out to cargo to build the
+`hazma._core` extension in the same pass as the Cython ones. No
+toolchain, no build — of *any* extension, not just the Rust one. Install
+it from rustup; edition 2024 needs rustc ≥ 1.85. Both this requirement
+and the Cython half disappear at the Phase 07 maturin cutover.
+
+**Editing a `.rs` and re-running pytest tests the OLD extension, exactly
+like a `.pyx`.** And the trap has an extra step, because the fast
+iteration command is not the publishing one: `cargo build` and
+`cargo test` work out of `rust/target/`, which nothing Python imports.
+Only `pip install -e .` re-links the crate into the tree as
+`hazma/_core.abi3.so`. So iterate with
+`cargo test --manifest-path rust/Cargo.toml --no-default-features`, then
+reinstall before believing any Python-side result, and confirm with
+`python -c "import hazma._core; print(hazma._core.__file__)"` that the
+path is inside your worktree.
+
+**`cargo test` must be `--no-default-features`.** The crate's default
+`extension-module` feature tells PyO3 to leave CPython's symbols
+undefined for the interpreter that `dlopen`s the module. A test
+executable has no such interpreter, so with the feature on the harness
+fails to link — a wall of undefined `_Py*` symbols that reads like a
+broken toolchain rather than a wrong flag.
+
 **Never hand-edit generated `.c` / `.cpp`.** They are cythonize output.
 Edit the `.pyx` and rebuild.
 
@@ -204,11 +230,20 @@ repo's standard. Do not cite it as precedent, and do not import from
 
 **The CI test matrix is Python 3.10 through 3.14 on Linux, plus macOS on
 3.14**, matching `pyproject.toml`'s `requires-python = ">=3.10"`. Each
-entry installs non-editable, runs an import smoke test from outside the
-repo (so a broken Cython build or a missing package-data entry fails
-there rather than as a confusing collection error), reinstalls editable,
-and then runs the bare `pytest` — the parity corpus included, on every
-entry.
+entry installs a Rust toolchain (`dtolnay/rust-toolchain@stable`; without
+cargo nothing builds — see the `setuptools-rust` note above), installs
+hazma non-editable, runs an import smoke test from outside the repo (so a
+broken build or a missing package-data entry fails there rather than as a
+confusing collection error), reinstalls editable, and then runs `pytest`
+— bare on macOS, `--ignore=test/parity` everywhere else, per the
+capturing-platform bullet under Tests above.
+
+**CI has a third job, `rust`.** It runs the same three cargo gates
+`preflight.sh` does — `cargo fmt --check`,
+`cargo clippy --all-targets -- -D warnings`, and
+`cargo test --no-default-features` — on ubuntu only, since none of them
+is platform-sensitive. It installs a Python for the same reason the flag
+exists: the test harness links libpython for real.
 
 ## Git and orchestration
 

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -253,6 +253,34 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   disabled it on every entry including macOS; all seven checks passed for
   two PRs, and PR #53 caught it only by noticing the job reported `380
   passed` where a run including the corpus collects ~1019).
+- [renumbered-list-orphans-its-references] Inserting an item into a numbered
+  list silently falsifies every prose reference to the items after it — and
+  those references live outside the list, often outside the file, so
+  renumbering the list itself looks like the whole job. Sweep
+  `rg -n '[Gg]ate [0-9]|[Ss]tep [0-9]|item [0-9]'` (or the local ordinal
+  noun) across `docs/`, `.claude/`, `.codex/` and `docs/followups/` after
+  any insertion, and prefer *naming* the target over re-pinning a number
+  that will shift again at the next insertion (PR #56: three cargo gates
+  inserted as 4–6 renumbered markdownlint from 6 to 9, leaving
+  `docs/agents/preflight.md`'s "Markdown rules" section opening "Gate 6
+  runs against the committed `.markdownlint.jsonc`" — pointing at
+  `cargo test` — plus three live references in an open follow-up and two
+  in a resolved one; caught by review, and the list renumbering itself had
+  been done correctly). Distinct from [flat-vs-sectioned-numbering], which
+  is about two schemes coexisting without a key; this is one scheme whose
+  indices moved.
+- [unrun-workflow-cannot-close-a-criterion] A workflow with no
+  `pull_request` trigger is invisible to PR checks, so an exit criterion
+  phrased against it stays unmeasured no matter how green the PR is —
+  and "wired, and the recipe is documented upstream" is an argument, not
+  evidence. Dispatch it (`gh workflow run <file> --ref <branch>`) and
+  paste the job conclusions; check first that any publishing job is gated
+  (`if: github.event_name == 'release'`) so the dispatch is build-only.
+  Never mark the task Complete over the gap (PR #56: `release.yml`'s
+  cibuildwheel job carried two of Task 2.2's exit criteria and had never
+  run; the dispatched run passed on both platforms with `publish`
+  skipped, and the assertion step reported `5 wheel(s) carry
+  hazma/_core.abi3.so` per OS).
 - [marker-count-vs-outcome-count] A count of *declaration sites* and a
   count of *runtime outcomes* are different numbers, and prose that says
   "N skips" silently picks one. A marker on a parametrized class yields

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -19,12 +19,35 @@ before you stage anything.
 3. **`ruff check <paths>`** — the configured rule set lives under
    `[tool.ruff]` in `pyproject.toml`. `hazma/experimental/` and
    `notebooks/` are outside the gate.
-4. **`pytest`** — bare, with no target. `testpaths` in
+4. **`cargo fmt --manifest-path rust/Cargo.toml --check`**
+5. **`cargo clippy --manifest-path rust/Cargo.toml --all-targets --
+   -D warnings`**
+6. **`cargo test --manifest-path rust/Cargo.toml --no-default-features`**
+   — the `hazma._core` crate's own gates, unaffected by `--paths` (the
+   crate is small and always checked whole). They run *before* pytest
+   because they cost seconds against the suite's minutes.
+
+   `--no-default-features` is load-bearing rather than tidy: the crate's
+   default `extension-module` feature leaves CPython's symbols for the
+   loading interpreter to resolve, and a test executable has none, so
+   with the feature on the harness does not link at all. `--manifest-path`
+   rather than a `cd` keeps every gate anchored to the same worktree
+   root.
+
+   Three absence rules, because this crate is younger than the gate:
+   no `rust/` directory is a **SKIP** (branches cut before cython-to-rust
+   Phase 02 must still preflight), a missing `cargo` with the crate
+   present is a **WARN** — the same unrun-gate hole as a missing isort,
+   not a pass — and anything else is a hard FAIL.
+7. **`pytest`** — bare, with no target. `testpaths` in
    `pyproject.toml` is `["hazma", "test"]`, so a bare run is the whole
    suite: the in-package `*_test.py` modules, the `test/` tree, and the
    golden parity corpus under `test/parity/`. That is deliberately the
-   same collection `.github/workflows/ci.yml` runs, so a green gate here
-   predicts a green CI. Narrowing to a target (`pytest test/spectra`) is
+   same collection `.github/workflows/ci.yml` runs — on macOS. Every
+   other matrix entry adds `--ignore=test/parity`, because the corpus
+   only reproduces on the platform that captured it, so a green gate here
+   predicts a green CI but not the reverse. Narrowing to a target
+   (`pytest test/spectra`) is
    for iterating; run it bare before you commit. Budget minutes, not
    seconds — nearly all of it the parity corpus's nested adaptive
    quadrature (8m58s measured for the bare run on macOS/arm64 under
@@ -36,13 +59,17 @@ before you stage anything.
    exits 0 with `no tests ran`. Zero collected means the gate FAILED, not
    passed. Name real targets, not a filter you have not verified selects
    something.
-5. **`python -c "import hazma"`** — the import smoke. Hazma ships Cython
-   extensions; a `.pyx` edit that was never rebuilt, or a rebuild against
-   a different interpreter, produces a tree that lints and formats
-   cleanly and fails at import. Run this after any change under
-   `_utils/`, or to the `.pyx` in `spectra/`, `scalar_mediator/`,
-   `vector_mediator/`, and after any `setup.py` change.
-6. **`markdownlint --dot <changed .md files>`** — when curated docs
+8. **`python -c "import hazma"`** — the import smoke. Hazma ships
+   compiled extensions; an edit that was never rebuilt, or a rebuild
+   against a different interpreter, produces a tree that lints and
+   formats cleanly and fails at import. Run this after any change under
+   `_utils/`, to the `.pyx` in `spectra/`, `scalar_mediator/`,
+   `vector_mediator/`, to anything under `rust/`, and after any
+   `setup.py` change. Note that the three cargo gates above do **not**
+   cover this: `cargo test` exercises `rust/target/`, while Python
+   imports the `hazma/_core.abi3.so` that only `pip install -e .` puts
+   there — so a `.rs` change can be cargo-green and stale in the tree.
+9. **`markdownlint --dot <changed .md files>`** — when curated docs
    changed. Word-diff after any `--fix`: it can corrupt code spans.
    Run it from the repo root: the committed
    [`.markdownlint.jsonc`](../../.markdownlint.jsonc) is discovered
@@ -55,13 +82,13 @@ before you stage anything.
    exits **0**, so a typo'd path lints nothing and looks green.
    `preflight.sh` checks the `--md` paths exist; a bare `markdownlint`
    run does not.
-7. **Version-bump check** — only when the diff flips a
+10. **Version-bump check** — only when the diff flips a
    `projects/<slug>/PLAN.md` `status:` to `Complete`.
    `scripts/agents/preflight.sh --closing` verifies that `VERSION` in
    `hazma/__init__.py` actually moved relative to the trunk and that
    `CHANGELOG.md` carries a matching `## [X.Y.Z]` section. See
    [`../versioning.md`](../versioning.md).
-8. **Forbidden-token scan** over the diff: `breakpoint()`,
+11. **Forbidden-token scan** over the diff: `breakpoint()`,
    `pdb.set_trace()`, `import pdb`, and stray `print()` added to library
    code. Resolve or justify each hit. `git diff origin/master -- '*.py'`
    is the surface.
@@ -110,7 +137,7 @@ sees, compare `markdownlint --version` before assuming the doc is wrong.
 The path from a finished edit to a landed commit is strictly sequential:
 
 ```text
-edit → rebuild (if Cython) → run gates → read results
+edit → rebuild (if Cython or Rust) → run gates → read results
      → stage → commit → push → verify
 ```
 
@@ -139,21 +166,24 @@ path for every git write.
 ## Do not trust hooks or CI for this list
 
 There is no committed `.pre-commit-config.yaml` in this repo. CI
-(`.github/workflows/ci.yml`) runs an import smoke test, a bare `pytest`
-on Python 3.10–3.14 (the same collection gate 4 runs, parity corpus
-included), `black --check --diff hazma test`, and a deliberately
-narrow lint pass — `ruff check --isolated --select E9,F63,F7,F82` — whose
-`--isolated` flag ignores `[tool.ruff]` in `pyproject.toml`. So CI green
-means "no syntax errors, no undefined names, black-formatted, tests
-pass"; it says nothing about import order or the configured lint rules.
+(`.github/workflows/ci.yml`) runs an import smoke test and `pytest` on
+Python 3.10–3.14 plus macOS on 3.14 — the same collection gate 7 runs,
+but with `--ignore=test/parity` everywhere except macOS —
+`black --check --diff hazma test`, a deliberately narrow lint pass
+(`ruff check --isolated --select E9,F63,F7,F82`, whose `--isolated` flag
+ignores `[tool.ruff]` in `pyproject.toml`), and the same three cargo
+gates as 4–6 above in a dedicated `rust` job. So CI green means "no
+syntax errors, no undefined names, black-formatted, Rust formatted and
+clippy-clean, tests pass"; it says nothing about Python import order or
+the configured ruff rules, and off macOS nothing about the parity corpus.
 That is a floor, not this gate. Run this gate yourself.
 
 ## One-command form
 
 [`scripts/agents/preflight.sh`](../../scripts/agents/preflight.sh) runs
-black, isort, ruff, pytest (with the zero-collection guard), the import
-smoke, and optionally markdownlint, the version-bump gate, and the
-forbidden-token scan:
+black, isort, ruff, the three cargo gates, pytest (with the
+zero-collection guard), the import smoke, and optionally markdownlint,
+the version-bump gate, and the forbidden-token scan:
 
 ```bash
 scripts/agents/preflight.sh --paths "hazma/spectra test/spectra"
@@ -172,6 +202,8 @@ a blocked commit — fix and re-run; do not commit around a red gate.
 A `WARN` row means a tool is not installed and its gate did **not** run —
 it is a hole in your coverage, not a pass. Install the toolchain
 (`pip install --group dev`, which pulls black, isort, ruff, and pytest at
-the versions CI uses) rather than shipping on an unchecked gate. Do not
+the versions CI uses; `cargo` is not in any Python group — get it from
+rustup, and note you need it to build hazma from source at all) rather
+than shipping on an unchecked gate. Do not
 `pip install black` on its own: this script runs whatever is on `PATH`,
 so a hand-picked version silently formats the tree differently from CI.

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -103,7 +103,7 @@ separately.
 
 ## Markdown rules
 
-Gate 6 runs against the committed
+The markdownlint gate (gate 9 above) runs against the committed
 [`.markdownlint.jsonc`](../../.markdownlint.jsonc) at the repo root.
 Everything not listed there is at its markdownlint default, including
 **MD013's 80-column limit on prose** — the config buys tables and code

--- a/docs/agents/review-lenses.md
+++ b/docs/agents/review-lenses.md
@@ -132,9 +132,12 @@ These apply regardless of lens.
 - **Empirical execution.** When the diff adds or edits a docstring
   example, a README snippet, or claims a user-visible behavior, RUN it
   and paste the output. Static review does not catch a wrong number.
-- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` / `setup.py`,
-  confirm the cited test results came from a tree that was rebuilt. A
-  green run against a stale extension proves nothing.
+- **Rebuild awareness.** If the diff touches `.pyx` / `.pxd` / `rust/` /
+  `setup.py`, confirm the cited test results came from a tree that was
+  rebuilt. A green run against a stale extension proves nothing — and on
+  the Rust side `cargo test` is not a rebuild, since it works out of
+  `rust/target/` while Python imports the `hazma/_core.abi3.so` that only
+  `pip install -e .` refreshes.
 - **Read [`lessons.md`](lessons.md) first**, then check the diff against
   each listed recurring class.
 - **Apply the verdict rule** (above), including the re-review vocabulary

--- a/docs/followups/done/markdownlint-config-for-templates.md
+++ b/docs/followups/done/markdownlint-config-for-templates.md
@@ -45,7 +45,7 @@ the config.
 ## Entry points
 
 - `scripts/agents/preflight.sh` (markdownlint gate, ~line 214)
-- `docs/agents/preflight.md` (gate 6)
+- `docs/agents/preflight.md` (the markdownlint gate)
 - `projects/_template/` (the shapes that must lint clean)
 - `projects/cython-to-rust/phases/*.md` (inline pragmas to remove)
 - `projects/cython-to-rust/references/*.md` (inline pragmas to remove)
@@ -99,7 +99,7 @@ been covering.
 One bug fell out of verifying the gate: `markdownlint` treats its
 arguments as globs, so a path matching nothing prints the usage banner
 and exits **0** — a typo'd `--md` reported `PASS markdownlint` having
-linted nothing. Gate 6 in
+linted nothing. The markdownlint gate in
 [`preflight.sh`](../../../scripts/agents/preflight.sh) now checks each
 `--md` path exists before trusting the exit code, the same
 false-pass guard the pytest gate already had.

--- a/docs/followups/todo/markdownlint-skips-skill-file-shapes.md
+++ b/docs/followups/todo/markdownlint-skips-skill-file-shapes.md
@@ -18,8 +18,8 @@ and `projects/` — the two trees that PR's sweep covered. The skills under
 config accommodates *their* shapes.
 
 PR #48 was the first PR to edit a skill file and therefore the first to
-pass one to preflight gate 6. It fails, and not because of anything that
-PR changed:
+pass one to preflight's markdownlint gate. It fails, and not because of
+anything that PR changed:
 
 ```text
 $ markdownlint --dot .claude/skills/*/SKILL.md .codex/skills/*/SKILL.md
@@ -65,8 +65,9 @@ Decide one of:
 Then bring the skill trees into the swept set for real: run
 `markdownlint --dot` over `.claude/skills/` and `.codex/skills/` once,
 fix or relax whatever else surfaces, and say in
-[`docs/agents/preflight.md`](../../agents/preflight.md) gate 6 that the
-skill trees are in scope — otherwise the next agent rediscovers this.
+[`docs/agents/preflight.md`](../../agents/preflight.md)'s markdownlint
+gate that the skill trees are in scope — otherwise the next agent
+rediscovers this.
 
 ## Entry points
 
@@ -74,7 +75,8 @@ skill trees are in scope — otherwise the next agent rediscovers this.
   skill-file-scoped relaxation)
 - `.claude/skills/review-plan/SKILL.md`,
   `.claude/skills/task-pipeline/SKILL.md`
-- `docs/agents/preflight.md` (gate 6, which documents what the gate covers)
+- `docs/agents/preflight.md` (the markdownlint gate, which documents
+  what the gate covers)
 - Prior art: [`markdownlint-config-for-templates`](../done/markdownlint-config-for-templates.md)
 
 ## Risks / open questions

--- a/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
+++ b/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
@@ -69,10 +69,28 @@ yet: the walking skeleton proves the toolchain end to end.
   never earlier.
 - `scripts/agents/preflight.sh` grows `cargo fmt --check`,
   `cargo clippy -- -D warnings`, `cargo test` (skipped gracefully when
-  `rust/` absent, so pre-Phase-02 branches still preflight).
+  `rust/` absent, so pre-Phase-02 branches still preflight). The
+  spellings that actually run — added by Task 2.2 on 2026-08-08, because
+  two of the three carry a load-bearing flag — are
+  `cargo fmt --manifest-path rust/Cargo.toml --check`,
+  `cargo clippy --manifest-path rust/Cargo.toml --all-targets --
+  -D warnings`, and
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features`.
 - `docs/agents/` env notes + `AGENTS.md` Commands section document the
   rebuild loop (when a `.rs` edit requires re-running the editable
   install vs. plain `cargo test`).
+- **The cargo gates also run in CI, and the wheel assertion is a job
+  step rather than an eyeball.** Both added by Task 2.2 on 2026-08-08,
+  widening the first two bullets rather than reinterpreting them.
+  Reasons, in order: (1) `preflight.sh` is local discipline that nothing
+  enforces, and Phases 03–06 land the whole numerics layer in Rust, so
+  the gates belong somewhere that fails a PR — `ci.yml` gains a `rust`
+  job running the same three commands; (2) `release.yml` does not run on
+  pull requests, so "each wheel contains `hazma/_core.abi3.so`" could
+  otherwise only ever be checked by hand at release time — it is now a
+  step in `build-wheels` that fails the job, and it also fails when
+  `wheelhouse/` is empty, since a check that verifies nothing must not
+  look green.
 
 ### Task 2.3: Cross-language plumbing test
 

--- a/projects/cython-to-rust/rules.md
+++ b/projects/cython-to-rust/rules.md
@@ -67,7 +67,12 @@ a dangling reference. Prefer the annotated form
 1. Edition 2024; `cargo fmt --check` and `cargo clippy -- -D warnings`
    are part of the preflight gate from Phase 02 on; `cargo test` runs
    the kernel unit tests (analytic limits, edge cases) — the Python-side
-   corpus tests remain the cross-language gate.
+   corpus tests remain the cross-language gate. As of Task 2.2 all three
+   also run as CI's `rust` job, and the exact spellings (two carry a
+   load-bearing flag) are in
+   [`phases/phase-02-rust-scaffold.md`](phases/phase-02-rust-scaffold.md)'s
+   Task 2.2 exit criteria — quote from there rather than from this
+   sentence.
 2. **The extension is `hazma._core`** — one cdylib, PyO3 submodules per
    domain (`photon`, `positron`, `neutrino`, `scalar_mediator`,
    `vector_mediator`). Public Python import paths never change; wrapper

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -632,8 +632,10 @@ it from memory.)
   no test outcome moved) with the parity suite still in bit-equality
   mode, markdownlint green over 16 changed docs. `git diff origin/master
   -- hazma rust` and `-- setup.py pyproject.toml MANIFEST.in` are both
-  empty, so the compiled artifacts are the trunk's. `release.yml` is
-  wired but unexercised: it has no pull-request trigger.
+  empty, so the compiled artifacts are the trunk's. PR #56's eight
+  checks are green (including the new `rust` job, 30s), and the
+  dispatched `release.yml` run 31297673951 is `success` on both
+  platforms with `publish` skipped.
 - **Phase 02 Task 2.1 state (2026-08-08):** bare `pytest -q` →
   `1009 passed, 13 skipped` in 569.45s on the capturing environment
   (1022 collected), parity suite in **bit-equality mode**;
@@ -817,12 +819,17 @@ it from memory.)
   the cargo gates. The measurement that made it urgent still stands as
   history: all seven checks passed first try on PR #55 with no toolchain
   step at all, on ubuntu py3.10–3.14 plus macos py3.14, because the
-  runner images happen to ship cargo. **`release.yml` remains
-  unexercised** — it does not run on pull requests, so its
-  container-side rustup and its new abi3 assertion have local evidence
-  and cibuildwheel's documented recipe behind them but no observed run.
-  One `workflow_dispatch` against the branch closes that; Phase 07
-  Task 7.1 rewrites the job for maturin either way.
+  runner images happen to ship cargo. **`release.yml` was dispatched and
+  is green too** (PR #56 review round 1, run 31297673951): both
+  `build-wheels` jobs plus `build-sdist` succeeded, `publish` skipped on
+  its `github.event_name == 'release'` gate, and the new assertion step
+  reported `5 wheel(s) carry hazma/_core.abi3.so` per platform — 10
+  CPython-tagged wheels, `cp310`–`cp314` × {macOS arm64,
+  manylinux_2_28 x86_64}. That job has **no pull-request trigger**, so
+  any future change to it needs its own dispatch to be measured at all
+  (`../../../docs/agents/lessons.md`
+  `[unrun-workflow-cannot-close-a-criterion]`). Phase 07 Task 7.1
+  rewrites it for maturin and inherits that.
 - `spec_math`'s `li2` argument convention vs scipy's `spence` is
   unverified — Task 3.2 pins it before anything depends on it.
 - ~~Phase 01's corpus will capture `cross_section_prefactor`'s

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -23,7 +23,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | --- | ------- | ----------- | ---------------- | -------- |
 | 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | **Complete (2026-08-06)** — all five tasks done; [learnings](../learnings/phase-00-dead-code-purge.md) |
 | 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | **Complete (2026-08-08)** — all four tasks done; [learnings](../learnings/phase-01-parity-corpus.md) |
-| 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | **In Progress** — Task 2.1 complete (2026-08-08); 2.2 and 2.3 open |
+| 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | **In Progress** — Tasks 2.1 and 2.2 complete (2026-08-08); 2.3 open |
 | 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | Not started |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | Not started |
@@ -267,6 +267,26 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   `hazma/spectra/_neutrino/_muon.pyx:205` says "Photon energies". Two of
   the four become silent public-API narrowings if the port transcribes
   the design instead of the code. Task 3.5 decides each one.
+- **The Rust half of the build is now pinned rather than lucky** (Task
+  2.2). Until this task, CI had no toolchain step and passed anyway
+  because the GitHub-hosted images ship cargo — a dependency nothing in
+  the repo required and an image refresh could have removed from every
+  matrix entry at once. Every entry now installs one, CI grew a `rust`
+  job running the same three cargo gates as `preflight.sh`, and
+  `release.yml` grew a rustup step inside the manylinux container
+  (cibuildwheel builds Linux wheels in a container that cannot see a
+  host toolchain; macOS builds on the runner and uses the host one —
+  two artifacts, two mechanisms, exactly like `MANIFEST.in` vs the
+  wheel in Task 0.4).
+- **`cargo build` publishes nothing to Python** (Task 2.2). The crate
+  reaches an importable `hazma/_core.abi3.so` only through
+  `pip install -e .`; cargo works out of `rust/target/`. This is the
+  `.pyx`-rebuild trap with an extra step, since the fast iteration
+  command and the publishing command are now different commands. It is
+  written into `AGENTS.md`, `docs/agents/environment.md`,
+  `docs/agents/preflight.md`, and the rebuild-awareness bullet of all
+  seven review/commit skills, so Phases 03–06 inherit a reviewer who is
+  expected to challenge a cargo-only run quoted as a Python result.
 - **A worktree can inherit `.so` files whose source package is gone**
   (Task 1.1): this tree carried `_gamma_ray/` and `_phase_space/`
   extensions deleted in Task 0.2, giving 25 `.so` against `setup.py`'s
@@ -418,6 +438,21 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   task fixed the mode switch its own deliverable would otherwise have
   broken** — see the served-vs-importable finding above; shipped without
   it, this line could have claimed no better than 1e-8.
+
+- **Task 2.2, 2026-08-08 (CI, preflight, dev-loop docs): no public value
+  changes** (verified: `git diff origin/master -- hazma rust` is empty —
+  0 lines, and the tree was rebuilt from clean before anything was run).
+  The diff is workflows, `preflight.sh`, durable docs, skills and project
+  bookkeeping; no library module, kernel, signature, constant or build
+  *input* is reachable from it, so no grid evaluation applies. The
+  build's own inputs are untouched: `setup.py`, `pyproject.toml`,
+  `MANIFEST.in`, `rust/` and every `.pyx` are byte-identical to the
+  trunk, so the artifacts are too. Positive evidence rather than only
+  absence: a wheel built from this branch carries `hazma/_core.abi3.so`
+  inside a CPython-tagged wheel (`cp<XY>`, the interpreter that built
+  it — never `abi3`, and see `lessons.md`
+  `[wheel-tag-vs-extension-abi]`), which is Task 2.2's own
+  extension-level criterion measured on the final tree.
 
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
@@ -571,12 +606,34 @@ it from memory.)
   `test/parity/{cases.py,tolerances.py,test_parity.py,README.md}`; and
   the two canonical doc patches above. 25 files: 12 modified, 13 added.
   Full list in [phase-02/README.md](phase-02/README.md).
+- **Task 2.2** — the Rust toolchain pinned in both workflows
+  (`.github/workflows/ci.yml` gains a `rust` job and a per-entry
+  toolchain step; `.github/workflows/release.yml` gains the host
+  toolchain for macOS, rustup-in-container for Linux, `hazma._core` in
+  the wheel test command, and a step asserting every wheel carries
+  `hazma/_core.abi3.so`); the three cargo gates in
+  `scripts/agents/preflight.sh`; the `.rs` dev loop in `AGENTS.md`,
+  `docs/agents/environment.md` and `docs/agents/preflight.md`; the
+  rebuild-awareness sweep across `docs/agents/{review-lenses,README}.md`
+  and seven skill files under `.claude/` and `.codex/`; two canonical
+  patches (the phase file's Task 2.2 exit criteria, `../rules.md` Rust
+  rule 1); and one struck-through risk bullet in Task 2.1's note.
+  21 files: 20 modified, 1 added. Nothing under `hazma/` or `rust/`.
+  Full list in [phase-02/README.md](phase-02/README.md).
 
 ## Verification
 
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
 - Per-phase Verification sections live in `phase-XX/README.md`.
+- **Phase 02 Task 2.2 state (2026-08-08):** `scripts/agents/preflight.sh`
+  RESULT: PASS across all eleven rows — the three cargo gates green,
+  `pytest` at `1009 passed, 13 skipped` (byte-identical to Task 2.1's, so
+  no test outcome moved) with the parity suite still in bit-equality
+  mode, markdownlint green over 16 changed docs. `git diff origin/master
+  -- hazma rust` and `-- setup.py pyproject.toml MANIFEST.in` are both
+  empty, so the compiled artifacts are the trunk's. `release.yml` is
+  wired but unexercised: it has no pull-request trigger.
 - **Phase 02 Task 2.1 state (2026-08-08):** bare `pytest -q` →
   `1009 passed, 13 skipped` in 569.45s on the capturing environment
   (1022 collected), parity suite in **bit-equality mode**;
@@ -680,7 +737,17 @@ it from memory.)
   3). The three cargo gates are `cargo fmt --check`,
   `cargo clippy --all-targets -- -D warnings` and
   `cargo test --no-default-features`; the last one's flag is load-bearing,
-  since `extension-module` leaves the test harness unlinkable.
+  since `extension-module` leaves the test harness unlinkable. **As of
+  Task 2.2 you no longer have to remember to run them**: they are gates
+  4–6 of `scripts/agents/preflight.sh` (ahead of pytest, since they cost
+  seconds and it costs minutes) and CI's `rust` job.
+- **A `.rs` edit needs `pip install -e .`, not `cargo build`** (Task
+  2.2). Cargo works out of `rust/target/`, which nothing Python imports;
+  the editable install is what re-links the crate as
+  `hazma/_core.abi3.so`. Iterate with
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features`,
+  reinstall before quoting any pytest or parity number, and confirm with
+  `python -c "import hazma._core; print(hazma._core.__file__)"`.
 - **Phases 00 and 01 are both Complete** (2026-08-06 and 2026-08-08).
   Read
   [`../learnings/phase-00-dead-code-purge.md`](../learnings/phase-00-dead-code-purge.md)
@@ -688,9 +755,9 @@ it from memory.)
   [`../learnings/phase-01-parity-corpus.md`](../learnings/phase-01-parity-corpus.md)
   rather than their nine task notes — the learnings are the
   distillation, the notes are history. **Phase 02 is In Progress: Task
-  2.1 landed 2026-08-08; Tasks 2.2 (CI, preflight, dev-loop docs) and 2.3
-  (the plumbing test suite) are open and both depend only on 2.1.** No
-  phase carries a decision gate.
+  2.1 and Task 2.2 (CI, preflight, dev-loop docs) both landed
+  2026-08-08; Task 2.3 (the plumbing test suite) is the last one open,
+  and depends only on 2.1.** No phase carries a decision gate.
 - **The parity corpus is the gate from here on.** `python
   test/parity/generate.py --check` verifies it (still, with `_core`
   present); `test/parity/cases.py` is the single source of every entry
@@ -745,14 +812,17 @@ it from memory.)
 
 **Currently risky / unknown:**
 
-- **CI has no Rust toolchain step** until Phase 02 Task 2.2 adds one, and
-  is green regardless on today's runner images — all seven checks passed
-  first try on PR #55 with the hybrid build, ubuntu py3.10–3.14 plus
-  macos py3.14. Unpinned, though: nothing in the repo requires the
-  images to keep shipping cargo, and losing it takes the whole matrix
-  down at once. `release.yml`'s cibuildwheel job will certainly need its
-  own toolchain inside the manylinux container and does not run on pull
-  requests, so it is still unexercised.
+- ~~**CI has no Rust toolchain step**~~ — **added by Task 2.2
+  (2026-08-08)**, in both workflows, along with the `rust` job that runs
+  the cargo gates. The measurement that made it urgent still stands as
+  history: all seven checks passed first try on PR #55 with no toolchain
+  step at all, on ubuntu py3.10–3.14 plus macos py3.14, because the
+  runner images happen to ship cargo. **`release.yml` remains
+  unexercised** — it does not run on pull requests, so its
+  container-side rustup and its new abi3 assertion have local evidence
+  and cibuildwheel's documented recipe behind them but no observed run.
+  One `workflow_dispatch` against the branch closes that; Phase 07
+  Task 7.1 rewrites the job for maturin either way.
 - `spec_math`'s `li2` argument convention vs scipy's `spence` is
   unverified — Task 3.2 pins it before anything depends on it.
 - ~~Phase 01's corpus will capture `cross_section_prefactor`'s

--- a/projects/cython-to-rust/task-notes/phase-02/README.md
+++ b/projects/cython-to-rust/task-notes/phase-02/README.md
@@ -96,9 +96,12 @@ scaffold.
   the step fails on an empty `wheelhouse/` as well as on a missing
   `.so`. A check that can verify nothing and still report success is
   `docs/agents/lessons.md` `[gate-disabled-stays-green]` waiting to
-  happen. Confirming the job itself stays green still needs a manual
-  `workflow_dispatch` run against the branch; it is not a PR check and
-  no amount of local work substitutes.
+  happen. **Confirming the job itself needs a manual dispatch, and no
+  amount of local work substitutes** — round 1 of PR #56's review made
+  exactly that call. `gh workflow run release.yml --ref <branch>` is the
+  command; verify the publishing job is gated on
+  `github.event_name == 'release'` first, so the dispatch builds without
+  publishing. Measured cost: ~17 min for both platforms.
 - **`cargo test` and `cargo build` are not rebuilds** (Task 2.2, now
   written into `AGENTS.md` and `docs/agents/environment.md`). They work
   out of `rust/target/`, which nothing Python imports; only
@@ -202,8 +205,12 @@ modified, 1 added. Nothing under `hazma/` or `rust/`. Full list in
   block (SKIP / WARN / FAIL / PASS) were forced and observed rather than
   reasoned about. The abi3 criterion was measured by running
   `release.yml`'s own assertion script against a real hybrid wheel
-  (`cp312`-tagged, `hazma/_core.abi3.so` inside). `release.yml` itself
-  is unexercised — it has no PR trigger. Full tables in the task note.
+  (`cp312`-tagged, `hazma/_core.abi3.so` inside). **Review round 1 then
+  ran `release.yml` for real** (dispatch → run 31297673951, `success`;
+  `publish` skipped): 10 wheels across both platforms, each reported by
+  the assertion step as carrying the extension. PR #56's eight checks
+  are green, including the new `rust` job at 30s. Full tables in the
+  task note.
 
 ## Open Questions
 
@@ -218,15 +225,21 @@ modified, 1 added. Nothing under `hazma/` or `rust/`. Full list in
   entry now installs `dtolnay/rust-toolchain@stable` before building,
   `release.yml` gained the container-side toolchain the cibuildwheel job
   needs, and a third job runs the cargo gates.
-- **`release.yml` is still unexercised, and cannot be exercised by a
-  PR.** It fires only on `release: published` and `workflow_dispatch`, so
-  the toolchain wiring and the new abi3 assertion step in `build-wheels`
-  have been reasoned from cibuildwheel's documented Rust recipe and
-  verified locally against a real hybrid wheel — not observed in the
-  manylinux container. Whoever lands this should trigger one manual
-  `workflow_dispatch` run against the branch before treating the
-  Task 2.2 exit criterion "wheel-build job still succeeds" as measured.
-  Phase 07 Task 7.1 rewrites this job for maturin regardless.
+- ~~**`release.yml` is still unexercised, and cannot be exercised by a
+  PR.**~~ — **closed in PR #56's review round 1.** A reviewer refused a
+  `Complete` status resting on an unrun exit criterion; the fix was to
+  run it, not to soften it. `gh workflow run release.yml --ref <branch>`
+  → run 31297673951, conclusion `success`: both `build-wheels` jobs and
+  `build-sdist` green, `publish` **skipped** because it is gated on
+  `github.event_name == 'release'` (so a dispatch is build-only — check
+  that gate before dispatching anything). The assertion step printed
+  `5 wheel(s) carry hazma/_core.abi3.so` on each platform: 10 wheels,
+  `cp310`–`cp314` × {macOS arm64, manylinux_2_28 x86_64}, the unchanged
+  CPython-tagged matrix. Phase 07 Task 7.1 rewrites this job for maturin
+  and inherits the same obligation — a workflow without a
+  pull-request trigger has to be dispatched deliberately or its criteria
+  stay unmeasured (`docs/agents/lessons.md`
+  `[unrun-workflow-cannot-close-a-criterion]`).
 - ~~setuptools-rust + editable-install rebuild ergonomics under uv~~ —
   **answered by Task 2.1**: `uv pip install -e .` builds Cython and Rust
   in one pass with no extra flags, and re-running it after a `.rs` edit
@@ -273,9 +286,10 @@ path is final from day one: `hazma._core`.
 
 **Currently risky / unknown:**
 
-- `release.yml` (see Open Questions): wired, locally evidenced, never
-  run. It needs one `workflow_dispatch` before anyone calls its half of
-  the Task 2.2 criteria measured.
+- ~~`release.yml`: wired, locally evidenced, never run.~~ — dispatched
+  and green in PR #56's review round 1 (see Open Questions). It stays
+  invisible to PR checks, so any *future* change to it needs its own
+  dispatch.
 - The reference's dispatch contract now records four measured
   divergences from the live Cython. Task 2.3 asserts the *target*
   contract on `roundtrip`; Task 3.5 has to decide, per divergence,

--- a/projects/cython-to-rust/task-notes/phase-02/README.md
+++ b/projects/cython-to-rust/task-notes/phase-02/README.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 02
-**Status:** In Progress (Task 2.1 complete 2026-08-08)
+**Status:** In Progress (Tasks 2.1 and 2.2 complete 2026-08-08)
 **Plan References:** `../../phases/phase-02-rust-scaffold.md`
 **Related ADRs:** ADR-0001 (accepted)
 **Depends On:** Phase 01 complete
@@ -18,7 +18,7 @@ scaffold.
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
 | 2.1 | Crate + setuptools-rust integration | — | **Complete (2026-08-08)** | [task-2.1-crate-skeleton.md](task-2.1-crate-skeleton.md) |
-| 2.2 | CI, preflight, dev-loop docs | 2.1 | Not started | [task-2.2-ci-devloop.md](task-2.2-ci-devloop.md) |
+| 2.2 | CI, preflight, dev-loop docs | 2.1 | **Complete (2026-08-08)** | [task-2.2-ci-devloop.md](task-2.2-ci-devloop.md) |
 | 2.3 | Cross-language plumbing test | 2.1 | Not started | [task-2.3-plumbing-test.md](task-2.3-plumbing-test.md) |
 
 ## Exit Criteria
@@ -79,6 +79,43 @@ scaffold.
   `../../references/numerics-replacements.md`; Task 3.5 implements from
   that section and two of the four are public-API narrowings if taken
   silently.
+- **The macOS wheels are built on the runner; the Linux wheels are not**
+  (Task 2.2). cibuildwheel runs the Linux builds inside a manylinux
+  container that cannot see a toolchain installed on the host, so a
+  `dtolnay/rust-toolchain` step in `release.yml` serves macOS *only* and
+  Linux needs `CIBW_BEFORE_ALL_LINUX` (rustup inside the container) plus
+  `CIBW_ENVIRONMENT_LINUX` to put it on `PATH`. Both are in the job now.
+  This is the same shape as the `MANIFEST.in`-vs-wheel lesson from
+  Task 0.4: two artifacts, two mechanisms, and fixing one has never
+  fixed the other.
+- **`release.yml` does not run on pull requests**, so nothing about it
+  is verifiable from a PR check (Task 2.2). Its `build-wheels` job fires
+  on `release: published` and `workflow_dispatch` only. That is why the
+  "each wheel contains `hazma/_core.abi3.so`" criterion became a **step
+  inside the job** rather than a one-time manual inspection — and why
+  the step fails on an empty `wheelhouse/` as well as on a missing
+  `.so`. A check that can verify nothing and still report success is
+  `docs/agents/lessons.md` `[gate-disabled-stays-green]` waiting to
+  happen. Confirming the job itself stays green still needs a manual
+  `workflow_dispatch` run against the branch; it is not a PR check and
+  no amount of local work substitutes.
+- **`cargo test` and `cargo build` are not rebuilds** (Task 2.2, now
+  written into `AGENTS.md` and `docs/agents/environment.md`). They work
+  out of `rust/target/`, which nothing Python imports; only
+  `pip install -e .` re-links the crate into the tree as
+  `hazma/_core.abi3.so`. Measured:
+  `python -c "import hazma._core; print(hazma._core.__file__)"` resolves
+  to `<worktree>/hazma/_core.abi3.so`. The dev loop that follows is
+  cargo for iteration, editable install before any Python-side claim.
+- **Only one skill file is markdownlint-red, and it was already**
+  (Task 2.2). Of the seven skill files this task edited,
+  `.claude/skills/task-pipeline/SKILL.md` reports 7 errors (MD036,
+  MD032, MD031) on **both** `origin/master` and this branch; the other
+  six report 0. That is
+  [`../../../../docs/followups/todo/markdownlint-skips-skill-file-shapes.md`](../../../../docs/followups/todo/markdownlint-skips-skill-file-shapes.md),
+  not this diff — so `--md` gets the six clean ones and the count
+  comparison above is the evidence, rather than the file being quietly
+  dropped.
 
 ## Decisions and Implementation Notes
 
@@ -93,6 +130,29 @@ scaffold.
   allocation is what proves the Rust actually ran.
 - `Cargo.lock` is committed and shipped in the sdist; `MANIFEST.in`
   carries the crate because `global-include` covers no Rust pattern.
+- **Task 2.2 widened its first two exit criteria, deliberately, and
+  patched the phase file to say so.** (a) The three cargo gates run in
+  CI as a `rust` job, not only in `preflight.sh` — a gate that lives
+  only in local discipline enforces nothing, and Phases 03–06 put the
+  entire numerics layer behind it. (b) The wheel/abi3 criterion is a
+  failing job step rather than an eyeball, because `release.yml` never
+  runs on a PR. Both are additions to what the criteria asked for, not
+  reinterpretations of them.
+- The cargo gates sit **before** pytest in `preflight.sh`: they cost
+  seconds and the bare suite costs minutes, so a rustfmt diff should not
+  wait behind the parity corpus. They ignore `--paths` (the crate is
+  small and always checked whole) and use `--manifest-path` rather than
+  `cd rust`, which would leak into the gates after it — the script
+  anchors everything to `REPO_ROOT` on purpose.
+- Absence rules for the cargo gates: no `rust/` → SKIP (branches cut
+  before this phase must still preflight), `rust/` present but no
+  `cargo` → WARN, matching how a missing isort is already reported.
+  Both branches were executed, not reasoned about — see Verification.
+- `cargo_gate()` reads its status with `if capture ...; then` rather
+  than the `$?` idiom its four Python-gate siblings use. Not a
+  divergence worth undoing: shellcheck flags the older form (SC2181,
+  style) and the counts are 5 on `origin/master` and 5 here, so the new
+  helper simply did not add a sixth.
 
 ## Files Changed
 
@@ -107,6 +167,22 @@ canonical doc patches (`../../phases/phase-02-rust-scaffold.md`,
 `../../references/numerics-replacements.md`). Full list in
 [task-2.1-crate-skeleton.md](task-2.1-crate-skeleton.md).
 
+### Task 2.2
+
+CI (`.github/workflows/ci.yml`: a `rust` job plus a toolchain step in the
+test matrix; `.github/workflows/release.yml`: a host toolchain for macOS,
+rustup-in-container for Linux, `hazma._core` added to the wheel test
+command, and the abi3 assertion step); the three cargo gates in
+`scripts/agents/preflight.sh`; the dev-loop documentation in `AGENTS.md`,
+`docs/agents/environment.md` and `docs/agents/preflight.md`; the
+rebuild-awareness sweep across `docs/agents/{review-lenses,README}.md`
+and seven skill files; two canonical patches
+(`../../phases/phase-02-rust-scaffold.md` Task 2.2 exit criteria,
+`../../rules.md` Rust rule 1); and one struck-through risk bullet in
+[task-2.1-crate-skeleton.md](task-2.1-crate-skeleton.md). 21 files: 20
+modified, 1 added. Nothing under `hazma/` or `rust/`. Full list in
+[task-2.2-ci-devloop.md](task-2.2-ci-devloop.md).
+
 ## Verification
 
 - Per-task verification lives in each task note. Task 2.1's closing
@@ -117,20 +193,40 @@ canonical doc patches (`../../phases/phase-02-rust-scaffold.md`,
   `cargo fmt --check` and `cargo clippy -- -D warnings` clean, and the
   sdist installs and runs both toolchains in a fresh venv from outside
   the repo. Numbers in the task note.
+- **Task 2.2 state (2026-08-08)**, same interpreter, tree cleaned and
+  rebuilt first: `scripts/agents/preflight.sh` **RESULT: PASS** across
+  all eleven rows, including the three new `PASS … rust/` ones and
+  `pytest` at `1009 passed, 13 skipped … 571.34s` — byte-identical to
+  Task 2.1's, which is what shows no test outcome moved, with the parity
+  suite still in bit-equality mode. All four branches of the new gate
+  block (SKIP / WARN / FAIL / PASS) were forced and observed rather than
+  reasoned about. The abi3 criterion was measured by running
+  `release.yml`'s own assertion script against a real hybrid wheel
+  (`cp312`-tagged, `hazma/_core.abi3.so` inside). `release.yml` itself
+  is unexercised — it has no PR trigger. Full tables in the task note.
 
 ## Open Questions
 
-- **CI has no Rust toolchain step, and passes anyway on today's runner
-  images** (Task 2.2 still owns pinning it). Measured on PR #55: all
-  seven checks green first try, hybrid build included, on every matrix
-  entry — ubuntu py3.10–3.14 in 16m29s–19m59s and macos py3.14 in
-  16m49s. So the GitHub-hosted images ship a usable cargo and
-  setuptools-rust finds it unconfigured. **Nothing in the repo pins
-  that**, and an image refresh that dropped Rust would take the whole
-  matrix down at once, which is the argument for Task 2.2's explicit
-  step rather than against it. Untested either way: `release.yml`'s
-  cibuildwheel job, which does not run on pull requests and *will* need
-  a toolchain inside the manylinux container.
+- ~~**CI has no Rust toolchain step, and passes anyway on today's runner
+  images**~~ — **closed by Task 2.2 (2026-08-08).** The measurement that
+  opened it stands (PR #55: all seven checks green first try, hybrid
+  build included, ubuntu py3.10–3.14 in 16m29s–19m59s and macos py3.14
+  in 16m49s, with no toolchain step anywhere), and it was exactly the
+  argument for pinning: the images happened to ship cargo, nothing in
+  the repo required them to keep doing so, and an image refresh that
+  dropped Rust would have taken every matrix entry down at once. Every
+  entry now installs `dtolnay/rust-toolchain@stable` before building,
+  `release.yml` gained the container-side toolchain the cibuildwheel job
+  needs, and a third job runs the cargo gates.
+- **`release.yml` is still unexercised, and cannot be exercised by a
+  PR.** It fires only on `release: published` and `workflow_dispatch`, so
+  the toolchain wiring and the new abi3 assertion step in `build-wheels`
+  have been reasoned from cibuildwheel's documented Rust recipe and
+  verified locally against a real hybrid wheel — not observed in the
+  manylinux container. Whoever lands this should trigger one manual
+  `workflow_dispatch` run against the branch before treating the
+  Task 2.2 exit criterion "wheel-build job still succeeds" as measured.
+  Phase 07 Task 7.1 rewrites this job for maturin regardless.
 - ~~setuptools-rust + editable-install rebuild ergonomics under uv~~ —
   **answered by Task 2.1**: `uv pip install -e .` builds Cython and Rust
   in one pass with no extra flags, and re-running it after a `.rs` edit
@@ -141,7 +237,8 @@ canonical doc patches (`../../phases/phase-02-rust-scaffold.md`,
 ## Plan Impact
 
 **Impact Level:** None (this file is metadata, not a canonical change).
-Task 2.1's own canonical patches are recorded in its task note.
+Tasks 2.1's and 2.2's own canonical patches are recorded in their task
+notes.
 
 ## Handoff to Next Task
 
@@ -155,10 +252,19 @@ path is final from day one: `hazma._core`.
   `hazma/_core.abi3.so` beside the 20 Cython extensions (21 `.so` in the
   tree), `import hazma._core` works, and all five submodules are
   importable both as attributes and as `hazma._core.<name>`.
-- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and
-  `cargo test --no-default-features` are all green from `rust/`. Task 2.2
-  wires exactly those three spellings into `preflight.sh` — note the
-  `--no-default-features`, without which the test harness fails to link.
+- **The three cargo gates now run themselves, in two places** (Task
+  2.2). `scripts/agents/preflight.sh` runs them ahead of pytest, and
+  CI's `rust` job runs the same three; the exact spellings are in the
+  phase file's Task 2.2 exit criteria. Note `--no-default-features` on
+  the test one, without which the harness fails to link, and
+  `--manifest-path rust/Cargo.toml` so you can run them from the repo
+  root.
+- **`pip install -e .` is the only thing that republishes a `.rs` edit
+  to Python.** `cargo build` and `cargo test` work out of
+  `rust/target/`. Written into `AGENTS.md`,
+  `docs/agents/environment.md`, `docs/agents/preflight.md`, and the
+  rebuild-awareness bullet of every review skill — so a future reviewer
+  is expected to challenge a cargo-only run cited as a Python result.
 - `dispatch::map_unary` is the one implementation of the entry-point
   dispatch contract; Task 2.3's plumbing tests are written against
   `hazma._core.roundtrip`, which exercises every branch of it.
@@ -167,9 +273,15 @@ path is final from day one: `hazma._core`.
 
 **Currently risky / unknown:**
 
-- CI's Rust toolchain (see Open Questions) and the cibuildwheel job.
+- `release.yml` (see Open Questions): wired, locally evidenced, never
+  run. It needs one `workflow_dispatch` before anyone calls its half of
+  the Task 2.2 criteria measured.
 - The reference's dispatch contract now records four measured
   divergences from the live Cython. Task 2.3 asserts the *target*
   contract on `roundtrip`; Task 3.5 has to decide, per divergence,
   whether the ported entry points keep the Cython behavior or take the
   declared change.
+- **Task 2.3 is the last open task in this phase**, and it depends only
+  on Task 2.1. Nothing Task 2.2 changed constrains it beyond the new
+  obligation every task now inherits: a `.rs` edit means an editable
+  reinstall before any pytest number is quotable.

--- a/projects/cython-to-rust/task-notes/phase-02/task-2.1-crate-skeleton.md
+++ b/projects/cython-to-rust/task-notes/phase-02/task-2.1-crate-skeleton.md
@@ -672,8 +672,10 @@ parallel.
 
 **Still risky / open:**
 
-- CI carries no Rust toolchain step (Task 2.2). See Open Questions —
-  a red matrix on this PR is that task's trigger, not a mystery.
+- ~~CI carries no Rust toolchain step (Task 2.2). See Open Questions —
+  a red matrix on this PR is that task's trigger, not a mystery.~~ —
+  **closed by Task 2.2 on 2026-08-08**: both workflows now install one,
+  and CI grew a `rust` job for the cargo gates.
 - The four measured divergences between the reference's dispatch contract
   and the live Cython are now written down but not decided. Task 3.5
   decides each; two are public-API narrowings if taken by default.

--- a/projects/cython-to-rust/task-notes/phase-02/task-2.2-ci-devloop.md
+++ b/projects/cython-to-rust/task-notes/phase-02/task-2.2-ci-devloop.md
@@ -1,0 +1,467 @@
+# Task 2.2: CI, preflight, and dev-loop documentation
+
+**Date:** 2026-08-08
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-02-rust-scaffold.md` (Task 2.2);
+`../../rules.md` rule 6 (Rust conventions 1)
+**Related ADRs:** ADR-0001 (accepted)
+**Depends On:** Task 2.1
+
+## Objective
+
+Make the Rust half of the build a *gated* part of the repo rather than an
+accident of the runner image: pin a toolchain in CI, add the three cargo
+gates to `scripts/agents/preflight.sh`, and write the `.rs` rebuild loop
+into the durable docs so the next agent does not rediscover it.
+
+## Exit Criteria
+
+Copied from the phase file's Task 2.2 block:
+
+- CI installs the Rust toolchain on both OS matrices; full matrix green;
+  wheel-build job (`release.yml`) still succeeds with the hybrid build.
+  **Hybrid wheels stay CPython-version-tagged** — what is verified here
+  is extension-level only: each wheel contains `hazma/_core.abi3.so`,
+  i.e. the Rust extension is built against the limited API
+  (`abi3-py310`). Distribution-level abi3 wheel tags and the 2-wheel
+  matrix are asserted in Phase 07, never earlier.
+- `scripts/agents/preflight.sh` grows `cargo fmt --check`,
+  `cargo clippy -- -D warnings`, `cargo test` (skipped gracefully when
+  `rust/` absent, so pre-Phase-02 branches still preflight).
+- `docs/agents/` env notes + `AGENTS.md` Commands section document the
+  rebuild loop (when a `.rs` edit requires re-running the editable
+  install vs. plain `cargo test`).
+
+## Inputs Reviewed
+
+- `../../PLAN.md`, `../README.md` (project working memory),
+  `../../phases/phase-02-rust-scaffold.md`, `../../rules.md`.
+- `README.md` (this phase's working memory) — Task 2.1's findings, the
+  open question about CI's unpinned toolchain, and the three exact cargo
+  spellings it names.
+- `.github/workflows/ci.yml`, `.github/workflows/release.yml`,
+  `scripts/agents/preflight.sh`, `pyproject.toml`'s `[build-system]`,
+  `MANIFEST.in`, `rust/Cargo.toml`, `rust/build.rs`.
+- `docs/agents/environment.md`, `docs/agents/preflight.md`,
+  `docs/agents/lessons.md` (`[stale-ci-capability-claim]`,
+  `[gate-disabled-stays-green]`, `[sibling-copies-of-a-fixed-claim]`,
+  `[wheel-tag-vs-extension-abi]`).
+
+## Findings
+
+- **CI was green on borrowed luck.** Task 2.1's hybrid build passed all
+  seven checks on PR #55 with no toolchain step anywhere, because the
+  GitHub-hosted images ship a usable cargo and setuptools-rust finds it
+  unconfigured. Nothing in the repo required that, and because
+  `[build-system] requires` now names `setuptools-rust`, an image
+  refresh without Rust would not have degraded the Rust half — it would
+  have failed the *whole* build, on every matrix entry at once.
+- **The two wheel platforms need two different toolchains.**
+  cibuildwheel builds the macOS wheels on the runner itself, so a host
+  `dtolnay/rust-toolchain` step covers them; it builds the Linux wheels
+  inside a manylinux container that cannot see the host, so those need
+  rustup installed *in* the container (`CIBW_BEFORE_ALL_LINUX`) and put
+  on `PATH` for the build (`CIBW_ENVIRONMENT_LINUX`). Same shape as
+  Task 0.4's wheel-vs-sdist lesson: two artifacts, two mechanisms, and
+  fixing one has never fixed the other.
+- **`release.yml` cannot be verified by a pull request.** Its triggers
+  are `release: published` and `workflow_dispatch` only. So the exit
+  criterion "wheel-build job still succeeds with the hybrid build" is
+  not observable from this branch's checks — see Open Questions for what
+  closes it, and Verification for what was measured locally instead.
+- **`cargo build` publishes nothing to Python** — measured, not assumed.
+  Cargo works out of `rust/target/`; the importable artifact is
+  `hazma/_core.abi3.so`, and only `pip install -e .` puts it there.
+  `python -c "import hazma._core; print(hazma._core.__file__)"` resolves
+  to `<worktree>/hazma/_core.abi3.so`. This is the `.pyx` rebuild trap
+  with an extra step, because the fast iteration command
+  (`cargo test`) and the publishing command are now different commands —
+  which is exactly what the exit criterion asked to be written down.
+- **The rebuild-awareness claim had nine sibling copies.** `rg` over
+  `docs/` and both skill trees found the `.pyx` / `.pxd` / `setup.py`
+  triplet in `docs/agents/review-lenses.md`, six `.claude/skills/`
+  files, and one `.codex/skills/` file. Fixing only the two documents
+  the exit criterion names would have left seven authoritative-looking
+  copies telling a reviewer that a `.rs` diff needs no rebuild —
+  `docs/agents/lessons.md` `[sibling-copies-of-a-fixed-claim]` in its
+  across-files shape.
+- **Two CI-capability claims were already stale before this task
+  touched them**, both about the parity corpus: `docs/agents/`'s
+  preflight gate 4 said a bare `pytest` is "deliberately the same
+  collection `.github/workflows/ci.yml` runs" and its matrix bullet said
+  "the parity corpus included, on every entry". CI has run
+  `--ignore=test/parity` everywhere except macOS since PR #52/#53. Both
+  corrected here, since editing a durable doc puts its facts in scope
+  (`[touched-doc-inherits-its-citations]`, `[stale-ci-capability-claim]`).
+
+## Decisions and Implementation Notes
+
+- **The cargo gates go before pytest, not after.** They cost seconds;
+  the bare suite costs minutes, nearly all of it the parity corpus. A
+  rustfmt diff should not wait behind it. Cost: three trailing gates
+  renumbered in `preflight.sh` and `docs/agents/preflight.md`, which is
+  the same churn either insertion point would have caused.
+- **`--manifest-path rust/Cargo.toml` rather than `cd rust`.** The
+  script anchors itself to `REPO_ROOT` so every gate runs against the
+  worktree containing it; a `cd` inside one gate would leak into the
+  ones after it.
+- **Three rows, not one.** Each cargo command gets its own PASS/FAIL
+  row, so a failure names which of the three failed without reading the
+  captured output.
+- **Absence rules mirror the existing table.** No `rust/` → SKIP
+  (pre-Phase-02 branches must still preflight, per the exit criterion);
+  `rust/` present but no `cargo` → WARN, the same "gate did not run"
+  hole already used for a missing isort or ruff, and documented as such
+  in `preflight.md`.
+- **`cargo_gate()` reads its status as `if capture ...; then`** rather
+  than the `$?` idiom its four Python-gate siblings use. Deliberate
+  rather than inconsistent: shellcheck flags the older form (SC2181,
+  style-only), and the counts are 5 on `origin/master` and 5 here — the
+  new helper did not add a sixth. Rewriting the four existing sites
+  would be unrelated churn in a task about Rust.
+- **Two widenings past the literal exit criteria**, both recorded in the
+  phase file rather than only here:
+  1. *The cargo gates also run in CI*, as a dedicated `rust` job. The
+     criterion asked only that CI install a toolchain. But
+     `preflight.sh` is local discipline that nothing enforces, and
+     Phases 03–06 land the entire numerics layer in Rust; a formatting
+     and clippy gate that no PR check runs would be decorative by
+     Phase 04. `rules.md` Rust rule 1 makes the three gates canonical,
+     so this puts them somewhere that can fail.
+  2. *The wheel assertion is a job step, not an eyeball.* The criterion
+     says each wheel must contain `hazma/_core.abi3.so`. Since
+     `release.yml` never runs on a PR, checking that by hand once would
+     verify this branch and nothing after it. The step also fails on an
+     empty `wheelhouse/`, because a check that verifies nothing and
+     reports success is `[gate-disabled-stays-green]` waiting to happen.
+- **The filename is the abi3 assertion.** PyO3's `abi3-py310` feature is
+  what makes setuptools-rust install the cdylib as `_core.abi3.so`; a
+  plain `_core.cpython-312-*.so` would mean the feature silently stopped
+  applying. The *wheel* stays CPython-tagged and will until the last
+  Cython extension goes in Phase 06 — `lessons.md`
+  `[wheel-tag-vs-extension-abi]`, and the phase file says so twice.
+- **`dtolnay/rust-toolchain@stable`** for the toolchain, matching how
+  the repo already pins actions by tag (`pypa/cibuildwheel@v4.1.1`,
+  `actions/checkout@v7`). The `rust` job installs a Python for one
+  reason: `cargo test --no-default-features` links libpython for real.
+- **No new `lessons.md` entry.** Its contract admits entries a *review*
+  caught, each citing a real PR; nothing here was caught by review, and
+  an uncited lesson is a guess wearing a citation's clothes.
+
+## Files Changed
+
+- `.github/workflows/ci.yml` — new `rust` job (fmt / clippy / test);
+  `dtolnay/rust-toolchain@stable` before the build in every test-matrix
+  entry.
+- `.github/workflows/release.yml` — host toolchain step (macOS);
+  `CIBW_BEFORE_ALL_LINUX` + `CIBW_ENVIRONMENT_LINUX` (manylinux
+  container); `hazma._core` added to `CIBW_TEST_COMMAND`; new step
+  asserting every wheel carries `hazma/_core.abi3.so` and failing on an
+  empty `wheelhouse/`.
+- `scripts/agents/preflight.sh` — `cargo_gate()` helper and gates 4–6;
+  three trailing gates renumbered; header block and `--paths` help
+  updated.
+- `AGENTS.md` — Commands section gains the three cargo spellings and the
+  `.rs` rebuild loop; the compiled-layer sentence, the layout tree
+  (`rust/`) and Layering item 1 reconciled with the migration.
+- `docs/agents/environment.md` — four new Build-and-imports entries
+  (cargo required to build at all, `.rs` staleness, `cargo build` ≠
+  rebuild, `--no-default-features`); CI matrix bullet corrected and the
+  `rust` job described.
+- `docs/agents/preflight.md` — gates 4–6 added with their absence rules,
+  gates 7–11 renumbered, the import-smoke gate extended to `rust/`, the
+  stale "parity corpus included" claims corrected, and the CI-floor,
+  critical-path and WARN paragraphs reconciled.
+- `docs/agents/README.md`, `docs/agents/review-lenses.md`,
+  `.claude/skills/{task-pipeline,review-pr,commit-and-pr,execute-single-task,review-respond,review-cycle}/SKILL.md`,
+  `.codex/skills/execute-single-task/SKILL.md` — the rebuild-awareness
+  sweep.
+- `projects/cython-to-rust/phases/phase-02-rust-scaffold.md` — canonical:
+  Task 2.2 exit criteria gain the exact cargo spellings and a bullet
+  recording both widenings.
+- `projects/cython-to-rust/rules.md` — canonical: Rust rule 1 notes the
+  gates now run in CI too and points at the phase file for the exact
+  spellings.
+- `projects/cython-to-rust/task-notes/README.md`,
+  `projects/cython-to-rust/task-notes/phase-02/README.md`, and this note
+  — bookkeeping.
+- `projects/cython-to-rust/task-notes/phase-02/task-2.1-crate-skeleton.md`
+  — one line: its "CI carries no Rust toolchain step (Task 2.2)" risk
+  bullet struck through and dated, since a bald present-tense claim in a
+  Handoff section reads as current no matter which note it sits in.
+
+21 files: 20 modified, 1 added. Nothing under `hazma/` or `rust/`.
+
+## Verification
+
+Environment: the worktree was cleaned of stale build artifacts
+(`find hazma -name '*.c' -o -name '*.cpp' -o -name '*.so' | xargs rm -f`)
+and rebuilt from scratch — `uv venv --python 3.12` then
+`uv pip install -e . --group dev` on CPython 3.12.12, macOS/arm64, the
+corpus's capturing interpreter. `python -c "import hazma; …"` resolves
+inside the worktree.
+
+**The gate.** `scripts/agents/preflight.sh --paths "setup.py" --md
+"<16 changed docs>"` → **RESULT: PASS**, all eleven rows:
+
+```text
+PASS   black --check           setup.py
+PASS   isort --check-only      setup.py
+PASS   ruff check              setup.py
+PASS   cargo fmt --check       rust/
+PASS   cargo clippy            rust/
+PASS   cargo test              rust/
+PASS   pytest                  1009 passed, 13 skipped, 6 warnings in 571.34s (0:09:31)
+PASS   import hazma            version 2.1.0
+PASS   markdownlint            AGENTS.md docs/agents/… (16 files)
+SKIP   version bump            not a closing PR (pass --closing)
+PASS   forbidden tokens        none added
+```
+
+`--paths setup.py` rather than the default: **this branch touches no
+Python at all** (`git diff origin/master -- '*.py'` is empty), and the
+default `hazma test` is the directory form that returns thousands of
+pre-existing findings —
+[`../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md).
+`setup.py` is a real, checked file that keeps the three Python rows
+honest instead of omitted.
+
+**What the pytest row covers, and what it proves.** 1022 collected;
+`1009 passed, 13 skipped` is byte-identical to Task 2.1's closing state,
+which is the evidence that this task moved no test outcome. Categories:
+the in-package `*_test.py` modules, the `test/` tree (spectra,
+mediators, `rh_neutrino`, theory aggregation, utils), and the 626-block
+golden parity corpus over all 41 consumed entry points. The corpus ran
+in **bit-equality mode** — `pytest -q test/parity -k "capturing_tree or
+provenance or rust_core"` → `1 passed, 628 deselected`, i.e.
+`test/parity/test_parity.py::test_running_on_the_capturing_tree` passed
+rather than skipping, which is how the runner reports its mode.
+
+**The three cargo gates, run directly as well as through the gate:**
+`cargo fmt --manifest-path rust/Cargo.toml --check` → exit 0;
+`cargo clippy --manifest-path rust/Cargo.toml --all-targets --
+-D warnings` → exit 0; `cargo test --manifest-path rust/Cargo.toml
+--no-default-features` → `test result: ok. 2 passed; 0 failed` plus 0
+doc-tests, exit 0.
+
+**Every branch of the new gate block was executed, not reasoned about:**
+
+| Branch | How it was forced | Result |
+| --- | --- | --- |
+| `rust/` absent → SKIP | copied `preflight.sh` into a scratch tree with no `rust/` and ran it | three `SKIP … no rust/ crate in this tree` rows |
+| `cargo` absent → WARN | `env PATH=/usr/bin:/bin bash scripts/agents/preflight.sh …` | three `WARN … cargo not installed` rows |
+| gate fails → FAIL | appended `fn  badly_formatted( )->i32{42}` to `rust/src/kernels.rs`, ran, then `git checkout --` it | `FAIL cargo fmt --check` and `FAIL cargo clippy` (dead-code under `-D warnings`); `git status --short rust/` clean afterwards |
+| all green → PASS | the gate run above | three `PASS … rust/` rows |
+
+**The wheel / abi3 criterion, measured on the final tree.** `uv build
+--wheel` produced `hazma-2.1.0-cp312-cp312-macosx_11_0_arm64.whl`, and
+the *exact* script from `release.yml`'s new assertion step, run against
+a `wheelhouse/` holding it, printed
+`ok   hazma-2.1.0-…whl` / `1 wheel(s) carry hazma/_core.abi3.so`, exit
+0. The same script against an empty `wheelhouse/` exits 1 with
+`no wheels in wheelhouse/ — nothing was verified`. Note the wheel tag is
+`cp312-cp312` because a 3.12 venv built it — the invariant is
+`cp<XY>`, **never** `abi3`, while any Cython extension remains
+(`docs/agents/lessons.md` `[wheel-tag-vs-extension-abi]`); the abi3
+property is the `.so` filename inside.
+
+**`build-sdist` deliberately got no toolchain, and that was checked:**
+with cargo removed from `PATH` (`command -v cargo` → empty),
+`uv build --sdist` succeeded — building an sdist packages sources and
+compiles nothing. The tarball carries the crate (13 paths under
+`hazma-2.1.0/rust/`: `Cargo.toml`, `Cargo.lock`, `build.rs`, `src/*.rs`).
+
+**Workflow syntax:** both files parse (`yaml.safe_load`), `ci.yml` has
+jobs `[lint, rust, test]`, the folded scalars render as the exact
+commands documented in the phase file, and the toolchain step precedes
+`Build and install hazma` in the test job.
+
+**Static checks on the changed non-Python files:**
+`shellcheck scripts/agents/preflight.sh` → 5 SC2181 (style) hits,
+**the same 5 as `origin/master`** — the new helper added none.
+`scripts/agents/check_doc_citations.py <18 docs>` → `docs scanned: 18`,
+`in-repo citations checked: 11`, `out-of-range or ambiguous: NONE`
+(non-zero scope, per `lessons.md` `[changed-vs-sees-only-commits]`).
+
+**Intentionally deferred / not verifiable here:** `release.yml` does not
+run on pull requests, so its container-side rustup, its extended test
+command and its assertion step have local evidence and cibuildwheel's
+documented Rust recipe behind them, but **no observed run**. Closing that
+needs one `workflow_dispatch` — see Open Questions. Likewise "full
+matrix green" is a post-push observation by construction.
+
+## Open Questions
+
+- **`release.yml` has never run with any of this.** It is not a PR
+  check. Whoever lands this should fire one `workflow_dispatch` against
+  the branch and confirm `build-wheels` is green on both OSes and that
+  the new assertion step reports the wheel count it inspected. Until
+  then that half of the first exit criterion is *wired and locally
+  evidenced*, not *observed* — stated plainly rather than folded into a
+  green summary. Phase 07 Task 7.1 rewrites the job for maturin
+  regardless, so the window for this to matter is Phases 03–06.
+- **The `Dockerfile` builds hazma from a fresh clone in an image with no
+  cargo**, so it broke the moment Task 2.1 landed. No follow-up filed:
+  `phases/phase-07-cutover.md` Task 7.3 already owns removing it
+  alongside `requirements.txt`, and
+  [`../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md`](../../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md)
+  records that assignment. Noted here so the breakage is on the record
+  between now and then.
+
+## Plan Impact
+
+**Impact Level:** Phase file patched (no ADR).
+
+Two canonical documents changed, both because this task's output made
+their existing text incomplete rather than wrong:
+
+- `phases/phase-02-rust-scaffold.md`, Task 2.2 exit criteria — the
+  spellings that actually run (two carry a load-bearing flag the
+  shorthand omits), plus a bullet recording the two widenings above, so
+  the plan says what shipped instead of leaving it inferable from the
+  diff. Same precedent as Task 2.1's patch to its own criteria.
+- `rules.md` Rust rule 1 — the three gates now run in CI as well as
+  preflight, and the rule points at the phase file rather than
+  restating spellings that would then exist in two places.
+
+No ADR: nothing here revises ADR-0001, and no numerical, interface or
+ordering contract moved. `PLAN.md` needs no edit — its Phase 02 row
+describes the phase's deliverable, which is unchanged.
+
+## Stale-state sweep
+
+Run against this branch after every prose edit was frozen.
+
+**Identifier sweep** — the three names this task introduces:
+
+```console
+$ rg -n 'cargo_gate' projects/ docs/ scripts/ .github/
+scripts/agents/preflight.sh:212,213,234,236,238        KEPT (definition + 3 calls)
+projects/…/task-2.2-ci-devloop.md:117,162              KEPT (this note)
+projects/…/phase-02/README.md:151                      KEPT (phase memory)
+
+$ rg -n 'dtolnay/rust-toolchain' projects/ docs/ .github/
+.github/workflows/ci.yml:50,88                         KEPT (rust job, test matrix)
+.github/workflows/release.yml:24                       KEPT (macOS host)
+docs/agents/environment.md:233                         EDITED (CI matrix bullet)
+projects/…/phase-02/README.md:85,205                   EDITED
+projects/…/task-2.2-ci-devloop.md:62,144,155           KEPT (this note)
+
+$ rg -n 'CIBW_BEFORE_ALL_LINUX|CIBW_ENVIRONMENT_LINUX' projects/ docs/ .github/
+.github/workflows/release.yml:28,41,43,46              KEPT
+projects/…/phase-02/README.md:86,87                    EDITED
+projects/…/task-2.2-ci-devloop.md:64,65,158            KEPT (this note)
+```
+
+**Line-number citation sweep** — no `file:line` citation into code was
+added or invalidated; the mechanical check over all 18 touched docs,
+re-run after the last prose edit:
+
+```console
+$ scripts/agents/check_doc_citations.py <18 touched docs>
+docs scanned: 18
+in-repo citations checked: 11
+  resolved by exact: 8
+  resolved by suffix: 2
+  resolved by context: 1
+external citations skipped: 1
+out-of-range or ambiguous: NONE
+```
+
+**Markdown-link sweep** (the checker does not cover these —
+`lessons.md` `[status-encoding-path-reference]`): every relative link in
+every changed `.md` was resolved with `[ -e ]`. Two hits, both the same
+pre-existing forward reference to the note Task 2.3 creates —
+`phases/phase-02-rust-scaffold.md` and `task-notes/phase-02/README.md`
+each carry one, and `git show origin/master:<file> | grep -c` returns 1
+for both, so neither is this diff's. KEPT.
+
+**markdownlint** over all 17 changed docs except
+`.claude/skills/task-pipeline/SKILL.md` → exit 0. The invocation was
+proved to have non-zero scope rather than trusted: markdownlint prints
+its usage banner and exits **0** on arguments that match nothing (an
+earlier run with a trailing empty argument did exactly that), so a
+control file containing `#  bad` was linted with the same command shape
+and returned `MD019` with exit 1.
+
+**Forward-looking / stale-claim sweep:**
+
+```console
+$ rg -n '(Task [0-9.]+ will|will be added|still pending|today: ?stub)' \
+    projects/cython-to-rust/task-notes/phase-02/ \
+    projects/cython-to-rust/phases/phase-02-rust-scaffold.md \
+    docs/agents/preflight.md docs/agents/environment.md AGENTS.md
+(no hits outside task-2.1's own quoted sweep block)
+
+$ rg -n 'no Rust toolchain|has no Rust|parity corpus included' projects/ docs/ .claude/
+projects/…/task-2.1-crate-skeleton.md:675   EDITED — struck through, closed by this task
+projects/…/phase-02/README.md:197           EDITED — Open Question closed
+projects/…/task-notes/README.md:806         EDITED — risk bullet closed
+projects/…/task-2.2-ci-devloop.md:93,174    KEPT (this note describes the fix)
+docs/agents/preflight.md                    EDITED — both "parity corpus included" claims gone
+```
+
+**Count sweep:**
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| §Verification "1009 passed, 13 skipped" | `preflight.sh` pytest row | `1009 passed, 13 skipped … 571.34s` | OK |
+| §Verification "1022 collected" | 1009 + 13 | 1022 | OK |
+| §Verification "2 passed" cargo tests | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `ok. 2 passed; 0 failed` | OK |
+| §Verification "5 SC2181, same as master" | `shellcheck … \| grep -c SC2181` on both trees | 5 and 5 | OK |
+| §Findings "nine sibling copies" | `rg` for the `.pyx`/`.pxd` triplet | 1 in `docs/agents/`, 7 under `.claude/skills/`, 1 under `.codex/skills/` = 9 | OK |
+| §Verification "18 docs scanned" | `check_doc_citations.py` summary, re-run last | `docs scanned: 18` | OK |
+| §Verification "13 paths under `rust/`" | `tar tzf … \| grep '^hazma-2.1.0/rust/'` | 13 (incl. 2 directory entries) | OK |
+| phase README "7 markdownlint errors, both trees" | `markdownlint --dot` on branch vs `origin/master` copy | 7 and 7 (task-pipeline only; other six 0/0) | OK |
+| §Files Changed file list | `git diff origin/master --name-status` | 21 files: 20 `M` + 1 `A` | OK |
+
+**Numerical-impact statement:** **No public value changes** (verified:
+`git diff origin/master -- hazma rust` → 0 lines, and
+`git diff origin/master -- setup.py pyproject.toml MANIFEST.in` → 0
+lines). No library module, kernel, signature, constant or build *input*
+is reachable from this diff, so no grid evaluation applies; the compiled
+artifacts are the trunk's. Positive corroboration rather than absence
+alone: the parity corpus ran in bit-equality mode over all 41 consumed
+entry points and passed, and a wheel built from this branch carries
+`hazma/_core.abi3.so`.
+
+**Exit Criteria → evidence mapping:**
+
+| Exit-criterion bullet | Evidence | Status |
+| --- | --- | --- |
+| CI installs the Rust toolchain on both OS matrices | `ci.yml:88`, a step in the `test` job, which runs `ubuntu-latest` ×5 and `macos-latest` ×1; YAML parsed and step order confirmed | Done |
+| Full matrix green | Post-push observation by construction — not verifiable from an uncommitted tree | Deferred to the PR's checks |
+| `release.yml` wheel job still succeeds with the hybrid build | Wired (host toolchain + `CIBW_BEFORE_ALL_LINUX`); **not observed** — the job has no PR trigger. Needs one `workflow_dispatch` | Open Question |
+| Each wheel contains `hazma/_core.abi3.so` | New assertion step in `build-wheels`; its exact script run locally against a real `cp312` hybrid wheel → `1 wheel(s) carry hazma/_core.abi3.so`, and exit 1 on an empty `wheelhouse/` | Done |
+| Hybrid wheels stay CPython-tagged | Local wheel is `…-cp312-cp312-macosx_11_0_arm64.whl`; no wheel-tag claim added anywhere | Done |
+| `preflight.sh` grows the three cargo gates | Gates 4–6; the gate run above shows three `PASS … rust/` rows | Done |
+| Skipped gracefully when `rust/` absent | Forced in a scratch tree → three `SKIP … no rust/ crate in this tree` rows | Done |
+| `docs/agents/` env notes document the rebuild loop | `docs/agents/environment.md` — four new Build-and-imports entries; `docs/agents/preflight.md` gates 4–6 and gate 8 | Done |
+| `AGENTS.md` Commands section documents the rebuild loop | Commands block gains the three cargo spellings; new "Editing a `.rs`" paragraph naming `cargo build` as *not* the rebuild | Done |
+
+**Task-note self-consistency:** `**Status:** Complete` matches the phase
+README's Tasks-table cell and the project README's Phases row; every
+file named in §Files Changed appears in `git diff origin/master
+--name-status` (21 files: 20 modified, 1 added — this note); no
+function, flag or identifier cited in §Findings or §Decisions is absent
+from the diff.
+
+## Handoff to Next Task
+
+- **Read first:** `../README.md` (project working memory) and
+  [`README.md`](README.md) (this phase's), then the phase file. Task 2.3
+  is the last task in Phase 02 and depends only on Task 2.1 — nothing
+  here blocks it.
+- **Now safe to assume:** the three cargo gates run themselves, in
+  `preflight.sh` (gates 4–6, ahead of pytest) and in CI's `rust` job;
+  every CI entry installs a toolchain; and the `.rs` rebuild loop is
+  documented in `AGENTS.md`, `docs/agents/environment.md`,
+  `docs/agents/preflight.md` and every review skill. A future PR that
+  cites `cargo test` output as evidence about Python behavior should now
+  be challenged by the reviewer roster, not just by whoever remembers.
+- **Still risky:** `release.yml` is unexercised (Open Questions). And
+  the `rust` job's `cargo test` step links libpython through
+  `actions/setup-python`'s interpreter — sound in principle and green
+  locally, but the first push is the first time that specific
+  combination runs.

--- a/projects/cython-to-rust/task-notes/phase-02/task-2.2-ci-devloop.md
+++ b/projects/cython-to-rust/task-notes/phase-02/task-2.2-ci-devloop.md
@@ -66,10 +66,14 @@ Copied from the phase file's Task 2.2 block:
   Task 0.4's wheel-vs-sdist lesson: two artifacts, two mechanisms, and
   fixing one has never fixed the other.
 - **`release.yml` cannot be verified by a pull request.** Its triggers
-  are `release: published` and `workflow_dispatch` only. So the exit
+  are `release: published` and `workflow_dispatch` only, so the exit
   criterion "wheel-build job still succeeds with the hybrid build" is
-  not observable from this branch's checks — see Open Questions for what
-  closes it, and Verification for what was measured locally instead.
+  invisible to this branch's checks however green they are. The
+  consequence, made concrete by review round 1: such a criterion has to
+  be closed by an explicit `gh workflow run … --ref <branch>`, which is
+  safe here only because `publish` is gated on
+  `github.event_name == 'release'` and therefore skips. §Verification
+  carries the run.
 - **`cargo build` publishes nothing to Python** — measured, not assumed.
   Cargo works out of `rust/target/`; the importable artifact is
   `hazma/_core.abi3.so`, and only `pip install -e .` puts it there.
@@ -145,9 +149,23 @@ Copied from the phase file's Task 2.2 block:
   the repo already pins actions by tag (`pypa/cibuildwheel@v4.1.1`,
   `actions/checkout@v7`). The `rust` job installs a Python for one
   reason: `cargo test --no-default-features` links libpython for real.
-- **No new `lessons.md` entry.** Its contract admits entries a *review*
-  caught, each citing a real PR; nothing here was caught by review, and
-  an uncited lesson is a guess wearing a citation's clothes.
+- **Review round 1 (PR #56) landed two fixes**, both accepted:
+  1. *An inserted gate renumbered the list and orphaned the prose that
+     pointed at it.* `docs/agents/preflight.md`'s "Markdown rules"
+     section still opened "Gate 6 runs against the committed
+     `.markdownlint.jsonc`" — true before this task inserted the cargo
+     gates, and pointing at `cargo test` after. The class fix went wider
+     than the cited line: `rg 'Gate [0-9]|gate [0-9]'` found six more
+     live references, and rather than re-pin them to numbers that will
+     shift again at the next insertion, the markdownlint ones are now
+     **named** (`the markdownlint gate`). New `lessons.md` entry
+     `[renumbered-list-orphans-its-references]`.
+  2. *A `Complete` status cannot sit on an unrun exit criterion.* The
+     evidence mapping said `release.yml` had never run; the status said
+     done. Resolved by running it — see §Verification — rather than by
+     softening either. The reviewer's alternative (leave the task
+     incomplete) was the right fallback and would have been taken had
+     the dispatch failed.
 
 ## Files Changed
 
@@ -191,7 +209,17 @@ Copied from the phase file's Task 2.2 block:
   bullet struck through and dated, since a bald present-tense claim in a
   Handoff section reads as current no matter which note it sits in.
 
-21 files: 20 modified, 1 added. Nothing under `hazma/` or `rust/`.
+Added in review round 1:
+
+- `docs/agents/lessons.md` — two entries,
+  `[renumbered-list-orphans-its-references]` and
+  `[unrun-workflow-cannot-close-a-criterion]`, both citing PR #56.
+- `docs/followups/todo/markdownlint-skips-skill-file-shapes.md` (3
+  occurrences) and `docs/followups/done/markdownlint-config-for-templates.md`
+  (2) — ordinal references to the markdownlint gate, now named rather
+  than numbered.
+
+24 files: 23 modified, 1 added. Nothing under `hazma/` or `rust/`.
 
 ## Verification
 
@@ -280,27 +308,58 @@ commands documented in the phase file, and the toolchain step precedes
 **Static checks on the changed non-Python files:**
 `shellcheck scripts/agents/preflight.sh` → 5 SC2181 (style) hits,
 **the same 5 as `origin/master`** — the new helper added none.
-`scripts/agents/check_doc_citations.py <18 docs>` → `docs scanned: 18`,
+`scripts/agents/check_doc_citations.py <21 docs>` → `docs scanned: 21`,
 `in-repo citations checked: 11`, `out-of-range or ambiguous: NONE`
 (non-zero scope, per `lessons.md` `[changed-vs-sees-only-commits]`).
 
-**Intentionally deferred / not verifiable here:** `release.yml` does not
-run on pull requests, so its container-side rustup, its extended test
-command and its assertion step have local evidence and cibuildwheel's
-documented Rust recipe behind them, but **no observed run**. Closing that
-needs one `workflow_dispatch` — see Open Questions. Likewise "full
-matrix green" is a post-push observation by construction.
+**`release.yml`, observed** (added in review round 1 — the reviewer was
+right that a Complete status could not sit on top of an unrun exit
+criterion). `gh workflow run release.yml --ref
+claude/cython-to-rust/task-2.2-ci-preflight-dev-loop-docs` →
+[run 31297673951](https://github.com/LoganAMorrison/Hazma/actions/runs/31297673951),
+**conclusion `success`**:
+
+| Job | Conclusion | Evidence |
+| --- | --- | --- |
+| Build sdist | success | no toolchain step, as designed — an sdist packages sources and compiles nothing |
+| Build wheels (macos-latest) | success | host `dtolnay/rust-toolchain` path |
+| Build wheels (ubuntu-latest) | success | container path — `Running before_all…` then `Rust is installed now. Great!` |
+| Publish to PyPI | **skipped** | `if: github.event_name == 'release'` held; a dispatch run publishes nothing |
+
+The assertion step printed real output on both platforms — 10 wheels, the
+unchanged CPython-tagged matrix the phase file predicts, each carrying
+the abi3 extension:
+
+```text
+ok   hazma-2.1.0-cp310-cp310-macosx_11_0_arm64.whl
+… cp311, cp312, cp313, cp314 …
+5 wheel(s) carry hazma/_core.abi3.so
+
+ok   hazma-2.1.0-cp310-cp310-manylinux_2_28_x86_64.whl
+… cp311, cp312, cp313, cp314 …
+5 wheel(s) carry hazma/_core.abi3.so
+```
+
+**"Full matrix green"** is likewise now observed rather than deferred:
+all eight checks on [PR #56](https://github.com/LoganAMorrison/Hazma/pull/56)
+passed — `Lint` 16s, `Rust (fmt, clippy, test)` 30s, and the six `Test`
+entries 11m52s–19m50s. The `rust` job passing is what settles the one
+risk this task could not test locally: `cargo test
+--no-default-features` links libpython for real, and whether
+`actions/setup-python`'s interpreter satisfies that on a runner was
+reasoned, not measured. It does.
 
 ## Open Questions
 
-- **`release.yml` has never run with any of this.** It is not a PR
-  check. Whoever lands this should fire one `workflow_dispatch` against
-  the branch and confirm `build-wheels` is green on both OSes and that
-  the new assertion step reports the wheel count it inspected. Until
-  then that half of the first exit criterion is *wired and locally
-  evidenced*, not *observed* — stated plainly rather than folded into a
-  green summary. Phase 07 Task 7.1 rewrites the job for maturin
-  regardless, so the window for this to matter is Phases 03–06.
+- ~~**`release.yml` has never run with any of this.**~~ — **closed in
+  review round 1**, which is where it belonged: a reviewer refused a
+  `Complete` status sitting on top of an unrun exit criterion, and was
+  right to. Dispatched run 31297673951 is green on both platforms with
+  `publish` skipped; details in §Verification. The general lesson is
+  worth keeping: a workflow with no pull-request trigger is invisible to
+  PR checks, so its criteria need an explicit dispatch, not an argument
+  from plausibility. Phase 07 Task 7.1 rewrites this job for maturin and
+  inherits the same obligation.
 - **The `Dockerfile` builds hazma from a fresh clone in an image with no
   cargo**, so it broke the moment Task 2.1 landed. No follow-up filed:
   `phases/phase-07-cutover.md` Task 7.3 already owns removing it
@@ -355,12 +414,12 @@ projects/…/task-2.2-ci-devloop.md:64,65,158            KEPT (this note)
 ```
 
 **Line-number citation sweep** — no `file:line` citation into code was
-added or invalidated; the mechanical check over all 18 touched docs,
+added or invalidated; the mechanical check over all 21 touched docs,
 re-run after the last prose edit:
 
 ```console
-$ scripts/agents/check_doc_citations.py <18 touched docs>
-docs scanned: 18
+$ scripts/agents/check_doc_citations.py <21 touched docs>
+docs scanned: 21
 in-repo citations checked: 11
   resolved by exact: 8
   resolved by suffix: 2
@@ -402,6 +461,50 @@ projects/…/task-2.2-ci-devloop.md:93,174    KEPT (this note describes the fix)
 docs/agents/preflight.md                    EDITED — both "parity corpus included" claims gone
 ```
 
+**Gate-ordinal sweep (review round 1).** Inserting the cargo gates as
+4–6 pushed markdownlint from gate 6 to gate 9, and prose elsewhere still
+pointed at the old ordinals. The renumbering *inside* the list was
+correct; what rotted were references from outside it.
+
+### Pre-fix occurrences
+
+```console
+$ rg -n 'Gate 6|gate 6' docs/ .claude/ .codex/ AGENTS.md projects/ scripts/
+docs/agents/preflight.md:106                      → markdownlint   EDITED
+docs/followups/todo/markdownlint-skips-skill-file-shapes.md:21     EDITED
+docs/followups/todo/markdownlint-skips-skill-file-shapes.md:68     EDITED
+docs/followups/todo/markdownlint-skips-skill-file-shapes.md:77     EDITED
+docs/followups/done/markdownlint-config-for-templates.md:48        EDITED
+docs/followups/done/markdownlint-config-for-templates.md:102       EDITED
+projects/…/phase-00/task-0.2-delete-mc-slice.md:390                KEPT
+projects/…/phase-01/task-1.3-test-wiring.md:405                    KEPT
+```
+
+The two `KEPT` hits are dated task-note records of what a *past* PR ran,
+not instructions to a future reader; the repo treats task notes as
+history (`../README.md`: "the learnings are the distillation, the notes
+are history"). Rewriting them would falsify the record. Everything
+prescriptive was fixed, including the `done/` follow-up, whose line 102
+made a present-tense claim about `preflight.sh`'s current behavior.
+
+Fixed by **naming** the gate rather than renumbering it, so the next
+insertion cannot rot the same text again.
+
+### Post-fix occurrences
+
+```console
+$ rg -n 'Gate 6|gate 6' docs/ .claude/ .codex/ AGENTS.md projects/ scripts/
+projects/…/phase-00/task-0.2-delete-mc-slice.md:390                KEPT
+projects/…/phase-01/task-1.3-test-wiring.md:405                    KEPT
+
+$ rg -n 'Gate [0-9]+|gate [0-9]+|Gates [0-9]' docs/agents/ docs/followups/ \
+    scripts/agents/preflight.sh
+scripts/agents/preflight.sh:138,156,174,192,243,268,281,317,364   1,2,3,4-6,7,8,9,10,11 — match the implementation
+docs/agents/preflight.md:106                       gate 9 = markdownlint ✓
+docs/agents/preflight.md:170                       gate 7 = pytest ✓
+docs/followups/todo/preflight-isort-ruff-red-on-trunk.md:20,24     gates 2,3 = isort, ruff ✓ (unmoved)
+```
+
 **Count sweep:**
 
 | Claim location | Command | Actual | Status |
@@ -411,10 +514,10 @@ docs/agents/preflight.md                    EDITED — both "parity corpus inclu
 | §Verification "2 passed" cargo tests | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `ok. 2 passed; 0 failed` | OK |
 | §Verification "5 SC2181, same as master" | `shellcheck … \| grep -c SC2181` on both trees | 5 and 5 | OK |
 | §Findings "nine sibling copies" | `rg` for the `.pyx`/`.pxd` triplet | 1 in `docs/agents/`, 7 under `.claude/skills/`, 1 under `.codex/skills/` = 9 | OK |
-| §Verification "18 docs scanned" | `check_doc_citations.py` summary, re-run last | `docs scanned: 18` | OK |
+| §Verification "21 docs scanned" | `check_doc_citations.py` summary, re-run last | `docs scanned: 21` | OK |
 | §Verification "13 paths under `rust/`" | `tar tzf … \| grep '^hazma-2.1.0/rust/'` | 13 (incl. 2 directory entries) | OK |
 | phase README "7 markdownlint errors, both trees" | `markdownlint --dot` on branch vs `origin/master` copy | 7 and 7 (task-pipeline only; other six 0/0) | OK |
-| §Files Changed file list | `git diff origin/master --name-status` | 21 files: 20 `M` + 1 `A` | OK |
+| §Files Changed file list | `git diff origin/master --name-status` | 24 files: 23 `M` + 1 `A` | OK |
 
 **Numerical-impact statement:** **No public value changes** (verified:
 `git diff origin/master -- hazma rust` → 0 lines, and
@@ -431,10 +534,10 @@ entry points and passed, and a wheel built from this branch carries
 | Exit-criterion bullet | Evidence | Status |
 | --- | --- | --- |
 | CI installs the Rust toolchain on both OS matrices | `ci.yml:88`, a step in the `test` job, which runs `ubuntu-latest` ×5 and `macos-latest` ×1; YAML parsed and step order confirmed | Done |
-| Full matrix green | Post-push observation by construction — not verifiable from an uncommitted tree | Deferred to the PR's checks |
-| `release.yml` wheel job still succeeds with the hybrid build | Wired (host toolchain + `CIBW_BEFORE_ALL_LINUX`); **not observed** — the job has no PR trigger. Needs one `workflow_dispatch` | Open Question |
-| Each wheel contains `hazma/_core.abi3.so` | New assertion step in `build-wheels`; its exact script run locally against a real `cp312` hybrid wheel → `1 wheel(s) carry hazma/_core.abi3.so`, and exit 1 on an empty `wheelhouse/` | Done |
-| Hybrid wheels stay CPython-tagged | Local wheel is `…-cp312-cp312-macosx_11_0_arm64.whl`; no wheel-tag claim added anywhere | Done |
+| Full matrix green | PR #56: all eight checks pass — `Lint` 16s, `Rust (fmt, clippy, test)` 30s, six `Test` entries 11m52s–19m50s | Done |
+| `release.yml` wheel job still succeeds with the hybrid build | Dispatched run 31297673951 → `success`; both `build-wheels` jobs and `build-sdist` green, `publish` skipped | Done |
+| Each wheel contains `hazma/_core.abi3.so` | The assertion step's own output on both platforms: `5 wheel(s) carry hazma/_core.abi3.so` ×2. Locally it also exits 1 on an empty `wheelhouse/` | Done |
+| Hybrid wheels stay CPython-tagged | All 10 released wheels are `cp310`–`cp314` × {`macosx_11_0_arm64`, `manylinux_2_28_x86_64`}; no `abi3` wheel tag anywhere | Done |
 | `preflight.sh` grows the three cargo gates | Gates 4–6; the gate run above shows three `PASS … rust/` rows | Done |
 | Skipped gracefully when `rust/` absent | Forced in a scratch tree → three `SKIP … no rust/ crate in this tree` rows | Done |
 | `docs/agents/` env notes document the rebuild loop | `docs/agents/environment.md` — four new Build-and-imports entries; `docs/agents/preflight.md` gates 4–6 and gate 8 | Done |
@@ -443,9 +546,10 @@ entry points and passed, and a wheel built from this branch carries
 **Task-note self-consistency:** `**Status:** Complete` matches the phase
 README's Tasks-table cell and the project README's Phases row; every
 file named in §Files Changed appears in `git diff origin/master
---name-status` (21 files: 20 modified, 1 added — this note); no
+--name-status` (24 files: 23 modified, 1 added — this note); no
 function, flag or identifier cited in §Findings or §Decisions is absent
-from the diff.
+from the diff. The `Complete` status now rests on an evidence mapping
+whose every row reads `Done` — which was review round 1's whole point.
 
 ## Handoff to Next Task
 
@@ -460,8 +564,10 @@ from the diff.
   `docs/agents/preflight.md` and every review skill. A future PR that
   cites `cargo test` output as evidence about Python behavior should now
   be challenged by the reviewer roster, not just by whoever remembers.
-- **Still risky:** `release.yml` is unexercised (Open Questions). And
-  the `rust` job's `cargo test` step links libpython through
-  `actions/setup-python`'s interpreter — sound in principle and green
-  locally, but the first push is the first time that specific
-  combination runs.
+- **Nothing left risky in this task.** Both items that were open at
+  hand-off closed with evidence: the `rust` job's `cargo test` step does
+  link libpython through `actions/setup-python`'s interpreter on a
+  runner (PR #56, 30s), and `release.yml` is green end to end on a
+  dispatched run. What survives is a habit, not a risk — a workflow
+  without a pull-request trigger has to be dispatched deliberately or
+  its exit criteria stay unmeasured.

--- a/scripts/agents/preflight.sh
+++ b/scripts/agents/preflight.sh
@@ -13,8 +13,10 @@
 #       [--tests "test/spectra"] [--md "a.md b.md"] [--closing]
 #
 #   --paths "a b"    Space-separated files/dirs your diff touched. The
-#                    formatters and linters run against these. Defaults
-#                    to `hazma test` when omitted.
+#                    Python formatters and linters run against these.
+#                    Defaults to `hazma test` when omitted. It does not
+#                    scope the cargo gates: the Rust crate is small and
+#                    always checked whole.
 #   --tests "a b"    Space-separated pytest targets. Omit it and the gate
 #                    runs a bare `pytest -q`, which is the whole suite —
 #                    pyproject.toml's `testpaths = ["hazma", "test"]`, the
@@ -27,9 +29,10 @@
 #   --closing        Also run the version-bump gate; pass this on a PR
 #                    that flips a project PLAN status to Complete.
 #
-# Gates, in order: black --check, isort --check-only, ruff check, pytest,
-# import smoke, markdownlint (with --md), version bump (with --closing),
-# and a forbidden-token scan of the diff against the trunk (WARN only).
+# Gates, in order: black --check, isort --check-only, ruff check, the
+# three cargo gates over rust/, pytest, import smoke, markdownlint (with
+# --md), version bump (with --closing), and a forbidden-token scan of the
+# diff against the trunk (WARN only).
 #
 # Design notes:
 #   - `set -uo pipefail` (NOT `-e`): every gate runs so the table is
@@ -186,7 +189,58 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# Gate 4: pytest (with the zero-collection guard)
+# Gates 4-6: the Rust crate — cargo fmt / clippy / test
+# --------------------------------------------------------------------------
+#
+# Ahead of pytest on purpose: these cost seconds, the bare suite costs
+# minutes, and a rustfmt diff should not wait behind the parity corpus.
+#
+# `--manifest-path` rather than `cd rust`: the script anchors itself to
+# REPO_ROOT so every gate runs against the worktree containing it, and a
+# `cd` inside one gate would leak into the ones after it.
+#
+# `--no-default-features` on the test gate is load-bearing, not tidiness.
+# `extension-module` is a default-on feature that tells PyO3 to leave
+# CPython's symbols undefined for the interpreter to resolve; a test
+# executable has no interpreter, so with it on the harness does not link.
+#
+# Absence rules follow the rest of the table: no `rust/` is a SKIP (the
+# crate arrived in cython-to-rust Phase 02 and older branches must still
+# preflight), while a missing `cargo` with the crate present is a WARN —
+# the same "the gate did not run" hole as a missing isort.
+
+cargo_gate() {
+    # cargo_gate <label> <logfile-stem> <cargo args...>
+    local label="$1" stem="$2"
+    shift 2
+    local out="${TMPDIR_PF}/${stem}.log"
+    if capture "${out}" cargo "$@"; then
+        row PASS "${label}" "rust/"
+    else
+        row FAIL "${label}" "see output below"
+        tail_of "${out}"
+    fi
+}
+
+if [[ ! -d rust ]]; then
+    row SKIP "cargo fmt --check" "no rust/ crate in this tree"
+    row SKIP "cargo clippy" "no rust/ crate in this tree"
+    row SKIP "cargo test" "no rust/ crate in this tree"
+elif ! have cargo; then
+    row WARN "cargo fmt --check" "cargo not installed — Rust format unchecked"
+    row WARN "cargo clippy" "cargo not installed — Rust lint unchecked"
+    row WARN "cargo test" "cargo not installed — Rust tests did not run"
+else
+    cargo_gate "cargo fmt --check" cargo-fmt \
+        fmt --manifest-path rust/Cargo.toml --check
+    cargo_gate "cargo clippy" cargo-clippy \
+        clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
+    cargo_gate "cargo test" cargo-test \
+        test --manifest-path rust/Cargo.toml --no-default-features
+fi
+
+# --------------------------------------------------------------------------
+# Gate 7: pytest (with the zero-collection guard)
 # --------------------------------------------------------------------------
 
 if have pytest; then
@@ -211,7 +265,7 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# Gate 5: import smoke — the compiled extensions still load
+# Gate 8: import smoke — the compiled extensions still load
 # --------------------------------------------------------------------------
 
 OUT="${TMPDIR_PF}/import.log"
@@ -224,7 +278,7 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# Gate 6: markdownlint (only with --md)
+# Gate 9: markdownlint (only with --md)
 # --------------------------------------------------------------------------
 
 if [[ -n "${MD_FILES}" ]]; then
@@ -260,7 +314,7 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# Gate 7: version bump (only with --closing)
+# Gate 10: version bump (only with --closing)
 # --------------------------------------------------------------------------
 
 if [[ ${CLOSING} -eq 1 ]]; then
@@ -307,7 +361,7 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# Gate 8: forbidden tokens in the diff (advisory)
+# Gate 11: forbidden tokens in the diff (advisory)
 # --------------------------------------------------------------------------
 
 OUT="${TMPDIR_PF}/forbidden.log"


### PR DESCRIPTION
## Summary

- **CI installs a Rust toolchain, on every entry of both workflows.**
  Since Task 2.1 put `setuptools-rust` in `[build-system] requires`,
  cargo is needed to build hazma *at all* — not just its Rust half. CI
  had no toolchain step and passed anyway because the GitHub-hosted
  images happen to ship one (measured on #55: seven checks green first
  try). Nothing in the repo required that, and an image refresh without
  Rust would have failed the whole matrix at once.
- **`ci.yml` gains a `rust` job** running `cargo fmt --check`,
  `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --no-default-features` — the gates `rules.md` Rust rule 1
  already makes canonical, now enforced by a PR check instead of only by
  local discipline. Phases 03–06 land the entire numerics layer behind
  them.
- **`release.yml` gets a toolchain on both paths, and the abi3 criterion
  becomes a job step.** cibuildwheel builds the Linux wheels inside a
  manylinux container that cannot see a host toolchain, so those get
  rustup via `CIBW_BEFORE_ALL_LINUX` while macOS uses the runner's.
  Because that job has no pull-request trigger, "each wheel contains
  `hazma/_core.abi3.so`" is now a failing step rather than a one-time
  manual inspection — and it fails on an empty `wheelhouse/` too, so a
  check that verifies nothing cannot report success. **Wheels stay
  CPython-tagged**; abi3 here is extension-level only, asserted via the
  `.so` filename (`lessons.md` `[wheel-tag-vs-extension-abi]`).
- **`preflight.sh` grows the same three gates as 4–6**, ahead of pytest
  because they cost seconds and the bare suite costs minutes. No `rust/`
  → SKIP, so pre-Phase-02 branches still preflight; `rust/` without
  cargo → WARN, matching how a missing isort is already reported.
- **Docs record the trap the new toolchain creates:** `cargo build` and
  `cargo test` work out of `rust/target/`, which nothing Python imports,
  so only `pip install -e .` republishes a `.rs` edit. That claim had
  **nine sibling copies** of the `.pyx`/`.pxd` rebuild-awareness rule
  across `docs/agents/` and the skills; all nine are swept. Two stale CI
  claims are fixed in passing — both said the parity corpus runs on every
  matrix entry, which stopped being true in #52.
- **No public value changes.** `git diff origin/master -- hazma rust` and
  `-- setup.py pyproject.toml MANIFEST.in` are both 0 lines, so the
  compiled artifacts are the trunk's. No returned value moves.

### Two deliberate widenings

The exit criteria asked only that CI *install* a toolchain, and named the
wheel/abi3 property without saying how to check it. The `rust` job and
the assertion step go past that, for the reasons above; both are recorded
in the phase file's Task 2.2 criteria rather than left inferable from the
diff.

### Review round 1 (commit `ed60531`)

Two blocking findings, both accepted:

1. **Inserting the cargo gates as 4–6 orphaned the prose pointing at the
   old ordinals.** `docs/agents/preflight.md`'s "Markdown rules" section
   still opened "Gate 6 runs against the committed `.markdownlint.jsonc`"
   — by then pointing at `cargo test`. The list renumbering itself was
   correct; the external references were not. Six more live references
   turned up in the sweep (three in an open follow-up, two in a resolved
   one making a present-tense claim about `preflight.sh`), and all six
   now **name** the markdownlint gate rather than numbering it, so the
   next insertion cannot rot the same text again. Two hits in phase-00 /
   phase-01 task notes are dated records and were left alone.
2. **A `Complete` status cannot rest on an unrun exit criterion.** The
   task's own evidence mapping said `release.yml` had never run.
   Resolved by running it — see the Test plan — not by softening either
   side.

Both are class-shaped, so `docs/agents/lessons.md` gains
`[renumbered-list-orphans-its-references]` and
`[unrun-workflow-cannot-close-a-criterion]`.

## Project

`projects/cython-to-rust/` — Task 2.2: CI, preflight, and dev-loop
documentation.

See `projects/cython-to-rust/task-notes/phase-02/task-2.2-ci-devloop.md`
for implementation detail, decisions, and verification.

## Test plan

- [x] `scripts/agents/preflight.sh --paths "setup.py" --md "<20 changed docs>"`
      on the final tree — **RESULT: PASS**, all eleven rows:

      PASS   black --check           setup.py
      PASS   isort --check-only      setup.py
      PASS   ruff check              setup.py
      PASS   cargo fmt --check       rust/
      PASS   cargo clippy            rust/
      PASS   cargo test              rust/
      PASS   pytest                  1009 passed, 13 skipped, 5 warnings in 552.59s (0:09:12)
      PASS   import hazma            version 2.1.0
      PASS   markdownlint            <20 files>
      SKIP   version bump            not a closing PR (pass --closing)
      PASS   forbidden tokens        none added

      `--paths setup.py` because this branch touches **no Python**
      (`git diff origin/master -- '*.py'` is empty) and the default
      `hazma test` returns thousands of pre-existing findings
      (`docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`).

- [x] `1009 passed, 13 skipped` is byte-identical to Task 2.1's closing
      state — that is the evidence no test outcome moved. The parity
      corpus ran in **bit-equality mode**: `pytest -q test/parity -k
      "capturing_tree or provenance or rust_core"` → `1 passed, 628
      deselected`, i.e. `test_running_on_the_capturing_tree` passed
      rather than skipping.

- [x] **`release.yml` dispatched and observed** (round 1). It has no
      pull-request trigger, so a manual run is the only way to measure
      it; `publish` is gated on `github.event_name == 'release'`, which
      makes a dispatch build-only. `gh workflow run release.yml --ref
      <branch>` → [run 31297673951](https://github.com/LoganAMorrison/Hazma/actions/runs/31297673951),
      conclusion **`success`**:

      Build sdist                    success   (no toolchain, by design)
      Build wheels (macos-latest)    success   (host toolchain path)
      Build wheels (ubuntu-latest)   success   (`Rust is installed now. Great!` in before_all)
      Publish to PyPI                skipped   (release gate held)

      The assertion step's own output, per platform — 10 wheels, the
      unchanged CPython-tagged matrix, each carrying the abi3 extension:

      ok   hazma-2.1.0-cp310-cp310-macosx_11_0_arm64.whl
      … cp311, cp312, cp313, cp314 …
      5 wheel(s) carry hazma/_core.abi3.so

      ok   hazma-2.1.0-cp310-cp310-manylinux_2_28_x86_64.whl
      … cp311, cp312, cp313, cp314 …
      5 wheel(s) carry hazma/_core.abi3.so

- [x] **Every branch of the new gate block executed, not reasoned about.**
      `rust/` absent (scratch tree) → three `SKIP … no rust/ crate in
      this tree`; `cargo` absent (`env PATH=/usr/bin:/bin`) → three
      `WARN … cargo not installed`; deliberate breakage (a badly
      formatted `fn` appended to `rust/src/kernels.rs`, then reverted) →
      `FAIL cargo fmt --check` and `FAIL cargo clippy`; clean tree →
      three `PASS … rust/`.

- [x] The assertion script also exits 1 on an empty `wheelhouse/`
      (`no wheels in wheelhouse/ — nothing was verified`), so it cannot
      report success having checked nothing.

- [x] **`build-sdist` deliberately got no toolchain, and that was
      checked:** with cargo off `PATH` (`command -v cargo` → empty),
      `uv build --sdist` succeeded — an sdist packages sources and
      compiles nothing. The tarball carries the crate (13 paths under
      `hazma-2.1.0/rust/`). Confirmed again by the dispatched run.

- [x] Both workflows parse (`yaml.safe_load`); `ci.yml` jobs are
      `[lint, rust, test]`; the folded scalars render as the exact
      commands documented in the phase file; the toolchain step precedes
      `Build and install hazma`.

- [x] `shellcheck scripts/agents/preflight.sh` → 5 `SC2181` (style), the
      **same 5 as `origin/master`** — the new helper added none.
      `scripts/agents/check_doc_citations.py <21 docs>` → `docs scanned:
      21`, `out-of-range or ambiguous: NONE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)