### PR TITLE
feat(utils): port the cython constant tables to rust

### DIFF
--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -291,3 +291,21 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   skips survive" while enumerating five sites, and the task note
   attributed 13 skipped tests to 5 sites plus a `skipif` that never
   fired; the true split was 5 sites → 13 tests as 5 + 5 + 3).
+- [hand-written-population-in-a-derived-check] A count can be *measured*
+  with a real command and still be wrong, because the command was run
+  against a hand-written list of what to measure rather than against the
+  population enumerated from source. Derive the population with the same
+  `rg`/parse step that produces the values, so the check cannot silently
+  under-enumerate; a pairing table typed by hand is the population, and
+  it is exactly as trustworthy as typing. The failure hides when the
+  wrong answer collides with a different, correct number nearby (PR #58:
+  "all twelve masses in `constants.pxd` are bit-equal to
+  `hazma/parameters.py`'s" was checked by a script — over a
+  hand-written 12-pair list that omitted `MASS_KL` and `MASS_KS`. There
+  are 14. Twelve was also the correct count of spectra extensions that
+  `include` the header, two paragraphs up, so every internal
+  cross-check agreed). Distinct from [derived-count-not-rederived],
+  where no derivation happened, and from
+  [measurement-taken-before-the-task-ended], where a correct derivation
+  expired: here the derivation ran, on the final tree, over the wrong
+  domain.

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -347,10 +347,13 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   `_utils/constants.pxd` `1/137.035999084` (a pre-CODATA-2022 value —
   CODATA 2022 is 137.035999177(21), arXiv:2409.03787),
   `_utils/legacy_parameters.pxd` `1/137`, and `hazma/parameters.py:205`
-  `1/137.04`. The masses, by contrast, agree: all twelve in
+  `1/137.04`. The masses, by contrast, agree: all **fourteen** in
   `constants.pxd` are bit-equal to their `parameters.py` counterparts
-  (checked). The third α is pure Python and outside this project's
-  scope, but any future table-merge follow-up has to account for it.
+  (checked; `MASS_K0`/`MASS_KL`/`MASS_KS` share one value, so the
+  correspondence is 14 names onto 12 distinct numbers — see
+  [phase-03/README.md](phase-03/README.md) for why that count is a
+  trap). The third α is pure Python and outside this project's scope,
+  but any future table-merge follow-up has to account for it.
 - **One `.pyx` reads from *both* constant tables, and the port had to
   find that out rather than be told** (Task 3.1).
   `hazma/spectra/_photon/_pion.pyx` `include`s `constants.pxd`, so its

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -24,7 +24,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | **Complete (2026-08-06)** — all five tasks done; [learnings](../learnings/phase-00-dead-code-purge.md) |
 | 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | **Complete (2026-08-08)** — all four tasks done; [learnings](../learnings/phase-01-parity-corpus.md) |
 | 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | **Complete (2026-08-09)** — all three tasks done; [learnings](../learnings/phase-02-rust-scaffold.md) |
-| 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | Not started |
+| 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | In Progress — 3.1 done (2026-08-09), 3.2–3.5 open |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | Not started |
 | 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | Not started |
@@ -311,6 +311,79 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   public-API narrowing waiting to be copied into every Phase 04–06
   wrapper. Fixed to `"(x)"` — the same thing `hazma/_core.pyi` already
   described.
+- **A fresh env drops the parity corpus out of bit-equality mode, and
+  the cause is a NumPy patch release** (Task 3.1). `uv pip install -e .`
+  on a new venv resolved NumPy **2.5.2**; the corpus manifest records
+  **2.5.1**, and `tolerances.provenance` compares the whole numerics
+  environment, not just the kernel digest and the served-kernel
+  predicate. Result: `exact: False`, detail `numpy '2.5.1' -> '2.5.2'`,
+  the budgets in force, and a bare suite reporting **14 skipped instead
+  of 13** — the corpus's own signal working exactly as Task 2.3
+  documented, but it costs a re-run if you notice it only at the end.
+  **Build the env with `numpy==2.5.1` pinned**, and rebuild
+  `--no-build-isolation` so the extensions compile against the same
+  headers:
+
+  ```sh
+  uv pip install --python .venv/bin/python "numpy==2.5.1" setuptools \
+      wheel "cython==3.2.9" setuptools-rust
+  uv pip install --python .venv/bin/python -e . --no-build-isolation
+  ```
+
+  Check before trusting any parity claim, in one second and without
+  running the suite:
+
+  ```sh
+  python -c "import json,sys; sys.path.insert(0,'test/parity'); \
+  import tolerances; \
+  print(tolerances.provenance(json.load(open('test/parity/data/manifest.json'))))"
+  ```
+
+  The digest and the served-kernel predicate were both clean here — it
+  was purely the dependency. This will recur for every Phase 03–06 task
+  that builds a fresh env, and it will recur harder as NumPy and SciPy
+  move on.
+- **Hazma holds three fine-structure constants** (Task 3.1):
+  `_utils/constants.pxd` `1/137.035999084` (a pre-CODATA-2022 value —
+  CODATA 2022 is 137.035999177(21), arXiv:2409.03787),
+  `_utils/legacy_parameters.pxd` `1/137`, and `hazma/parameters.py:205`
+  `1/137.04`. The masses, by contrast, agree: all twelve in
+  `constants.pxd` are bit-equal to their `parameters.py` counterparts
+  (checked). The third α is pure Python and outside this project's
+  scope, but any future table-merge follow-up has to account for it.
+- **One `.pyx` reads from *both* constant tables, and the port had to
+  find that out rather than be told** (Task 3.1).
+  `hazma/spectra/_photon/_pion.pyx` `include`s `constants.pxd`, so its
+  `MPI` / `ME` / `MMU` aliases are PDG values — but its five hard-coded
+  kinematic literals (`ENG_MU_PIRF`, `GAMMA_MU_PIRF`, `BETA_MU_PIRF`,
+  `ENG_GAM_MAX_MURF`, `ENG_GAM_MAX_PIRG`) reproduce **bit-exactly** from
+  `legacy_parameters.pxd`'s masses and from no other table — someone
+  evaluated the formulas once, against the older header, and pasted the
+  digits. Recomputing them from the header the file actually includes
+  moves `ENG_MU_PIRF` by 4.7e-5 MeV and every charged-pion photon
+  spectrum with it. The divergence recorded in
+  `../references/cython-inventory.md` §Bugs 3 was between two *files*;
+  this one is inside a single module, so "which header does this
+  extension include" is not enough to answer "which masses does it use".
+  **Phase 04 must not consolidate it**; `constants::derived::photon_pion`
+  carries both halves with the reasoning, and two tests in each language
+  fail if either half moves.
+- **A per-file bit-equality check cannot catch a consolidation**
+  (Task 3.1). Adopting one table's masses in the other passes every
+  file-by-file comparison — each side still matches *some* source. What
+  catches it is a literal roster of the 19 names the two `.pxd` share
+  and the 12 they disagree on, asserted as a partition
+  (`test_the_two_tables_diverge_on_exactly_the_recorded_names`). A
+  computed partition would have accepted any partition, which is the
+  general shape: rule 4's content is that a specific split does not move,
+  so the test has to name it.
+- **`R_FACTOR`'s Cython comment has an exponent typo** (Task 3.1). Both
+  muon kernels annotate the literal `1.0001870858234163` with a
+  `12 r^2 ln(r^2)` log term; only `r^4` reproduces the digits. The number
+  is right, the comment is wrong, and the `.pyx` is left untouched — but
+  a Phase 04 port that recomputes from the comment instead of copying the
+  number lands 0.3% away — `0.9972020119096803` against
+  `1.0001870858234163`. Pinned in `test_core_constants.py`.
 - **A worktree can inherit `.so` files whose source package is gone**
   (Task 1.1): this tree carried `_gamma_ray/` and `_phase_space/`
   extensions deleted in Task 0.2, giving 25 `.so` against `setup.py`'s
@@ -496,6 +569,26 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   change under `hazma/` across all three tasks is the non-executable
   `hazma/_core.pyi` stub.
 
+- **Task 3.1, 2026-08-09 (constants module): no public value changes**
+  (verified: `git diff origin/master -- hazma` is empty — 0 lines, on a
+  tree cleaned and rebuilt before anything was run). The diff is one new
+  Rust module that no Python imports and no Rust kernel calls, the
+  `pub mod` line that admits it, one new test module, and project
+  bookkeeping; no library module, kernel, signature, constant or build
+  *input* under `hazma/` is reachable from it. Measured rather than only
+  argued: the bare suite ran the parity corpus in **bit-equality mode** —
+  `rtol = 0` across all 41 consumed entry points, 179,695 pinned values —
+  and passed, at `1088 passed, 13 skipped` (+25 on Phase 02's 1063, all
+  of them the new module; the skip count is unchanged, which is what
+  proves the mode). What the task *did* produce is 224 constants that now
+  exist in two places at once, and the argument that the second copy is
+  bit-for-bit the first: 25 Python tests comparing source to source, five
+  `cargo test` units, and a thirteen-mutation validity campaign. **Every
+  Phase 04–06 drift line below this one is measured against Rust kernels
+  reading these tables**, so a wrong value here would surface as a kernel
+  bug rather than a constants bug — which is the whole reason the task
+  refuses to trust its own transcription.
+
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
 it from memory.)
@@ -513,6 +606,14 @@ it from memory.)
   `.pyx` cimport their `__pyx_capi__` symbols — recorded in the
   Phase 04 file's Goal block.
 - Constants bit-parity before consolidation → `../rules.md` rule 4.
+  **Implemented in Task 3.1** as three namespaces mapped to sources:
+  `constants::pdg` ← `_utils/constants.pxd` (151), `constants::legacy` ←
+  `_utils/legacy_parameters.pxd` (48), `constants::derived::<source_pyx>`
+  ← the module-local `DEF`s of the five `.pyx` that declare any (25).
+  Every module-local `DEF` is carried, aliases included, so the coverage
+  check can rescan the tree rather than trust a transcribed list; the
+  module is `pub` in `lib.rs` where its neighbours are private, because
+  224 unread `const`s in a private module is a wall of `dead_code`.
 - **Plan-review round 1 (2026-08-03)** forced four canonical changes:
   (1) `version_bump` → `major` (Phase 00 deletes
   `hazma/deprecated/rambo.py`; any `deprecated/` removal is `major`
@@ -672,10 +773,28 @@ it from memory.)
   Phases row updated. Nothing under `hazma/`. Full list in
   [phase-02/README.md](phase-02/README.md).
 
+### Phase 03
+
+- **Task 3.1** — new `rust/src/constants.rs` (224 `pub const`s in
+  `pdg` / `legacy` / `derived::*`, a `# Sources` provenance header, and
+  five unit tests); `pub mod constants;` plus its rationale paragraph in
+  `rust/src/lib.rs`; new `test/test_core_constants.py` (25 tests). No
+  canonical patch — the phase file's three Task 3.1 criteria are
+  satisfied as written. Nothing under `hazma/`. Full list in
+  [phase-03/README.md](phase-03/README.md).
+
 ## Verification
 
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
+- **Phase 03 Task 3.1 state (2026-08-09):** bare `pytest -q` →
+  `1088 passed, 13 skipped` on the capturing environment, parity suite
+  included and in bit-equality mode;
+  `pytest test/test_core_constants.py -q` → `25 passed in 0.03s`;
+  `cargo test --no-default-features` → `7 passed` (5 new), clippy and
+  fmt clean; `scripts/agents/preflight.sh` RESULT: PASS. Thirteen
+  mutations — nine Python, four Rust — each caught by the test whose
+  name claimed it (table in the task note).
 - Per-phase Verification sections live in `phase-XX/README.md`.
 - **Phase 02 closing state (2026-08-09):** bare `pytest -q` →
   `1063 passed, 13 skipped` on the capturing environment (1076
@@ -818,8 +937,24 @@ it from memory.)
   and
   [`../learnings/phase-02-rust-scaffold.md`](../learnings/phase-02-rust-scaffold.md)
   rather than their twelve task notes — the learnings are the
-  distillation, the notes are history. **The next task is Phase 03,
-  Task 3.1.** No phase carries a decision gate.
+  distillation, the notes are history. **Phase 03 is in progress:
+  Task 3.1 landed 2026-08-09, so the next task is 3.2, 3.3 or 3.5 (all
+  dependency-free) or 3.4 (unblocked by 3.1).** No phase carries a
+  decision gate.
+- **`hazma_core::constants` exists and is bit-equal to the Cython**
+  (Task 3.1). `constants::pdg` is `hazma/_utils/constants.pxd` (151
+  values), `constants::legacy` is `hazma/_utils/legacy_parameters.pxd`
+  (48), and `constants::derived::<source_pyx>` holds the module-local
+  `DEF`s of the five `.pyx` that declare any (25). When porting a
+  kernel, name the table its `.pyx` `include`s — `pdg` for everything
+  under `hazma/spectra/**`, `legacy` for the four mediator spectrum
+  extensions — **except** `derived::photon_pion`, which legitimately
+  reads both (see Findings). Two gates hold this:
+  `test/test_core_constants.py` (25 tests, 0.03s, needs no build, runs
+  on every platform) compares the Rust and Cython *sources* bit-for-bit,
+  and five `cargo test` units check the compiled side. Both die with the
+  Cython, and each says in its own text what to delete when a `.pyx`
+  goes.
 - **`test/test_core_dispatch.py` is the template every Phase 04–06 kernel
   swap copies** (Task 2.3; 54 tests, 0.27s, platform-independent). It
   pins every branch of `dispatch::map_unary` through

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 03
-**Status:** Not started
+**Status:** In Progress (Task 3.1 complete 2026-08-09)
 **Plan References:** `../../phases/phase-03-numerics-foundation.md`
 **Related ADRs:** ADR-0002 (Accepted 2026-08-04 — governs the
 provenance of Tasks 3.2/3.3, no longer gates them)
@@ -18,7 +18,7 @@ foundation.
 
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
-| 3.1 | Constants module | — | Not started | [task-3.1-constants.md](task-3.1-constants.md) |
+| 3.1 | Constants module | — | **Complete (2026-08-09)** | [task-3.1-constants.md](task-3.1-constants.md) |
 | 3.2 | Special functions | — (ADR-0002 accepted) | Not started | [task-3.2-specfun.md](task-3.2-specfun.md) |
 | 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | — (ADR-0002 accepted) | Not started | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
 | 3.4 | Interpolation + boost kernels | 3.1 | Not started | [task-3.4-interp-boost.md](task-3.4-interp-boost.md) |
@@ -36,25 +36,90 @@ foundation.
 
 ## Findings
 
-_None yet._
+- **`hazma/spectra/_photon/_pion.pyx` reads from both constant tables at
+  once** (Task 3.1). It `include`s `constants.pxd`, so its `MPI` / `ME` /
+  `MMU` aliases are PDG values — but its five hard-coded kinematic
+  literals (`ENG_MU_PIRF`, `GAMMA_MU_PIRF`, `BETA_MU_PIRF`,
+  `ENG_GAM_MAX_MURF`, `ENG_GAM_MAX_PIRG`) reproduce **bit-exactly** from
+  the *legacy* masses and from no other table. Recomputing them from the
+  header the file includes moves `ENG_MU_PIRF` by 4.7e-5 MeV and every
+  charged-pion photon spectrum with it. Preserved as-is per rule 4 and
+  pinned in both languages; **Phase 04 must not consolidate it.**
+- **The two `.pxd` share 19 names and disagree on 12** (Task 3.1): ten
+  masses plus `ALPHA_EM` and `RATIO_E_MU_MASS_SQ`. The seven that agree
+  are the form factors and decay constants. The partition is a literal
+  roster in `test/test_core_constants.py`, so a silent consolidation
+  fails there even though every file-by-file bit-equality check would
+  still pass.
+- **`R_FACTOR`'s Cython comment has an exponent typo** (Task 3.1): both
+  muon kernels annotate `1.0001870858234163` with a `12 r^2 ln(r^2)` log
+  term, but only `r^4` reproduces the digits. The number is right and
+  the comment is wrong; the `.pyx` is left untouched and the correct
+  formula is pinned in the test.
+- **Pin `numpy==2.5.1` when building an env for this phase** (Task 3.1).
+  A fresh `uv pip install -e .` resolves 2.5.2, which puts the parity
+  corpus into budget mode (`exact: False`, detail
+  `numpy '2.5.1' -> '2.5.2'`) and turns the bare suite's skip count from
+  13 into 14. The kernel digest and the served-kernel predicate were both
+  clean — it is purely the dependency. Recipe and the one-second
+  provenance check are in [../README.md](../README.md) under Findings.
+- **`clippy::excessive_precision` is on by default** (Task 3.1) and fires
+  on any literal transcribed verbatim with trailing significant zeros
+  (`0.9998770`). `constants.rs` carries a module-level `allow` with the
+  reason. Later verbatim transcriptions in this phase will hit the same
+  lint.
 
 ## Decisions and Implementation Notes
 
-_None yet._
+- **Three namespaces, mapped to sources** (Task 3.1):
+  `constants::pdg` ← `hazma/_utils/constants.pxd` (151 values),
+  `constants::legacy` ← `hazma/_utils/legacy_parameters.pxd` (48), and
+  `constants::derived::<source_pyx>` ← the module-local `DEF`s of the
+  five `.pyx` that declare any (25). A Phase 04 kernel names the table
+  its `.pyx` `include`s.
+- **Every module-local `DEF` is carried, including pure aliases**
+  (Task 3.1), which is what lets the coverage check rescan the tree and
+  be total rather than a transcribed list.
+- **`pub mod constants;` while its neighbours in `lib.rs` are private**
+  (Task 3.1) — nothing reads the tables yet and a private module of 224
+  unread `const`s is a wall of `dead_code` under `-D warnings`.
+- **The bit-equality gate parses text on both sides** (Task 3.1) rather
+  than importing `hazma._core`: no build, 0.03s, platform-independent,
+  and sound because both CPython and rustc parse decimal literals
+  correctly-rounded. The compiled side is covered by five `cargo test`
+  units in `constants.rs`.
 
 ## Files Changed
 
-_None yet — phase not started._
+### Task 3.1
+
+- `rust/src/constants.rs` — **new**, 224 `pub const`s in three
+  namespaces plus five unit tests and a `# Sources` provenance header.
+- `rust/src/lib.rs` — `pub mod constants;` and the paragraph on why.
+- `test/test_core_constants.py` — **new**, 25 tests.
 
 ## Verification
 
-- `cargo test` (foundation units); scipy-comparison pytest suite green
-  in CI.
+- **Task 3.1 (2026-08-09):**
+  `pytest test/test_core_constants.py -q` → `25 passed in 0.03s`;
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features` →
+  `7 passed` (5 new); clippy and fmt clean; bare `pytest -q` →
+  `1088 passed, 13 skipped` with the parity corpus in bit-equality mode
+  (skip count unchanged at 13). Thirteen mutations, each caught by the
+  test whose name claims it — table in the task note.
+- Remaining tasks: `cargo test` (foundation units); scipy-comparison
+  pytest suite green in CI.
 
 ## Open Questions
 
 - `spec_math::li2` convention vs `scipy.special.spence` — Task 3.2
   resolves.
+- **Which PDG edition each `constants.pxd` value came from is recorded
+  nowhere** (Task 3.1). The `± uncertainty` annotations are the only
+  provenance; some entries predate the current edition (α⁻¹ is
+  pre-CODATA-2022). `constants.rs` cites the PDG review index for the
+  tables rather than claiming an edition per value. Not blocking, and
+  not to be resolved by re-sourcing values — rule 4 forbids that.
 
 ## Plan Impact
 
@@ -68,8 +133,25 @@ phase is unblocked — ADR-0002 was accepted 2026-08-04 — but 3.2/3.3
 must honor its provenance rule: cephes lineage and netlib QUADPACK
 only, nothing GSL-derived in the tree or the dependency graph.
 
-**Currently safe to assume:** every live integral is finite-interval —
-`qagi` is out of scope.
+**Currently safe to assume:**
 
-**Currently risky / unknown:** `qelg` Fortran→Rust translation is the
-fiddliest item in the project; budget review time accordingly.
+- Every live integral is finite-interval — `qagi` is out of scope.
+- **Task 3.1 is done, so `hazma_core::constants` exists and Task 3.4 is
+  unblocked.** `constants::{pdg, legacy}` are the two Cython tables and
+  `constants::derived::<source_pyx>` the module-local `DEF`s, all
+  bit-equal to the Cython and held there by
+  `test/test_core_constants.py` (25 tests, 0.03s, platform-independent)
+  and five `cargo test` units. Name the table the `.pyx` you are porting
+  `include`s: `pdg` for everything under `hazma/spectra/**`, `legacy`
+  for the four mediator spectrum extensions.
+
+**Currently risky / unknown:**
+
+- `qelg` Fortran→Rust translation is the fiddliest item in the project;
+  budget review time accordingly.
+- **`derived::photon_pion` deliberately mixes both tables** — PDG
+  aliases, legacy-frozen literals. Read that module's doc comment before
+  touching the charged-pion photon kernel in Phase 04.
+- `derived::positron_pion::ENG_MU_PI_RF` and
+  `derived::photon_pion::ENG_MU_PIRF` are the same physical quantity,
+  different numbers, one underscore apart.

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -56,6 +56,20 @@ foundation.
   term, but only `r^4` reproduces the digits. The number is right and
   the comment is wrong; the `.pyx` is left untouched and the correct
   formula is pinned in the test.
+- **Two different twelves live in this phase's docs, and conflating them
+  cost a review round** (Task 3.1, PR #58). `constants.pxd` is `include`d
+  by **12 spectra extensions** and declares **14 masses** — but only 12
+  *distinct* mass values, since `MASS_K0` / `MASS_KL` / `MASS_KS` all
+  carry 497.611. The task note first claimed "all twelve masses are
+  bit-equal to `hazma/parameters.py`'s"; the check behind that claim ran
+  a real script over a hand-typed 12-pair list that omitted `MASS_KL`
+  and `MASS_KS`, and the wrong answer matched the (correct) extension
+  count two paragraphs away, so nothing looked inconsistent. All 14 do
+  agree — re-derived by enumerating `^DEF MASS_` from the header and
+  matching on bit pattern rather than on a typed name pairing. **Any
+  count in this phase gets its population enumerated from source**, not
+  from a list someone wrote out; see
+  `docs/agents/lessons.md` `[hand-written-population-in-a-derived-check]`.
 - **Pin `numpy==2.5.1` when building an env for this phase** (Task 3.1).
   A fresh `uv pip install -e .` resolves 2.5.2, which puts the parity
   corpus into budget mode (`exact: False`, detail

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md
@@ -95,7 +95,7 @@ From the phase file, verbatim:
   revised α⁻¹ to 137.035999177(21) (arXiv:2409.03787, cross-checked
   against NIST). `legacy_parameters.pxd` has `1/137`.
   `hazma/parameters.py:205` has a third, `1/137.04`. By contrast **every
-  one of the twelve masses in `constants.pxd` is bit-equal to its
+  one of the fourteen masses in `constants.pxd` is bit-equal to its
   `hazma/parameters.py` counterpart** (checked, not assumed). All three
   αs are kept; the third is pure Python and outside this project's scope
   entirely, but it belongs in the same conversation as the table merge.
@@ -279,6 +279,30 @@ Four against the Rust unit tests, same method:
 
 Nothing deferred.
 
+### Review round 1 (PR #58)
+
+- **Blocking, accepted:** the mass count was wrong in five places — the
+  `constants.rs` header, this note twice, the working memory, and the PR
+  body all said "twelve". `constants.pxd` declares **fourteen** `MASS_*`,
+  and all fourteen are bit-equal to `hazma/parameters.py`'s. The original
+  check *ran*, but over a hand-typed 12-pair list that silently omitted
+  `MASS_KL` and `MASS_KS`; the wrong answer then agreed with the correct
+  count of twelve `include`-ing spectra extensions two paragraphs above,
+  so every internal cross-check looked consistent. Re-derived by
+  enumerating `^DEF MASS_` from the header and matching on bit pattern
+  instead of on typed names. New class in `docs/agents/lessons.md`:
+  `[hand-written-population-in-a-derived-check]`.
+- **Non-blocking, accepted:** `cargo doc` gained a fourth warning,
+  `redundant explicit link target` at `constants.rs:589` —
+  `[`photon_pion::ENG_MU_PIRF`](photon_pion::ENG_MU_PIRF)` where the
+  label already resolves. Simplified to `[`photon_pion::ENG_MU_PIRF`]`;
+  `cargo doc` is back to the three pre-existing `links to private item`
+  warnings in `lib.rs`. **This one was mine to have caught**: the
+  verification above grepped `^warning: unresolved`, which is a subset of
+  the warnings `cargo doc` emits, so "0 unresolved intra-doc links" was
+  true and yet read as "clean". The grep is now `^warning` with a
+  by-category count.
+
 ## Numerical Impact
 
 **No public value changes** (verified: `git diff origin/master -- hazma`
@@ -394,11 +418,20 @@ per module: pdg 151, legacy 48, photon_pion 8, photon_rho 3,
 19 shared names: 12 divergent, 7 identical
 13 WIDTH_* in pdg, 0 in legacy
 12 .pyx include ../../_utils/constants.pxd; 4 include legacy_parameters.pxd
-all 12 pdg masses bit-equal to hazma/parameters.py; ALPHA_EM is not
+14 MASS_* in constants.pxd, all bit-equal to hazma/parameters.py
+            (K0/KL/KS share 497.611 -> 14 names, 12 distinct values);
+            ALPHA_EM is not
 
-$ cargo doc --manifest-path rust/Cargo.toml --no-deps --no-default-features
-0 unresolved intra-doc links (3 pre-existing "links to private item"
- warnings in lib.rs, unchanged by this diff)
+$ cargo doc --no-deps --no-default-features 2>&1 | grep -E '^warning' \
+    | sort | uniq -c
+   1 warning: `hazma-core` (lib doc) generated 3 warnings
+   1 warning: public documentation for `_core` links to private item `dispatch`
+   2 warning: public documentation for `_core` links to private item `kernels`
+(all three pre-existing in lib.rs and untouched by this diff. Counting by
+ category, not grepping for one phrase -- the first pass here grepped
+ '^warning: unresolved' and so reported "0 unresolved links" while this
+ diff had in fact added a `redundant explicit link target`. Review round 1
+ caught it.)
 ```
 
 **Numerical-impact statement:** No public value changes (verified:

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md
@@ -1,0 +1,447 @@
+# Task 3.1: Constants module
+
+**Date:** 2026-08-09
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-03-numerics-foundation.md` (Task 3.1);
+`../../rules.md` rule 4 (Constants 1), rules 6–8 (Rust conventions 1–3)
+**Related ADRs:** none
+**Depends On:** Phase 02 complete
+
+## Objective
+
+Give the Rust crate the constant tables every later kernel port stands
+on: both of hazma's divergent Cython tables, in two namespaces that keep
+the divergence verbatim, plus the module-local `DEF`s individual `.pyx`
+files declare — with the transcription checked by machine rather than by
+reading.
+
+## Exit Criteria
+
+From the phase file, verbatim:
+
+- `rust/src/constants.rs` carries every `DEF` from `_utils/constants.pxd`
+  and every value from `_utils/legacy_parameters.pxd`, in **two distinct
+  namespaces** preserving the known divergences verbatim (rules.md
+  rule 4).
+- A test extracts values from the `.pxd` sources (script or generated
+  fixture) and asserts bit-equality — no hand-transcription trust.
+- Derived module-local `DEF`s (e.g. `eng_mu_pi_rf`) become `const fn` or
+  literal consts with the same float semantics.
+
+## Inputs Reviewed
+
+- `../../PLAN.md` (all sections, incl. Numerical impact);
+  `../README.md`; `../../rules.md`; the phase file's Task 3.1 block.
+- `hazma/_utils/constants.pxd` (151 `DEF`s) and
+  `hazma/_utils/legacy_parameters.pxd` (48 `cdef double`s), in full.
+- Every `.pyx` under `hazma/` carrying module-local `DEF`s — five files,
+  found by `rg -n '^\s*DEF\s' hazma/` rather than from the inventory.
+- `rust/src/{lib,kernels,dispatch}.rs` for the crate's layering and
+  doc-comment conventions; `test/parity/cases.py` for the `REPO_ROOT`
+  idiom.
+- `docs/agents/lessons.md`, `docs/agents/environment.md`.
+- External, for the module header's `# Sources` block: the PDG constants
+  review index
+  (<https://pdg.lbl.gov/2025/reviews/constants_atomic_and_related.html>);
+  CODATA 2022, Mohr, Newell, Taylor & Tiesinga,
+  [arXiv:2409.03787](https://arxiv.org/abs/2409.03787), cross-checked
+  against NIST's current α⁻¹ = 137.035999177(21)
+  (<https://physics.nist.gov/cgi-bin/cuu/Value?alphinv>).
+
+## Findings
+
+- **The two tables share 19 names and disagree on 12 of them.** Ten
+  masses (`MASS_E`, `MASS_MU`, `MASS_PI0`, `MASS_PI`, `MASS_K0`,
+  `MASS_K`, `MASS_ETA`, `MASS_ETAP`, `MASS_RHO`, `MASS_OMEGA`) plus
+  `ALPHA_EM` and the derived `RATIO_E_MU_MASS_SQ`. The seven that agree
+  are the form factors and decay constants (`F_A_PI`, `F_V_PI`,
+  `F_V_PI_SLOPE`, `F_A_K`, `F_V_K`, `DECAY_CONST_PI`, `DECAY_CONST_K`).
+  That partition is now a literal roster in
+  `test/test_core_constants.py`, because rule 4's whole content is that
+  it does not move — a computed partition would accept any partition.
+- **`hazma/spectra/_photon/_pion.pyx` mixes the two tables inside one
+  module, and nothing said so before now.** It `include`s
+  `constants.pxd`, so its `MPI` / `ME` / `MMU` aliases are PDG values —
+  but its five hard-coded kinematic literals reproduce **bit-exactly**
+  from the *legacy* masses and from no other table:
+
+  | `DEF` | Formula (legacy masses) |
+  | --- | --- |
+  | `ENG_MU_PIRF` | `0.5 (mπ² + mμ²) / mπ` |
+  | `GAMMA_MU_PIRF` | `ENG_MU_PIRF / mμ` |
+  | `BETA_MU_PIRF` | `sqrt(1 − 1/γ²)` |
+  | `ENG_GAM_MAX_MURF` | `(mμ² − mₑ²) / (2 mμ)` |
+  | `ENG_GAM_MAX_PIRG` | `ENG_GAM_MAX_MURF · γ (1 + β)` |
+
+  Recomputing them from the header the file actually includes moves
+  `ENG_MU_PIRF` by 4.7e-5 MeV and every charged-pion photon spectrum
+  with it. **Phase 04 must not tidy this up.** Both halves of the mix
+  are pinned, in Python and in Rust.
+- **`R_FACTOR`'s comment has an exponent typo.** Both muon kernels
+  (`spectra/_positron/_muon.pyx:14`, `spectra/_neutrino/_muon.pyx:22`)
+  annotate the literal `1.0001870858234163` as
+  `1 / (1 - 8 r^2 + 8 r^6 - r^8 - 12 r^2 ln(r^2))`. Only `r^4` on the
+  log term reproduces the digits: the commented form evaluates to
+  `0.9972020119096803`, 3.0e-3 relative from the published
+  `1.0001870858234163`, so the number settles it. Unlike the
+  `_photon/_pion.pyx` literals this one is frozen against the **PDG**
+  table, so it agrees with the `R` beside it. Pinned both ways; the
+  Cython comment is left alone (untouched file, and the number is
+  unambiguous).
+- **Hazma holds three different fine-structure constants, and only the
+  masses agree with themselves.** `constants.pxd` has
+  `1/137.035999084(21)` — a pre-2022 CODATA adjustment; CODATA 2022
+  revised α⁻¹ to 137.035999177(21) (arXiv:2409.03787, cross-checked
+  against NIST). `legacy_parameters.pxd` has `1/137`.
+  `hazma/parameters.py:205` has a third, `1/137.04`. By contrast **every
+  one of the twelve masses in `constants.pxd` is bit-equal to its
+  `hazma/parameters.py` counterpart** (checked, not assumed). All three
+  αs are kept; the third is pure Python and outside this project's scope
+  entirely, but it belongs in the same conversation as the table merge.
+- **`constants.pxd` is `include`d by twelve spectra extensions, not
+  eleven** — counted at execution time
+  (`rg -c 'include "../../_utils/constants.pxd"' -g '*.pyx' hazma`),
+  because the header's own summary sentence is the sort of number that
+  goes stale as Phases 04-06 delete files.
+- **`clippy::excessive_precision` is on by default and fires on verbatim
+  transcription.** Trailing zeros the `.pxd` writes for significant
+  figures (`0.9998770`, `0.0023900`, `1.760e-2`) are digits clippy wants
+  dropped. Dropping them would break character-for-character diffability
+  against the Cython without changing one f64, so the module carries
+  `#![allow(clippy::excessive_precision)]` with that reason stated.
+- **A fresh env silently puts the parity corpus into budget mode, over a
+  NumPy patch release.** The first bare-suite run on this branch came
+  back `1087 passed, 14 skipped` — 14, where Phase 02 closed at 13, and
+  the working memory records an unchanged 13 as the tell that the corpus
+  is in bit-equality mode. It was not this task's diff:
+  `tolerances.provenance` compares the whole numerics environment, and
+  `uv pip install -e .` had resolved NumPy **2.5.2** against the
+  manifest's **2.5.1** (`exact: False`, detail
+  `numpy '2.5.1' -> '2.5.2'`). The kernel digest was identical
+  (`f5e6e269be47`) and `cases.rust_core_kernels()` was empty, so both
+  port-specific predicates were clean. Pinning `numpy==2.5.1` and
+  rebuilding `--no-build-isolation` restored `exact: True`, and the
+  numbers reported below are from that tree. Recipe and a one-second
+  provenance check are now in `../README.md` — **this will recur for
+  every Phase 03–06 task that builds a fresh env.**
+- **The `.pyx` `DEF`s only ever reference the PDG header.** All five
+  files with module-local `DEF`s `include` `constants.pxd`; the four
+  mediator extensions that `include` the legacy header declare no `DEF`s
+  of their own. Asserted, not assumed
+  (`test_every_derived_pyx_includes_the_table_it_is_scored_against`).
+
+## Decisions and Implementation Notes
+
+- **Namespaces are `pdg` and `legacy`**, mapped to the two `.pxd` in the
+  module header rather than named for the files (`constants::constants`
+  would have been the alternative). A third namespace, `derived`, holds
+  the module-local `DEF`s in one submodule per source `.pyx`
+  (`derived::photon_pion`, …), so a Phase 04 port has one place to look
+  and the coverage check can be total.
+- **Every module-local `DEF` is carried, not only the derived ones.**
+  The exit criterion asks for the derived ones; including the pure
+  aliases (`MPI = MASS_PI`) costs three lines per module and buys a
+  *total* coverage assertion —
+  `test_no_pyx_declares_constants_this_module_ignores` rescans the tree
+  and fails if any `.pyx` grows or loses a `DEF`. For
+  `derived::photon_pion` it is the point: PDG aliases and legacy
+  literals sit side by side, which is the documentation Phase 04 needs.
+- **Hard-coded `DEF`s stay literals; computed ones become `const`
+  expressions** in the same association order as the Cython. That is
+  both what the sources have and what Rust allows — `sqrt` and `ln` are
+  not `const`, so the six frozen literals could not be expressions even
+  if we wanted them to be. `const fn` was not needed: nothing here takes
+  an argument.
+- **The test compares source text to source text, and says so.** It
+  parses the `.pxd`, the `.pyx` and `constants.rs`, evaluates all three
+  through one restricted AST evaluator, and compares IEEE payloads. Both
+  CPython's `float()` and rustc's literal parsing are correctly rounded,
+  so this is a sound bit-equality claim about what the two files
+  *denote*. It deliberately does **not** import `hazma._core`: it needs
+  no build, runs in 0.03s, and holds on every platform — unlike the
+  parity corpus. The compiled side is `cargo test`'s job, and
+  `rust/src/constants.rs` carries five unit tests that recheck the
+  derived values against runtime arithmetic and pin both tables' split.
+- **Rust name resolution is reimplemented, `use` parsing is not.** The
+  parser resolves `pdg::MASS_E` from inside `derived::positron_muon` by
+  walking outward from the current module, exactly as Rust does. That
+  keeps the Rust source idiomatic (short qualified paths that show
+  provenance at the point of use) without the test needing to understand
+  `use`.
+- **`pub mod constants;` in `lib.rs`, where its neighbours are private.**
+  Nothing in the crate reads the tables yet, and a private module of
+  ~220 unread `const`s is a wall of `dead_code` under `-D warnings`. The
+  reason is recorded in `lib.rs`'s header alongside the existing
+  layering note.
+- **The 199 `.pxd` literals were transcribed by a throwaway script**
+  (`.pxd` → `pub const`, comments carried through) rather than retyped.
+  The script is not committed: it is worth nothing after one run, and
+  the permanent guarantee is the test, which is independent of how the
+  file was produced.
+- **`test/test_core_constants.py` is dated by construction and says so.**
+  It reads Cython, so it dies with it; the module docstring and
+  `require()`'s failure message tell Phases 04–06 to drop each row as its
+  `.pyx` goes and delete the module with the last `.pxd`. That is a
+  `pytest.fail` with instructions, not a `FileNotFoundError`.
+
+## Files Changed
+
+- `rust/src/constants.rs` — **new.** 224 `pub const`s in three
+  namespaces (`pdg` 151, `legacy` 48, `derived::*` 25), the `# Sources`
+  provenance header, and five `cargo test` unit tests.
+- `rust/src/lib.rs` — `pub mod constants;` plus a header paragraph on
+  why it is `pub`.
+- `test/test_core_constants.py` — **new.** 25 tests: parser
+  self-checks, name/bit-equality against both `.pxd` and all five
+  `.pyx`, the frozen-literal provenance reconstructions, and the rule-4
+  divergence roster.
+- `projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md` —
+  this note.
+- `projects/cython-to-rust/task-notes/phase-03/README.md` — Task 3.1 row
+  and phase-scoped findings.
+- `projects/cython-to-rust/task-notes/README.md` — Findings, Numerical
+  impact so far, Decisions, Files Changed, Handoff.
+
+## Verification
+
+Commands and their real output, all from the task worktree on the
+capturing environment (CPython 3.12.12, macOS/arm64):
+
+- `.venv/bin/python -m pytest test/test_core_constants.py -q` →
+  **`25 passed in 0.03s`**. Coverage by category:
+  - *Parser self-checks* (4): module set, non-trivial table sizes,
+    rejection of unsupported syntax and undefined names, injectivity of
+    the `.upper()` name fold (`etap_BR_pi0_pi0_eta` is the one name it
+    has to fold).
+  - *`.pxd` tables* (4, parametrized): name-set equality and bit-equality
+    for `pdg` and `legacy`.
+  - *Module-local `DEF`s* (10, parametrized): the same two checks for
+    each of the five `.pyx`.
+  - *Completeness* (2): no `.pyx` in the tree declares a `DEF` this
+    module ignores; each derived source `include`s the table it is
+    scored against.
+  - *Frozen-literal provenance* (3): `_photon/_pion.pyx`'s five
+    kinematic literals reconstruct from `legacy` and from no other
+    table, its three aliases come from `pdg`, and `R_FACTOR` is the
+    Michel normalization over the PDG ratio with the `r^4` log term.
+  - *Rule 4* (2): the shared-name partition into divergent (12) and
+    identical (7), and the legacy `WIDTH_*` section still empty against
+    13 in `pdg`.
+- `cargo test --manifest-path rust/Cargo.toml --no-default-features` →
+  **`7 passed; 0 failed`** (5 new in `constants::tests`, 2 pre-existing
+  in `kernels::tests`).
+- `cargo clippy --manifest-path rust/Cargo.toml --all-targets --
+  -D warnings` → clean. `cargo fmt --manifest-path rust/Cargo.toml
+  --check` → clean.
+- Bare `pytest` (via the preflight gate) → **`1088 passed, 13 skipped,
+  5 warnings in 557.28s`** (+25 on Phase 02's 1063, all of them the new
+  module). The skip count is unchanged at 13, which is the tell that the
+  parity suite ran in **bit-equality mode** — all 41 consumed entry
+  points, 179,695 pinned
+  values, `rtol = 0`.
+- `scripts/agents/preflight.sh --paths "test/test_core_constants.py"
+  --md "<the three changed .md>"` → **RESULT: PASS** across all eleven
+  rows (version bump SKIP: not a closing PR). The first run of it caught
+  one real thing, an MD013 over-length line in `../README.md` that this
+  note's own re-derivation had introduced; fixed and re-run green.
+
+**Test validity — thirteen mutations, each caught by the test whose name
+claims it.** Nine against the Python module (restored between runs):
+
+| Mutation | Caught by |
+| --- | --- |
+| `pdg::MASS_TAU` last digit | `TestTables::test_values_are_bit_equal[pdg]` |
+| `legacy::MASS_OMEGA` last digit | `…[legacy]` |
+| `pdg::BR_PHI_TO_MU_MU_A` deleted | `TestTables::test_names_match_exactly[pdg]` + bit-equality |
+| `legacy::MASS_E := pdg::MASS_E` (the consolidation) | `test_the_two_tables_diverge_on_exactly_the_recorded_names` + `…[legacy]` |
+| `photon_pion::ENG_MU_PIRF` recomputed from `pdg` | `test_photon_pion_literals_come_from_the_legacy_table` + `TestDerived…[photon_pion]` |
+| `R_FACTOR` := `0.9972020119096803`, the comment's `r^2` log term | `test_r_factor_is_the_michel_normalization_over_the_pdg_ratio` + both muon modules |
+| `WIDTH_K` resurrected in `legacy` | `test_the_legacy_widths_table_is_still_empty` + two others |
+| `GAMMA_MU`: `/ MMU` → `/ MPI` | `TestDerived::test_values_are_bit_equal[positron_pion]` |
+| a new `DEF R3` added to `_positron/_muon.pyx` | `TestDerived::test_names_match_exactly[positron_muon]` |
+
+One further mutation — re-associating `ENG_MU_PI_RF` as
+`0.5 / MPI * (…)` — passed, correctly: at these masses all three
+associations give the identical payload
+(`0x1.b71ced218b450p+6`, checked directly), so the mutation changed no
+value. The value-changing slip in the same expression is the `GAMMA_MU`
+row above.
+
+Four against the Rust unit tests, same method:
+
+| Mutation | Caught by |
+| --- | --- |
+| the consolidation | `the_two_tables_disagree_where_the_cython_says_they_do` |
+| `ENG_MU_PIRF` from `pdg` | `photon_pion_mixes_the_two_tables` |
+| `R_FACTOR` := the typo'd formula's value | `r_factor_reproduces_from_the_pdg_mass_ratio` |
+| `ENG_E_PI_RF` uses `MMU` for `ME` | `const_folding_matches_a_runtime_evaluation` |
+
+Nothing deferred.
+
+## Numerical Impact
+
+**No public value changes** (verified: `git diff origin/master -- hazma`
+is empty — 0 lines, on a tree cleaned and rebuilt with
+`uv pip install -e .` before anything was run;
+`.venv/bin/python -c "import hazma._core; print(hazma._core.__file__)"`
+resolves inside this worktree, and the tree carries 21 `.so` — the 20
+Cython extensions plus `hazma/_core.abi3.so`).
+
+No grid evaluation applies: the diff adds a Rust module that no Python
+imports and no Rust kernel calls, one `pub mod` line, one test module,
+and project bookkeeping. No library module, signature, constant or build
+*input* under `hazma/` is reachable from it. Measured rather than only
+argued: the bare suite ran the parity corpus in bit-equality mode
+(`rtol = 0`, 41 entry points, 179,695 pinned values) and passed, at
+`1088 passed, 13 skipped`.
+
+The numbers this task *does* move are inside the Rust crate, where they
+had no prior value — and the whole task is the argument that they are
+the Cython's numbers bit-for-bit rather than approximately.
+
+## Open Questions
+
+- **Which PDG edition each `constants.pxd` value came from is not
+  recorded anywhere in the tree.** The `± uncertainty` annotations are
+  the only provenance the Cython left; they match `hazma/parameters.py`,
+  which says "PDG March 2022" against the CKM block only. Some entries
+  are demonstrably older than the current edition (m[τ] = 1776.86 ±
+  0.12 MeV; α⁻¹ = 137.035999084, a pre-CODATA-2022 adjustment). The
+  module header cites the PDG review index for the tables rather than
+  claiming an edition per value, which is honest but weaker than it
+  could be. Not blocking, and **not** something to resolve by re-sourcing
+  values — rule 4 forbids that. Filing it only if the consolidation
+  follow-up below is taken up.
+- The two consolidation follow-ups this module makes concrete but does
+  not touch:
+  [`positron-spectrum-nan-at-legacy-electron-mass`](../../../../docs/followups/todo/positron-spectrum-nan-at-legacy-electron-mass.md)
+  (ripens before Phases 05/06) and the general table merge, which
+  `../../PLAN.md` scopes out. `constants.rs`'s two namespaces are what
+  either would edit.
+
+## Plan Impact
+
+**Impact Level:** None.
+
+Canonical-contract diff performed: the phase file's three Task 3.1 exit
+criteria were read one at a time against the shipped diff and each is
+satisfied as written — two namespaces preserving the divergences, a test
+that extracts from the `.pxd` sources and asserts bit-equality, and
+derived module-local `DEF`s as literal consts and `const` expressions
+with the same float semantics. Task 3.4's "Depends on: Task 3.1" is now
+satisfiable. No gate sentence, exit criterion or active ADR is made
+factually wrong by this task, so nothing in `PLAN.md`, the phase file,
+`rules.md` or any ADR is patched. `rules.md` rule 4 is *implemented*
+here, not revised.
+
+## Stale-state sweep
+
+```text
+$ git -C <wt> diff origin/master --stat
+ projects/cython-to-rust/task-notes/README.md            | 141 +++-
+ projects/cython-to-rust/task-notes/phase-03/README.md   | 104 ++-
+ .../task-notes/phase-03/task-3.1-constants.md           | 445 ++++++++++
+ rust/src/constants.rs                                   | 750 +++++++++++++++++
+ rust/src/lib.rs                                         |   7 +
+ test/test_core_constants.py                             | 569 ++++++++++++
+ 6 files changed, 2002 insertions(+), 14 deletions(-)
+ (this note's own row is measured before the block quoting it was
+  finalized; the residual is this edit and nothing else)
+
+$ git -C <wt> status --short
+M  projects/cython-to-rust/task-notes/README.md
+M  projects/cython-to-rust/task-notes/phase-03/README.md
+A  projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md
+A  rust/src/constants.rs
+M  rust/src/lib.rs
+A  test/test_core_constants.py
+
+$ git -C <wt> rev-parse --abbrev-ref HEAD --show-toplevel
+claude/cython-to-rust/task-3.1-constants-module
+<wt>   (not master, and the worktree - preflight.md's pre-commit assertion)
+
+$ git -C <wt> diff origin/master -- hazma | wc -l
+0
+
+$ rg -n 'TODO|FIXME|breakpoint\(|import pdb|[^_a-z]print\(' \
+     rust/src/constants.rs rust/src/lib.rs test/test_core_constants.py
+(no occurrences)
+
+$ rg -c 'constants\.rs|test_core_constants' <the three changed .md>
+task-notes/README.md:5
+task-notes/phase-03/README.md:8
+task-notes/phase-03/task-3.1-constants.md:19
+
+$ rg -n '_build\.py' rust/src/constants.rs test/test_core_constants.py \
+     projects/cython-to-rust/task-notes/phase-03/
+(no occurrences; the hits under task-notes/phase-00/ are Task 0.4's own
+ dated record of its sweep, untouched here)
+
+$ rg -n 'constants\.pxd|legacy_parameters' docs/
+docs/followups/README.md:44            (WIDTH_K/WIDTH_PI, done)
+docs/followups/done/legacy-parameters-width-exponent-bug.md   (17 lines)
+docs/followups/todo/positron-spectrum-nan-at-legacy-electron-mass.md:14,15,57,73,74
+(all still accurate: they describe the divergence this task preserves
+ rather than resolves, and none cites a line number this diff moves.
+ docs/source/ has no occurrence — no public Python object is renamed.)
+
+$ python3 -c "..."   # every numeric claim in this note, re-derived
+199 .pxd constants (151 pdg + 48 legacy); 25 module-local DEFs across 5 .pyx
+224 pub const in rust/src/constants.rs  -> 199 + 25, matches
+per module: pdg 151, legacy 48, photon_pion 8, photon_rho 3,
+            positron_muon 3, positron_pion 6, neutrino_muon 5
+19 shared names: 12 divergent, 7 identical
+13 WIDTH_* in pdg, 0 in legacy
+12 .pyx include ../../_utils/constants.pxd; 4 include legacy_parameters.pxd
+all 12 pdg masses bit-equal to hazma/parameters.py; ALPHA_EM is not
+
+$ cargo doc --manifest-path rust/Cargo.toml --no-deps --no-default-features
+0 unresolved intra-doc links (3 pre-existing "links to private item"
+ warnings in lib.rs, unchanged by this diff)
+```
+
+**Numerical-impact statement:** No public value changes (verified:
+`git diff origin/master -- hazma` is empty — 0 lines; and the bare suite
+below ran the parity corpus in bit-equality mode, `rtol = 0` across all
+41 consumed entry points and 179,695 pinned values).
+
+Doc-consistency sweep §1/§2/§7/§11/§12 run over the diff. Every count in
+this note and in `constants.rs`'s header was re-derived from the live
+tree rather than carried from an earlier draft — which caught three
+drafting errors before they shipped: the `.pxd` split (151/48, not the
+174/25 first written), the include count (twelve spectra extensions, not
+eleven), and the number of frozen literals (seven, not six). The sibling
+occurrences of each were updated together (§11), and both new files were
+swept as fresh creations (§12).
+
+## Handoff to Next Task
+
+**Read first:** this note's Findings, then `rust/src/constants.rs`'s
+module header — it is the durable version of the same facts and travels
+with the code.
+
+**Now safe to assume:**
+
+- `hazma_core::constants::{pdg, legacy}` are the two Cython tables, and
+  `constants::derived::<source_pyx>` holds every module-local `DEF`, all
+  bit-equal to the Cython and held there by two independent gates
+  (`test/test_core_constants.py`, 25 tests, 0.03s, platform-independent;
+  and five `cargo test` units). A Phase 04 kernel names the table its
+  `.pyx` `include`s — `pdg` for everything under `hazma/spectra/**`,
+  `legacy` for the four mediator spectrum extensions.
+- Task 3.4 (interp + boost) is unblocked.
+
+**Still risky:**
+
+- **`derived::photon_pion` mixes both tables and that is correct.** Its
+  aliases are PDG, its five frozen literals are legacy. A Phase 04 port
+  that "cleans this up" moves published photon spectra; the two tests
+  named in that module's doc comment are what stop it.
+- `derived::positron_pion::ENG_MU_PI_RF` and
+  `derived::photon_pion::ENG_MU_PIRF` are the same physical quantity,
+  different numbers, and one underscore apart. Read the module, not the
+  name.
+- Nothing in the crate consumes these yet, so the first Phase 04 swap is
+  the first time a wrong *choice* of table (as opposed to a wrong value)
+  can show up. The parity corpus is what catches that.

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -1,0 +1,750 @@
+//! The two constant tables hazma's Cython layer compiles against.
+//!
+//! Hazma carries **two** tables that disagree, and the disagreement is
+//! load-bearing: `hazma/_utils/constants.pxd` is `include`d by the twelve
+//! spectra extensions and `hazma/_utils/legacy_parameters.pxd` by the four
+//! mediator ones, and the two give different masses, branching ratios and
+//! fine-structure constants for the same particles. Merging them would move
+//! published spectra, so this module reproduces both, verbatim, in two
+//! namespaces — [`pdg`] and [`legacy`] — exactly as
+//! `projects/cython-to-rust/rules.md` rule 4 (Constants 1) requires.
+//! Consolidation is a separate, declared numerical change; do not "fix" a
+//! value here.
+//!
+//! # Sources
+//!
+//! Every value is transcribed from the `.pxd` byte-for-byte, including the
+//! `± uncertainty` annotations, which are the Cython's own. Those
+//! annotations are the only provenance the Cython recorded — it names no
+//! edition — so the citations below are for the *tables*, not per value,
+//! and this port deliberately re-sources nothing:
+//!
+//! - Particle masses, widths and branching ratios: Particle Data Group,
+//!   *Review of Particle Physics* — <https://pdg.lbl.gov/>, whose constants
+//!   reviews are indexed at
+//!   <https://pdg.lbl.gov/2025/reviews/constants_atomic_and_related.html>.
+//!   Every mass in [`pdg`] is bit-equal to its counterpart in the
+//!   pure-Python `hazma/parameters.py` (checked, all twelve), which cites
+//!   "PDG March 2022"; several entries (m(tau) = 1776.86 +- 0.12 MeV, for
+//!   one) are older than the current edition. A handful of branching ratios
+//!   are marked in the source as taken from Pythia 8.306 rather than the
+//!   PDG, and say so inline.
+//! - Fine-structure constant: [`pdg::ALPHA_EM`] is `1/137.035999084(21)`, a
+//!   pre-2022 CODATA adjustment — CODATA 2022 revised α⁻¹ to
+//!   137.035999177(21) (Mohr, Newell, Taylor & Tiesinga,
+//!   [arXiv:2409.03787](https://arxiv.org/abs/2409.03787);
+//!   <https://physics.nist.gov/cgi-bin/cuu/Value?alphinv>). [`legacy`] uses
+//!   the cruder `1/137`, and `hazma/parameters.py:205` a third value again,
+//!   `1/137.04` — the masses are the only part of the tree that agrees with
+//!   itself. All three are kept as they are; reconciling them is the
+//!   consolidation this port is forbidden to perform.
+//!
+//! # Layout
+//!
+//! | Module | Ported from | Consumed by |
+//! | --- | --- | --- |
+//! | [`pdg`] | `hazma/_utils/constants.pxd` | the `hazma/spectra/**` kernels |
+//! | [`legacy`] | `hazma/_utils/legacy_parameters.pxd` | the four mediator spectrum kernels |
+//! | [`derived`] | module-local `DEF`s in individual `.pyx` | that one kernel module |
+//!
+//! `test/test_core_constants.py` re-parses all three sources and this file
+//! and asserts every value is bit-equal, so nothing here rests on careful
+//! typing. It also reconstructs [`derived`]'s seven hard-coded literals from
+//! the formulas their comments imply and pins which table each came from.
+#![allow(clippy::excessive_precision)]
+// The literals are transcribed from the `.pxd` verbatim so that a diff
+// against the Cython source is meaningful. Several carry trailing zeros
+// (`0.9998770`, `0.0023900`) that clippy would rather see dropped; dropping
+// them would make the two files stop matching character-for-character
+// without changing a single f64.
+
+/// `hazma/_utils/constants.pxd` — the PDG-era table.
+///
+/// `include`d by all twelve `hazma/spectra/**` extensions. Its masses are
+/// bit-equal to `hazma/parameters.py`'s; its `ALPHA_EM` is not.
+pub mod pdg {
+    // =========================================================
+    // ---- Masses in MeV --------------------------------------
+    // =========================================================
+
+    pub const MASS_E: f64 = 0.5109989461; // m[e-] = 0.5109989461 ± 3.1e-09
+    pub const MASS_MU: f64 = 105.6583745; // m[mu-] = 105.6583745 ± 2.4e-06
+    pub const MASS_TAU: f64 = 1776.86; // m[tau-] = 1776.86 ± 0.12
+    pub const MASS_PI0: f64 = 134.9768; // m[pi0] = 134.9768 ± 0.0005
+    pub const MASS_PI: f64 = 139.57039; // m[pi+] = 139.57039 ± 0.00018
+    pub const MASS_ETA: f64 = 547.862; // m[eta] = 547.862 ± 0.017
+    pub const MASS_ETAP: f64 = 957.78; // m[eta'(958)] = 957.78 ± 0.06
+    pub const MASS_K: f64 = 493.677; // m[K+] = 493.677 ± 0.016
+    pub const MASS_K0: f64 = 497.611; // m[K0] = 497.611 ± 0.013
+    pub const MASS_KL: f64 = 497.611; // m[K(L)0] = 497.611 ± 0.013
+    pub const MASS_KS: f64 = 497.611; // m[K(S)0] = 497.611 ± 0.013
+    pub const MASS_RHO: f64 = 775.26; // m[rho(770)0] = 775.26 ± 0.23
+    pub const MASS_OMEGA: f64 = 782.66; // m[omega(782)] = 782.66 ± 0.13
+    pub const MASS_PHI: f64 = 1019.461; // m[phi(1020)] = 1019.461 ± 0.016
+
+    // =========================================================
+    // ---- π⁺ Branching Ratios --------------------------------
+    // =========================================================
+
+    // BR(μ+, νμ) = (99.98770±0.00004) %
+    pub const BR_PI_TO_MU_NUMU: f64 = 0.9998770;
+    // BR(e+, νe) = ( 1.230±0.004  )×10−4
+    pub const BR_PI_TO_E_NUE: f64 = 1.230e-4;
+
+    // =========================================================
+    // ---- π⁰ Branching Ratios --------------------------------
+    // =========================================================
+
+    // BR(γ, γ) = (98.823±0.034) %
+    pub const BR_PI0_TO_A_A: f64 = 98.823e-2;
+    // BR(e+, e−, γ) = (1.174±0.035) %
+    pub const BR_PI0_TO_E_E_A: f64 = 1.174e-2;
+    // BR(e+, e+, e−, e−) = (3.34±0.16 )×10−5
+    pub const BR_PI0_TO_E_E_E_E: f64 = 3.34e-5;
+
+    // =========================================================
+    // ---- η Branching Ratios ---------------------------------
+    // =========================================================
+
+    // BR(γ, γ) = (39.41±0.20) %
+    pub const BR_ETA_TO_A_A: f64 = 39.41e-2;
+    // BR(π0, π0, π0) = (32.68±0.23) %
+    pub const BR_ETA_TO_PI0_PI0_PI0: f64 = 32.68e-2;
+    // BR(π0, γ, γ) = ( 2.56±0.22)×10−4
+    pub const BR_ETA_TO_PI0_A_A: f64 = 2.56e-4;
+    // BR(π+, π−, π0) = (22.92±0.28) %
+    pub const BR_ETA_TO_PI_PI_PI0: f64 = 22.92e-2;
+    // BR(π+, π−, γ) = ( 4.22±0.08) %
+    pub const BR_ETA_TO_PI_PI_A: f64 = 4.22e-2;
+    // BR(e+, e−, γ) = ( 6.9±0.4 )×10−3
+    pub const BR_ETA_TO_E_E_A: f64 = 6.9e-3;
+    // BR(μ+, μ−, γ) = ( 3.1±0.4 )×10−4
+    pub const BR_ETA_TO_MU_MU_A: f64 = 3.1e-4;
+    // BR(μ+, μ−) = ( 5.8±0.8 )×10−6
+    pub const BR_ETA_TO_MU_MU: f64 = 5.8e-6;
+    // BR(π+, π−, e+, e−)  = ( 2.68±0.11)×10−4
+    pub const BR_ETA_TO_PI_PI_E_E: f64 = 2.68e-4;
+    // BR(e+, e−, e+, e−) = ( 2.40±0.22)×10−5
+    pub const BR_ETA_TO_E_E_E_E: f64 = 2.40e-5;
+
+    // =========================================================
+    // ---- ρ⁰ Branching Ratios --------------------------------
+    // =========================================================
+
+    pub const BR_RHO_TO_PI_PI: f64 = 0.9988447;
+    // BR(π⁰, γ) = 4.7e-4
+    pub const BR_RHO_TO_PI0_A: f64 = 4.7e-4;
+    // BR(η, γ) = 3.00e-4
+    pub const BR_RHO_TO_ETA_A: f64 = 3.00e-4;
+    // BR(π⁺, π⁻, π⁰) = 1.01e-4
+    pub const BR_RHO_TO_PI_PI_PI0: f64 = 1.01e-4;
+    // BR(e⁺, e⁻) = 4.72e-5
+    pub const BR_RHO_TO_E_E: f64 = 4.72e-5;
+    // BR(μ⁺, μ⁻) = 4.55e-5
+    pub const BR_RHO_TO_MU_MU: f64 = 4.55e-5;
+    // BR(π⁰, π⁰, γ) = 4.5e-5
+    pub const BR_RHO_TO_PI0_PI0_A: f64 = 4.5e-5;
+    // BR(π⁺, π⁻, π⁺, π⁻) = 1.8e-5
+    pub const BR_RHO_TO_PI_PI_PI_PI: f64 = 1.8e-5;
+    // BR(π⁺, π⁻, π⁰, π⁰) = 1.6e-5
+    pub const BR_RHO_TO_PI_PI_PI0_PI0: f64 = 1.6e-5;
+    // BR(π⁺, π⁻, γ) = 9.9e-3
+    pub const BR_RHO_TO_PI_PI_A: f64 = 9.9e-3;
+
+    // =========================================================
+    // ---- ρ⁺ Branching Ratios --------------------------------
+    // =========================================================
+
+    pub const RHOP_TO_PI_PI0: f64 = 0.9995502;
+    // BR(π±, γ) = 4.5e-4
+    pub const RHOP_TO_PI_A: f64 = 4.5e-4;
+
+    // =========================================================
+    // ---- K-Long Branching Ratios ----------------------------
+    // =========================================================
+
+    // BR(π0, π0, π0) = (19.52±0.12 ) %
+    pub const BR_KL_TO_PI0_PI0_PI0: f64 = 19.52e-2;
+    // BR(π+, π−, π0) = (12.54±0.05 ) %
+    pub const BR_KL_TO_PI_PI_PI0: f64 = 12.54e-2;
+    // BR(π±, e∓, νe) = (40.55±0.11 ) %
+    pub const BR_KL_TO_PI_E_NUE: f64 = 40.55e-2;
+    // BR(π±, μ∓, νμ) =  (27.04±0.07 ) %
+    pub const BR_KL_TO_PI_MU_NUMU: f64 = 27.04e-2;
+    // BR(π+, π−) = ( 1.967±0.010)×10−3
+    pub const BR_KL_TO_PI_PI: f64 = 1.967e-3;
+    // BR(π0, π0) = ( 8.64±0.06 )×10−4
+    pub const BR_KL_TO_PI0_PI0: f64 = 8.64e-4;
+    // BR(γ, γ) = ( 5.47±0.04 )×10−4
+    pub const BR_KL_TO_A_A: f64 = 5.47e-4;
+    // BR(π0, π±, e∓, ν) = ( 5.20±0.11 )×10−5
+    pub const BR_KL_TO_PI0_PI_E_NU: f64 = 5.20e-5;
+    // BR(π±, e∓, ν, e+, e−) = ( 1.26±0.04 )×10−5
+    pub const BR_KL_TO_PI_E_E_E_NU: f64 = 1.26e-5;
+
+    // =========================================================
+    // ---- K-Short Branching Ratios ---------------------------
+    // =========================================================
+
+    // BR(π+, π−) = (69.20±0.05) %
+    pub const BR_KS_TO_PI_PI: f64 = 69.20e-2;
+    // BR(π0, π0) = (30.69±0.05) %
+    pub const BR_KS_TO_PI0_PI0: f64 = 30.69e-2;
+    // BR(π+, π−, e+, e−) = ( 4.79±0.15)×10−5
+    pub const BR_KS_TO_PI_PI_E_E: f64 = 4.79e-5;
+    // BR(π±, e∓, νe) =  ( 7.04±0.08)×10−4
+    pub const BR_KS_TO_PI_E_NUE: f64 = 7.04e-4;
+    // BR(γ, γ) = ( 2.63±0.17)×10−6
+    pub const BR_KS_TO_A_A: f64 = 2.63e-6;
+    // BR(π+, π−, π0) = ( 3.5+1.1−0.9)×10−7
+    pub const BR_KS_TO_PI_PI_PI0: f64 = 3.5e-7;
+    // BR(π+, π−, γ) = ( 1.79±0.05)×10−3
+    pub const BR_KS_TO_PI_PI_A: f64 = 1.79e-3;
+    // BR(π0, γ, γ) =  ( 4.9±1.8 )×10−8
+    pub const BR_KS_TO_PI0_A_A: f64 = 4.9e-8;
+    // BR(π0, e+, e−) = ( 3.0+1.5−1.2)×10−9
+    pub const BR_KS_TO_PI0_E_E: f64 = 3e-9;
+    // BR(π0, μ+, μ−) = ( 2.9+1.5−1.2)×10−9
+    pub const BR_KS_TO_PI0_MU_MU: f64 = 2.9e-9;
+
+    // =========================================================
+    // ---- K⁰ Branching Ratios --------------------------------
+    // =========================================================
+
+    pub const BR_K0_TO_KL: f64 = 0.5;
+    pub const BR_K0_TO_KS: f64 = 0.5;
+
+    // =========================================================
+    // ---- K⁰' (K⁰-star) Branching Ratios ---------------------
+    // =========================================================
+
+    // Taken from Pythia8306
+    pub const BR_K0STAR_TO_K_PI: f64 = 0.6649467;
+    pub const BR_K0STAR_TO_K0_PI0: f64 = 0.3326633;
+    pub const BR_K0STAR_TO_K0_A: f64 = 0.0023900;
+
+    // =========================================================
+    // ---- K⁺, K⁻ Branching Ratios ----------------------------
+    // =========================================================
+
+    // BR(μ+, νμ) = (63.56 ± 0.11) %
+    pub const BR_K_TO_MU_NUMU: f64 = 63.56e-2;
+    // BR(e+, νe) = (1.582 ± 0.007)×10−5
+    pub const BR_K_TO_E_NUE: f64 = 1.582e-5;
+    // BR(π+, π0) = (20.67 ± 0.08 ) %
+    pub const BR_K_TO_PI_PI0: f64 = 20.67e-2;
+    // BR(π+, π+, π−) = (5.583 ± 0.024) %
+    pub const BR_K_TO_PI_PI_PI: f64 = 5.583e-2;
+    // BR(π+, π0, π0) = (1.760 ± 0.023) %
+    pub const BR_K_TO_PI_PI0_PI0: f64 = 1.760e-2;
+    // BR(π0, e+, νe) = (5.07 ± 0.04) %
+    pub const BR_K_TO_E_NUE_PI0: f64 = 5.07e-2;
+    // BR(π0, μ+, νμ)   (3.352 ± 0.033) %
+    pub const BR_K_TO_MU_NUMU_PI0: f64 = 3.352e-2;
+    // BR(π0, π0, e+, νe) = (2.55 ± 0.04)×10−5
+    pub const BR_K_TO_E_NUE_PI0_PI0: f64 = 2.55e-5;
+    // BR(π+, π−, e+, νe) =  (4.247 ± 0.024)×10−5
+    pub const BR_K_TO_E_NUE_PI_PI: f64 = 4.247e-5;
+    // Taken from Pythia8306 (can't find in PDG)
+    pub const BR_K_TO_MU_NUMU_PI0_PI0: f64 = 0.0000140;
+    // BR(π+, π−, μ+, νμ) =  (1.4 ± 0.9)×10−5
+    pub const BR_K_TO_MU_NUMU_PI_PI: f64 = 1.4e-5;
+    // BR(e+, νe, e+, e−) =  (2.48 ± 0.20 )×10−8
+    pub const BR_K_TO_E_E_E_NUE: f64 = 2.48e-8;
+    // BR(μ+, νμ, e+, e−) =  (7.06 ± 0.31 )×10−8
+    pub const BR_K_TO_MU_E_E_NUMU: f64 = 7.06e-8;
+    // BR(e+, νe, μ+, μ−) =  (1.7 ± 0.5  )×10−8
+    pub const BR_K_TO_MU_MU_E_NUE: f64 = 1.7e-8;
+    // BR(π+, e+, e−) = (3.00 ± 0.09 )×10−7
+    pub const BR_K_TO_PI_E_E: f64 = 3.00e-7;
+    // BR(π+, μ+, μ−) = (9.4 ± 0.6  )×10−8
+    pub const BR_K_TO_PI_MU_MU: f64 = 9.4e-8;
+
+    // =========================================================
+    // ---- K⁺' (K-star) Branching Ratios ----------------------
+    // =========================================================
+
+    pub const BR_KSTAR_TO_K0_PI: f64 = 0.6660067;
+    pub const BR_KSTAR_TO_K_PI0: f64 = 0.3330033;
+    pub const BR_KSTAR_TO_K_A: f64 = 0.0009900;
+
+    // =========================================================
+    // ---- Eta' Branching Ratios ------------------------------
+    // =========================================================
+
+    // BR(π⁺, π⁻, η) = (42.5 ± 0.5) %
+    pub const BR_ETAP_TO_PI_PI_ETA: f64 = 42.5e-2;
+    // BR(ρ⁰, γ) = (29.5 ± 0.4) % (including non-resonant π+ + π− + γ)
+    pub const BR_ETAP_TO_RHO_A: f64 = 29.5e-2;
+    // BR(π⁰, π⁰, η) = (22.4 ± 0.5) %
+    pub const BR_ETAP_TO_PI0_PI0_ETA: f64 = 22.4e-2;
+    // BR(ω, γ) = ( 2.52 ± 0.07) %
+    pub const BR_ETAP_TO_OMEGA_A: f64 = 2.52e-2;
+    // BR(γ, γ) = ( 2.307 ± 0.033) %
+    pub const BR_ETAP_TO_A_A: f64 = 2.307e-2;
+    // BR(π⁰, π⁰, π⁰) = ( 2.50 ± 0.17 )×10−3
+    pub const BR_ETAP_TO_PI0_PI0_PI0: f64 = 2.50e-3;
+    // BR(μ⁺, μ⁻, γ) = (1.13 ± 0.28)×10−4
+    pub const BR_ETAP_TO_MU_MU_A: f64 = 1.13e-4;
+    // BR(ω, e⁺, e⁻) = ( 2.0 ± 0.4  )×10−4
+    pub const BR_ETAP_TO_OMEGA_E_E: f64 = 2e-4;
+    // BR(π⁺, π⁻, π⁰) = (3.61 ± 0.17)×10−3
+    // BR(π⁺, π⁻, π⁰) = (3.8 ± 0.5)×10−3 (S-wave)
+    pub const BR_ETAP_TO_PI_PI_PI0: f64 = 3.61e-3;
+    // BR(π∓, ρ±) = (7.4 ± 2.3)×10−4
+    pub const BR_ETAP_TO_PI_RHOP: f64 = 7.4e-4;
+    // BR(π⁺, π⁻, π⁺, π⁻) = (8.4 ± 0.9)×10−5
+    pub const BR_ETAP_TO_PI_PI_PI_PI: f64 = 8.4e-5;
+    // BR(π⁺, π⁻, π⁰, π⁰) = (1.8 ± 0.4)×10−4
+    pub const BR_ETAP_TO_PI_PI_PI0_PI0: f64 = 1.8e-4;
+    // BR(π⁺, π⁻, e⁺, e⁻) = (2.4 +1.3 −1.0)×10−3
+    pub const BR_ETAP_TO_PI_PI_E_E: f64 = 2.4e-3;
+    // BR(γ, e⁺, e⁻) = (4.91 ± 0.27)×10−4
+    pub const BR_ETAP_TO_E_E_A: f64 = 4.91e-4;
+    // BR(π⁰, γ, γ) = (3.20 ± 0.24)×10−3
+    // BR(π⁰, γ, γ) = (6.2 ± 0.9)×10−4 (non resonant)
+    pub const BR_ETAP_TO_PI0_A_A: f64 = 3.20e-3;
+
+    // =========================================================
+    // ---- ω Branching Ratios ---------------------------------
+    // =========================================================
+
+    // BR(π⁺, π⁻, π⁰) = 89.2 ± 0.7 %
+    pub const BR_OMEGA_TO_PI_PI_PI0: f64 = 89.2e-2;
+    // BR(π⁰, γ) = 8.34 ± 0.26 %
+    pub const BR_OMEGA_TO_PI0_A: f64 = 8.34e-2;
+    // BR(π⁺, π⁻) = 1.53 +0.11 −0.13 %
+    pub const BR_OMEGA_TO_PI_PI: f64 = 1.53e-2;
+    // BR(η, γ) = 4.5e-4 ± 0.4e-4
+    pub const BR_OMEGA_TO_ETA_A: f64 = 4.5e-4;
+    // BR(π⁰, e⁺, e⁻) = 7.7e-4 ± 0.6e-4
+    pub const BR_OMEGA_TO_PI0_E_E: f64 = 7.7e-4;
+    // BR(π⁰, μ⁺, μ⁻) = 1.34e-4 ± 0.18e-4
+    pub const BR_OMEGA_TO_PI0_MU_MU: f64 = 1.34e-4;
+    // BR(e⁺, e⁻) = 7.39e-5 ± 0.19e-5
+    pub const BR_OMEGA_TO_E_E: f64 = 7.39e-5;
+    // BR(μ⁺, μ⁻) = 7.4e-5 ± 1.8e-5
+    pub const BR_OMEGA_TO_MU_MU: f64 = 7.4e-5;
+    // BR(π⁰, π⁰, γ) = 6.7e-5 ± 1.1e-5
+    pub const BR_OMEGA_TO_PI0_PI0_A: f64 = 6.7e-5;
+
+    // =========================================================
+    // ---- φ Branching Ratios ---------------------------------
+    // =========================================================
+
+    // BR(K⁺, K⁻) = (49.2 ± 0.5) %
+    pub const BR_PHI_TO_K_K: f64 = 49.2e-2;
+    // BR(KL, KS) = (34.0 ± 0.4) %
+    pub const BR_PHI_TO_KL_KS: f64 = 34.0e-2;
+    // PDG: BR(ρ, π⁰) + BR(ρ⁺, π⁻) + BR(ρ⁻, π⁺) +  BR(π⁺, π⁻, π⁰) = (15.24 ± 0.33) %
+    // The below is taken from Pythia8306
+    pub const BR_PHI_TO_RHOP_PI: f64 = 0.0420984;
+    pub const BR_PHI_TO_RHO_PI0: f64 = 0.0420984;
+    pub const BR_PHI_TO_PI_PI_PI0: f64 = 0.0270000;
+    // BR(η, γ) = (1.303 ± 0.025) %
+    pub const BR_PHI_TO_ETA_A: f64 = 1.303e-2;
+    // BR(π⁰, γ) = (1.32 ± 0.06)×10−3
+    pub const BR_PHI_TO_PI0_A: f64 = 1.32e-3;
+    // BR(e⁺, e⁻) = (2.974 ± 0.034)×10−4
+    pub const BR_PHI_TO_E_E: f64 = 2.974e-4;
+    // BR(μ⁺, μ⁻) = (2.86 ± 0.19)×10−4
+    pub const BR_PHI_TO_MU_MU: f64 = 2.86e-4;
+    // BR(η, e⁺, e⁻) = (1.08 ± 0.04)×10−4
+    pub const BR_PHI_TO_ETA_E_E: f64 = 1.08e-4;
+    // BR(π⁺, π⁻) = (7.3 ± 1.3)×10−5
+    pub const BR_PHI_TO_PI_PI: f64 = 7.3e-5;
+    // BR(ω, π⁰) = (4.7 ± 0.5)×10−5
+    pub const BR_PHI_TO_OMEGA_PI0: f64 = 4.7e-5;
+    // BR(π⁺, π⁻, γ) = (4.1 ± 1.3)×10−5
+    pub const BR_PHI_TO_PI_PI_A: f64 = 4.1e-5;
+    // BR(f₀(980), γ) = (3.22 ± 0.19)×10−4
+    pub const BR_PHI_TO_F0980_A: f64 = 3.22e-4;
+    // BR(π⁰, π⁰, γ) = (1.12 ± 0.06)×10−4
+    pub const BR_PHI_TO_PI0_PI0_A: f64 = 1.12e-4;
+    // BR(π⁺, π⁻, π⁺, π⁻) = (3.9 +2.8 −2.2)×10−6
+    pub const BR_PHI_TO_PI_PI_PI_PI: f64 = 3.9e-6;
+    // BR(π⁰, e⁺, e⁻) = (1.33 +0.07 −0.10)×10−5
+    pub const BR_PHI_TO_PI0_E_E: f64 = 1.33e-5;
+    // BR(π⁰, η, γ) = (7.27 ± 0.30)×10−5
+    pub const BR_PHI_TO_PI0_ETA_A: f64 = 7.27e-5;
+    // BR(a₀(980), γ) = (7.6 ± 0.6)×10−5
+    pub const BR_PHI_TO_A0980_A: f64 = 7.6e-5;
+    // BR(η'(958), γ) = (6.22 ± 0.21)×10−5
+    pub const BR_PHI_TO_ETAP_A: f64 = 6.22e-5;
+    // BR(μ⁺, μ⁻, γ) = (1.4 ± 0.5)×10−5
+    pub const BR_PHI_TO_MU_MU_A: f64 = 1.4e-5;
+
+    // =========================================================
+    // ---- Decay Widths ---------------------------------------
+    // =========================================================
+
+    pub const WIDTH_E: f64 = 0.0; // Γ[e-] = 0.0 ± 0.0
+    pub const WIDTH_MU: f64 = 2.9959837e-16; // Γ[mu-] = 2.9959837e-16 ± 3e-22
+    pub const WIDTH_TAU: f64 = 2.267e-09; // Γ[tau-] = 2.267e-09 ± 4e-12
+    pub const WIDTH_PI0: f64 = 7.81e-06; // Γ[pi0] = 7.81e-06 ± 1.2e-07
+    pub const WIDTH_PI: f64 = 2.5284e-14; // Γ[pi+] = 2.5284e-14 ± 5e-18
+    pub const WIDTH_ETA: f64 = 0.00131; // Γ[eta] = 0.00131 ± 5e-05
+    pub const WIDTH_ETAP: f64 = 0.188; // Γ[eta'(958)] = 0.188 ± 0.006
+    pub const WIDTH_K: f64 = 5.317e-14; // Γ[K+] = 5.317e-14 ± 9e-17
+    // DEF WIDTH_K0 = None # Γ[K0] = None ± None
+    pub const WIDTH_KL: f64 = 1.287e-14; // Γ[K(L)0] = 1.287e-14 ± 5e-17
+    pub const WIDTH_KS: f64 = 7.3508e-12; // Γ[K(S)0] = 7.3508e-12 ± 2.9e-15
+    pub const WIDTH_RHO: f64 = 149.1; // Γ[rho(770)0] = 149.1 ± 0.8
+    pub const WIDTH_OMEGA: f64 = 8.68; // Γ[omega(782)] = 8.68 ± 0.13
+    pub const WIDTH_PHI: f64 = 4.249; // Γ[phi(1020)] = 4.249 ± 0.013
+
+    // =========================================================
+    // ---- Other Constants ------------------------------------
+    // =========================================================
+
+    // 1/137.035999084(21)
+    pub const ALPHA_EM: f64 = 1.0 / 137.035999084; // Fine structure constant.
+    pub const RATIO_E_MU_MASS_SQ: f64 = (MASS_E / MASS_MU) * (MASS_E / MASS_MU);
+
+    // FA = 0.0119 ± 0.0001
+    pub const F_A_PI: f64 = 0.0119;
+    // FV = 0.0254 ± 0.0017
+    pub const F_V_PI: f64 = 0.0254;
+    // FV slope parameter a= 0.10 ± 0.06
+    pub const F_V_PI_SLOPE: f64 = 0.10;
+
+    pub const F_A_K: f64 = 0.042;
+    pub const F_V_K: f64 = 0.096;
+
+    pub const DECAY_CONST_PI: f64 = 130.41; // PDG convention
+    pub const DECAY_CONST_K: f64 = 156.1; // PDG convention
+}
+
+/// `hazma/_utils/legacy_parameters.pxd` — the older table.
+///
+/// `include`d by the four mediator spectrum extensions
+/// (`{scalar,vector}_mediator/*_{decay_spectrum,positron_spec}.pyx`) and by
+/// nothing else. Its masses, branching ratios and α differ from [`pdg`];
+/// see [`self`] for why they stay that way.
+///
+/// One departure from verbatim predates this task: the `WIDTHS` section is
+/// empty because two malformed, never-referenced entries were deleted on
+/// 2026-08-05 (see the comment in the `.pxd`).
+pub mod legacy {
+    // MASSES (MeV)
+    pub const MASS_E: f64 = 0.510998928; // electron
+    pub const MASS_MU: f64 = 105.6583715; // muon
+    pub const MASS_PI0: f64 = 134.9766; // neutral pion
+    pub const MASS_PI: f64 = 139.57018; // Charged pion
+    pub const MASS_K0: f64 = 497.61; // neutral kaon
+    pub const MASS_K: f64 = 493.68; // charged Kaon
+    pub const MASS_ETA: f64 = 547.86; // eta
+    pub const MASS_ETAP: f64 = 957.8; // eta prime
+    pub const MASS_RHO: f64 = 775.3; // rho
+    pub const MASS_OMEGA: f64 = 782.7; // omega
+
+    // BRANCHING RATIOS
+    pub const BR_PI0_TO_GG: f64 = 0.9882; // Pi0   -> g   + g
+    pub const BR_PI_TO_MUNU: f64 = 0.9998; // pi    -> mu  + nu
+    pub const BR_PI_TO_ENU: f64 = 0.000123; // pi    -> e  + nu
+
+    pub const BR_KS_TO_PIPI: f64 = 0.6920; // ks    -> pi  + pi
+    pub const BR_KS_TO_PI0PI0: f64 = 0.3069; // ks    -> pi0 + pi0
+
+    pub const BR_KL_TO_PIENU: f64 = 0.4055; // kl    -> pi  + e   + nu
+    pub const BR_KL_TO_PIMUNU: f64 = 0.2704; // kl    -> pi  + mu  + nu
+    pub const BR_KL_TO_3PI0: f64 = 0.1952; // kl    -> pi0 + pi0  + pi0
+    pub const BR_KL_TO_2PIPI0: f64 = 0.1254; // kl    -> pi  + pi  + pi0
+
+    pub const BR_K_TO_MUNU: f64 = 0.6356; // k     -> mu  + nu
+    pub const BR_K_TO_PIPI0: f64 = 0.2067; // k     -> pi  + pi0
+    pub const BR_K_TO_3PI: f64 = 0.05583; // k     -> pi  + pi  + pi
+    pub const BR_K_TO_PI0ENU: f64 = 0.0507; // k     -> pi0 + e   + nu
+    pub const BR_K_TO_PI0MUNU: f64 = 0.03352; // k     -> pi0 + mu  + nu
+    pub const BR_K_TO_PI2PI0: f64 = 0.01760; // k     -> pi  + pi0 + pi0
+
+    pub const BR_ETA_TO_GG: f64 = 0.3941; // eta   -> g   + g
+    pub const BR_ETA_TO_3PI0: f64 = 0.3268; // eta   -> pi0 + pi0 + pi0
+    pub const BR_ETA_TO_2PIPI0: f64 = 0.2292; // eta   -> pi  + pi  + pi0
+    pub const BR_ETA_TO_2PIG: f64 = 0.0422; // eta   -> pi  + pi  + g
+    pub const BR_ETAP_TO_2PIETA: f64 = 0.429; // eta'  -> pi  + pi  + eta
+    pub const BR_ETAP_TO_RHOG: f64 = 0.291; // eta'  -> rho + g
+    pub const ETAP_BR_PI0_PI0_ETA: f64 = 0.222; // eta'  -> pi0 + pi0 + eta
+    pub const BR_ETAP_TO_OMEGAG: f64 = 0.0275; // eta'  -> omega + g
+    pub const BR_ETAP_TO_GG: f64 = 0.0220; // eta'  -> g   + g
+    pub const BR_ETAP_TO_3PI0: f64 = 0.0214; // eta'  -> pi0 + pi0 + pi-
+    pub const BR_ETAP_TO_MUMUG: f64 = 0.0108; // eta'  -> mu  + mu  + g
+
+    pub const BR_OMEGA_TO_2PIPI0: f64 = 0.892; // omega -> pi + pi   + pi0
+    pub const BR_OMEGA_TO_PI0G: f64 = 0.0828; // omega -> pi0 + g
+    pub const BR_OMEGA_TO_2PI: f64 = 0.0153; // omega -> pi + pi
+
+    // WIDTHS
+    //
+    // Deliberately empty. This table used to define WIDTH_K and WIDTH_PI with
+    // `**` where a decimal exponent was meant -- `3.3406**-13.` is
+    // exponentiation, evaluating to 1.5498e-7 rather than a width of order
+    // 1e-13 MeV -- and no including module referenced either name. Deleted
+    // rather than repaired: constants.pxd is the canonical source for decay
+    // widths and carries both PDG-cited (Gamma[K+] = 5.317e-14 MeV,
+    // Gamma[pi+] = 2.5284e-14 MeV). See
+    // docs/followups/done/legacy-parameters-width-exponent-bug.md.
+
+    // MISC.
+    pub const ALPHA_EM: f64 = 1.0 / 137.0; // Fine structure constant.
+    pub const RATIO_E_MU_MASS_SQ: f64 = (MASS_E / MASS_MU) * (MASS_E / MASS_MU);
+    pub const F_A_PI: f64 = 0.0119;
+    pub const F_V_PI: f64 = 0.0254;
+    pub const F_V_PI_SLOPE: f64 = 0.1;
+    pub const F_A_K: f64 = 0.042;
+    pub const F_V_K: f64 = 0.096;
+    pub const DECAY_CONST_PI: f64 = 130.41; // PDG convention
+    pub const DECAY_CONST_K: f64 = 156.1; // PDG convention
+}
+
+/// Module-local `DEF`s — constants a single `.pyx` defines for itself.
+///
+/// Each submodule is named for the `.pyx` it comes from and holds exactly
+/// that file's `DEF`s, so a Phase 04 kernel port has one place to look and
+/// the coverage check in `test/test_core_constants.py` can be total.
+///
+/// Two kinds live here and they behave differently:
+///
+/// - *Computed* `DEF`s (`R`, `ENG_MU_PI_RF`, …). Cython evaluates these at
+///   compile time from whichever table the file `include`s, so they track
+///   that table. They are `const` expressions here for the same reason,
+///   written in the same association order so the rounding matches.
+/// - *Hard-coded* `DEF`s (`R_FACTOR`, `BETA_MU_PIRF`, …). Someone evaluated
+///   a formula once and pasted the digits, so these are frozen against
+///   whatever the table said that day. [`derived::photon_pion`]'s five are frozen
+///   against [`legacy`] even though that file `include`s [`pdg`] — see
+///   there. They stay literals, which is both what the Cython has and what
+///   Rust permits (`sqrt` and `ln` are not `const`).
+pub mod derived {
+    /// `hazma/spectra/_photon/_pion.pyx`.
+    ///
+    /// **Mixed provenance, preserved deliberately.** The file `include`s
+    /// [`pdg`](super::pdg), so `MPI` / `ME` / `MMU` below are PDG values —
+    /// but its five hard-coded pion/muon kinematic literals reproduce
+    /// bit-exactly from [`legacy`](super::legacy)'s masses and from no other
+    /// table. Recomputing them from `pdg` moves `ENG_MU_PIRF` by 4.7e-5 MeV
+    /// and every photon spectrum from charged-pion decay with it, so they
+    /// are left exactly as the Cython has them.
+    /// `test/test_core_constants.py::test_photon_pion_literals_come_from_the_legacy_table`
+    /// is what turns that claim into a check.
+    pub mod photon_pion {
+        use super::super::pdg;
+
+        /// Maximum photon energy in the muon rest frame, `(m_mu^2 - m_e^2) /
+        /// (2 m_mu)` over the [`legacy`](super::super::legacy) masses, in MeV.
+        pub const ENG_GAM_MAX_MURF: f64 = 52.82795006985128;
+        /// Maximum photon energy in the pion rest frame: [`ENG_GAM_MAX_MURF`]
+        /// boosted by [`GAMMA_MU_PIRF`] / [`BETA_MU_PIRF`], in MeV.
+        pub const ENG_GAM_MAX_PIRG: f64 = 69.78345771948752;
+        /// Muon energy in the pion rest frame, `(m_pi^2 + m_mu^2) / (2 m_pi)`
+        /// over the [`legacy`](super::super::legacy) masses, in MeV.
+        pub const ENG_MU_PIRF: f64 = 109.77820123634007;
+        /// Charged pion mass in MeV. PDG value — unlike the literals above.
+        pub const MPI: f64 = pdg::MASS_PI;
+        /// Electron mass in MeV. PDG value — unlike the literals above.
+        pub const ME: f64 = pdg::MASS_E;
+        /// Muon mass in MeV. PDG value — unlike the literals above.
+        pub const MMU: f64 = pdg::MASS_MU;
+        /// Muon velocity in the pion rest frame, dimensionless.
+        pub const BETA_MU_PIRF: f64 = 0.27138337509758564;
+        /// Muon Lorentz factor in the pion rest frame, dimensionless.
+        pub const GAMMA_MU_PIRF: f64 = 1.0389919859434902;
+    }
+
+    /// `hazma/spectra/_photon/_rho.pyx`. Three aliases, no arithmetic.
+    pub mod photon_rho {
+        use super::super::pdg;
+
+        /// Charged pion mass in MeV.
+        pub const MPI: f64 = pdg::MASS_PI;
+        /// Neutral pion mass in MeV.
+        pub const MPI0: f64 = pdg::MASS_PI0;
+        /// Rho(770) mass in MeV.
+        pub const MRHO: f64 = pdg::MASS_RHO;
+    }
+
+    /// `hazma/spectra/_positron/_muon.pyx`.
+    pub mod positron_muon {
+        use super::super::pdg;
+
+        /// Electron-to-muon mass ratio, dimensionless.
+        pub const R: f64 = pdg::MASS_E / pdg::MASS_MU;
+        /// [`R`] squared.
+        pub const R2: f64 = R * R;
+        /// Michel-spectrum normalization,
+        /// `1 / (1 - 8r^2 + 8r^6 - r^8 - 12 r^4 ln(r^2))` at `r =` [`R`].
+        ///
+        /// Hard-coded, and unlike [`super::photon_pion`]'s literals it is
+        /// frozen against the *PDG* table, so it agrees with the [`R`] beside
+        /// it. The `.pyx` comment above it writes the log term as
+        /// `12 r^2 ln(r^2)`; the exponent is a typo — only `r^4` reproduces
+        /// the digits, and `test/test_core_constants.py` pins that.
+        pub const R_FACTOR: f64 = 1.0001870858234163;
+    }
+
+    /// `hazma/spectra/_positron/_pion.pyx`.
+    ///
+    /// Every value computed, so this module tracks [`pdg`](super::pdg)
+    /// with nothing frozen. Note `ENG_MU_PI_RF` is the same physical
+    /// quantity as [`photon_pion::ENG_MU_PIRF`](photon_pion::ENG_MU_PIRF) and *not* the same
+    /// number — different table, and the two spellings differ by an
+    /// underscore.
+    pub mod positron_pion {
+        use super::super::pdg;
+
+        /// Muon mass in MeV.
+        pub const MMU: f64 = pdg::MASS_MU;
+        /// Charged pion mass in MeV.
+        pub const MPI: f64 = pdg::MASS_PI;
+        /// Electron mass in MeV.
+        pub const ME: f64 = pdg::MASS_E;
+        /// Muon energy in the pion rest frame, in MeV.
+        pub const ENG_MU_PI_RF: f64 = 0.5 * (MPI * MPI + MMU * MMU) / MPI;
+        /// Electron energy in the pion rest frame, in MeV.
+        pub const ENG_E_PI_RF: f64 = 0.5 * (MPI * MPI + ME * ME) / MPI;
+        /// Muon Lorentz factor in the pion rest frame, dimensionless.
+        pub const GAMMA_MU: f64 = ENG_MU_PI_RF / MMU;
+    }
+
+    /// `hazma/spectra/_neutrino/_muon.pyx`.
+    ///
+    /// `R`, `R2` and `R_FACTOR` are the same three the positron muon
+    /// kernel defines; `R4` and `R6` are extra.
+    pub mod neutrino_muon {
+        use super::super::pdg;
+
+        /// Electron-to-muon mass ratio, dimensionless.
+        pub const R: f64 = pdg::MASS_E / pdg::MASS_MU;
+        /// [`R`] squared.
+        pub const R2: f64 = R * R;
+        /// [`R`] to the fourth.
+        pub const R4: f64 = R2 * R2;
+        /// [`R`] to the sixth.
+        pub const R6: f64 = R4 * R2;
+        /// Michel-spectrum normalization; see
+        /// [`super::positron_muon::R_FACTOR`].
+        pub const R_FACTOR: f64 = 1.0001870858234163;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{derived, legacy, pdg};
+
+    /// The whole point of two namespaces: they disagree, and rule 4 says the
+    /// disagreement survives the port. If this ever passes trivially,
+    /// someone has consolidated the tables without declaring it.
+    #[test]
+    fn the_two_tables_disagree_where_the_cython_says_they_do() {
+        for (name, a, b) in [
+            ("MASS_E", pdg::MASS_E, legacy::MASS_E),
+            ("MASS_MU", pdg::MASS_MU, legacy::MASS_MU),
+            ("MASS_PI0", pdg::MASS_PI0, legacy::MASS_PI0),
+            ("MASS_PI", pdg::MASS_PI, legacy::MASS_PI),
+            ("MASS_K0", pdg::MASS_K0, legacy::MASS_K0),
+            ("MASS_K", pdg::MASS_K, legacy::MASS_K),
+            ("MASS_ETA", pdg::MASS_ETA, legacy::MASS_ETA),
+            ("MASS_ETAP", pdg::MASS_ETAP, legacy::MASS_ETAP),
+            ("MASS_RHO", pdg::MASS_RHO, legacy::MASS_RHO),
+            ("MASS_OMEGA", pdg::MASS_OMEGA, legacy::MASS_OMEGA),
+            ("ALPHA_EM", pdg::ALPHA_EM, legacy::ALPHA_EM),
+            (
+                "RATIO_E_MU_MASS_SQ",
+                pdg::RATIO_E_MU_MASS_SQ,
+                legacy::RATIO_E_MU_MASS_SQ,
+            ),
+        ] {
+            assert_ne!(a.to_bits(), b.to_bits(), "{name} must stay divergent");
+        }
+    }
+
+    /// …and agree on the handful the Cython copied across unchanged, so the
+    /// test above is measuring a real split rather than two unrelated tables.
+    #[test]
+    fn the_two_tables_agree_where_the_cython_says_they_do() {
+        for (name, a, b) in [
+            ("F_A_PI", pdg::F_A_PI, legacy::F_A_PI),
+            ("F_V_PI", pdg::F_V_PI, legacy::F_V_PI),
+            ("F_V_PI_SLOPE", pdg::F_V_PI_SLOPE, legacy::F_V_PI_SLOPE),
+            ("F_A_K", pdg::F_A_K, legacy::F_A_K),
+            ("F_V_K", pdg::F_V_K, legacy::F_V_K),
+            (
+                "DECAY_CONST_PI",
+                pdg::DECAY_CONST_PI,
+                legacy::DECAY_CONST_PI,
+            ),
+            ("DECAY_CONST_K", pdg::DECAY_CONST_K, legacy::DECAY_CONST_K),
+        ] {
+            assert_eq!(a.to_bits(), b.to_bits(), "{name} must stay identical");
+        }
+    }
+
+    /// `photon_pion`'s frozen literals were computed from `legacy`, but the
+    /// same file's aliases come from `pdg`. Both halves are asserted here so
+    /// a future "cleanup" that unifies them fails in Rust as well as Python.
+    #[test]
+    fn photon_pion_mixes_the_two_tables() {
+        assert_eq!(
+            derived::photon_pion::MMU.to_bits(),
+            pdg::MASS_MU.to_bits(),
+            "the aliases follow the included pdg table"
+        );
+        let from_legacy = 0.5
+            * (legacy::MASS_PI * legacy::MASS_PI + legacy::MASS_MU * legacy::MASS_MU)
+            / legacy::MASS_PI;
+        assert_eq!(
+            derived::photon_pion::ENG_MU_PIRF.to_bits(),
+            from_legacy.to_bits(),
+            "the frozen literals do not"
+        );
+        assert_ne!(
+            derived::photon_pion::ENG_MU_PIRF.to_bits(),
+            derived::positron_pion::ENG_MU_PI_RF.to_bits(),
+            "the two spellings are two different numbers"
+        );
+    }
+
+    /// The muon-decay normalization is frozen against `pdg`, so it must
+    /// reproduce from the `R` sitting next to it. `ln` is not `const`, which
+    /// is why the constant is a literal and this check is a runtime test.
+    #[test]
+    fn r_factor_reproduces_from_the_pdg_mass_ratio() {
+        let r = derived::positron_muon::R;
+        let (r2, r4) = (r * r, r * r * r * r);
+        let r6 = r4 * r2;
+        let r8 = r4 * r4;
+        let expected = 1.0 / (1.0 - 8.0 * r2 + 8.0 * r6 - r8 - 12.0 * r4 * r2.ln());
+        assert_eq!(
+            derived::positron_muon::R_FACTOR.to_bits(),
+            expected.to_bits()
+        );
+        assert_eq!(
+            derived::neutrino_muon::R_FACTOR.to_bits(),
+            derived::positron_muon::R_FACTOR.to_bits()
+        );
+    }
+
+    /// Cython folds `DEF`s at compile time in Python; these are `const`
+    /// expressions folded by rustc. Same operations, same order, so the same
+    /// bits — asserted rather than assumed, against a runtime recomputation.
+    #[test]
+    fn const_folding_matches_a_runtime_evaluation() {
+        let (mpi, mmu, me) = (pdg::MASS_PI, pdg::MASS_MU, pdg::MASS_E);
+        assert_eq!(
+            derived::positron_pion::ENG_MU_PI_RF.to_bits(),
+            (0.5 * (mpi * mpi + mmu * mmu) / mpi).to_bits()
+        );
+        assert_eq!(
+            derived::positron_pion::ENG_E_PI_RF.to_bits(),
+            (0.5 * (mpi * mpi + me * me) / mpi).to_bits()
+        );
+        assert_eq!(
+            derived::neutrino_muon::R6.to_bits(),
+            {
+                let r2 = (me / mmu) * (me / mmu);
+                r2 * r2 * r2
+            }
+            .to_bits()
+        );
+    }
+}

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -24,7 +24,7 @@
 //!   reviews are indexed at
 //!   <https://pdg.lbl.gov/2025/reviews/constants_atomic_and_related.html>.
 //!   Every mass in [`pdg`] is bit-equal to its counterpart in the
-//!   pure-Python `hazma/parameters.py` (checked, all twelve), which cites
+//!   pure-Python `hazma/parameters.py` (checked, all fourteen), which cites
 //!   "PDG March 2022"; several entries (m(tau) = 1776.86 +- 0.12 MeV, for
 //!   one) are older than the current edition. A handful of branching ratios
 //!   are marked in the source as taken from Pythia 8.306 rather than the
@@ -60,8 +60,10 @@
 
 /// `hazma/_utils/constants.pxd` — the PDG-era table.
 ///
-/// `include`d by all twelve `hazma/spectra/**` extensions. Its masses are
-/// bit-equal to `hazma/parameters.py`'s; its `ALPHA_EM` is not.
+/// `include`d by all twelve `hazma/spectra/**` extensions -- a different
+/// twelve from the fourteen masses below, which is a collision worth
+/// reading twice. All fourteen masses are bit-equal to
+/// `hazma/parameters.py`'s; its `ALPHA_EM` is not.
 pub mod pdg {
     // =========================================================
     // ---- Masses in MeV --------------------------------------
@@ -586,7 +588,7 @@ pub mod derived {
     ///
     /// Every value computed, so this module tracks [`pdg`](super::pdg)
     /// with nothing frozen. Note `ENG_MU_PI_RF` is the same physical
-    /// quantity as [`photon_pion::ENG_MU_PIRF`](photon_pion::ENG_MU_PIRF) and *not* the same
+    /// quantity as [`photon_pion::ENG_MU_PIRF`] and *not* the same
     /// number — different table, and the two spellings differ by an
     /// underscore.
     pub mod positron_pion {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,7 +14,14 @@
 //! submodules are registration only. So "the PyO3 layer lives
 //! separately" (rules.md rule 8) is about keeping it out of [`kernels`],
 //! not about confining it to one file.
+//!
+//! [`constants`] sits below `kernels` in that stack and is `pub` while
+//! its neighbours are private — nothing in this crate reads it yet, and a
+//! private module of unread `const`s is a wall of `dead_code`. Publishing
+//! it is also honest: the tables are the crate's most reusable surface,
+//! and Phases 03–06 consume them from every kernel module.
 
+pub mod constants;
 mod dispatch;
 mod kernels;
 mod neutrino;

--- a/test/test_core_constants.py
+++ b/test/test_core_constants.py
@@ -1,0 +1,569 @@
+"""Bit-equality of ``rust/src/constants.rs`` against the Cython it ports.
+
+The Rust crate carries roughly 220 physical constants transcribed from
+three kinds of Cython source: the two ``.pxd`` tables that
+``hazma/spectra/**`` and the mediator extensions ``include``, and the
+module-local ``DEF`` entries a handful of ``.pyx`` files declare for
+themselves. Transcription at that volume is exactly the sort of thing a
+reader signs off on and a typo survives, so nothing here trusts the
+transcription: every value on both sides is re-derived from source and
+compared **bit for bit**.
+
+What this module proves, and what it does not
+---------------------------------------------
+It parses text. Both parsers hand their expressions to the same
+restricted evaluator, so the comparison is between what the two source
+files *denote*, under IEEE-754 correctly-rounded decimal-to-``f64``
+conversion — which CPython's ``float()`` and rustc's literal parsing
+both guarantee. That is the right question for a constants table, and it
+runs on every platform in milliseconds without a built extension.
+
+It says nothing about the compiled crate. ``cargo test`` covers that
+side: ``rust/src/constants.rs``'s own unit tests re-check the derived
+values against runtime arithmetic and pin the divergences between the
+two tables. The two halves are complementary and neither replaces the
+other.
+
+Lifetime
+--------
+This module reads the Cython, so it dies with it. When Phases 04-06
+delete a ``.pyx`` named in :data:`DERIVED_SOURCES`, delete its row; when
+the last ``.pxd`` goes in Phase 06, delete the module. The parity corpus
+under ``test/parity/`` is what pins the numbers after that. Each test
+below fails with that instruction rather than a ``FileNotFoundError``.
+
+See ``projects/cython-to-rust/rules.md`` rule 4 (Constants 1) for why
+the two tables are kept apart in the first place.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import re
+import struct
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: One namespace's constants; and the mapping from namespace to those.
+Table = dict[str, float]
+Namespaces = dict[str, Table]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUST_CONSTANTS = REPO_ROOT / "rust" / "src" / "constants.rs"
+
+#: ``DEF NAME = expr`` — the compile-time constants of ``constants.pxd``
+#: and of every ``.pyx`` that declares its own.
+DEF_RE = re.compile(r"^DEF\s+(\w+)\s*=\s*([^#]+?)\s*(?:#.*)?$")
+#: ``cdef double NAME = expr`` — how ``legacy_parameters.pxd`` spells the
+#: same thing.
+CDEF_RE = re.compile(r"^cdef\s+double\s+(\w+)\s*=\s*([^#]+?)\s*(?:#.*)?$")
+
+_RUST_CONST_RE = re.compile(r"^pub const (\w+)\s*:\s*f64\s*=\s*(.+?);\s*(?://.*)?$")
+_RUST_MOD_RE = re.compile(r"^pub mod (\w+)\s*\{$")
+# The lookbehind keeps the `e` of `1.230e-4` from reading as an identifier.
+_RUST_PATH_RE = re.compile(r"(?<![\w.])[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*")
+
+#: The two ``.pxd`` tables, keyed by the Rust module that ports each.
+CYTHON_TABLES = {
+    "pdg": (Path("hazma/_utils/constants.pxd"), DEF_RE),
+    "legacy": (Path("hazma/_utils/legacy_parameters.pxd"), CDEF_RE),
+}
+
+#: The ``.pyx`` files that declare module-local ``DEF`` entries, keyed by the
+#: ``derived::`` submodule that ports each. Every value in this mapping
+#: is checked against a fresh scan of the tree by
+#: :func:`test_no_pyx_declares_constants_this_module_ignores`, so a file
+#: cannot quietly appear or disappear from the list.
+DERIVED_SOURCES = {
+    "derived::photon_pion": Path("hazma/spectra/_photon/_pion.pyx"),
+    "derived::photon_rho": Path("hazma/spectra/_photon/_rho.pyx"),
+    "derived::positron_muon": Path("hazma/spectra/_positron/_muon.pyx"),
+    "derived::positron_pion": Path("hazma/spectra/_positron/_pion.pyx"),
+    "derived::neutrino_muon": Path("hazma/spectra/_neutrino/_muon.pyx"),
+}
+
+#: Which ``.pxd`` each of those ``.pyx`` ``include``-s, and therefore
+#: which table its *computed* ``DEF`` entries resolve names against. All five
+#: take ``constants.pxd``; the mediator extensions that take the legacy
+#: header declare no ``DEF`` entries of their own.
+DERIVED_INCLUDES = dict.fromkeys(DERIVED_SOURCES, "pdg")
+
+#: Loose floors for the sanity check that the parsers matched *something*.
+#: Deliberately well under the real counts (151 / 48 / 25) so that editing
+#: a table is not also editing this test.
+FLOOR_PDG = 100
+FLOOR_LEGACY = 30
+FLOOR_DERIVED = 20
+#: Decay widths in ``constants.pxd``. The legacy table has none, on
+#: purpose -- see :func:`test_the_legacy_widths_table_is_still_empty`.
+PDG_WIDTH_COUNT = 13
+
+
+# ---------------------------------------------------------------------
+# ---- Source parsing -------------------------------------------------
+# ---------------------------------------------------------------------
+
+
+class _Evaluator(ast.NodeVisitor):
+    """Evaluate a float expression against a name → value mapping.
+
+    Deliberately tiny: literals, names, unary minus, and the five binary
+    operators the two languages spell the same way. ``**`` is included
+    because Cython uses it and Python evaluates it identically; the Rust
+    side never produces one, since Rust has no such operator.
+    """
+
+    _BINOPS: ClassVar[dict[type[ast.operator], Callable[[float, float], float]]] = {
+        ast.Add: lambda a, b: a + b,
+        ast.Sub: lambda a, b: a - b,
+        ast.Mult: lambda a, b: a * b,
+        ast.Div: lambda a, b: a / b,
+        ast.Pow: lambda a, b: a**b,
+    }
+
+    def __init__(self, scope: Table) -> None:
+        self.scope = scope
+
+    def visit_Constant(self, node: ast.Constant) -> float:
+        if not isinstance(node.value, (int, float)) or isinstance(node.value, bool):
+            raise ValueError(f"not a number: {node.value!r}")
+        return float(node.value)
+
+    def visit_Name(self, node: ast.Name) -> float:
+        try:
+            return self.scope[node.id]
+        except KeyError:
+            raise ValueError(f"undefined constant {node.id!r}") from None
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> float:
+        value = self.visit(node.operand)
+        if isinstance(node.op, ast.USub):
+            return -value
+        if isinstance(node.op, ast.UAdd):
+            return +value
+        raise ValueError(f"unsupported unary operator {node.op!r}")
+
+    def visit_BinOp(self, node: ast.BinOp) -> float:
+        try:
+            op = self._BINOPS[type(node.op)]
+        except KeyError:
+            raise ValueError(f"unsupported operator {node.op!r}") from None
+        return op(self.visit(node.left), self.visit(node.right))
+
+    def generic_visit(self, node: ast.AST) -> float:
+        raise ValueError(f"unsupported syntax {type(node).__name__}")
+
+
+def _evaluate(expression: str, scope: Table) -> float:
+    """Evaluate `expression` in `scope`, rejecting anything exotic."""
+    tree = ast.parse(expression.strip(), mode="eval")
+    return _Evaluator(scope).visit(tree.body)
+
+
+def parse_cython(path: Path, pattern: re.Pattern[str], base: Table) -> Table:
+    """Return the constants `path` declares, in declaration order.
+
+    `base` seeds the scope with the table the file ``include``-s, so a
+    ``.pyx`` whose ``DEF`` entries reference ``MASS_MU`` resolves it. Later
+    declarations see earlier ones, matching Cython.
+    """
+    scope = dict(base)
+    values: Table = {}
+    for line in path.read_text().splitlines():
+        match = pattern.match(line.strip())
+        if match is None:
+            continue
+        name, expression = match.group(1), match.group(2)
+        value = _evaluate(expression, scope)
+        scope[name] = value
+        values[name] = value
+    return values
+
+
+def parse_rust(path: Path) -> Namespaces:
+    """Return ``{module path: {NAME: value}}`` for a Rust constants file.
+
+    Modules are tracked by brace depth, so ``derived::photon_pion`` comes
+    out fully qualified. Name resolution walks outward from the current
+    module exactly as Rust's does, which is what lets the source write
+    ``pdg::MASS_E`` from inside ``derived::positron_muon`` — and what
+    lets this parser stay ignorant of ``use`` statements.
+    """
+    modules: Namespaces = {}
+    flat: Table = {}
+    stack: list[str] = []
+    depth_of_module: list[int] = []
+    depth = 0
+
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("#[cfg(test)]"):
+            # The unit tests below carry braces inside format strings, and
+            # nothing past here declares a constant. Stopping is cheaper
+            # than teaching the brace counter about string literals.
+            break
+        if match := _RUST_MOD_RE.match(line):
+            stack.append(match.group(1))
+            depth_of_module.append(depth)
+            modules.setdefault("::".join(stack), {})
+            depth += 1
+            continue
+        if match := _RUST_CONST_RE.match(line):
+            module = "::".join(stack)
+            name, expression = match.group(1), match.group(2)
+            value = _evaluate(*_rustify(expression, module, flat))
+            modules[module][name] = value
+            flat[f"{module}::{name}" if module else name] = value
+            continue
+        depth += line.count("{") - line.count("}")
+        while depth_of_module and depth <= depth_of_module[-1]:
+            stack.pop()
+            depth_of_module.pop()
+    return modules
+
+
+def _rustify(expression: str, module: str, flat: Table) -> tuple[str, Table]:
+    """Rewrite Rust paths in `expression` into plain Python identifiers.
+
+    Returns the rewritten expression and the scope it needs. Each
+    ``a::b::C`` is resolved by trying it under the current module, then
+    each enclosing module, then the crate root — Rust's own rule — and
+    replaced by a mangled identifier.
+    """
+    parts = module.split("::") if module else []
+    scope: Table = {}
+
+    def replace(match: re.Match[str]) -> str:
+        path = match.group(0)
+        for i in range(len(parts), -1, -1):
+            candidate = "::".join([*parts[:i], path])
+            if candidate in flat:
+                mangled = candidate.replace("::", "__")
+                scope[mangled] = flat[candidate]
+                return mangled
+        raise AssertionError(
+            f"{path!r} in module {module!r} resolves to no constant declared "
+            f"earlier in {RUST_CONSTANTS.name}"
+        )
+
+    return _RUST_PATH_RE.sub(replace, expression), scope
+
+
+def bits(value: float) -> str:
+    """Hex of the IEEE-754 payload — the only equality this module uses.
+
+    ``==`` would call ``0.0`` and ``-0.0`` equal and every NaN unequal.
+    Neither case arises in a constants table today, but a table is
+    exactly where a sign-of-zero change would hide.
+    """
+    return struct.pack("<d", value).hex()
+
+
+def require(path: Path) -> Path:
+    """Return `path`, or fail with what to do now that it is gone."""
+    if not path.exists():
+        pytest.fail(
+            f"{path} no longer exists. Phases 04-06 of the cython-to-rust "
+            f"project delete the Cython this module reads; when they do, "
+            f"drop the corresponding row from CYTHON_TABLES or "
+            f"DERIVED_SOURCES (and delete this module once the last one "
+            f"goes). test/parity/ is what pins the numbers afterwards."
+        )
+    return path
+
+
+# ---------------------------------------------------------------------
+# ---- Fixtures -------------------------------------------------------
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rust() -> Namespaces:
+    return parse_rust(require(RUST_CONSTANTS))
+
+
+@pytest.fixture(scope="module")
+def tables() -> Namespaces:
+    return {
+        name: parse_cython(require(REPO_ROOT / path), pattern, {})
+        for name, (path, pattern) in CYTHON_TABLES.items()
+    }
+
+
+# ---------------------------------------------------------------------
+# ---- The parsers themselves -----------------------------------------
+# ---------------------------------------------------------------------
+
+
+class TestParsers:
+    """A silent parser would turn every check below into a tautology."""
+
+    def test_the_rust_file_yields_the_expected_modules(self, rust: Namespaces) -> None:
+        assert set(rust) == {"pdg", "legacy", "derived", *DERIVED_SOURCES}
+        assert rust["derived"] == {}, "derived holds submodules, not constants"
+
+    def test_each_table_is_substantial(
+        self, rust: Namespaces, tables: Namespaces
+    ) -> None:
+        # Guards against a regex that matches nothing. The real counts
+        # are 151 / 48 in the two .pxd and 25 module-local DEFs across
+        # five .pyx; the floors are loose so ordinary edits to the tables
+        # do not have to touch this test.
+        assert len(tables["pdg"]) > FLOOR_PDG
+        assert len(tables["legacy"]) > FLOOR_LEGACY
+        assert sum(len(rust[m]) for m in DERIVED_SOURCES) > FLOOR_DERIVED
+
+    def test_an_unsupported_expression_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unsupported syntax"):
+            _evaluate("sqrt(2.0)", {})
+        with pytest.raises(ValueError, match="undefined constant"):
+            _evaluate("NOT_A_CONSTANT", {})
+
+    def test_uppercasing_a_cython_name_cannot_collide(
+        self, tables: Namespaces, derived: Namespaces
+    ) -> None:
+        # The Rust side is SCREAMING_SNAKE by convention, so the name
+        # comparison below upper-cases the Cython. That is only sound
+        # while the mapping stays injective -- `etap_BR_pi0_pi0_eta` in
+        # the legacy table and the lowercase `DEF`s of
+        # `_positron/_pion.pyx` are the names it has to fold.
+        for label, table in {**tables, **derived}.items():
+            folded = [name.upper() for name in table]
+            assert len(set(folded)) == len(folded), label
+
+
+# ---------------------------------------------------------------------
+# ---- The two .pxd tables --------------------------------------------
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("table", sorted(CYTHON_TABLES))
+class TestTables:
+    def test_names_match_exactly(
+        self, rust: Namespaces, tables: Namespaces, table: str
+    ) -> None:
+        assert {name.upper() for name in tables[table]} == set(rust[table])
+
+    def test_values_are_bit_equal(
+        self, rust: Namespaces, tables: Namespaces, table: str
+    ) -> None:
+        mismatched = {
+            name: (bits(value), bits(rust[table][name.upper()]))
+            for name, value in tables[table].items()
+            if bits(value) != bits(rust[table][name.upper()])
+        }
+        assert not mismatched
+
+
+# ---------------------------------------------------------------------
+# ---- Module-local DEFs ----------------------------------------------
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def derived(tables: Namespaces) -> Namespaces:
+    return {
+        module: parse_cython(
+            require(REPO_ROOT / path), DEF_RE, tables[DERIVED_INCLUDES[module]]
+        )
+        for module, path in DERIVED_SOURCES.items()
+    }
+
+
+@pytest.mark.parametrize("module", sorted(DERIVED_SOURCES))
+class TestDerived:
+    def test_names_match_exactly(
+        self, rust: Namespaces, derived: Namespaces, module: str
+    ) -> None:
+        assert {name.upper() for name in derived[module]} == set(rust[module])
+
+    def test_values_are_bit_equal(
+        self, rust: Namespaces, derived: Namespaces, module: str
+    ) -> None:
+        mismatched = {
+            name: (bits(value), bits(rust[module][name.upper()]))
+            for name, value in derived[module].items()
+            if bits(value) != bits(rust[module][name.upper()])
+        }
+        assert not mismatched
+
+
+def test_no_pyx_declares_constants_this_module_ignores() -> None:
+    """`DERIVED_SOURCES` is complete against the tree, not a snapshot."""
+    found = {
+        path.relative_to(REPO_ROOT)
+        for path in (REPO_ROOT / "hazma").rglob("*.pyx")
+        if any(DEF_RE.match(line.strip()) for line in path.read_text().splitlines())
+    }
+    assert found == set(DERIVED_SOURCES.values())
+
+
+def test_every_derived_pyx_includes_the_table_it_is_scored_against() -> None:
+    """The scope a computed ``DEF`` resolves in is the ``include``, not a guess."""
+    headers = {"pdg": "constants.pxd", "legacy": "legacy_parameters.pxd"}
+    for module, path in DERIVED_SOURCES.items():
+        text = require(REPO_ROOT / path).read_text()
+        included = [
+            table
+            for table, header in headers.items()
+            if re.search(rf'^include\s+"[^"]*{re.escape(header)}"', text, re.M)
+        ]
+        assert included == [DERIVED_INCLUDES[module]], path
+
+
+# ---------------------------------------------------------------------
+# ---- Provenance of the frozen literals ------------------------------
+# ---------------------------------------------------------------------
+#
+# Seven DEFs are hard-coded digit strings rather than expressions -- someone
+# evaluated a formula once and pasted the result. Their comments name the
+# formula but not the mass table, and the two tables give different
+# answers. Bit-equality against the .pyx (above) would be satisfied by any
+# digits at all, so these tests reconstruct each literal and pin which
+# table it came from. That is the difference between "the port copied the
+# Cython" and "the port knows what the Cython means".
+
+
+def kinematics(table: dict[str, float]) -> dict[str, float]:
+    """Pion/muon decay kinematics from one mass table, in MeV.
+
+    ``eng_mu`` and ``eng_gam_max_murf`` are the muon energy and the
+    maximum photon energy in the pion and muon rest frames respectively;
+    ``eng_gam_max_pirg`` boosts the latter into the pion rest frame.
+    """
+    mpi, mmu, me = table["MASS_PI"], table["MASS_MU"], table["MASS_E"]
+    eng_mu = 0.5 * (mpi * mpi + mmu * mmu) / mpi
+    gamma = eng_mu / mmu
+    beta = math.sqrt(1 - 1 / (gamma * gamma))
+    eng_gam_max_murf = (mmu * mmu - me * me) / (2 * mmu)
+    return {
+        "ENG_MU_PIRF": eng_mu,
+        "GAMMA_MU_PIRF": gamma,
+        "BETA_MU_PIRF": beta,
+        "ENG_GAM_MAX_MURF": eng_gam_max_murf,
+        "ENG_GAM_MAX_PIRG": eng_gam_max_murf * gamma * (1 + beta),
+    }
+
+
+def test_photon_pion_literals_come_from_the_legacy_table(
+    rust: Namespaces, tables: Namespaces
+) -> None:
+    """All five reproduce from ``legacy``, and none of them from ``pdg``.
+
+    ``hazma/spectra/_photon/_pion.pyx`` ``include``-s ``constants.pxd``,
+    so this is a genuine mix inside one module: its three mass aliases are
+    PDG values while its five kinematic literals are frozen against the
+    older table. Recomputing them from the header the file actually
+    includes moves ``ENG_MU_PIRF`` by 4.7e-5 MeV and every charged-pion
+    photon spectrum with it, which is why rule 4 forbids the tidy-up.
+    """
+    frozen = rust["derived::photon_pion"]
+    from_legacy = kinematics(tables["legacy"])
+    from_pdg = kinematics(tables["pdg"])
+
+    assert {name: bits(value) for name, value in from_legacy.items()} == {
+        name: bits(frozen[name]) for name in from_legacy
+    }
+    assert all(bits(from_pdg[name]) != bits(frozen[name]) for name in from_pdg)
+
+
+def test_photon_pion_mass_aliases_come_from_the_pdg_table(
+    rust: Namespaces, tables: Namespaces
+) -> None:
+    """The other half of the mix, so the test above is not half a story."""
+    frozen = rust["derived::photon_pion"]
+    for alias, canonical in (("MPI", "MASS_PI"), ("ME", "MASS_E"), ("MMU", "MASS_MU")):
+        assert bits(frozen[alias]) == bits(tables["pdg"][canonical])
+        assert bits(frozen[alias]) != bits(tables["legacy"][canonical])
+
+
+def test_r_factor_is_the_michel_normalization_over_the_pdg_ratio(
+    rust: Namespaces,
+) -> None:
+    """``R_FACTOR`` reproduces, and its ``.pyx`` comment has a typo.
+
+    The comment above the literal in both muon kernels reads
+    ``1 / (1 - 8 r^2 + 8 r^6 - r^8 - 12 r^2 ln(r^2))``. The log term's
+    exponent is wrong: only ``r^4`` reproduces the digits, and the
+    difference is a factor of ``r^2 ~ 2.3e-5`` on that term, so the
+    published value settles it. Pinned here so a port that trusts the
+    comment over the number fails loudly.
+    """
+    r = rust["derived::positron_muon"]["R"]
+    r2, r4 = r * r, r * r * r * r
+    r6, r8 = r4 * r2, r4 * r4
+    log = math.log(r2)
+
+    correct = 1 / (1 - 8 * r2 + 8 * r6 - r8 - 12 * r4 * log)
+    as_commented = 1 / (1 - 8 * r2 + 8 * r6 - r8 - 12 * r2 * log)
+
+    assert bits(rust["derived::positron_muon"]["R_FACTOR"]) == bits(correct)
+    assert bits(rust["derived::neutrino_muon"]["R_FACTOR"]) == bits(correct)
+    assert bits(as_commented) != bits(correct)
+
+
+# ---------------------------------------------------------------------
+# ---- The divergence itself ------------------------------------------
+# ---------------------------------------------------------------------
+
+#: Every name the two ``.pxd`` share. Ten masses plus alpha and the mass
+#: ratio diverge; the seven form factors and decay constants agree. Kept
+#: as a literal roster because the whole content of rule 4 is that this
+#: partition does not move — a computed one would accept any partition.
+SHARED_AND_DIVERGENT = {
+    "MASS_E",
+    "MASS_MU",
+    "MASS_PI0",
+    "MASS_PI",
+    "MASS_K0",
+    "MASS_K",
+    "MASS_ETA",
+    "MASS_ETAP",
+    "MASS_RHO",
+    "MASS_OMEGA",
+    "ALPHA_EM",
+    "RATIO_E_MU_MASS_SQ",
+}
+SHARED_AND_EQUAL = {
+    "F_A_PI",
+    "F_V_PI",
+    "F_V_PI_SLOPE",
+    "F_A_K",
+    "F_V_K",
+    "DECAY_CONST_PI",
+    "DECAY_CONST_K",
+}
+
+
+def test_the_two_tables_diverge_on_exactly_the_recorded_names(rust: Namespaces) -> None:
+    """rules.md rule 4, as an assertion.
+
+    A consolidation that quietly adopted one table's masses everywhere
+    would pass every bit-equality test above — those compare Rust to
+    Cython file by file — and fail only here.
+    """
+    pdg, legacy = rust["pdg"], rust["legacy"]
+    shared = set(pdg) & set(legacy)
+    assert shared == SHARED_AND_DIVERGENT | SHARED_AND_EQUAL
+
+    diverged = {name for name in shared if bits(pdg[name]) != bits(legacy[name])}
+    assert diverged == SHARED_AND_DIVERGENT
+
+
+def test_the_legacy_widths_table_is_still_empty(rust: Namespaces) -> None:
+    """Two malformed width entries were deleted on 2026-08-05.
+
+    ``docs/followups/done/legacy-parameters-width-exponent-bug.md``
+    records why: ``3.3406**-13.`` is exponentiation, not a decimal
+    exponent, and nothing referenced either name. If a ``WIDTH_*``
+    reappears in the legacy namespace it was resurrected, not ported.
+    """
+    assert not [name for name in rust["legacy"] if name.startswith("WIDTH_")]
+    widths = [name for name in rust["pdg"] if name.startswith("WIDTH_")]
+    assert len(widths) == PDG_WIDTH_COUNT


### PR DESCRIPTION
## Summary

- Adds `rust/src/constants.rs` — **224 `pub const`s in three namespaces**, each mapped to its Cython source: `pdg` (151, `hazma/_utils/constants.pxd`), `legacy` (48, `hazma/_utils/legacy_parameters.pxd`), and `derived::<source_pyx>` (25, the module-local `DEF`s of the five `.pyx` that declare any). The two tables disagree on **12 of the 19 names they share**; the divergence is reproduced verbatim, per `projects/cython-to-rust/rules.md` rule 4. Computed `DEF`s became `const` expressions in the Cython's association order; the seven hard-coded ones stayed literals (`sqrt`/`ln` are not `const`, and literals are what the sources have).
- **The transcription is checked, not reviewed.** `test/test_core_constants.py` (25 tests) re-derives every value from source on both sides and compares IEEE payloads — no build, 0.03s, platform-independent. Five `cargo test` units cover the compiled side. Thirteen mutations were each caught by the test whose name claims it.
- `pub mod constants;` in `lib.rs` where its neighbours are private: nothing reads the tables yet, and a private module of 224 unread `const`s is a wall of `dead_code` under `-D warnings`.

**Three things the check found that reading would not have:**

1. **`hazma/spectra/_photon/_pion.pyx` reads from both tables at once.** It `include`s `constants.pxd`, so its `MPI`/`ME`/`MMU` aliases are PDG values — but its five hard-coded kinematic literals reproduce **bit-exactly** from the *legacy* masses and from no other table. Recomputing them from the header the file actually includes would move `ENG_MU_PIRF` by 4.7e-5 MeV and every charged-pion photon spectrum with it. Left exactly as the Cython has them; both halves of the mix are pinned in Python and in Rust. **Phase 04 must not consolidate this.**
2. **`R_FACTOR`'s comment has an exponent typo.** Both muon kernels annotate `1.0001870858234163` with a `12 r^2 ln(r^2)` log term; only `r^4` reproduces the digits. A port trusting the comment lands at `0.9972020119096803`, 0.3% away. The `.pyx` is untouched; the correct formula is pinned.
3. **Hazma carries three fine-structure constants** — `1/137.035999084` (`constants.pxd`, a pre-CODATA-2022 value; CODATA 2022 revised α⁻¹ to 137.035999177(21), [arXiv:2409.03787](https://arxiv.org/abs/2409.03787)), `1/137` (`legacy_parameters.pxd`), and `1/137.04` (`hazma/parameters.py:205`). All **fourteen** masses, by contrast, agree between `constants.pxd` and `parameters.py` (bit-equal; `MASS_K0`/`MASS_KL`/`MASS_KS` share 497.611, so it is 14 names onto 12 distinct values). All three αs are kept; reconciling them is the consolidation this project scopes out.

**No public value changes.** `git diff origin/master -- hazma` is empty, and the parity corpus ran at `rtol = 0` across all 41 consumed entry points and 179,695 pinned values.

## Project

`projects/cython-to-rust/` — Phase 03, Task 3.1: Constants module.

See `projects/cython-to-rust/task-notes/phase-03/task-3.1-constants.md` for implementation detail, decisions, the mutation table, and verification.

## Test plan

- [x] `scripts/agents/preflight.sh --paths "test/test_core_constants.py" --md "<3 docs>"` → **RESULT: PASS**, all eleven rows:

```text
PASS   black --check           test/test_core_constants.py
PASS   isort --check-only      test/test_core_constants.py
PASS   ruff check              test/test_core_constants.py
PASS   cargo fmt --check       rust/
PASS   cargo clippy            rust/
PASS   cargo test              rust/
PASS   pytest                  1088 passed, 13 skipped, 5 warnings in 563.15s (0:09:23)
PASS   import hazma            version 2.1.0
PASS   markdownlint            projects/cython-to-rust/task-notes/...
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
```

  `1088 passed` is +25 on Phase 02's 1063, all of them the new module. The **skip count is unchanged at 13**, which is how the parity corpus reports it ran in bit-equality mode rather than under the declared budgets.

- [x] `pytest test/test_core_constants.py -q` → `25 passed in 0.03s`
- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features` → `7 passed; 0 failed` (5 new in `constants::tests`, 2 pre-existing in `kernels::tests`)
- [x] `cargo doc --no-deps 2>&1 | grep -E '^warning' | sort | uniq -c` → the 3 pre-existing `links to private item` warnings in `lib.rs`, none added
- [x] **Test validity:** 13 mutations (9 Python, 4 Rust), each caught by the test whose name claims it — table in the task note. One further mutation (re-associating `ENG_MU_PI_RF`) correctly passed: all three associations give the identical payload at these masses.

**Environment note for reviewers:** a fresh `uv pip install -e .` resolves NumPy 2.5.2, but the corpus manifest records 2.5.1 — `tolerances.provenance` compares the whole numerics environment, so the parity suite silently drops to budget mode and the bare suite reports 14 skipped instead of 13. Pin `numpy==2.5.1` and rebuild `--no-build-isolation` to reproduce the run above. Recipe is in `projects/cython-to-rust/task-notes/README.md` under Findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review round 1 (commit `d0a58f2`)

Both findings accepted and fixed.

- **Blocking — mass count.** `constants.pxd` declares **14** `MASS_*`, not 12, and all 14 are bit-equal to `hazma/parameters.py`'s. Corrected in five places: the `constants.rs` header (x2), the task note (x2), the working memory, and this body. The original check *ran*, but over a hand-typed 12-pair list that omitted `MASS_KL` and `MASS_KS` — and 12 was also the correct count of spectra extensions that `include` the header two paragraphs above, so every internal cross-check agreed. Re-derived by enumerating `^DEF MASS_` from the header and matching on bit pattern rather than on typed names. New `docs/agents/lessons.md` class: `[hand-written-population-in-a-derived-check]`.
- **Non-blocking — rustdoc.** Removed the redundant explicit link target at `constants.rs:589`; `cargo doc` is back to 3 warnings, all pre-existing. My verification had grepped `^warning: unresolved`, a subset of what `cargo doc` emits, so "0 unresolved links" was true and still hid a warning this diff added.

No executable change in the fix commit — comments and durable docs only. Preflight re-run: `RESULT: PASS`, `pytest 1088 passed, 13 skipped` (unchanged).
