### PR TITLE
test(suite): pin the hazma._core dispatch contract from python

### DIFF
--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -92,7 +92,7 @@ total landed at 21–32 days across ~33 tasks.
 | --- | ------- | ------ | ------ | ---------- |
 | 00 | Dead-code purge | [`phases/phase-00-dead-code-purge.md`](phases/phase-00-dead-code-purge.md) | 1–2 | **Complete (2026-08-06)** — 32→20 extensions, zero C++, `gamma_ray` removal (ADR-0003); [learnings](learnings/phase-00-dead-code-purge.md) |
 | 01 | Golden parity corpus | [`phases/phase-01-parity-corpus.md`](phases/phase-01-parity-corpus.md) | 2–3 | **Complete (2026-08-08)** — 41 entry points pinned, one pytest gate, legacy `.npy` suites retired; parity scoped to the capturing platform ([learnings](learnings/phase-01-parity-corpus.md)) |
-| 02 | Rust scaffold | [`phases/phase-02-rust-scaffold.md`](phases/phase-02-rust-scaffold.md) | 1–2 | `hazma._core` (abi3) building beside Cython via setuptools-rust |
+| 02 | Rust scaffold | [`phases/phase-02-rust-scaffold.md`](phases/phase-02-rust-scaffold.md) | 1–2 | **Complete (2026-08-09)** — `hazma._core` (abi3) building beside Cython via setuptools-rust, gated in CI and preflight, dispatch contract pinned from Python ([learnings](learnings/phase-02-rust-scaffold.md)) |
 | 03 | Numerics foundation | [`phases/phase-03-numerics-foundation.md`](phases/phase-03-numerics-foundation.md) | 3–5 | constants, spence/K-Bessels, QUADPACK port, interp, boost, dispatch |
 | 04 | Spectra kernels | [`phases/phase-04-spectra-kernels.md`](phases/phase-04-spectra-kernels.md) | 4–6 | 16 entry points swapped; twins deleted (4 capi survivors defer to 06) |
 | 05 | Mediator cross sections | [`phases/phase-05-mediator-cross-sections.md`](phases/phase-05-mediator-cross-sections.md) | 2–3 | 16 kernels + 2 thermal ⟨σv⟩ swapped, 2 dead exports dropped; relic validation |

--- a/projects/cython-to-rust/learnings/phase-02-rust-scaffold.md
+++ b/projects/cython-to-rust/learnings/phase-02-rust-scaffold.md
@@ -1,0 +1,187 @@
+# Phase 02 Learnings: Rust scaffold
+
+Synthesized at phase close (2026-08-09) from the three task notes
+([2.1](../task-notes/phase-02/task-2.1-crate-skeleton.md),
+[2.2](../task-notes/phase-02/task-2.2-ci-devloop.md),
+[2.3](../task-notes/phase-02/task-2.3-plumbing-test.md)) and
+[`../task-notes/phase-02/README.md`](../task-notes/phase-02/README.md).
+Read this instead of the notes; the notes are history.
+
+## 1. Implementation Reality Check
+
+The phase delivered what it promised — `hazma._core` at its final import
+path, abi3, built beside the 20 Cython extensions by one
+`pip install -e .`, gated in CI and in `preflight.sh`, with the dispatch
+contract pinned from Python. No ADR was needed: ADR-0001 already fixed
+the framework choice and this phase is its first executable form.
+
+What the plan did **not** anticipate is that all three tasks had to widen
+their own exit criteria, and each widening was the same shape — *a
+scaffold that is merely present is not the thing the criterion meant*:
+
+- **Task 2.1**: the crate's mere existence switched the parity gate out
+  of bit-equality mode, because `tolerances.provenance` keyed on
+  "`hazma._core` is importable". Shipped as written, Phases 02–03 would
+  have run against 1e-8 budgets with nothing turning red. The predicate
+  now asks whether a kernel is *served* (`cases.rust_core_kernels()`).
+- **Task 2.2**: two gates that existed but could not fail anything — the
+  cargo checks lived only in local discipline, and the wheel/abi3
+  criterion lived in a workflow with no pull-request trigger. Both became
+  things that fail a job.
+- **Task 2.3**: `roundtrip` advertised `(x, /)` while accepting `x=`.
+  A template that misdescribes its own signature propagates the error to
+  every kernel that copies it.
+
+The generalization, and the one thing to carry into Phases 03–07: **in
+this project, "it exists" and "it is load-bearing" are different claims,
+and the gap between them is always silent.** Every criterion in the
+remaining phases deserves the question "what turns red if this is
+wrong?" before it is called done. Three of the three tasks here found a
+`[gate-disabled-stays-green]` instance by asking it.
+
+## 2. Critical Context for Future Work
+
+- **`hazma._core` is the final import path, from now on.** One cdylib,
+  five submodules (`photon`, `positron`, `neutrino`, `scalar_mediator`,
+  `vector_mediator`), each registered in `sys.modules` under its
+  fully-qualified name so both `from hazma._core import photon` and
+  `from hazma._core.photon import <kernel>` work. Public Python import
+  paths never change; wrappers re-export behind the existing names
+  (`../rules.md` Rust rule 2).
+- **`dispatch::map_unary` is the single implementation of the
+  entry-point dispatch contract.** Phases 03–06 call it rather than
+  touching PyO3 inside a kernel (`../rules.md` Rust rule 3). Its measured
+  behavior, now pinned by `test/test_core_dispatch.py`:
+  - `float` / NumPy scalar / 0-d `float64` array → Python `float`;
+  - 1-D `float64` array → a **fresh, non-aliasing** 1-D `float64` array;
+  - anything else → `ValueError`, prefixed with the `quantity` string the
+    kernel passes.
+  - **Rank is checked before dtype** — a 2-D int64 array reports the
+    dimension error.
+  - **A 0-d array still enforces dtype**, where a Python `int` does not:
+    the 0-d path is inside the array branch behind the typed view.
+  - **Non-`float` NumPy scalars are accepted** (`np.float32`, `np.int64`,
+    `np.uint8`, `np.bool_`) via the `extract::<f64>` arm.
+- **The `PyFloat` fast path is ordered first on purpose.** The `numpy`
+  crate *panics* rather than raising when NumPy cannot be imported —
+  `cast::<PyUntypedArray>` reaches for the array-API capsule. Every
+  kernel inherits that ordering; do not reorder it for tidiness.
+- **Kernels are PyO3-free.** `src/kernels.rs` is plain
+  `fn(f64, …) -> f64`, which is what keeps `cargo test` GIL-free and
+  interpreter-free. The PyO3 layer is `dispatch.rs` plus registration.
+- **`pip install -e .` is the only thing that republishes a `.rs` edit.**
+  `cargo build` and `cargo test` work out of `rust/target/`, which
+  nothing Python imports. Iterate with
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features`,
+  reinstall before quoting any Python-side number, confirm with
+  `python -c "import hazma._core; print(hazma._core.__file__)"`.
+- **The parity gate is in bit-equality mode and stays there** until the
+  first Phase 04 kernel is served. Do not re-key it on
+  `rust_core_available()`. Both `tolerances.provenance` and
+  `assert_no_rust_core` flip permanently at that first swap, so the
+  [ill-conditioned-points corpus repair](../../../docs/followups/todo/parity-corpus-pins-ill-conditioned-points.md)
+  must land **before** it.
+
+## 3. Quirk Log & Edge Cases
+
+- **PyO3 0.29.2 renamed `Bound::downcast` to `Bound::cast`.** Every
+  tutorial still says `downcast`.
+- **`cargo build` needs three things setuptools-rust supplies for you:**
+  an explicit empty `[workspace]` in `rust/Cargo.toml` (a stray
+  `Cargo.toml` anywhere above the checkout captures the crate — a
+  home-directory one did), macOS's `-undefined dynamic_lookup` (emitted
+  from `rust/build.rs` as a cdylib-only link arg; PyO3 0.29 does not add
+  it), and `extension-module` *off* for `cargo test` — it is a default-on
+  optional feature and the harness will not link with it.
+- **`text_signature` is a claim, not a constraint.** It sets what
+  `inspect.signature` reports and nothing else; enforcing positional-only
+  needs `#[pyo3(signature = (x, /))]`. The Cython entry points being
+  replaced are `def` functions and accept keywords, so keyword-accepting
+  is the correct target and a `/` in a `text_signature` is a latent
+  public-API narrowing.
+- **A "fresh" array from the `numpy` crate does not own its data.**
+  `owndata` is `False` and `.base` is a `PySliceContainer` wrapping the
+  Rust `Vec`. Assert non-aliasing (`is not`, `.base is not`,
+  `np.shares_memory`, mutate-and-check), never `owndata` — that assertion
+  is red on correct code.
+- **The two wheel platforms need two different toolchains.**
+  cibuildwheel builds macOS wheels on the runner (a host
+  `dtolnay/rust-toolchain` step covers them) and Linux wheels inside a
+  manylinux container that cannot see the host (`CIBW_BEFORE_ALL_LINUX`
+  installs rustup in the container, `CIBW_ENVIRONMENT_LINUX` puts it on
+  `PATH`). Same shape as Phase 00's `MANIFEST.in`-vs-wheel lesson: two
+  artifacts, two mechanisms, and fixing one has never fixed the other.
+  **Phase 07 Task 7.1 rewrites this job for maturin and inherits it.**
+- **`release.yml` has no pull-request trigger**, so nothing about it is
+  verifiable from a PR check however green the PR is. Closing one of its
+  criteria takes an explicit `gh workflow run release.yml --ref <branch>`
+  (safe because `publish` is gated on
+  `github.event_name == 'release'` — check that gate before dispatching).
+  Measured cost ~17 min for both platforms.
+- **The live Cython dispatch is not the contract the reference
+  described** — four measured divergences, now written into
+  `../references/numerics-replacements.md`: a 0-d array raises rather
+  than taking the scalar path; a Python list is accepted; shape errors
+  are `AssertionError` (and vanish under `python -O`), not `ValueError`;
+  and `hazma/spectra/_neutrino/_muon.pyx:205` says "Photon energies".
+  **Task 3.5 decides each one**, and two of the four are user-visible
+  narrowings if transcribed from the design instead of the code.
+
+## 4. Test Infrastructure State
+
+- **`test/test_core_dispatch.py` is the template every kernel swap
+  copies** (54 tests, 0.27s, platform-independent). Copy it per kernel:
+  swap `roundtrip` for the kernel and `QUANTITY` for the wording that
+  kernel passes to `map_unary`, keep every test, and add the kernel's
+  *numerical* tests beside them rather than merged in — plumbing failures
+  and physics failures should not need the same debugging. The copy
+  instructions live in the module docstring so they travel with the file.
+- **It deliberately does not re-pin values against Cython.** The parity
+  corpus does that at bit-equality across all 41 entry points; a second,
+  looser numerical gate would only be one more thing to keep in sync.
+- **No `importorskip` on `hazma._core`.** From this phase on the
+  extension is in every build, so a missing `_core` is a build failure
+  that must fail loudly.
+- **The three cargo gates run themselves, in two places**:
+  `scripts/agents/preflight.sh` (gates 4–6, ahead of pytest because they
+  cost seconds and the bare suite costs minutes) and CI's `rust` job.
+  Exact spellings are in the phase file's Task 2.2 exit criteria; note
+  `--no-default-features` on the test one and `--manifest-path
+  rust/Cargo.toml` so they run from the repo root. Absence rules: no
+  `rust/` → SKIP, `rust/` but no `cargo` → WARN.
+- **Suite size across the phase**, all on the corpus's capturing
+  environment (CPython 3.12.12, macOS/arm64), parity in bit-equality mode
+  throughout: 1006/13 at Phase 01 close → 1009/13 (Task 2.1, +3
+  served-kernel predicate tests) → 1009/13 (Task 2.2, byte-identical,
+  which is what showed no test outcome moved) → 1063/13 (Task 2.3, +54).
+  The skip count never moved; that is the tell that the parity gate
+  stayed in exact mode — budget mode is reported as a *skip* on
+  `test_running_on_the_capturing_tree`, so a budget-mode run would have
+  shown 14.
+- **Mutation campaigns are cheap here and worth running.** Task 2.3 ran
+  six mutations of `dispatch.rs`/`lib.rs`, each rebuilt with
+  `uv pip install -e .` and re-run (~45s per cycle), and every one was
+  caught by the test whose name claimed it. For a module whose assertions
+  all pass against unmodified code by construction, that is the only real
+  evidence it tests anything.
+
+## 5. Follow-on seeds
+
+None new. Phase 02 opened no follow-up that is not already filed, and
+closed two of its own open questions in-phase (CI's unpinned toolchain,
+`release.yml` unexercised). The live items this phase hands forward all
+predate it and are already tracked:
+
+- [parity corpus pins ill-conditioned points](../../../docs/followups/todo/parity-corpus-pins-ill-conditioned-points.md)
+  — **read before Phase 04**, and land before the first swap, because
+  that swap flips the corpus out of repairable, bit-equality mode
+  permanently.
+- [model spectra reject scalar energies](../../../docs/followups/todo/model-spectra-reject-scalar-energies.md)
+  — the model-level half of dispatch divergences 1 and 2; resolving it by
+  normalizing at the public boundary also settles the 0-d case, and
+  deciding the two separately risks two different answers.
+- [positron spectrum `nan` at the legacy electron mass](../../../docs/followups/todo/positron-spectrum-nan-at-legacy-electron-mass.md)
+  — ripens before Phases 05/06.
+- [sdist ships generated C and docs](../../../docs/followups/todo/sdist-ships-generated-c-and-docs.md)
+  — time-boxed to before Phase 07 Task 7.1, since maturin reads neither
+  `MANIFEST.in` nor `[tool.setuptools]`.

--- a/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
+++ b/projects/cython-to-rust/phases/phase-02-rust-scaffold.md
@@ -1,7 +1,7 @@
 ---
 phase: 02
 title: Rust scaffold
-status: Not started
+status: Complete
 ---
 
 # Phase 02: Rust scaffold
@@ -104,6 +104,17 @@ yet: the walking skeleton proves the toolchain end to end.
   and 2-D error paths raising `ValueError` with the contract message
   (see `../references/numerics-replacements.md`, dispatch contract).
 - The same test module is the template later kernel swaps copy.
+- **`roundtrip`'s advertised signature matches the one that works, and
+  matches the Cython convention it replaces.** Added by Task 2.3 on
+  2026-08-09, widening the task past "tests only" because the criterion
+  above is not satisfiable otherwise: `#[pyo3(text_signature = "(x, /)")]`
+  made `inspect.signature` report positional-only while `roundtrip(x=1.5)`
+  worked, and the Cython entry points are `def` functions that accept
+  keywords (measured: `dnde_photon(egam=…, emu=…)` returns a value). A
+  template that advertises a narrower signature than the API it replaces
+  propagates a public-API narrowing into every Phase 04–06 wrapper that
+  copies it. Fixed to `"(x)"`, which is also what `hazma/_core.pyi`
+  already described.
 
 ## Exit Criteria
 

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -23,7 +23,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | --- | ------- | ----------- | ---------------- | -------- |
 | 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | **Complete (2026-08-06)** — all five tasks done; [learnings](../learnings/phase-00-dead-code-purge.md) |
 | 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | **Complete (2026-08-08)** — all four tasks done; [learnings](../learnings/phase-01-parity-corpus.md) |
-| 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | **In Progress** — Tasks 2.1 and 2.2 complete (2026-08-08); 2.3 open |
+| 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | **Complete (2026-08-09)** — all three tasks done; [learnings](../learnings/phase-02-rust-scaffold.md) |
 | 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | Not started |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | Not started |
@@ -287,6 +287,30 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   `docs/agents/preflight.md`, and the rebuild-awareness bullet of all
   seven review/commit skills, so Phases 03–06 inherit a reviewer who is
   expected to challenge a cargo-only run quoted as a Python result.
+- **The dispatch contract is now pinned from Python, and three of its
+  behaviors were not in the prose** (Task 2.3).
+  `test/test_core_dispatch.py` holds every branch of
+  `dispatch::map_unary` through `hazma._core.roundtrip`: (a) **rank is
+  checked before dtype**, so a 2-D int64 array reports the dimension
+  message; (b) **a 0-d array still enforces dtype** where a Python `int`
+  does not, because the 0-d path lives inside the array branch behind the
+  typed view; (c) **non-`float` NumPy scalars are accepted**
+  (`np.float32`, `np.int64`, `np.uint8`, `np.bool_`) via the
+  `extract::<f64>` arm. **That module is the template Phases 04–06
+  copy** — swap the kernel and the `QUANTITY` wording, keep every test,
+  add the numerical tests beside rather than merged in. Two side facts
+  worth carrying: bit patterns survive intact (NaN payload included), so
+  the module argues about no tolerances; and a "fresh" array from the
+  `numpy` crate has `owndata == False` with a `PySliceContainer` base, so
+  **non-aliasing is the assertable property, never `owndata`**.
+- **`text_signature` is a claim PyO3 does not enforce** (Task 2.3).
+  `roundtrip` advertised `(x, /)` while `roundtrip(x=1.5)` worked;
+  enforcing positional-only takes `#[pyo3(signature = (x, /))]`. The
+  Cython entry points are `def` functions that accept keywords
+  (measured), so a `/` in a template's `text_signature` is a latent
+  public-API narrowing waiting to be copied into every Phase 04–06
+  wrapper. Fixed to `"(x)"` — the same thing `hazma/_core.pyi` already
+  described.
 - **A worktree can inherit `.so` files whose source package is gone**
   (Task 1.1): this tree carried `_gamma_ray/` and `_phase_space/`
   extensions deleted in Task 0.2, giving 25 `.so` against `setup.py`'s
@@ -454,6 +478,24 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   `[wheel-tag-vs-extension-abi]`), which is Task 2.2's own
   extension-level criterion measured on the final tree.
 
+- **Task 2.3, 2026-08-09 (cross-language plumbing test): no public value
+  changes** (verified: `git diff origin/master -- hazma` is empty — 0
+  lines, on a tree cleaned and rebuilt before anything was run). The diff
+  is one new test module, one non-executable hunk in `rust/src/lib.rs`
+  (`roundtrip`'s advertised `text_signature`, on the scaffold probe
+  nothing under `hazma/` imports), and project bookkeeping; no library
+  module, kernel, signature, constant or build *input* is reachable from
+  it. Measured rather than only argued: the bare suite ran the parity
+  corpus in **bit-equality mode** — `rtol = 0` across all 41 consumed
+  entry points, 179,695 pinned values — and passed, at
+  `1063 passed, 13 skipped` (+54 on Task 2.2's 1009, all of them the new
+  module; the skip count is unchanged, which is what proves the mode).
+  No ad-hoc grid sweep is reported because the corpus is a stricter grid
+  than any of them. **Phase 02 therefore closes with the public compiled
+  surface exactly where Phase 00 left it** — the whole phase's only
+  change under `hazma/` across all three tasks is the non-executable
+  `hazma/_core.pyi` stub.
+
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
 it from memory.)
@@ -620,12 +662,31 @@ it from memory.)
   rule 1); and one struck-through risk bullet in Task 2.1's note.
   21 files: 20 modified, 1 added. Nothing under `hazma/` or `rust/`.
   Full list in [phase-02/README.md](phase-02/README.md).
+- **Task 2.3** — phase closure. New `test/test_core_dispatch.py`
+  (54 tests in six classes, the template every Phase 04–06 kernel swap
+  copies); one non-executable hunk in `rust/src/lib.rs` (`roundtrip`'s
+  `text_signature` `"(x, /)"` → `"(x)"` plus the doc comment recording
+  why); one canonical patch (`../phases/phase-02-rust-scaffold.md`'s
+  Task 2.3 exit criteria gained the signature bullet). Phase closed:
+  learnings written, phase frontmatter `status: Complete`, `PLAN.md`
+  Phases row updated. Nothing under `hazma/`. Full list in
+  [phase-02/README.md](phase-02/README.md).
 
 ## Verification
 
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
 - Per-phase Verification sections live in `phase-XX/README.md`.
+- **Phase 02 closing state (2026-08-09):** bare `pytest -q` →
+  `1063 passed, 13 skipped` on the capturing environment (1076
+  collected), parity suite included and in **bit-equality mode**;
+  `scripts/agents/preflight.sh` RESULT: PASS across all eleven rows, the
+  three cargo gates green. `git diff origin/master -- hazma` is empty, so
+  the public compiled surface is exactly where Phase 00 left it — the
+  whole phase's only change under `hazma/` is the non-executable
+  `hazma/_core.pyi` stub. Task 2.3's 54 new tests were validated by a
+  six-mutation campaign against `rust/src/{dispatch,lib}.rs`, each
+  mutation rebuilt and caught by the test whose name claimed it.
 - **Phase 02 Task 2.2 state (2026-08-08):** `scripts/agents/preflight.sh`
   RESULT: PASS across all eleven rows — the three cargo gates green,
   `pytest` at `1009 passed, 13 skipped` (byte-identical to Task 2.1's, so
@@ -750,16 +811,25 @@ it from memory.)
   `cargo test --manifest-path rust/Cargo.toml --no-default-features`,
   reinstall before quoting any pytest or parity number, and confirm with
   `python -c "import hazma._core; print(hazma._core.__file__)"`.
-- **Phases 00 and 01 are both Complete** (2026-08-06 and 2026-08-08).
-  Read
-  [`../learnings/phase-00-dead-code-purge.md`](../learnings/phase-00-dead-code-purge.md)
-  and
+- **Phases 00, 01 and 02 are all Complete** (2026-08-06, 2026-08-08 and
+  2026-08-09). Read
+  [`../learnings/phase-00-dead-code-purge.md`](../learnings/phase-00-dead-code-purge.md),
   [`../learnings/phase-01-parity-corpus.md`](../learnings/phase-01-parity-corpus.md)
-  rather than their nine task notes — the learnings are the
-  distillation, the notes are history. **Phase 02 is In Progress: Task
-  2.1 and Task 2.2 (CI, preflight, dev-loop docs) both landed
-  2026-08-08; Task 2.3 (the plumbing test suite) is the last one open,
-  and depends only on 2.1.** No phase carries a decision gate.
+  and
+  [`../learnings/phase-02-rust-scaffold.md`](../learnings/phase-02-rust-scaffold.md)
+  rather than their twelve task notes — the learnings are the
+  distillation, the notes are history. **The next task is Phase 03,
+  Task 3.1.** No phase carries a decision gate.
+- **`test/test_core_dispatch.py` is the template every Phase 04–06 kernel
+  swap copies** (Task 2.3; 54 tests, 0.27s, platform-independent). It
+  pins every branch of `dispatch::map_unary` through
+  `hazma._core.roundtrip`. Copying it means: swap `roundtrip` for the
+  kernel and `QUANTITY` for the wording that kernel passes to
+  `map_unary`, keep every test, and add the kernel's numerical tests
+  *beside* them rather than merged in. The instructions are in the module
+  docstring so they travel with the file. It deliberately re-pins no
+  value against Cython — the corpus does that, at bit-equality, across
+  all 41 entry points.
 - **The parity corpus is the gate from here on.** `python
   test/parity/generate.py --check` verifies it (still, with `_core`
   present); `test/parity/cases.py` is the single source of every entry
@@ -780,13 +850,17 @@ it from memory.)
   it in Phase 07). Neither ships a deleted path; neither ships the agent
   scaffolding any more.
 - **The suites are merged and green on the capturing platform**: bare
-  `pytest -q` → 1006 passed / 13 skipped at Phase 01 close (Task 1.4,
-  2026-08-08), from 935/30 at Task 1.3. Task 1.4's delta: +69 aggregation
-  tests, +2 from the `rh_neutrino` rename, −17 skips as the two legacy
-  mediator classes left. Forcing budget mode drops one test to a skip
-  rather than failing — the parity suite reports its mode that way.
-  Re-derive rather than quoting; the historical series is in
-  [`phase-01/README.md`](phase-01/README.md).
+  `pytest -q` → 1063 passed / 13 skipped at Phase 02 close (Task 2.3,
+  2026-08-09), from 1006/13 at Phase 01 close and 935/30 at Task 1.3.
+  The Phase 02 deltas: +3 (Task 2.1's scaffold checks), 0 (Task 2.2,
+  byte-identical, which is what showed no test outcome moved), +54
+  (Task 2.3's plumbing module). **The skip count has not moved since
+  Phase 01 closed**, and that is the tell: forcing budget mode drops one
+  test to a skip rather than failing, so an unchanged 13 is how the
+  parity suite reports it is still in bit-equality mode. Re-derive rather
+  than quoting; the historical series is in
+  [`phase-01/README.md`](phase-01/README.md) and
+  [`phase-02/README.md`](phase-02/README.md).
 - **`test/test_theory_aggregation.py` is the model-layer gate the corpus
   cannot be** (Task 1.4): identities over `hazma/theory/`'s pure-Python
   aggregation, no golden data, 0.6s, and the only numerical gate in the

--- a/projects/cython-to-rust/task-notes/phase-02/README.md
+++ b/projects/cython-to-rust/task-notes/phase-02/README.md
@@ -3,7 +3,9 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 02
-**Status:** In Progress (Tasks 2.1 and 2.2 complete 2026-08-08)
+**Status:** Complete (2026-08-09 — Tasks 2.1 and 2.2 on 2026-08-08,
+Task 2.3 on 2026-08-09;
+[learnings](../../learnings/phase-02-rust-scaffold.md))
 **Plan References:** `../../phases/phase-02-rust-scaffold.md`
 **Related ADRs:** ADR-0001 (accepted)
 **Depends On:** Phase 01 complete
@@ -19,12 +21,14 @@ scaffold.
 | --- | ------ | ------------ | -------- | ----------- |
 | 2.1 | Crate + setuptools-rust integration | — | **Complete (2026-08-08)** | [task-2.1-crate-skeleton.md](task-2.1-crate-skeleton.md) |
 | 2.2 | CI, preflight, dev-loop docs | 2.1 | **Complete (2026-08-08)** | [task-2.2-ci-devloop.md](task-2.2-ci-devloop.md) |
-| 2.3 | Cross-language plumbing test | 2.1 | Not started | [task-2.3-plumbing-test.md](task-2.3-plumbing-test.md) |
+| 2.3 | Cross-language plumbing test | 2.1 | **Complete (2026-08-09)** | [task-2.3-plumbing-test.md](task-2.3-plumbing-test.md) |
 
 ## Exit Criteria
 
-- All rows Complete; phase file frontmatter `status: Complete`.
-- Phase learnings at `../../learnings/phase-02-rust-scaffold.md`.
+- ~~All rows Complete; phase file frontmatter `status: Complete`.~~ —
+  **met 2026-08-09.**
+- ~~Phase learnings at `../../learnings/phase-02-rust-scaffold.md`.~~ —
+  **written 2026-08-09.**
 
 ## Inputs Reviewed
 
@@ -119,6 +123,30 @@ scaffold.
   not this diff — so `--md` gets the six clean ones and the count
   comparison above is the evidence, rather than the file being quietly
   dropped.
+- **Three dispatch behaviors the reference prose did not state**, all
+  measured against the built extension in Task 2.3 and now pinned by
+  `test/test_core_dispatch.py`: (a) **rank is checked before dtype**, so
+  a 2-D int64 array reports `must be 0 or 1-dimensional.`; (b) **a 0-d
+  array still enforces dtype** where a Python `int` does not — the 0-d
+  path lives inside the array branch behind the typed view, so
+  `roundtrip(4)` is `4.0` and `roundtrip(np.array(4))` is a `ValueError`;
+  (c) **non-`float` NumPy scalars are accepted** (`np.float32`,
+  `np.int64`, `np.uint8`, `np.bool_`) via the `extract::<f64>` arm. A
+  Task 3.5 decision that changes any of them now turns a named test red.
+- **`text_signature` is a claim PyO3 does not enforce** (Task 2.3).
+  `roundtrip` advertised `(x, /)` while `roundtrip(x=1.5)` worked;
+  enforcing positional-only needs `#[pyo3(signature = (x, /))]`. The
+  Cython entry points are `def` functions that take keywords — measured,
+  `dnde_photon(egam=100.0, emu=200.0)` returns
+  `2.0036713127483527e-05` — so keyword-accepting is the target and the
+  `/` was a latent public-API narrowing waiting to be copied into every
+  Phase 04–06 wrapper. Fixed to `"(x)"`, which is what `hazma/_core.pyi`
+  already described.
+- **A "fresh" array from the `numpy` crate does not own its data** (Task
+  2.3). `roundtrip(a).flags.owndata` is `False` and `.base` is a
+  `PySliceContainer` wrapping the Rust `Vec`. Assert non-aliasing
+  (`is not`, `.base is not`, `np.shares_memory`, mutate-and-check) rather
+  than `owndata`, which is red on correct code.
 
 ## Decisions and Implementation Notes
 
@@ -186,6 +214,17 @@ and seven skill files; two canonical patches
 modified, 1 added. Nothing under `hazma/` or `rust/`. Full list in
 [task-2.2-ci-devloop.md](task-2.2-ci-devloop.md).
 
+### Task 2.3
+
+New `test/test_core_dispatch.py` (54 tests in six classes — the template
+every Phase 04–06 kernel swap copies); a one-line non-executable change
+in `rust/src/lib.rs` (`roundtrip`'s `text_signature` `"(x, /)"` → `"(x)"`
+plus the doc comment recording why); the phase-closure bookkeeping
+(`../../phases/phase-02-rust-scaffold.md` frontmatter and Task 2.3 exit
+criteria, `../../PLAN.md`'s Phases row, `../README.md`, this file) and
+`../../learnings/phase-02-rust-scaffold.md`. Nothing under `hazma/`.
+Full list in [task-2.3-plumbing-test.md](task-2.3-plumbing-test.md).
+
 ## Verification
 
 - Per-task verification lives in each task note. Task 2.1's closing
@@ -211,6 +250,20 @@ modified, 1 added. Nothing under `hazma/` or `rust/`. Full list in
   the assertion step as carrying the extension. PR #56's eight checks
   are green, including the new `rust` job at 30s. Full tables in the
   task note.
+- **Task 2.3 state (2026-08-09)**, same interpreter, tree cleaned (40
+  stale `.c`/`.so`) and rebuilt first, and rebuilt again after the
+  `lib.rs` edit: `test/test_core_dispatch.py` → `54 passed in 0.27s`;
+  bare `pytest -q` → `1063 passed, 13 skipped, 5 warnings in 552.68s`
+  (1076 collected, +54 on Task 2.2's 1022 — all of them the new module),
+  parity suite still in **bit-equality mode** (skip count unchanged at
+  13). The three cargo gates green. `scripts/agents/preflight.sh`
+  RESULT: PASS. The 54 assertions were validated by a **six-mutation
+  campaign** against `rust/src/{dispatch,lib}.rs` — text_signature
+  reverted, array path returning the input object, dtype checked before
+  rank, `{quantity}` dropped from a message, 0-d array rejected, array
+  path reading the raw buffer instead of the view — each applied,
+  rebuilt, run, reverted, and each caught by the test whose name claimed
+  it. Full tables in the task note.
 
 ## Open Questions
 
@@ -255,9 +308,12 @@ notes.
 
 ## Handoff to Next Task
 
-**For the next agent working in Phase 02:** read `../../PLAN.md`,
-`../README.md`, this file, then the phase file. The extension's import
-path is final from day one: `hazma._core`.
+**Phase 02 is Complete (2026-08-09).** The next task is **Phase 03,
+Task 3.1**. Read
+[`../../learnings/phase-02-rust-scaffold.md`](../../learnings/phase-02-rust-scaffold.md)
+rather than this phase's three task notes — the learnings are the
+distillation, the notes are history. The extension's import path was
+final from day one: `hazma._core`.
 
 **Currently safe to assume:**
 
@@ -279,8 +335,17 @@ path is final from day one: `hazma._core`.
   rebuild-awareness bullet of every review skill — so a future reviewer
   is expected to challenge a cargo-only run cited as a Python result.
 - `dispatch::map_unary` is the one implementation of the entry-point
-  dispatch contract; Task 2.3's plumbing tests are written against
-  `hazma._core.roundtrip`, which exercises every branch of it.
+  dispatch contract, and as of Task 2.3 **every branch of it is pinned
+  from Python** by `test/test_core_dispatch.py` (54 tests, 0.27s,
+  platform-independent), written against `hazma._core.roundtrip`.
+- **That module is the template Phase 04–06 swaps copy.** Swap
+  `roundtrip` for the kernel and `QUANTITY` for the wording that kernel
+  passes to `map_unary`, keep every test, and add the kernel's numerical
+  tests *beside* them rather than merged in. The copy instructions are in
+  the module docstring so they travel with the file. It deliberately does
+  not re-pin values against Cython — that is the corpus's job.
+- **Do not assert `owndata` on a returned array**; it is `False` on
+  correct code. Non-aliasing is the assertable property.
 - The parity gate is in bit-equality mode again and stays there until a
   real kernel lands. Do not re-key it on `rust_core_available()`.
 
@@ -290,12 +355,15 @@ path is final from day one: `hazma._core`.
   and green in PR #56's review round 1 (see Open Questions). It stays
   invisible to PR checks, so any *future* change to it needs its own
   dispatch.
-- The reference's dispatch contract now records four measured
-  divergences from the live Cython. Task 2.3 asserts the *target*
-  contract on `roundtrip`; Task 3.5 has to decide, per divergence,
-  whether the ported entry points keep the Cython behavior or take the
-  declared change.
-- **Task 2.3 is the last open task in this phase**, and it depends only
-  on Task 2.1. Nothing Task 2.2 changed constrains it beyond the new
-  obligation every task now inherits: a `.rs` edit means an editable
+- The reference's dispatch contract records four measured divergences
+  from the live Cython. Task 2.3 asserted the *target* contract on
+  `roundtrip`, with a comment at each of the two that surface at this
+  layer (0-d array, Python list) naming Task 3.5 as the decision point.
+  **Task 3.5 still has to decide, per divergence**, whether the ported
+  entry points keep the Cython behavior or take the declared change —
+  what changed is that either answer now moves a named test rather than
+  passing unnoticed.
+- ~~**Task 2.3 is the last open task in this phase.**~~ — **closed
+  2026-08-09.** No task in Phase 02 remains open. The obligation every
+  later task inherits is unchanged: a `.rs` edit means an editable
   reinstall before any pytest number is quotable.

--- a/projects/cython-to-rust/task-notes/phase-02/task-2.3-plumbing-test.md
+++ b/projects/cython-to-rust/task-notes/phase-02/task-2.3-plumbing-test.md
@@ -1,0 +1,330 @@
+# Task 2.3: Cross-language plumbing test
+
+**Date:** 2026-08-09
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-02-rust-scaffold.md` (Task 2.3);
+`../../references/numerics-replacements.md` (Entry-point dispatch
+contract); `../../rules.md` rule 8 (Rust conventions 3)
+**Related ADRs:** ADR-0001 (accepted)
+**Depends On:** Task 2.1
+
+## Objective
+
+Pin the `hazma._core` entry-point dispatch contract from the Python side
+— every branch of `dispatch::map_unary`, exercised through the scaffold's
+`roundtrip` probe — in a test module written to be the template Phases
+04–06 copy for each real kernel.
+
+## Exit Criteria
+
+Copied from the phase file's Task 2.3 block:
+
+- pytest exercises the round-trip function for: float in/float out, 1-D
+  array in/out (dtype, shape, ownership), 0-d array, wrong-dtype and 2-D
+  error paths raising `ValueError` with the contract message (see
+  `../../references/numerics-replacements.md`, dispatch contract).
+- The same test module is the template later kernel swaps copy.
+
+## Inputs Reviewed
+
+- `../../PLAN.md`, `../README.md` (project working memory),
+  `../../phases/phase-02-rust-scaffold.md`, `../../rules.md`.
+- `README.md` (this phase's working memory) — Task 2.1's dispatch
+  findings, the NumPy-panic ordering constraint, and its handoff line
+  naming `map_unary` as the thing Task 2.3 must exercise.
+- `../../references/numerics-replacements.md`, "Entry-point dispatch
+  contract" **and** its "What the Cython actually does today" subsection.
+- `rust/src/{lib,dispatch,kernels}.rs`, `hazma/_core.pyi`.
+- `test/test_theory_aggregation.py` (house style for a contract-shaped,
+  golden-data-free test module), `test/conftest.py`,
+  `pyproject.toml`'s `[tool.pytest.ini_options]`.
+- `docs/agents/lessons.md`, `docs/agents/doc-consistency.md`,
+  `docs/agents/environment.md`, `docs/agents/preflight.md`.
+
+## Findings
+
+- **Every assertion in the new module was measured against the built
+  extension before it was written.** A 26-case probe over `roundtrip`
+  (`float`, `int`, `bool`, four NumPy scalar types, 0-d/1-D/2-D/3-D
+  arrays in five dtypes, empty, non-contiguous, Fortran-order, read-only,
+  `list`, `str`, `None`, `complex`, and the arity/keyword forms) is what
+  the tests encode. Three behaviors were *not* predictable from the
+  contract prose and are now pinned:
+  - **Rank is checked before dtype.** `roundtrip(np.ones((2, 2),
+    dtype=np.int64))` reports `must be 0 or 1-dimensional.`, not the
+    dtype message. That ordering is the order the checks appear in
+    `map_unary`, and reordering them would silently reword a
+    user-visible exception.
+  - **A 0-d array still enforces dtype**, even though a Python `int` does
+    not. The 0-d scalar path lives *inside* the array branch, behind the
+    typed view, whereas an `int` reaches `extract::<f64>`. So
+    `roundtrip(4)` is `4.0` and `roundtrip(np.array(4))` is a
+    `ValueError`.
+  - **Non-`float` NumPy scalars are accepted** (`np.float32`, `np.int64`,
+    `np.uint8`, `np.bool_`). They are neither `float` subclasses nor
+    ndarrays, so they fall past both fast paths to `extract::<f64>`,
+    which takes them. The module's docstring called out only `np.float64`
+    before this task.
+- **`roundtrip` advertised a signature it did not have.** `#[pyo3(
+  text_signature = "(x, /)")]` made `inspect.signature` report
+  positional-only, while `roundtrip(x=1.5)` worked — `text_signature` is
+  a doc claim PyO3 does not enforce (enforcing it needs `#[pyo3(
+  signature = (x, /))]`). Measured against the layer being replaced:
+  `hazma.spectra._photon._muon.dnde_photon(egam=100.0, emu=200.0)`
+  returns `2.0036713127483527e-05` — the Cython entry points are `def`
+  functions and take keywords. So the *claim* was the defect, not the
+  behavior: copied into a Phase 04 wrapper, a positional-only signature
+  would have been a public-API narrowing. Fixed to `"(x)"`, which is also
+  what `hazma/_core.pyi` already described.
+- **Bit patterns survive the round trip intact, NaN payload included.**
+  `struct.pack("<d", roundtrip(float("nan")))` is `000000000000f87f`,
+  byte-identical to the input; so are `-0.0`, both infinities, the
+  smallest subnormal (`5e-324`) and the largest finite. That is what lets
+  the module assert bit-equality everywhere and argue about no
+  tolerances — the property Task 2.1 chose the identity kernel for.
+- **The freshly-allocated array does not own its data.**
+  `roundtrip(a).flags.owndata` is `False` and `.base` is a
+  `PySliceContainer` — the `numpy` crate's wrapper around the Rust `Vec`.
+  So "fresh" has to be asserted as *non-aliasing* (`result is not
+  values`, `result.base is not values`, `np.shares_memory` false, and
+  mutating the result leaves the input alone), never as `owndata`. An
+  `owndata` assertion would have been red on correct code.
+- **A read-only input is accepted and a non-contiguous one is read in
+  order.** `map_unary` iterates the ndarray *view*, so `np.arange(6.0)
+  [::2]` yields `[0., 2., 4.]` rather than the buffer's first three
+  elements. Worth a test of its own: rewriting the array path to read a
+  raw pointer would pass every other assertion in the module.
+
+## Decisions and Implementation Notes
+
+- **One module, `test/test_core_dispatch.py`, at the top of `test/`.**
+  It sits beside `test_theory_aggregation.py` — the other gate that is a
+  contract rather than stored data — and outside `test/parity/`, which is
+  generated and platform-scoped. This module is neither: it is
+  hand-written, and every assertion in it holds on any platform.
+- **No `pytest.importorskip("hazma._core")`.** From Phase 02 on the
+  extension is in every build, so a missing `_core` is a build failure
+  and must fail loudly. A skip here would be `docs/agents/lessons.md`
+  `[gate-disabled-stays-green]` in the one module whose whole job is to
+  notice that the cross-language path is broken.
+- **The module pins the *target* contract, and says so at each
+  divergence.** Two of the reference's four measured Cython/contract
+  divergences surface at this layer — a 0-d array (Cython raises,
+  `map_unary` returns a float) and a Python list (Cython accepts,
+  `map_unary` raises). Both are asserted as the scaffold behaves, with a
+  comment at the assertion naming Task 3.5 as the decision point. The
+  alternative — leaving them untested because they are unsettled — would
+  make the eventual Task 3.5 change invisible.
+- **It does not re-pin any value against Cython.** That is
+  `test/parity/`'s job at bit-equality across all 41 entry points; a
+  second, looser numerical gate here would only be one more thing to keep
+  in sync. The module's docstring says this explicitly so a copier does
+  not add one.
+- **The `text_signature` fix shipped in this task rather than as a
+  follow-up.** It is one line in the file whose contract this task
+  exists to pin, the test that catches it is one of the module's own, and
+  deferring it would have meant a template that advertises a signature
+  narrower than the API it replaces. `rust/src/lib.rs` carries the
+  reasoning in a doc comment so a future reader does not "restore" the
+  `/`.
+- **Copy instructions are in the module docstring, not in a project
+  doc.** A template whose usage notes live somewhere else stops being
+  copied correctly on the first swap; the file names what to change
+  (`roundtrip` → the kernel, `QUANTITY` → the kernel's wording) and what
+  not to (do not merge plumbing and physics assertions).
+
+## Files Changed
+
+- `test/test_core_dispatch.py` — **new**, 54 tests. Six classes:
+  `TestScalarPath` (float / NumPy-scalar / int / bool in, `float` out,
+  bit-for-bit over ten special values), `TestZeroDimensionalArray`,
+  `TestArrayPath` (dtype, shape, values, empty, non-contiguous,
+  read-only, non-aliasing), `TestErrorPaths` (2-D/3-D/Fortran-order/(1,1),
+  five wrong dtypes, rank-before-dtype, five non-numeric types, the list
+  narrowing, and the quantity-name prefix), `TestSignature`.
+- `rust/src/lib.rs` — `roundtrip`'s `text_signature` `"(x, /)"` → `"(x)"`,
+  plus the doc comment recording why. No executable change.
+- `projects/cython-to-rust/task-notes/phase-02/task-2.3-plumbing-test.md`
+  — this note.
+- `projects/cython-to-rust/task-notes/phase-02/README.md` — Task 2.3 row
+  → Complete, findings, files, verification, handoff; phase closure.
+- `projects/cython-to-rust/task-notes/README.md` — Phase 02 row →
+  Complete, findings, numerical-impact entry, files, handoff.
+- `projects/cython-to-rust/phases/phase-02-rust-scaffold.md` —
+  frontmatter `status: Not started` → `Complete`; Task 2.3 exit criteria
+  widened to name the `text_signature` fix (see §Plan Impact).
+- `projects/cython-to-rust/PLAN.md` — Phases table row 02.
+- `projects/cython-to-rust/learnings/phase-02-rust-scaffold.md` — **new**,
+  phase closure.
+
+## Verification
+
+**Environment.** The tree was cleaned (`find hazma -name '*.c' -o -name
+'*.so' | xargs rm -f`, 40 files) and rebuilt with `uv pip install -e .`
+before anything was run, and again after the `lib.rs` edit — `cargo
+build` publishes nothing to Python (Task 2.2). Confirmed each time:
+`python -c "import hazma._core; print(hazma._core.__file__)"` →
+`<worktree>/hazma/_core.abi3.so`, 21 `.so` in the tree.
+
+**The new module.**
+
+```text
+.venv/bin/python -m pytest test/test_core_dispatch.py -q
+54 passed in 0.27s
+```
+
+What the 54 cover, by class:
+
+| Class | Tests | Covers |
+| --- | --- | --- |
+| `TestScalarPath` | 17 | `float` (10 special values, bit-for-bit), `np.float64` fast path, four other NumPy scalar types, `int`, `bool` |
+| `TestZeroDimensionalArray` | 11 | 0-d `float64` → `float` over the same ten values; 0-d wrong dtype rejected |
+| `TestArrayPath` | 6 | dtype/shape/values, special values, empty, non-contiguous, read-only, non-aliasing |
+| `TestErrorPaths` | 19 | 4 rank errors, 5 dtype errors, rank-before-dtype, 5 non-numeric, the `list` narrowing, 3 quantity-prefix checks |
+| `TestSignature` | 1 | `inspect.signature` is `(x)`; the keyword call works |
+
+**Full suite** (bare `pytest`, the gate CI runs):
+
+```text
+.venv/bin/python -m pytest -q
+1063 passed, 13 skipped, 5 warnings in 552.68s (0:09:12)
+```
+
+1076 collected, +54 on Task 2.2's 1022. The skip count is unchanged at
+13, which is what shows the parity suite is still in **bit-equality
+mode** (forcing budget mode turns
+`test_running_on_the_capturing_tree` into a skip — see
+`test/parity/README.md`).
+
+**Test validity — mutation campaign.** Six mutations of the production
+code, each applied, rebuilt with `uv pip install -e .`, run, and
+reverted. Every one is caught, and by the tests whose names claim it:
+
+| Mutation | Result |
+| --- | --- |
+| M1 `text_signature` back to `"(x, /)"` | 1 failed — `TestSignature` |
+| M2 array path returns the input object instead of a fresh array | 2 failed — `test_result_is_a_fresh_array_that_does_not_alias_the_input`, `test_non_contiguous_input_is_read_in_order` |
+| M3 dtype checked before rank | 6 failed — all four rank cases, `test_rank_is_checked_before_dtype`, the dimension quantity-prefix case |
+| M4 `{quantity}` dropped from the dimension message | 2 failed — `test_rank_is_checked_before_dtype`, quantity-prefix `[dimension]` |
+| M5 0-d array rejected instead of taking the scalar path | 10 failed — all of `TestZeroDimensionalArray`'s float cases |
+| M6 array path reads the raw buffer instead of the view | 1 failed — `test_non_contiguous_input_is_read_in_order` |
+
+M1 is the stash-proof check for this task's one production change: the
+signature test fails with the fix reverted, passes with it.
+
+**Cargo gates**, from the repo root:
+
+```text
+cargo fmt --manifest-path rust/Cargo.toml --check                       clean
+cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings   clean
+cargo test --manifest-path rust/Cargo.toml --no-default-features        2 passed
+```
+
+**Preflight:** `scripts/agents/preflight.sh --paths
+"test/test_core_dispatch.py" --md "<the 6 changed docs>"` → **RESULT:
+PASS**, all eleven rows (`version bump` SKIP — not a closing PR).
+
+One invocation trap, hit on the first run and worth carrying: **preflight
+resolves every Python tool from `PATH`, and this worktree's `.venv` is
+not on it by default** (fish). A bare run reports `FAIL black not
+installed`, `WARN isort`, `WARN ruff`, `FAIL pytest` — four rows that say
+*missing tool*, not *red gate*, and one of them (`WARN`) is a hole rather
+than a pass. Run it as
+`env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh …`. Note
+also that the `import hazma` row passes either way, because Python puts
+the repo root on `sys.path` when preflight runs from there — it is not
+evidence the venv was used.
+
+**Deferred:** nothing. The exit criteria name array *ownership*, which is
+covered as non-aliasing rather than `owndata` — see §Findings for why
+`owndata` is `False` on correct code.
+
+## Open Questions
+
+- None opened by this task. The two divergences its assertions pin
+  (0-d array, Python list) are Task 3.5's to decide, already tracked in
+  `../../references/numerics-replacements.md` and in this phase's
+  README; this task adds a failing test to whichever way 3.5 goes, which
+  is the outcome that makes the decision visible.
+
+## Plan Impact
+
+**Impact Level:** Update phase file.
+
+Two canonical edits, both in
+`../../phases/phase-02-rust-scaffold.md`:
+
+1. **Task 2.3's exit criteria gained a third bullet** naming the
+   `text_signature` fix. The task was widened past the plan's wording —
+   the plan asked for tests only — so the plan now says so, the same way
+   Task 2.1 and Task 2.2 recorded their widenings. The reason it is
+   canonical rather than a note: the criterion "the same test module is
+   the template later kernel swaps copy" is not satisfiable by a template
+   whose probe advertises a narrower signature than the Cython it
+   replaces.
+2. **The phase's frontmatter `status:` → `Complete`**, with the phase
+   learnings written and `PLAN.md`'s Phases row updated. Task 2.3 is the
+   last task in Phase 02.
+
+No ADR. Nothing here revises ADR-0001, and the dispatch contract itself
+is unchanged — this task pins it, it does not decide it.
+
+## Stale-state sweep
+
+Commands run against this branch
+(`claude/cython-to-rust/task-2.3-cross-language-plumbing-test`).
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Branch / worktree | `git rev-parse --abbrev-ref HEAD`; `--show-toplevel` | `claude/cython-to-rust/task-2.3-cross-language-plumbing-test` (**not** `master`); `…/.claude/worktrees/cython-to-rust-next-99fe4c` |
+| Full change inventory | `git status --short`; `git diff origin/master --stat` | 8 files, `+1025 / −37`; 3 added, 5 modified. Nothing untracked left unaccounted (`git add -A` run before the check, so `??` cannot hide a file) |
+| Numerical-impact statement | `git diff origin/master -- hazma \| wc -l` | `0` — see below |
+| Rust diff is non-executable | `git diff origin/master -- rust` | one hunk in `src/lib.rs`: `text_signature "(x, /)"` → `"(x)"` plus a 6-line doc comment. No statement changed |
+| Task 2.3 status siblings | `rg -n "2\.3" projects/cython-to-rust --glob '*.md'` | 20 hits. The four status-bearing ones — phase file §Task 2.3, `phase-02/README.md` table row, its Files/Verification sections, this note's header — all read `Complete (2026-08-09)`. The rest are prose or links |
+| Phase-02 status siblings | `rg -n "^status:" phases/phase-02-rust-scaffold.md`; `rg -n "phase-02" PLAN.md task-notes/README.md` | `status: Complete`; `PLAN.md` Phases row and `task-notes/README.md` Phases row both `**Complete (2026-08-09)**` |
+| Closure is machine-readable | `scripts/agents/resolve_task.py --project cython-to-rust` | `{"status": "ready", "task_id": "3.1", …, "phase": "03"}` — the resolver has moved off Phase 02, which is the check that the table edits actually parse |
+| Stale "2.3 open / not started" | `rg -n "2\.3.*(Not started\|open)" projects/` | 2 hits, both intentional: this sweep row itself, and the struck-through `~~Task 2.3 is the last open task~~` bullet in `phase-02/README.md` |
+| Test-count claims | `rg -n "1009 passed\|1022 collected\|1006 passed" projects/cython-to-rust --glob '*.md'` | 20 hits, all inside dated Task 1.4 / 2.1 / 2.2 records. This task's counts are **new rows**, not edits to those — the two live roll-ups (`task-notes/README.md` "suites are merged" bullet, `phase-02/README.md` Verification) were updated to 1063/13 |
+| Collected count | `pytest --collect-only -q \| tail -1` | `1076 tests collected` (= 1063 + 13, and +54 on Task 2.2's 1022) |
+| Per-class test counts | `pytest test/test_core_dispatch.py --collect-only -q` | 17 / 11 / 6 / 19 / 1 = 54, matching the §Verification table row for row |
+| Debug leftovers | `rg -n "TODO\|FIXME\|breakpoint\(\)\|pdb\|print\(" test/test_core_dispatch.py rust/src/lib.rs` | no occurrences |
+| Markdown + citations | `scripts/agents/preflight.sh --md "<6 changed docs>"` | `PASS markdownlint` |
+| Full gate | `scripts/agents/preflight.sh --paths … --md …` | **RESULT: PASS**, all eleven rows (`version bump` SKIP — not a closing PR) |
+
+**Numerical-impact statement.** No public value changes (verified:
+`git diff origin/master -- hazma` is empty — 0 lines). The only
+non-documentation change under `rust/` is `roundtrip`'s advertised
+signature string; `roundtrip` is the scaffold probe and nothing under
+`hazma/` imports it. The stronger statement, from the bare suite above:
+the parity corpus ran in **bit-equality mode** — `rtol = 0` across all 41
+consumed entry points, 179,695 pinned values — and passed. No ad-hoc grid
+sweep is reported because the corpus is a stricter grid than any of them.
+
+## Handoff to Next Task
+
+**Phase 02 is Complete.** The next task is **Phase 03, Task 3.1**.
+
+- Read `../../learnings/phase-02-rust-scaffold.md` rather than this
+  phase's three task notes — the learnings are the distillation, the
+  notes are history.
+- **`test/test_core_dispatch.py` is the template.** Copy it per kernel:
+  swap `roundtrip` for the kernel and `QUANTITY` for the wording that
+  kernel passes to `map_unary`, keep every test, and add the kernel's
+  numerical tests *beside* them rather than merged into them. The
+  module's docstring carries these instructions so they travel with the
+  file.
+- **The contract is now pinned from the Python side, including three
+  things the reference prose did not state**: rank is checked before
+  dtype, a 0-d array still enforces dtype where a Python `int` does not,
+  and non-`float` NumPy scalars are accepted. A Task 3.5 decision that
+  changes any of them will turn a named test red rather than passing
+  unnoticed.
+- **Do not assert `owndata` on a returned array.** It is `False` on
+  correct code — the `numpy` crate's `Vec` wrapper owns the buffer.
+  Non-aliasing is the assertable property.
+- Still risky / unknown, unchanged by this task: `spec_math`'s `li2`
+  convention (Task 3.2 pins it), the ill-conditioned-points corpus
+  repair, which must land **before** the first Phase 04 swap flips the
+  parity gate out of bit-equality mode permanently, and the four
+  Cython/contract dispatch divergences Task 3.5 must decide.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,8 +32,14 @@ use pyo3::prelude::*;
 /// in / fresh 1-D array out, `ValueError` on everything else — without
 /// any physics to get wrong. Phase 02 Task 2.3's test module is written
 /// against it and is the template later kernel swaps copy.
+///
+/// The advertised signature is `(x)`, not `(x, /)`: `text_signature` is a
+/// claim PyO3 does not enforce, `roundtrip(x=1.5)` works, and the Cython
+/// entry points this crate replaces are `def` functions that accept their
+/// arguments by keyword. A positional-only claim would misdescribe this
+/// function and, copied into a Phase 04 wrapper, narrow the public API.
 #[pyfunction]
-#[pyo3(text_signature = "(x, /)")]
+#[pyo3(text_signature = "(x)")]
 fn roundtrip(x: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
     dispatch::map_unary(x, "Input values", kernels::roundtrip)
 }

--- a/test/test_core_dispatch.py
+++ b/test/test_core_dispatch.py
@@ -1,0 +1,328 @@
+"""Cross-language plumbing: the ``hazma._core`` entry-point dispatch contract.
+
+This module is the **template** every later kernel swap copies (cython-to-rust
+Phase 02, Task 2.3). It pins the argument-conversion, return-type and error
+behavior that :func:`hazma._core.dispatch.map_unary` implements once for all of
+Phases 03-06, exercised through the scaffold's plumbing probe
+``hazma._core.roundtrip`` -- the identity, so every assertion here is about the
+*plumbing* and none of it is about physics.
+
+The contract, from
+``projects/cython-to-rust/references/numerics-replacements.md`` ("Entry-point
+dispatch contract"):
+
+* a Python ``float``, a NumPy scalar, or a 0-d ``float64`` array returns a
+  Python ``float``;
+* a 1-D ``float64`` array returns a **fresh** 1-D ``float64`` array of the same
+  length;
+* anything else raises ``ValueError``, naming the quantity the caller passed.
+
+Copying this module for a real kernel means: keep every test below, swap
+``roundtrip`` for the kernel and ``QUANTITY`` for the wording that kernel passes
+to ``map_unary`` (``"Photon energies"``, ``"Positron energies"``, ...), and add
+the kernel's *numerical* tests beside them. Do not merge the two halves --
+plumbing failures and physics failures should not need the same debugging.
+
+Two things this module deliberately does **not** do:
+
+* It does not pin values against the Cython twin. That is the parity corpus's
+  job (``test/parity/``), which holds all 41 consumed entry points to
+  bit-equality on its capturing platform. A second, looser numerical gate here
+  would only be one more thing to keep in sync.
+* It does not assume the live Cython dispatch and this contract agree. They do
+  not, in four measured ways recorded in the reference above; the two that
+  surface at this layer -- a 0-d array (Cython raises, ``map_unary`` returns a
+  float) and a Python list (Cython accepts, ``map_unary`` raises) -- are called
+  out at their assertions below. **Task 3.5 decides each divergence**; until
+  then these tests pin the target contract, which is what the scaffold
+  implements, and are expected to be revisited by that task rather than by a
+  kernel swap.
+
+Every assertion below was measured against the built extension before it was
+written, not derived from the contract prose.
+"""
+
+from __future__ import annotations
+
+import inspect
+import struct
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from hazma._core import roundtrip
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# The wording `roundtrip` passes to `map_unary` as its `quantity`. Every error
+# message the contract produces is prefixed with it, which is how a ported
+# kernel keeps its Cython twin's user-visible exception text (rules.md rule 1).
+QUANTITY = "Input values"
+
+DIMENSION_ERROR = f"{QUANTITY} must be 0 or 1-dimensional."
+TYPE_ERROR = f"{QUANTITY} must be a float or a NumPy array."
+
+
+def dtype_error(dtype: str) -> str:
+    """The dtype-rejection message for a non-``float64`` array."""
+    return f"{QUANTITY} must be a float64 array; got dtype {dtype}."
+
+
+def bits(x: float) -> bytes:
+    """The IEEE-754 bit pattern of ``x``.
+
+    Compared instead of ``==`` so that ``-0.0`` is distinguished from ``0.0``
+    and a NaN compares equal to itself. The kernel under test is the identity,
+    so *every* input bit pattern must survive the round trip, including the
+    ones ``==`` cannot see.
+    """
+    return struct.pack("<d", x)
+
+
+# Values chosen to cover the float64 range and its special cases: signed zeros
+# (invisible to `==`), a subnormal, both finite extremes, both infinities, and
+# a NaN (whose payload is also preserved -- measured, not assumed).
+SCALARS = [
+    0.0,
+    -0.0,
+    1.0,
+    -1.5,
+    5e-324,  # smallest positive subnormal
+    2.2250738585072014e-308,  # smallest positive normal
+    1.7976931348623157e308,  # largest finite
+    float("inf"),
+    float("-inf"),
+    float("nan"),
+]
+
+
+class TestScalarPath:
+    """float in -> float out."""
+
+    @pytest.mark.parametrize("value", SCALARS)
+    def test_python_float_round_trips_bit_for_bit(self, value: float) -> None:
+        result = roundtrip(value)
+        assert type(result) is float
+        assert bits(result) == bits(value)
+
+    def test_numpy_float64_returns_a_python_float(self) -> None:
+        # np.float64 subclasses float, so it takes the PyFloat fast path that
+        # exists specifically to keep a scalar call from touching NumPy at all
+        # (the `numpy` crate panics rather than raises when NumPy is absent --
+        # Task 2.1). The return type is the plain builtin either way.
+        result = roundtrip(np.float64(2.5))
+        assert type(result) is float
+        assert bits(result) == bits(2.5)
+
+    @pytest.mark.parametrize(
+        "value",
+        [np.float32(2.5), np.int64(7), np.uint8(3), np.bool_(True)],
+        ids=["float32", "int64", "uint8", "bool_"],
+    )
+    def test_other_numpy_scalars_are_accepted(self, value: np.generic) -> None:
+        # These are neither `float` subclasses nor ndarrays, so they fall past
+        # both fast paths to the `extract::<f64>` arm. They are still scalars
+        # and the contract says a scalar returns a float.
+        result = roundtrip(value)
+        assert type(result) is float
+        assert bits(result) == bits(float(value))
+
+    @pytest.mark.parametrize("value", [3, True], ids=["int", "bool"])
+    def test_python_int_and_bool_are_accepted(self, value: int) -> None:
+        # `float(x)` semantics, matching what the Cython entry points accept
+        # for an energy argument today.
+        result = roundtrip(value)
+        assert type(result) is float
+        assert bits(result) == bits(float(value))
+
+
+class TestZeroDimensionalArray:
+    """0-d array in -> float out.
+
+    This is the first of the two contract/Cython divergences this layer sees:
+    the live Cython raises ``AssertionError`` on a 0-d array because
+    ``ndarray`` defines ``__len__`` on the *type*, so its ``hasattr(x,
+    '__len__')`` dispatch sends a 0-d array down the array path and the
+    ``len(shape) == 1`` guard then rejects it. ``map_unary`` treats it as the
+    scalar it is. Task 3.5 decides whether the ported entry points keep the
+    Cython behavior or take this (widening, user-visible) change.
+    """
+
+    @pytest.mark.parametrize("value", SCALARS)
+    def test_zero_dim_float64_array_returns_a_python_float(self, value: float) -> None:
+        result = roundtrip(np.array(value))
+        assert type(result) is float
+        assert bits(result) == bits(value)
+
+    def test_zero_dim_array_still_enforces_dtype(self) -> None:
+        # The scalar path an ndarray takes is inside the array branch, so the
+        # dtype check applies to it too -- a 0-d int64 array is rejected even
+        # though a Python int is accepted. That asymmetry is deliberate: the
+        # int comes through `extract::<f64>`, the array through a typed view.
+        with pytest.raises(ValueError, match=r"got dtype int64\."):
+            roundtrip(np.array(4, dtype=np.int64))
+
+
+class TestArrayPath:
+    """1-D float64 array in -> fresh 1-D float64 array out."""
+
+    def test_dtype_shape_and_values(self) -> None:
+        values = np.array([1.0, 2.0, 3.5, -7.25])
+        result = roundtrip(values)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float64
+        assert result.shape == values.shape
+        assert result.tobytes() == values.tobytes()
+
+    def test_special_values_survive_bit_for_bit(self) -> None:
+        values = np.array(SCALARS, dtype=np.float64)
+        assert roundtrip(values).tobytes() == values.tobytes()
+
+    def test_empty_array_returns_an_empty_array(self) -> None:
+        # A length-0 array is a legitimate energy grid, and the mapping loop
+        # must not special-case it into a scalar or an error.
+        result = roundtrip(np.array([], dtype=np.float64))
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float64
+        assert result.shape == (0,)
+
+    def test_non_contiguous_input_is_read_in_order(self) -> None:
+        # `map_unary` iterates the ndarray *view*, not the underlying buffer,
+        # so a strided slice must yield its own elements rather than the
+        # buffer's first n. This test fails loudly if the array path is ever
+        # rewritten to read a raw pointer.
+        values = np.arange(6.0)[::2]
+        assert not values.flags.c_contiguous
+        result = roundtrip(values)
+        assert result.tobytes() == np.array([0.0, 2.0, 4.0]).tobytes()
+        assert result.flags.c_contiguous
+
+    def test_readonly_input_is_accepted(self) -> None:
+        # The view taken on the caller's array is read-only, so a read-only
+        # input must not be rejected -- callers pass sliced or frozen grids.
+        values = np.array([1.0, 2.0])
+        values.flags.writeable = False
+        assert roundtrip(values).tobytes() == values.tobytes()
+
+    def test_result_is_a_fresh_array_that_does_not_alias_the_input(self) -> None:
+        # The point of the whole probe. The identity kernel means an equal
+        # result proves nothing on its own: a dispatch layer that returned its
+        # argument untouched would satisfy every value assertion above. A
+        # *fresh* allocation is what proves Rust ran and produced the values,
+        # and it is also the contract -- callers must be able to mutate a
+        # returned spectrum without corrupting the grid they passed in.
+        values = np.array([1.0, 2.0, 3.0])
+        result = roundtrip(values)
+
+        assert result is not values
+        assert result.base is not values
+        assert not np.shares_memory(result, values)
+
+        result[0] = 99.0
+        assert values[0] == 1.0
+
+
+class TestErrorPaths:
+    """Everything the contract rejects, and the message it rejects it with."""
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.ones((2, 2)),
+            np.ones((2, 2, 2)),
+            np.asfortranarray(np.ones((2, 2))),
+            np.ones((1, 1)),
+        ],
+        ids=["2d", "3d", "2d-fortran-order", "2d-single-element"],
+    )
+    def test_multidimensional_arrays_raise_value_error(
+        self, values: np.ndarray
+    ) -> None:
+        # Note the last case: a (1, 1) array holds exactly one value but is
+        # still 2-D, and the contract is about rank, not size.
+        with pytest.raises(ValueError, match=r"must be 0 or 1-dimensional\.$"):
+            roundtrip(values)
+
+    @pytest.mark.parametrize(
+        ("dtype", "name"),
+        [
+            (np.int64, "int64"),
+            (np.int32, "int32"),
+            (np.float32, "float32"),
+            (np.complex128, "complex128"),
+            (np.bool_, "bool"),
+        ],
+    )
+    def test_wrong_dtype_arrays_raise_value_error_naming_the_dtype(
+        self, dtype: type, name: str
+    ) -> None:
+        # PyO3 would raise TypeError when the typed view fails to extract;
+        # `map_unary` maps it to ValueError so the whole contract raises one
+        # exception type, and names the offending dtype so the message is
+        # actionable rather than merely correct.
+        with pytest.raises(ValueError) as excinfo:
+            roundtrip(np.array([1, 2], dtype=dtype))
+        assert str(excinfo.value) == dtype_error(name)
+
+    def test_rank_is_checked_before_dtype(self) -> None:
+        # An array that is both 2-D and wrong-dtype reports the dimension. The
+        # ordering is worth pinning because it is the order the checks appear
+        # in `map_unary`, and a reordering would silently change a
+        # user-visible message that this suite otherwise matches exactly.
+        with pytest.raises(ValueError) as excinfo:
+            roundtrip(np.ones((2, 2), dtype=np.int64))
+        assert str(excinfo.value) == DIMENSION_ERROR
+
+    @pytest.mark.parametrize(
+        "value",
+        ["1.0", None, 1 + 2j, {"a": 1.0}, object()],
+        ids=["str", "none", "complex", "dict", "object"],
+    )
+    def test_non_numeric_input_raises_value_error(self, value: object) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            roundtrip(value)
+        assert str(excinfo.value) == TYPE_ERROR
+
+    def test_a_python_list_is_rejected(self) -> None:
+        # The second contract/Cython divergence at this layer, and the one that
+        # is a *narrowing*: the Cython entry points call `np.array(...)` before
+        # the memoryview cast, so `dnde_photon([10.0, 20.0], 200.0)` works
+        # today. A typed PyO3 view will not take a list. Task 3.5 must either
+        # call `np.asarray` at the public boundary or declare the narrowing;
+        # this assertion pins what the scaffold does so that decision is made
+        # deliberately rather than discovered by a user.
+        with pytest.raises(ValueError) as excinfo:
+            roundtrip([1.0, 2.0])
+        assert str(excinfo.value) == TYPE_ERROR
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda: roundtrip(np.ones((2, 2))),
+            lambda: roundtrip(np.array([1, 2])),
+            lambda: roundtrip(None),
+        ],
+        ids=["dimension", "dtype", "type"],
+    )
+    def test_every_message_names_the_quantity(self, call: Callable[[], object]) -> None:
+        # `quantity` is how a ported kernel keeps its twin's wording. If it
+        # ever stops reaching the message, every Phase 04-06 kernel silently
+        # starts reporting the wrong argument name.
+        with pytest.raises(ValueError) as excinfo:
+            call()
+        assert str(excinfo.value).startswith(QUANTITY)
+
+
+class TestSignature:
+    """The advertised signature matches the one that actually works."""
+
+    def test_signature_is_introspectable_and_accepts_a_keyword(self) -> None:
+        # PyO3's `text_signature` is a *claim*; it does not constrain the call.
+        # The Cython entry points are `def` functions and accept their
+        # arguments by keyword (`dnde_photon(egam=..., emu=...)` works today),
+        # so a positional-only claim here would both misdescribe this function
+        # and, copied into a Phase 04 wrapper, narrow the public API.
+        assert str(inspect.signature(roundtrip)) == "(x)"
+        assert bits(roundtrip(x=1.5)) == bits(1.5)


### PR DESCRIPTION
## Summary

- **Adds `test/test_core_dispatch.py`** (54 tests) — pins every branch of `dispatch::map_unary` from the Python side, through the scaffold's `hazma._core.roundtrip` probe: scalar in / `float` out, 1-D array in / **fresh non-aliasing** array out, 0-d array, and the rank / dtype / type error paths with their exact messages. Written to be the **template each Phase 04–06 kernel swap copies**; the copy instructions live in the module docstring so they travel with the file. It deliberately re-pins no value against Cython — `test/parity/` does that, at bit-equality, across all 41 consumed entry points.
- **Three contract behaviors the reference prose did not state are now pinned**, all measured against the built extension before the tests were written: rank is checked *before* dtype (a 2-D int64 array reports the dimension message); a 0-d array still enforces dtype where a Python `int` does not (the 0-d path sits inside the array branch behind the typed view); and non-`float` NumPy scalars are accepted via the `extract::<f64>` arm. A Task 3.5 decision that changes any of them now turns a named test red instead of passing unnoticed.
- **One production fix, in `rust/src/lib.rs`:** `roundtrip` advertised `text_signature = "(x, /)"` while `roundtrip(x=1.5)` worked — `text_signature` is a claim PyO3 does not enforce. The Cython entry points are `def` functions that take keywords (measured: `dnde_photon(egam=100.0, emu=200.0)` → `2.0036713127483527e-05`), so a positional-only claim was a public-API narrowing waiting to be copied into every Phase 04–06 wrapper. Now `"(x)"`, which is what `hazma/_core.pyi` already described. Non-executable change; the phase file's Task 2.3 exit criteria were patched to record the widening.
- **Closes Phase 02.** Phase learnings written, phase frontmatter `status: Complete`, `PLAN.md` Phases row and both working-memory READMEs updated. `scripts/agents/resolve_task.py --project cython-to-rust` now returns Task 3.1 / phase 03.

**Numerical impact: none.** `git diff origin/master -- hazma` is empty (0 lines). The only change under `rust/` is an advertised signature string on the scaffold probe, which nothing under `hazma/` imports. Measured rather than only argued: the parity corpus ran in **bit-equality mode** — `rtol = 0` across all 41 consumed entry points, 179,695 pinned values — and passed. Phase 02 therefore closes with the public compiled surface exactly where Phase 00 left it.

## Project

`projects/cython-to-rust/` — Task 2.3: Cross-language plumbing test.

See `projects/cython-to-rust/task-notes/phase-02/task-2.3-plumbing-test.md` for implementation detail, decisions, and verification; `projects/cython-to-rust/learnings/phase-02-rust-scaffold.md` for the phase distillation.

## Test plan

- [x] Preflight, copy-paste runnable as written (review round 1 replaced a `<the 6 changed docs>` placeholder here and in the task note — a recorded command that fails on its literal argument is not evidence):

```sh
DOCS="projects/cython-to-rust/PLAN.md \
projects/cython-to-rust/phases/phase-02-rust-scaffold.md \
projects/cython-to-rust/task-notes/README.md \
projects/cython-to-rust/task-notes/phase-02/README.md \
projects/cython-to-rust/task-notes/phase-02/task-2.3-plumbing-test.md \
projects/cython-to-rust/learnings/phase-02-rust-scaffold.md \
docs/agents/lessons.md"

env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh \
    --paths "test/test_core_dispatch.py" --md "$DOCS"
```

→ **RESULT: PASS**, all eleven rows (`version bump` SKIP — not a closing PR):

```text
PASS   black --check           test/test_core_dispatch.py
PASS   isort --check-only      test/test_core_dispatch.py
PASS   ruff check              test/test_core_dispatch.py
PASS   cargo fmt --check       rust/
PASS   cargo clippy            rust/
PASS   cargo test              rust/
PASS   pytest                  1063 passed, 13 skipped, 5 warnings in 534.36s (0:08:54)
PASS   import hazma            version 2.1.0
PASS   markdownlint            <the 7 files named in $DOCS above>
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
```

- [x] 1076 collected (`pytest --collect-only -q` → `1076 tests collected`), +54 on Task 2.2's 1022 — all of them the new module. **The skip count is unchanged at 13**, which is what proves the parity suite is still in bit-equality mode: budget mode is reported as a *skip* on `test_running_on_the_capturing_tree`, so a budget-mode run would have shown 14.

- [x] The new module alone: `pytest test/test_core_dispatch.py -q` → `54 passed in 0.27s`. Per-class, verified against `--collect-only`: `TestScalarPath` 17, `TestZeroDimensionalArray` 11, `TestArrayPath` 6, `TestErrorPaths` 19, `TestSignature` 1.

- [x] **Test validity — six-mutation campaign.** Because every assertion in this module passes against unmodified code by construction, each was proven to fire by mutating the production code, rebuilding with `uv pip install -e .`, running, and reverting. Every mutation is caught, by the test whose name claims it:

| Mutation | Result |
| --- | --- |
| `text_signature` back to `"(x, /)"` | 1 failed — `TestSignature` |
| array path returns the input object instead of a fresh array | 2 failed — `test_result_is_a_fresh_array_that_does_not_alias_the_input`, `test_non_contiguous_input_is_read_in_order` |
| dtype checked before rank | 6 failed — all four rank cases, `test_rank_is_checked_before_dtype`, the dimension quantity-prefix case |
| `{quantity}` dropped from the dimension message | 2 failed — `test_rank_is_checked_before_dtype`, quantity-prefix `[dimension]` |
| 0-d array rejected instead of taking the scalar path | 10 failed — all of `TestZeroDimensionalArray`'s float cases |
| array path reads the raw buffer instead of the view | 1 failed — `test_non_contiguous_input_is_read_in_order` |

- [x] Rebuild discipline: the tree was cleaned (40 stale `.c`/`.so`, none of them `_core.abi3.so`) and rebuilt with `uv pip install -e .` before anything was run, and rebuilt again after the `lib.rs` edit — `cargo build` publishes nothing to Python. Confirmed each time: `python -c "import hazma._core; print(hazma._core.__file__)"` → `<worktree>/hazma/_core.abi3.so`, 21 `.so` in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
