### PR TITLE
feat(utils): port the finite-interval quadpack subset to rust

### DIFF
--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -208,7 +208,16 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   `51 passed / 20 skipped` survived because Task 0.1 had fixed the
   *sibling* copy in the project README and never swept the class, and a
   single task note carried two different byte counts for the same
-  directory). Generalizes [stale-ci-capability-claim] from workflows to
+  directory; PR #60: a wrong call-site count was swept by grepping the
+  *paired* phrases it usually appeared in — `eleven`, `six of the
+  eleven` — which fixed twelve copies and missed two more that carried
+  the bare number word alone, one of them in the same file's own
+  "all twelve occurrences were swept" record. Key the sweep on the
+  **claim** — every numeral or number word within N characters of
+  `call site`, in either order — not on the phrasing the number happened
+  to arrive in, and never let the sweep's own summary assert a
+  completeness its pattern cannot support).
+  Generalizes [stale-ci-capability-claim] from workflows to
   any repo fact, and applies *within* one file as much as across
   several.
 - [elided-doc-paths] A `.../foo.py` shorthand in a durable doc is not

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -216,7 +216,17 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   **claim** — every numeral or number word within N characters of
   `call site`, in either order — not on the phrasing the number happened
   to arrive in, and never let the sweep's own summary assert a
-  completeness its pattern cannot support).
+  completeness its pattern cannot support. Round 2 of the same PR showed
+  that claim-keyed is still not enough while the pattern is *line*-keyed:
+  three more copies survived, two of them wrapped across a newline
+  (`the four\n  spectra/mediator-spectrum calls`) and one using a synonym
+  (`those six sites` where the anchor was `call site`) — including two in
+  the canonical reference the earlier round claimed to have swept, which
+  then held three different counts of the same thing. **Reflow the file to
+  one line before matching, and alternate the synonyms** —
+  `re.sub(r"\n\s*(//|#|\*)?\s*", " ", text)` then a single regex over the
+  result — because prose wraps wherever the formatter put it and a
+  line-oriented `rg` cannot see a claim that straddles the break).
   Generalizes [stale-ci-capability-claim] from workflows to
   any repo fact, and applies *within* one file as much as across
   several.
@@ -326,6 +336,22 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   [measurement-taken-before-the-task-ended], where a correct derivation
   expired: here the derivation ran, on the final tree, over the wrong
   domain.
+- [bound-parameter-sized-the-allocation] A parameter that *bounds* work is
+  not a prediction of it, so sizing a buffer by one turns a caller's
+  permissive input into an allocation request. `scipy.integrate.quad`
+  accepts `limit` up to `INT_MAX`; the QUADPACK port allocated its five
+  `limit`-length workspaces up front, so `limit = INT_MAX` reserved ~80 GiB
+  before the first panel was evaluated — and Rust **aborts** on allocation
+  failure rather than unwinding, so it can never surface as a Python
+  exception, against an exit criterion of "never panics across FFI"
+  (PR #60). Two traps around it: the eager allocation is *invisible* on a
+  platform whose allocator overcommits (peak RSS moved 18.2 → 18.6 MB on
+  macOS, so a passing test proved nothing), and a first-round fix that
+  merely rejects values *above* the range leaves the same hazard directly
+  below it. Grow on demand instead, and make the guard test ask for a size
+  no allocator can satisfy — a mutation reverting to eager sizing must
+  fail loudly (`memory allocation of 36028797018963976 bytes failed`,
+  SIGABRT) rather than depending on the host's memory policy.
 - [signed-zero-lost-by-a-derived-formula] A wrapper that reaches its answer
   by *arithmetic on* an upstream routine's outputs, rather than by calling
   it, inherits an argument case the upstream never had — and `-0.0` is the

--- a/hazma/_core.pyi
+++ b/hazma/_core.pyi
@@ -7,13 +7,17 @@ import numpy as np
 # vector_mediator — exist but are empty until Phases 03-06 fill them;
 # each gets its own stub alongside its first kernel.
 #
-# There is a sixth submodule, `special` (cython-to-rust Task 3.2), and it
-# is deliberately not stubbed: it exposes `spence`, `bessel_k1` and
-# `bessel_kn` only so `test/test_core_special.py` can sweep them against
-# scipy. The kernels that will use them call the Rust side directly, and
-# nothing under `hazma/` imports it — a stub would advertise a surface
-# this package does not mean to offer. Its three functions follow the
-# same dispatch contract `roundtrip` documents below.
+# Two further submodules, `special` (cython-to-rust Task 3.2) and `quad`
+# (Task 3.3), are deliberately not stubbed. `special` exposes `spence`,
+# `bessel_k1` and `bessel_kn` only so `test/test_core_special.py` can
+# sweep them against scipy — its three functions follow the same dispatch
+# contract `roundtrip` documents below. `quad` exposes the QUADPACK port
+# only so `test/test_core_quad.py` can put one Python integrand through
+# both it and `scipy.integrate.quad`; it takes a callable rather than an
+# array and so has no dispatch contract to describe. The kernels that
+# will use either call the Rust side directly, and nothing under `hazma/`
+# imports them — a stub would advertise a surface this package does not
+# mean to offer.
 
 # `roundtrip` is the scaffold's plumbing probe, not physics. It follows
 # the dispatch contract every ported entry point uses: a Python float, a

--- a/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
@@ -118,6 +118,54 @@ bullet's parenthetical anticipated turned out to be in *scipy*, not in
   subdivisions, invalid breakpoints) — returns a Result, never panics
   across FFI.
 
+**Criteria added during execution** (2026-08-10; the second bullet's
+"pin it empirically" instruction was right, and what it turned up
+reshapes the other three):
+
+- **The breakpoint contract belongs to scipy, not to QUADPACK, and both
+  live degeneracies are *discards*.** `scipy.integrate.quad` filters in
+  Python before `qagpe` ever sees the list — `np.unique`, then strictly
+  interior — so `points=[-1, 1]` on `[-1, 1]` leaves **zero** breakpoints
+  and the heavy-mediator thermal entries are dropped. Consequence: five of
+  the twelve live call sites run `qagpe` with an *empty* list, because
+  `points is None` — not "no breakpoint survived" — is what selects
+  `qagse`. The port therefore has to keep that dispatch distinction even
+  though it is almost never observable (measured: the two routines agree
+  on value, `neval` and `last` in every one of 3,776 random combinations
+  that converged, and differ only once `limit` is exhausted).
+- **Only `qk21` is on the live path.** Both `qagse` and `qagpe` evaluate
+  with the 21-point rule and nothing else, so `qk15` — which this task's
+  first criterion names — is reachable from no hazma call site. It is
+  ported anyway, and earns its place as an independent second rule for
+  the cross-checks rather than as production code.
+- **The agreement criterion is met with two orders of headroom, and its
+  boundary is `limit`.** Over 11,274 random (integrand, tolerance, limit,
+  points) combinations against scipy 1.18.0: the 4,461 runs that
+  converged reproduced scipy's `neval` and `last` on all but **5**
+  (0.11%), with the value within 3.6e-2 of the requested tolerance (the
+  criterion allows 10x) and 8.2e-11 relative at worst. The 6,813 that
+  exhausted `limit` can separate without bound — 4.5e-5 in that sweep,
+  11% on a hand-picked case — because Wynn's ε-algorithm is chaotic on a
+  sequence that is not converging; identical subdivision plus a few ulp
+  in the table is enough. Termination flags agreed on all 11,274. No live
+  integrand shape reaches the second regime — each returns `ier = 0`, and
+  `test/test_core_quad.py` asserts it rather than assuming it.
+- **Two heuristics inside the adaptive loop need purpose-built inputs.**
+  `qagpe`'s `ndin` flag and `qagse`'s roundoff counters change only
+  *which* subinterval is bisected next, so they survive every test built
+  from the reference problems and the live shapes — a mutation campaign
+  found both. The inputs that expose them were found by mutating and
+  searching (`sin(293.25/x)` over a 39-point grid moves by a factor of
+  48 without `ndin`; a near-delta spike at 0.16309 with `points=[0.5]`
+  moves by 2,800 when the 0.99 roundoff threshold is relaxed) and are
+  pinned in `TestAdaptiveHeuristics` at a deliberately coarse
+  `rtol = 1e-6`, both sitting in the limit-exhausted regime.
+- **The corpus's served-kernel predicate stays sound.** The scipy oracle
+  lives in Python, so the port is exposed as `hazma._core.quad` and joins
+  `hazma._core.special` in `cases._CORE_TEST_ONLY_MODULES`, under the
+  same importer guard Task 3.2 built. Same mechanism, not a widened
+  exemption.
+
 ### Task 3.4: Interpolation + boost kernels
 
 **Task note:** [`../task-notes/phase-03/task-3.4-interp-boost.md`](../task-notes/phase-03/task-3.4-interp-boost.md)

--- a/projects/cython-to-rust/references/numerics-replacements.md
+++ b/projects/cython-to-rust/references/numerics-replacements.md
@@ -112,6 +112,38 @@ sorted/duplicate/endpoint-coincident/out-of-interval points must be
 pinned *empirically* and replicated exactly, errors included — do not
 derive the contract from QUADPACK documentation alone (Task 3.3).
 
+**Measured, 2026-08-10 (Task 3.3), against scipy 1.18.0.** The contract
+is not QUADPACK's at all — it is three lines of Python in
+`scipy/integrate/_quadpack_py.py`'s `_quad`: `np.unique(points)`, then
+`[a < p]`, then `[p < b]`, after `quad` has already ordered the limits
+(`flip, a, b = b < a, min(a, b), max(a, b)`) and with the result negated
+afterwards if it flipped. So: **sort ascending, drop duplicates, keep
+only strictly interior points.** Endpoint-coincident points, points
+outside `[a, b]` and `NaN` all vanish silently; `-0.0` and `0.0` collapse
+to one entry. The only errors are `ValueError`s raised from
+`quad`: an unattainable tolerance, and `limit <= npts` counted **after**
+filtering (scipy's message quotes the caller's unfiltered length, which
+is a message defect, not a contract).
+
+Two consequences the paragraph above did not anticipate:
+
+- **Both live degeneracies are discards.** `points=[-1, 1]` on `[-1, 1]`
+  leaves *zero* break points, and a heavy mediator drops both of the
+  thermal call's mediator entries. Five of the twelve live call sites
+  therefore run `qagpe` with an empty break-point list.
+- **`points is None` selects `qagse`, not "no break point survived".**
+  scipy dispatches before it filters, so those six sites run `qagpe`.
+  That matters rarely but not never: `qagpe` measures the "smallest
+  interval" by subdivision level and `qagse` by interval length, so
+  `qagpe` extrapolates one bisection earlier. Over 3,776 random
+  (integrand, tolerance, limit) combinations the two agreed on value,
+  `neval` and `last` in every run that converged, and differed in 45 —
+  all of them runs that exhausted `limit`.
+
+Also measured there, and worth carrying into Phases 04–06: only `qk21`
+is on the live path. `qagse` and `qagpe` both evaluate with the 21-point
+rule and nothing else, so `qk15` is reachable from no hazma call site.
+
 Oracle strategy: primary oracle is scipy itself, via (a) direct
 Python-side comparisons on each live integrand shape and (b) the Phase
 01 corpus. See ADR-0002 for what the cyphus crates may and may not be

--- a/projects/cython-to-rust/references/numerics-replacements.md
+++ b/projects/cython-to-rust/references/numerics-replacements.md
@@ -102,7 +102,7 @@ keeps corpus drift near zero, at ~1,500–2,500 lines of Rust. Infinite
 intervals (`qagi`) are not needed — every live integral is finite.
 
 **Breakpoint degeneracies present in the live calls** (they shape the
-Task 3.3 preprocessing contract): the four spectra/mediator-spectrum
+Task 3.3 preprocessing contract): the five spectra/mediator-spectrum
 `points=[-1, 1]` calls pass breakpoints that coincide with *both*
 integration endpoints; the thermal ⟨σv⟩ calls pass
 `[2, m_med/mx, 2·m_med/mx]`, whose lower entry equals the lower bound
@@ -132,7 +132,7 @@ Two consequences the paragraph above did not anticipate:
   thermal call's mediator entries. Five of the twelve live call sites
   therefore run `qagpe` with an empty break-point list.
 - **`points is None` selects `qagse`, not "no break point survived".**
-  scipy dispatches before it filters, so those six sites run `qagpe`.
+  scipy dispatches before it filters, so those five sites run `qagpe`.
   That matters rarely but not never: `qagpe` measures the "smallest
   interval" by subdivision level and `qagse` by interval length, so
   `qagpe` extrapolates one bisection earlier. Over 3,776 random

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -702,7 +702,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   exemption. Measured rather than only argued: the bare suite ran the
   parity corpus in **bit-equality mode** — `rtol = 0` across all 41
   consumed entry points, 179,695 pinned values — and passed, at
-  `1207 passed, 13 skipped` (+53 on Task 3.2's 1154, all of them this
+  `1212 passed, 13 skipped` (+58 on Task 3.2's 1154, all of them this
   task's tests; the skip count is unchanged, which is what proves the
   mode). What the task *did* produce, numerically, is an integrator that
   reproduces `scipy.integrate.quad`'s subdivision on 4,456 of 4,461
@@ -964,7 +964,7 @@ it from memory.)
   unit tests) and `rust/src/quad_probe.rs` (registration-only
   `hazma._core.quad`, taking a Python callable so scipy and the port see
   the same integrand); `rust/src/lib.rs` admits both. New
-  `test/test_core_quad.py` (53 tests in 8 classes).
+  `test/test_core_quad.py` (58 tests in 8 classes).
   `test/parity/{cases.py,test_parity.py,README.md}` gain the
   `hazma._core.quad` exemption. `hazma/_core.pyi` gains a comment — the
   only change under `hazma/`, and non-executable. **Two canonical
@@ -979,10 +979,10 @@ it from memory.)
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
 - **Phase 03 Task 3.3 state (2026-08-10):** bare `pytest -q` →
-  `1207 passed, 13 skipped` on the capturing environment, parity suite
+  `1212 passed, 13 skipped` on the capturing environment, parity suite
   included and in bit-equality mode (skip count unchanged at 13);
-  `pytest test/test_core_quad.py -q` → `53 passed in 0.73s`;
-  `cargo test --no-default-features` → `40 passed` (24 new); clippy and
+  `pytest test/test_core_quad.py -q` → `58 passed in 5.10s`;
+  `cargo test --no-default-features` → `43 passed` (27 new); clippy and
   fmt clean; `scripts/agents/preflight.sh` RESULT: PASS. Seventeen
   mutations against `rust/src/quad.rs`, 15 caught on the first pass and
   the two survivors (`qagpe`'s `ndin`, `qagse`'s roundoff threshold)
@@ -1218,7 +1218,7 @@ it from memory.)
   it in Phase 07). Neither ships a deleted path; neither ships the agent
   scaffolding any more.
 - **The suites are merged and green on the capturing platform**: bare
-  `pytest -q` → **1207 passed / 13 skipped** as of Task 3.3
+  `pytest -q` → **1212 passed / 13 skipped** as of Task 3.3
   (2026-08-10), from 1154/13 at Task 3.2, 1088/13 at Task 3.1,
   1063/13 at Phase 02 close,
   1006/13 at Phase 01 close and 935/30 at Task 1.3. The Phase 02 deltas:
@@ -1226,7 +1226,8 @@ it from memory.)
   what showed no test outcome moved), +54 (Task 2.3's plumbing module);
   Phase 03 so far: +25 (Task 3.1's constants), +66 (Task 3.2's specfun
   module plus one corpus guard, of which +12 landed in review round 1),
-  +53 (Task 3.3's QUADPACK module).
+  +58 (Task 3.3's QUADPACK module, of which +6 landed in review
+  round 1).
   **The skip count has not moved since
   Phase 01 closed**, and that is the tell: forcing budget mode drops one
   test to a skip rather than failing, so an unchanged 13 is how the

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -24,7 +24,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | 00 | Dead-code purge | [phase-00-dead-code-purge.md](../phases/phase-00-dead-code-purge.md) | [phase-00/README.md](phase-00/README.md) | **Complete (2026-08-06)** — all five tasks done; [learnings](../learnings/phase-00-dead-code-purge.md) |
 | 01 | Golden parity corpus | [phase-01-parity-corpus.md](../phases/phase-01-parity-corpus.md) | [phase-01/README.md](phase-01/README.md) | **Complete (2026-08-08)** — all four tasks done; [learnings](../learnings/phase-01-parity-corpus.md) |
 | 02 | Rust scaffold | [phase-02-rust-scaffold.md](../phases/phase-02-rust-scaffold.md) | [phase-02/README.md](phase-02/README.md) | **Complete (2026-08-09)** — all three tasks done; [learnings](../learnings/phase-02-rust-scaffold.md) |
-| 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | In Progress — 3.1 and 3.2 done (2026-08-09), 3.3–3.5 open |
+| 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | In Progress — 3.1 and 3.2 done (2026-08-09), 3.3 done (2026-08-10), 3.4–3.5 open |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | Not started |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | Not started |
 | 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | Not started |
@@ -420,6 +420,49 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   moment anything under `hazma/` imports an exempted module. **Any later
   task putting a non-kernel on the extension inherits this mechanism and
   must not widen the exemption to quiet a red mode check.**
+- **The quadrature break-point contract is scipy's, not QUADPACK's**
+  (Task 3.3), and the plan's own instruction to pin it empirically is
+  what surfaced that. `scipy.integrate.quad` filters `points` in Python
+  before `qagpe` ever sees them — `np.unique`, then strictly interior —
+  so the rule a documentation-driven port would implement (sort, and
+  `ier = 6` unless the extremes equal `a` and `b`) is unreachable, and
+  the five `points=[-1, 1]` call sites would have **errored** under it.
+  Both live degeneracies turn out to be discards, and the consequence is
+  a dispatch one: `points is None` selects `qagse`, "no break point
+  survived" does not, so five of the twelve live call sites run `qagpe`
+  with an *empty* list. This is the same shape as Task 3.2's `kn`
+  finding — the plan's model of a third-party library is a hypothesis,
+  and the sweep that "confirms" it is the only thing that can refute it.
+- **The QUADPACK port tracks scipy wherever QUADPACK converges, and only
+  there** (Task 3.3). Over 11,274 random (integrand, tolerance, limit,
+  points) combinations the 4,461 converged runs reproduced scipy's
+  `neval` and `last` on all but **5** (0.11%) and landed within 3.6e-2 of
+  the requested tolerance (8.2e-11 relative worst case); the 6,813 that
+  exhausted `limit` can separate without bound (4.5e-5 in that sweep, 11%
+  on a hand-picked case), because Wynn's ε-algorithm is chaotic on a
+  non-converging sequence. Termination flags agreed on all 11,274.
+  **Phases 04–06 inherit the obligation**: no live shape reaches the
+  second regime today, every one returns `ier = 0`, and
+  `test/test_core_quad.py` asserts it — a future kernel that does reach it
+  would be a silent change, since QUADPACK returns a number either way.
+  **The sweep's parameter space is part of its result:** an earlier
+  6,000-combination design capped at two break points reported *zero*
+  subdivision mismatches among converged runs, and the mismatches only
+  appeared once 9- and 39-point grids entered the draw.
+- **A mutation harness can poison its own baseline** (Task 3.3). Two
+  copies of the campaign ran concurrently, because the first was read as
+  having failed to start when it had not, so the second's "pristine"
+  source already carried the first's mutation and every result was
+  measured against a wrong Gauss–Kronrod table. The tell was easy to
+  rationalise — mutating a `qk15` weight reported `qk21` tests failing —
+  and what settled it was a check owing nothing to the crate: re-parsing
+  the Fortran `data` statements and comparing f64 bit patterns against the
+  Rust literals. **Assert a green baseline before a campaign and again
+  after it, and hold a lock.** Two smaller siblings worth carrying:
+  `cargo test`'s default parallelism interleaves `test NAME ... FAILED`
+  lines, so a scraped failure list names the wrong tests
+  (`-- --test-threads=1`); and a background job reported as failed may
+  still be running.
 - **A worktree can inherit `.so` files whose source package is gone**
   (Task 1.1): this tree carried `_gamma_ray/` and `_phase_space/`
   extensions deleted in Task 0.2, giving 25 `.so` against `setup.py`'s
@@ -649,6 +692,28 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   measured against these**, so a wrong choice here would surface as a
   kernel bug rather than a specfun bug.
 
+- **Task 3.3, 2026-08-10 (QUADPACK port): no public value changes**
+  (verified: `git diff origin/master -- hazma` is one file,
+  `hazma/_core.pyi`, and the hunk is a comment block — no executable line
+  under `hazma/` is reachable from this diff, on a tree rebuilt before
+  anything was run). The rest is a new PyO3-free Rust module that no
+  Python imports and no Rust kernel yet calls, its registration-only
+  Python probe, one new test module, and the parity corpus's served-kernel
+  exemption. Measured rather than only argued: the bare suite ran the
+  parity corpus in **bit-equality mode** — `rtol = 0` across all 41
+  consumed entry points, 179,695 pinned values — and passed, at
+  `1207 passed, 13 skipped` (+53 on Task 3.2's 1154, all of them this
+  task's tests; the skip count is unchanged, which is what proves the
+  mode). What the task *did* produce, numerically, is an integrator that
+  reproduces `scipy.integrate.quad`'s subdivision on 4,456 of 4,461
+  converged runs and its value to within 3.6e-2 of the requested
+  tolerance. **Phase 04's spectra kernels and Phase 05's thermal ⟨σv⟩ are
+  the first swaps whose drift lines will be measured against this**, so a
+  wrong choice here would surface as a kernel bug rather than a
+  quadrature bug — and the divergence regime (`limit` exhausted) is one
+  no live call site enters today, asserted in
+  `test/test_core_quad.py` rather than assumed.
+
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
 it from memory.)
@@ -725,6 +790,19 @@ it from memory.)
   No ADR: nothing revises ADR-0002, no interface or ordering moves, and
   the decision is a per-function implementation choice carried by the
   code, the phase file and the task note.
+- **Task 3.3 (2026-08-10)** patched two canonical documents in the same
+  PR as the code, for the same reason as Task 3.2. The phase-03 file's
+  Task 3.3 block gained four "criteria added during execution" bullets:
+  the break-point contract is scipy's rather than QUADPACK's and both
+  live degeneracies are discards; only `qk21` is on the live path, so
+  `qk15` is a cross-check rather than production code; the agreement
+  criterion is met with two orders of headroom and its boundary is
+  `limit`; and two adaptive-loop heuristics needed purpose-built inputs.
+  `../references/numerics-replacements.md` gained the measured contract,
+  because its own sentence — "must be pinned *empirically*" — is the
+  instruction, and leaving the answer in a task note would make the next
+  reader re-derive it. No ADR: nothing revises ADR-0002 (the provenance
+  is exactly what it prescribes), and no interface or ordering moves.
 - **Plan-review round 2 (2026-08-03)**, two completeness fixes: the
   inventory's boost-retirement claim corrected to Phase 06 Task 6.4
   (capi survivor `hazma/spectra/_positron/_pion.pyx:10` cimports the
@@ -880,10 +958,38 @@ it from memory.)
   cephes wrapper. Full list in
   [phase-03/README.md](phase-03/README.md).
 
+- **Task 3.3** — new `rust/src/quad.rs` (`qk15` / `qk21` / `qelg` /
+  `qpsrt` / `qagse` / `qagpe` plus the scipy-shaped `quad` driver and
+  `filter_points`, a `# Sources and licensing` provenance header, and 24
+  unit tests) and `rust/src/quad_probe.rs` (registration-only
+  `hazma._core.quad`, taking a Python callable so scipy and the port see
+  the same integrand); `rust/src/lib.rs` admits both. New
+  `test/test_core_quad.py` (53 tests in 8 classes).
+  `test/parity/{cases.py,test_parity.py,README.md}` gain the
+  `hazma._core.quad` exemption. `hazma/_core.pyi` gains a comment — the
+  only change under `hazma/`, and non-executable. **Two canonical
+  patches:** the phase file's Task 3.3 block gained four "criteria added
+  during execution" bullets, and
+  [`../references/numerics-replacements.md`](../references/numerics-replacements.md)
+  gained the measured break-point contract. Full list in
+  [phase-03/README.md](phase-03/README.md).
+
 ## Verification
 
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
+- **Phase 03 Task 3.3 state (2026-08-10):** bare `pytest -q` →
+  `1207 passed, 13 skipped` on the capturing environment, parity suite
+  included and in bit-equality mode (skip count unchanged at 13);
+  `pytest test/test_core_quad.py -q` → `53 passed in 0.73s`;
+  `cargo test --no-default-features` → `40 passed` (24 new); clippy and
+  fmt clean; `scripts/agents/preflight.sh` RESULT: PASS. Seventeen
+  mutations against `rust/src/quad.rs`, 15 caught on the first pass and
+  the two survivors (`qagpe`'s `ndin`, `qagse`'s roundoff threshold)
+  covered by tests written afterwards against inputs found by searching
+  with each mutation in place. The Gauss–Kronrod literals are bit-equal
+  to the netlib Fortran (47 values, checked by a script that parses both
+  sides independently of the crate).
 - **Phase 03 Task 3.2 state (2026-08-09; PR #59 review round 1,
   2026-08-10):** bare `pytest -q` →
   `1154 passed, 13 skipped` on the capturing environment, parity suite
@@ -1052,9 +1158,9 @@ it from memory.)
   [`../learnings/phase-02-rust-scaffold.md`](../learnings/phase-02-rust-scaffold.md)
   rather than their twelve task notes — the learnings are the
   distillation, the notes are history. **Phase 03 is in progress:
-  Tasks 3.1 and 3.2 both landed 2026-08-09, so the next task is 3.3 or
-  3.5 (dependency-free) or 3.4 (unblocked by 3.1).** No phase carries a
-  decision gate.
+  Tasks 3.1 and 3.2 landed 2026-08-09 and Task 3.3 on 2026-08-10, so the
+  next task is 3.5 (dependency-free) or 3.4 (unblocked by 3.1).** No
+  phase carries a decision gate.
 - **`hazma_core::constants` exists and is bit-equal to the Cython**
   (Task 3.1). `constants::pdg` is `hazma/_utils/constants.pxd` (151
   values), `constants::legacy` is `hazma/_utils/legacy_parameters.pxd`
@@ -1079,6 +1185,19 @@ it from memory.)
   docstring so they travel with the file. It deliberately re-pins no
   value against Cython — the corpus does that, at bit-equality, across
   all 41 entry points.
+- **Task 3.3 is done, so `hazma_core::quad` exists.** Call
+  `quad(&mut f, a, b, &QuadOpts { epsabs, epsrel, limit, points })` —
+  **not** `qagse`/`qagpe`, which skip the argument preprocessing every
+  `.pyx` inherits from `scipy.integrate.quad`. It returns
+  `Result<QuadOutcome, QuadError>`: `Err` only where scipy raises
+  `ValueError`, with `QuadOutcome::ier` carrying what scipy would have
+  warned about, because hazma's call sites read `quad(...)[0]` and never
+  see the warning. When porting a call site, copy its
+  `epsabs`/`epsrel`/`points` from the `.pyx` verbatim — the twelve sites
+  use five different tolerance combinations and two reach scipy's
+  defaults by passing no keyword at all. `hazma._core.quad` is a test
+  surface and must stay importer-free, or the parity corpus leaves
+  bit-equality mode.
 - **The parity corpus is the gate from here on.** `python
   test/parity/generate.py --check` verifies it (still, with `_core`
   present); `test/parity/cases.py` is the single source of every entry
@@ -1099,14 +1218,15 @@ it from memory.)
   it in Phase 07). Neither ships a deleted path; neither ships the agent
   scaffolding any more.
 - **The suites are merged and green on the capturing platform**: bare
-  `pytest -q` → **1154 passed / 13 skipped** as of Task 3.2
-  (2026-08-10, after PR #59 review round 1), from 1088/13 at Task 3.1,
+  `pytest -q` → **1207 passed / 13 skipped** as of Task 3.3
+  (2026-08-10), from 1154/13 at Task 3.2, 1088/13 at Task 3.1,
   1063/13 at Phase 02 close,
   1006/13 at Phase 01 close and 935/30 at Task 1.3. The Phase 02 deltas:
   +3 (Task 2.1's scaffold checks), 0 (Task 2.2, byte-identical, which is
   what showed no test outcome moved), +54 (Task 2.3's plumbing module);
   Phase 03 so far: +25 (Task 3.1's constants), +66 (Task 3.2's specfun
-  module plus one corpus guard, of which +12 landed in review round 1).
+  module plus one corpus guard, of which +12 landed in review round 1),
+  +53 (Task 3.3's QUADPACK module).
   **The skip count has not moved since
   Phase 01 closed**, and that is the tell: forcing budget mode drops one
   test to a skip rather than failing, so an unchanged 13 is how the

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -279,7 +279,7 @@ foundation.
   same integrand).
 - `rust/src/lib.rs` — `pub mod quad;` + `mod quad_probe;`, the submodule
   registration, and the reconciled paragraphs on the two probe modules.
-- `test/test_core_quad.py` — **new**, 53 tests in 8 classes.
+- `test/test_core_quad.py` — **new**, 58 tests in 8 classes.
 - `test/parity/cases.py`, `test/parity/test_parity.py`,
   `test/parity/README.md` — `hazma._core.quad` added to
   `_CORE_TEST_ONLY_MODULES`, and the three places naming `special` alone
@@ -294,13 +294,13 @@ foundation.
 ## Verification
 
 - **Task 3.3 (2026-08-10):** bare `pytest -q` →
-  `1207 passed, 13 skipped` on the capturing environment, parity suite
+  `1212 passed, 13 skipped` on the capturing environment, parity suite
   included and in bit-equality mode (skip count unchanged at 13, which is
-  what proves the mode; +53 on Task 3.2's 1154, all of them this task's
-  new tests). `pytest test/test_core_quad.py -q` → `53 passed in 0.73s`
+  what proves the mode; +58 on Task 3.2's 1154, all of them this task's
+  new tests). `pytest test/test_core_quad.py -q` → `58 passed in 5.10s`
   (8 classes, population derived by `--collect-only`);
   `cargo test --manifest-path rust/Cargo.toml --no-default-features` →
-  `40 passed` (24 new); clippy and fmt clean;
+  `43 passed` (27 new); clippy and fmt clean;
   `scripts/agents/preflight.sh` RESULT: PASS. Seventeen mutations against
   `quad.rs`, each from a green baseline and reverted after — 15 caught on
   the first pass, and the two that were not (`ndin`, the roundoff

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -3,7 +3,8 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 03
-**Status:** In Progress (Tasks 3.1 and 3.2 complete 2026-08-09)
+**Status:** In Progress (Tasks 3.1 and 3.2 complete 2026-08-09; Task 3.3
+complete 2026-08-10)
 **Plan References:** `../../phases/phase-03-numerics-foundation.md`
 **Related ADRs:** ADR-0002 (Accepted 2026-08-04 — governs the
 provenance of Tasks 3.2/3.3, no longer gates them)
@@ -20,7 +21,7 @@ foundation.
 | --- | ------ | ------------ | -------- | ----------- |
 | 3.1 | Constants module | — | **Complete (2026-08-09)** | [task-3.1-constants.md](task-3.1-constants.md) |
 | 3.2 | Special functions | — (ADR-0002 accepted) | **Complete (2026-08-09)** | [task-3.2-specfun.md](task-3.2-specfun.md) |
-| 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | — (ADR-0002 accepted) | Not started | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
+| 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | — (ADR-0002 accepted) | **Complete (2026-08-10)** | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
 | 3.4 | Interpolation + boost kernels | 3.1 | Not started | [task-3.4-interp-boost.md](task-3.4-interp-boost.md) |
 | 3.5 | Dispatch and error layer | — | Not started | [task-3.5-dispatch.md](task-3.5-dispatch.md) |
 
@@ -118,6 +119,56 @@ foundation.
   does not have**, and `+0.0` passing says nothing about `-0.0`. Sweep
   both signs of zero against the oracle at every order or branch, not
   just the one a reviewer names.
+- **The quadrature break-point contract belongs to scipy, not to
+  QUADPACK** (Task 3.3). `scipy.integrate.quad` filters `points` in
+  Python before `qagpe` sees them — `np.unique`, then strictly interior —
+  so the QUADPACK rule a doc-driven port would implement (sort, and
+  `ier = 6` unless the extremes equal `a` and `b`) is unreachable. Read
+  the wrong way round, the five `points=[-1, 1]` call sites would have
+  **errored**, because QUADPACK rejects a break point equal to an
+  endpoint and scipy silently drops it. Both live degeneracies are
+  discards: `points=[-1, 1]` on `[-1, 1]` leaves nothing, and the heavy
+  mediator's `m/mx`, `2 m/mx` fall outside `max(50/x, 100|150)`.
+- **`points is None` selects `qagse` — "no break point survived" does
+  not** (Task 3.3). scipy dispatches before it filters, so five of the
+  twelve live call sites run `qagpe` with an *empty* list. The two
+  routines are nearly indistinguishable (identical value, `neval` and
+  `last` across 3,776 random combinations that converged; differing on 45,
+  all of which exhausted `limit`), which is a trap for the test as much as
+  for the port: the obvious singular integrands cannot tell them apart, so
+  a test written on one would pass against either.
+- **The port tracks scipy wherever QUADPACK converges, and only there**
+  (Task 3.3). Over 11,274 random (integrand, tolerance, limit, points)
+  combinations: the 4,461 converged runs reproduced scipy's `neval` and
+  `last` on all but **5** (0.11%) and landed within 3.6e-2 of the
+  requested tolerance (8.2e-11 relative worst case); the 6,813 that
+  exhausted `limit` can separate without bound (4.5e-5 there, 11% on a
+  hand-picked case), because Wynn's ε-algorithm is chaotic on a
+  non-converging sequence. Termination flags agreed on all 11,274.
+  **Phases 04–06: no live shape reaches the second regime** — each
+  returns `ier = 0` and `test/test_core_quad.py` asserts it.
+  **A narrower sweep is what made this look cleaner than it is:** an
+  earlier 6,000-combination design using at most two break points found
+  *zero* subdivision mismatches among converged runs, and the mismatches
+  only appeared once 9- and 39-point grids went into the draw. A sweep's
+  parameter space is part of its result.
+- **Only `qk21` is on the live path** (Task 3.3): `qagse` and `qagpe` both
+  evaluate with the 21-point rule and nothing else, so `qk15` — named in
+  the exit criteria — is reachable from no hazma call site. Kept as an
+  independent second rule for the cross-checks, not as production code.
+- **A mutation harness can poison its own baseline** (Task 3.3). Two
+  copies of the campaign ran concurrently after the first was wrongly
+  read as failed to start, so the second's "pristine" source already
+  carried the first's mutation and every result was measured against a
+  wrong Gauss–Kronrod table. The tell was easy to rationalise — mutating a
+  `qk15` weight reported `qk21` tests failing — and what settled it was a
+  check owing nothing to the crate: re-parsing the Fortran `data`
+  statements and comparing f64 bit patterns. **Assert a green baseline
+  before a campaign and again after**, and hold a lock. Two smaller
+  siblings: `cargo test`'s default parallelism interleaves
+  `test NAME ... FAILED` lines so a scraped failure list names the wrong
+  tests (`-- --test-threads=1`), and a background job reported as failed
+  may still be running.
 - **A Python-visible test surface on `hazma._core` reads as a started
   port** (Task 3.2). Registering `hazma._core.special` flipped the
   parity corpus straight out of bit-equality mode
@@ -155,6 +206,31 @@ foundation.
   All three bindings route through `dispatch::map_unary`, so the sweeps
   run as arrays rather than as 25k-iteration Python loops — the kind of
   test that otherwise gets trimmed to a dozen points later.
+- **The QUADPACK translation is deliberately literal** (Task 3.3):
+  1-based indexing kept by giving every array a dead element 0, every
+  `go to` a labelled `break` carrying its Fortran statement number, same
+  variable names, same magic constants. Idiomatic Rust would read better
+  and be much harder to check against the source. The cost is three
+  module-level clippy `allow`s (`needless_range_loop`,
+  `explicit_counter_loop`, `int_plus_one`), each with its reason written
+  down.
+- **`quad` is the entry point Phases 04–06 call, not `qagse`/`qagpe`**
+  (Task 3.3) — it is the one that reproduces scipy's limit ordering and
+  break-point filtering, so twelve call sites do not each re-derive them.
+  `ier` rides along inside `Ok`; only the inputs scipy raises
+  `ValueError` for are `Err`, because hazma's call sites read
+  `quad(...)[0]` and never see scipy's warning.
+- **The Gauss–Kronrod tables were extracted by script, not typed**
+  (Task 3.3), and are pinned by **degree of exactness** (22 for `qk15`,
+  31 for `qk21`) plus a complement test that the next even degree is not
+  exact — a wrong digit breaks exactness, where a spot check against one
+  integral could be passed by a rule that is merely close.
+- **`quad_probe` takes a Python callable on purpose** (Task 3.3). A menu
+  of Rust integrands would compare a Rust integrand against a Python one
+  and blame the quadrature for the difference; with a callback the
+  integrand is byte-identical on both sides. Same shape as `special_probe`
+  and it inherits the same `_CORE_TEST_ONLY_MODULES` exemption and
+  importer guard rather than widening them.
 - **Only `n = 2` is live, but `bessel_kn` carries general `n`**
   (Task 3.2), because the recurrence is general and the order factor
   `2m/x` is *invisible* at n = 2 (it is `2/x` there). Both the ν = 2
@@ -192,8 +268,47 @@ foundation.
   (three Task 3.2 criteria added),
   `../../references/numerics-replacements.md` (the measured block).
 
+### Task 3.3
+
+- `rust/src/quad.rs` — **new**, 1,972 lines: `qk15`, `qk21`, `qelg`,
+  `qpsrt`, `qagse`, `qagpe`, the scipy-shaped `quad` driver and
+  `filter_points`, a `# Sources and licensing` provenance header, the
+  call-site table, and 24 unit tests.
+- `rust/src/quad_probe.rs` — **new**, registration-only
+  `hazma._core.quad` (a Python callable in, so scipy and the port see the
+  same integrand).
+- `rust/src/lib.rs` — `pub mod quad;` + `mod quad_probe;`, the submodule
+  registration, and the reconciled paragraphs on the two probe modules.
+- `test/test_core_quad.py` — **new**, 53 tests in 8 classes.
+- `test/parity/cases.py`, `test/parity/test_parity.py`,
+  `test/parity/README.md` — `hazma._core.quad` added to
+  `_CORE_TEST_ONLY_MODULES`, and the three places naming `special` alone
+  reconciled.
+- `hazma/_core.pyi` — the unstubbed-submodule comment now covers both
+  probes (the only change under `hazma/`, non-executable).
+- **Two canonical patches:** `../../phases/phase-03-numerics-foundation.md`
+  (four Task 3.3 criteria added during execution) and
+  `../../references/numerics-replacements.md` (the measured break-point
+  contract).
+
 ## Verification
 
+- **Task 3.3 (2026-08-10):** bare `pytest -q` →
+  `1207 passed, 13 skipped` on the capturing environment, parity suite
+  included and in bit-equality mode (skip count unchanged at 13, which is
+  what proves the mode; +53 on Task 3.2's 1154, all of them this task's
+  new tests). `pytest test/test_core_quad.py -q` → `53 passed in 0.73s`
+  (8 classes, population derived by `--collect-only`);
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features` →
+  `40 passed` (24 new); clippy and fmt clean;
+  `scripts/agents/preflight.sh` RESULT: PASS. Seventeen mutations against
+  `quad.rs`, each from a green baseline and reverted after — 15 caught on
+  the first pass, and the two that were not (`ndin`, the roundoff
+  threshold) are what `TestAdaptiveHeuristics` was written for, with both
+  re-run against the final tree. The Gauss–Kronrod literals are checked
+  against the netlib Fortran as f64 bit patterns (47 values,
+  `MISMATCHES: 0`) by a script independent of the crate — which is what
+  caught a poisoned mutation baseline. Tables in the task note.
 - **Task 3.2 (2026-08-09; PR #59 review round 1, 2026-08-10):** bare
   `pytest -q` → `1154 passed, 13 skipped` on the capturing environment,
   parity suite included and in bit-equality mode (skip count unchanged

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
@@ -177,6 +177,21 @@ into the phase file in this same PR (see `## Plan Impact`).
 
 ## Decisions and Implementation Notes
 
+- **Review round 1 (PR #60, 2026-08-10) — `limit` is validated at the
+  Python boundary, not by PyO3.** The probe took `limit: usize`, so
+  `limit = -1` died in PyO3's conversion with `OverflowError` where scipy
+  raises `ValueError` — the docstring's "raises `ValueError` for exactly
+  the inputs scipy raises `ValueError` for" was simply false. It now
+  takes `i64` and reproduces *both* of scipy's rejections: `< 1` folds
+  onto `0` and takes the existing `QuadError::LimitTooSmall` path (one
+  message, not two spellings), and `> i32::MAX` raises `OverflowError`
+  exactly as scipy's own C-`int` conversion does. That upper guard is
+  load-bearing beyond the contract: `limit` sizes the `qagse`/`qagpe`
+  workspace at 16 bytes an entry, so `limit = 10**12` was a 16 TB
+  allocation request that this machine happened to satisfy lazily —
+  whether it survives is a property of the platform's overcommit policy,
+  not of the code, and the exit criteria say "never panics across FFI".
+  Six new tests, each validity-checked against a mutation.
 - **Literal translation, 1-based indexing preserved.** Every array in
   `quad.rs` carries a dead element 0 so the Fortran's `alist(maxerr)`
   reads as `alist[maxerr]`, and every `go to` is a labelled `break`
@@ -392,8 +407,9 @@ four "criteria added during execution" bullets, for the same reason Task
 3.2's did: the criteria as written were satisfiable in a way that would
 have been wrong, and the shape of the answer belongs in the canonical
 document rather than only here. The breakpoint contract is scipy's
-rather than QUADPACK's and both live degeneracies are discards (so six
-call sites run `qagpe` with an empty list); only `qk21` is on the live
+rather than QUADPACK's and both live degeneracies are discards (so five
+of the twelve call sites run `qagpe` with an empty list); only `qk21` is
+on the live
 path; the agreement criterion is met with four orders of headroom and its
 boundary is `limit`; and the corpus's served-kernel predicate stays sound
 through the existing exemption.
@@ -472,13 +488,43 @@ success-shaped line for a zero-file scan (`docs/agents/lessons.md`,
 **Call-site count, re-derived rather than carried over.** Every prose
 copy of "eleven live call sites" and "six of the eleven" was wrong, in
 seven files, and had been copied from the reference's *seven-row table*
-rather than counted. `grep -rn --include='*.pyx' "quad(" hazma | grep -v
-'#'` → **12** live sites, of which **5** pass `points=[-1, 1]`. All
-twelve occurrences across `rust/src/quad.rs`, `test/test_core_quad.py`,
-this note, `phase-03/README.md`, `../README.md`,
-`../../references/numerics-replacements.md` and the phase file were
-swept — `docs/agents/lessons.md`, `[derived-count-not-rederived]` and
-`[sibling-copies-of-a-fixed-claim]`.
+rather than counted. Re-derived by classifying each match as live or
+commented:
+
+```sh
+grep -rn "quad(" --include='*.pyx' hazma \
+  | awk -F: '{l=$0; sub(/^[^:]*:[^:]*:/,"",l); gsub(/^[ \t]*/,"",l);
+              print (substr(l,1,1)=="#" ? "COMMENTED" : "LIVE"), $1":"$2}'
+```
+
+→ **12 live** sites and 11 commented ones, of which **5** live sites pass
+`points=[-1, 1]` (the sixth `points=[-1, 1]` match,
+`hazma/spectra/_positron/_muon.pyx:134`, is commented out).
+
+**The first pass of this sweep was itself incomplete, and review caught
+it** (PR #60). It grepped the *paired* phrases `eleven` and
+`six of the eleven` and fixed twelve occurrences across
+`rust/src/quad.rs`, `test/test_core_quad.py`, this note,
+`phase-03/README.md`, `../README.md`,
+`../../references/numerics-replacements.md` and the phase file — then
+recorded "all twelve occurrences were swept", which was a completeness
+claim the grep could not support. A thirteenth copy survived in this
+note's own `## Plan Impact` section, reading "so six call sites run
+`qagpe` with an empty list": the bare number word with no `eleven`
+anywhere near it, so the pattern never saw it.
+
+Re-sweeping with a pattern keyed on the *claim* rather than on the
+phrasing — every number word or numeral within 40 characters of
+`call site` / `live call` / `points=[-1` / `qagpe with an empty`, in
+either order — then turned up a **fourteenth**, in
+`test/test_core_quad.py:307` ("the branch all six `points=[-1, 1]` call
+sites take"). Both stragglers are the same shape as the twelve that were
+found: a count copied into prose that no longer sits beside the number it
+was copied from. **Sweep the bare numeral and the number word against the
+claim, not the phrase that happened to carry them** —
+`docs/agents/lessons.md`, `[sibling-copies-of-a-fixed-claim]` and
+`[derived-count-not-rederived]`. The final pattern, and its output, are
+in the review-response record below.
 
 **Stale-sibling sweep on the submodule prose** — `rg -n 'per-domain
 submodule|five per-domain|sixth submodule' rust/ test/ hazma/ docs/`:

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
@@ -136,7 +136,7 @@ into the phase file in this same PR (see `## Plan Impact`).
 - **Two adaptive-loop heuristics survive every test built from the spec.**
   `qagpe`'s `ndin` flag and `qagse`'s roundoff counters change only which
   subinterval is bisected next, so mutating either passed every test the
-  module held at the time — 51 of the eventual 53, the two additions
+  module held at the time — 51 of what were then 53, the two additions
   being the tests written to catch these — and all 24 `cargo` units
   besides. Inputs that expose them exist but had to be
   *searched for* with the mutation in place: `sin(293.25/x)` over a
@@ -177,6 +177,27 @@ into the phase file in this same PR (see `## Plan Impact`).
 
 ## Decisions and Implementation Notes
 
+- **Review round 2 (PR #60, 2026-08-10) — the `limit`-length workspaces
+  are grown on demand, not allocated at `limit`.** Round 1 capped `limit`
+  at `i32::MAX` to match scipy and called the hazard closed; it was not.
+  `qagse` allocates five `limit`-length arrays (40 bytes a subinterval)
+  and `qagpe` six (44), so a `limit` just *under* the new cap still
+  reserved ~80 GiB and ~88 GiB before the first panel was evaluated —
+  and Rust aborts the process on allocation failure rather than
+  unwinding, so it could never have become a Python exception. The
+  round-1 test even asserted the opposite ("never allocates the full
+  workspace"), which was false as written. The arrays now start at
+  `WORKSPACE_SEED = 64` subintervals (or the initial partition, whichever
+  is larger) and double, capped at `limit + 2`; every index in both
+  routines is at most `last`, which grows by one per iteration, so one
+  slot of headroom is sufficient. Three `cargo` tests cover it, and the
+  one that matters asks for `usize::MAX / 4096` — a size no allocator can
+  satisfy, so it discriminates on every platform rather than only where
+  the allocator declines to overcommit. Reverting to eager sizing dies
+  with `memory allocation of 36028797018963976 bytes failed` / SIGABRT.
+  **This is why the round-1 measurement was not evidence**: peak RSS went
+  18.2 → 18.6 MB at `limit = INT_MAX`, because macOS maps zero pages
+  lazily. The reservation was real and the test could not see it.
 - **Review round 1 (PR #60, 2026-08-10) — `limit` is validated at the
   Python boundary, not by PyO3.** The probe took `limit: usize`, so
   `limit = -1` died in PyO3's conversion with `OverflowError` where scipy
@@ -258,7 +279,7 @@ into the phase file in this same PR (see `## Plan Impact`).
 - `rust/src/lib.rs` — `pub mod quad;` + `mod quad_probe;`, the submodule
   registration, and the reconciled paragraphs on why the two probe
   modules are the exception to "registration only means per-domain".
-- `test/test_core_quad.py` — **new**, 53 tests in 8 classes.
+- `test/test_core_quad.py` — **new**, 58 tests in 8 classes.
 - `test/parity/cases.py`, `test/parity/README.md`,
   `test/parity/test_parity.py` — `hazma._core.quad` added to
   `_CORE_TEST_ONLY_MODULES`, and the three places that named `special`
@@ -281,12 +302,18 @@ the final tree.
 
 | Gate | Command | Result |
 | --- | --- | --- |
-| Rust units | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `40 passed` (24 new; `grep -c '#\[test\]' rust/src/quad.rs` → 24) |
+| Rust units | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `43 passed` (27 new; `grep -c '#\[test\]' rust/src/quad.rs` → 27) |
 | Rust format | `cargo fmt --manifest-path rust/Cargo.toml --check` | clean |
 | Rust lint | `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` | clean |
-| New module | `pytest test/test_core_quad.py -q` | `53 passed in 0.73s` |
-| Full suite | `pytest -q` (via preflight) | `1207 passed, 13 skipped` — see below |
+| New module | `pytest test/test_core_quad.py -q` | `58 passed in 5.10s` |
+| Full suite | `pytest -q` (via preflight) | `1212 passed, 13 skipped` — see below |
 | Full gate | `scripts/agents/preflight.sh --paths … --md …` | **RESULT: PASS** |
+
+**These are the round-2 figures and they supersede the pre-review ones**
+(`40` / `53` / `1207`, and `24` Rust units). Review round 1 added six
+Python tests and round 2 three Rust ones, so every count in this section
+had to be re-derived rather than adjusted — see the note under
+`### Validity` on why the arithmetic was not trusted.
 
 Test population, derived rather than counted by hand:
 
@@ -295,14 +322,14 @@ pytest test/test_core_quad.py --collect-only -q \
   | awk -F'::' '/::/{print $2}' | sort | uniq -c
 ```
 
-8 classes / 53 tests — `TestBreakPointPreprocessing` 8,
+8 classes / 58 tests — `TestBreakPointPreprocessing` 8,
 `TestReferenceProblems` 9, `TestLiveIntegrandShapes` 14,
 `TestKronrodRules` 5, `TestTerminationFlags` 6,
 `TestDivergenceRegime` 2, `TestAdaptiveHeuristics` 2,
-`TestErrorBehavior` 7.
+`TestErrorBehavior` 12.
 
-**The parity corpus ran in bit-equality mode.** `1207 passed, 13 skipped`
-is +53 on Task 3.2's `1154 passed, 13 skipped`, all of them this task's
+**The parity corpus ran in bit-equality mode.** `1212 passed, 13 skipped`
+is +58 on Task 3.2's `1154 passed, 13 skipped`, all of them this task's
 new tests, and **the skip count is unchanged** — which is what proves the
 mode, since forcing budget mode drops one test to a skip rather than
 failing. Confirmed independently before the run:
@@ -335,10 +362,12 @@ failing. Confirmed independently before the run:
   `full_output` appends.
 - **Divergence regime** (2) and **adaptive heuristics** (2): documented
   above.
-- **Error behavior** (7): invalid tolerances, `limit = 0`, the
-  subdivision limit, an exception raised by the integrand (propagated
-  unchanged, integrand called once), a non-float return, a `NaN`
-  integrand, and a zero-width interval.
+- **Error behavior** (12): invalid tolerances; every `limit < 1`
+  (`0`, `-1`, `-100`) raising `ValueError` as scipy does and every
+  `limit > i32::MAX` raising `OverflowError` as scipy does, plus the
+  largest accepted `limit`; the subdivision limit; an exception raised by
+  the integrand (propagated unchanged, integrand called once); a
+  non-float return; a `NaN` integrand; and a zero-width interval.
 
 ### Validity
 
@@ -465,7 +494,7 @@ unstubbed. No executable line under `hazma/` is reachable from this diff,
 so no grid evaluation applies. The positive evidence is the parity corpus
 running in **bit-equality mode** inside the bare suite — `rtol = 0`
 across all 41 consumed entry points and 179,695 pinned values, at
-`1207 passed, 13 skipped` with the skip count unchanged (see
+`1212 passed, 13 skipped` with the skip count unchanged (see
 `## Verification`).
 
 **Doc citations** — `scripts/agents/check_doc_citations.py <the six

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
@@ -1,0 +1,545 @@
+# Task 3.3: QUADPACK port (qk15, qk21, qelg, qags, qagp)
+
+**Date:** 2026-08-10
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-03-numerics-foundation.md`
+(Task 3.3), `../../references/numerics-replacements.md`
+(§`scipy.integrate.quad` (QUADPACK) call sites), `../../rules.md` rule 5
+(Licensing 1), rules 6–9 (Rust conventions 1–4)
+**Related ADRs:** ADR-0002 (Accepted 2026-08-04 — fixes the provenance:
+public-domain netlib QUADPACK, nothing GSL-derived)
+**Depends On:** none
+
+## Objective
+
+Replace the twelve live `scipy.integrate.quad` call sites' integrator
+with an in-tree Rust translation of the netlib QUADPACK Fortran —
+`qk15`, `qk21`, `qelg`, `qpsrt`, `qagse`, `qagpe` — plus the
+scipy-shaped driver that reproduces scipy's own break-point
+preprocessing, so a ported kernel calls one function and inherits the
+argument handling the `.pyx` inherited from scipy.
+
+## Exit Criteria
+
+Copied from `../../phases/phase-03-numerics-foundation.md` §Task 3.3:
+
+- Finite-interval `qags` and `qagp` in `rust/src/quad.rs`, translated
+  from netlib QUADPACK Fortran (provenance header per rules.md rule 5),
+  closure-based API carrying `epsabs`/`epsrel`/`limit`/breakpoints.
+- **Breakpoint preprocessing contract, pinned empirically against
+  scipy** (do not design it from the QUADPACK docs alone): determine by
+  experiment what `scipy.integrate.quad(points=...)` does with unsorted
+  lists, duplicates, points coinciding with the endpoints, and points
+  outside `[a, b]` — then replicate that behavior (including any raised
+  errors) exactly. Both degenerate cases occur live. Tests cover three
+  parameter regimes per thermal call: breakpoints interior (resonance
+  active), breakpoints at/near threshold, and breakpoints outside the
+  interval (inactive).
+- Unit tests: QUADPACK's own reference problems, plus every live
+  integrand *shape* from the call-site table in
+  `../../references/numerics-replacements.md`, compared against
+  `scipy.integrate.quad` at matching settings — agreement within 10× the
+  requested tolerance, and within 1e-12 rel on smooth cases.
+- Error/abnormal-termination behavior mapped (roundoff, max
+  subdivisions, invalid breakpoints) — returns a Result, never panics
+  across FFI.
+
+Plus the four **criteria added during execution**, which are patched
+into the phase file in this same PR (see `## Plan Impact`).
+
+## Inputs Reviewed
+
+- `../../PLAN.md` (Scope, Numerical impact, Phases), `../README.md`,
+  `phase-03/README.md`, `../../phases/phase-03-numerics-foundation.md`.
+- `../../references/numerics-replacements.md` §quad call sites — the
+  seven-row table (twelve call sites) and the breakpoint-degeneracy
+  paragraph.
+- `../../rules.md` (all sections), `../../adrs/ADR-0002-license-clean-numerics.md`.
+- `docs/agents/lessons.md`, `docs/agents/environment.md`,
+  `docs/agents/doc-consistency.md`.
+- The live Cython: `hazma/spectra/_photon/_pion.pyx`,
+  `_photon/_rho.pyx`, `_positron/_pion.pyx`, `_neutrino/_pion.pyx`, both
+  `_c_*_mediator_cross_sections.pyx`, and the four mediator spectrum
+  modules.
+- **netlib QUADPACK Fortran**, retrieved 2026-08-10 from
+  <https://www.netlib.org/quadpack/>: `dqk15.f`, `dqk21.f`, `dqelg.f`,
+  `dqpsrt.f`, `dqagse.f`, `dqagpe.f`.
+- `scipy/integrate/_quadpack_py.py` (scipy 1.18.0), which is where the
+  break-point contract actually lives.
+- Task 3.2's `rust/src/special.rs` / `special_probe.rs` and
+  `test/test_core_special.py` as the pattern for a PyO3-free kernel
+  module with a Python-visible test surface.
+
+## Findings
+
+- **The break-point contract is scipy's, not QUADPACK's.** The exit
+  criterion's instruction to pin it empirically was right for a reason
+  it did not state: the whole contract is three lines of Python in
+  `scipy/integrate/_quadpack_py.py`'s `_quad` — `np.unique(points)`, then
+  `[a < p]`, then `[p < b]` — run *after* `quad` has ordered the limits
+  and before `qagpe` sees anything. QUADPACK's own breakpoint handling
+  (sort, and `ier = 6` if the extremes do not match `a` and `b`) is
+  unreachable from scipy. Reading the QUADPACK documentation would have
+  produced a port that *errors* on the five `points=[-1, 1]` call sites,
+  because QUADPACK rejects a breakpoint equal to an endpoint and scipy
+  silently drops it.
+- **Both live degeneracies are discards, and that changes which routine
+  runs.** `points=[-1, 1]` on `[-1, 1]` leaves **zero** interior
+  breakpoints; the heavy-mediator thermal entries `m/mx`, `2 m/mx`
+  likewise drop when they exceed `max(50/x, 100|150)`. But scipy
+  dispatches on `points is None` *before* filtering, so five of the twelve
+  live call sites run **`qagpe` with an empty list**, not `qagse`. A port
+  that treated "no breakpoint survived" as "no breakpoints" would pick
+  the wrong routine.
+- **…and the two routines are almost, but not quite,
+  indistinguishable.** `qagpe` decides an interval is the smallest by
+  subdivision `level`, `qagse` by comparing length against `small`, so
+  `qagpe` extrapolates one bisection earlier. Over 3,776 random
+  (integrand, tolerance, limit) combinations they returned identical
+  values, `neval` and `last` on every run that converged and differed on
+  45 — all of them runs that exhausted `limit`. The test that pins the
+  dispatch had to be *built around* that: the obvious singular integrands
+  cannot tell the routines apart, and a test using one would have passed
+  against either. `|x − 1/3|^(−9/10)·cos(50x)` at `limit = 10` puts an
+  11% gap between them.
+- **Only `qk21` is on the live path.** `scipy.integrate.quad` on a finite
+  interval runs `qagse` or `qagpe`, and both evaluate with the 21-point
+  Gauss–Kronrod rule and nothing else. `qk15` — named in this task's
+  first exit criterion — is reachable from no hazma call site. It is
+  ported anyway (the criterion says so) and earns its keep as an
+  independent second rule: the cross-rule agreement test would not exist
+  without it.
+- **The port and scipy diverge essentially only where QUADPACK says it
+  failed.** 11,274 random (integrand, tolerance, limit, points)
+  combinations: the 4,461 that converged reproduced scipy's `neval` and
+  `last` on all but **5** (0.11%), with the value within 3.6e-2 of the
+  requested tolerance and 8.2e-11 relative at worst. The 6,813 that
+  exhausted `limit` can separate without bound — 4.5e-5 in that sweep,
+  11% on a hand-picked case. Termination flags agreed on all 11,274. The
+  mechanism is not a translation defect: the subdivision is identical
+  there too (pinned in `TestDivergenceRegime`), and Wynn's ε-algorithm is
+  chaotic on a sequence that is not converging, so a few ulp in the table
+  is enough. Every live shape returns `ier = 0`, asserted rather than
+  assumed.
+- **A sweep's parameter space is part of its result, and this one nearly
+  shipped a cleaner claim than the truth.** An earlier 6,000-combination
+  design drew `points` from `{None, [], [0.5], [0.25, 0.75], [-1, 1]}` —
+  at most two break points — and reported **zero** subdivision mismatches
+  among 2,812 converged runs. That would have gone into three durable
+  docs as "reproduces scipy's subdivision exactly". Adding 9- and
+  39-point grids to the draw produced 5 mismatches in 4,461, and the
+  first many-break-point case looked at by hand
+  (`1/((x − 0.16619)² + 1e-14)` over a 19-point grid) diverges in
+  `neval`/`last` while both implementations converge and agree on the
+  value to 9.2e-13. The published figures are the wider sweep's.
+- **Two adaptive-loop heuristics survive every test built from the spec.**
+  `qagpe`'s `ndin` flag and `qagse`'s roundoff counters change only which
+  subinterval is bisected next, so mutating either passed every test the
+  module held at the time — 51 of the eventual 53, the two additions
+  being the tests written to catch these — and all 24 `cargo` units
+  besides. Inputs that expose them exist but had to be
+  *searched for* with the mutation in place: `sin(293.25/x)` over a
+  39-point grid moves by a factor of 48 without `ndin`, and a near-delta
+  spike at 0.16309 with `points=[0.5]` moves by 2,800 when the 0.99
+  roundoff threshold is relaxed. Both live in the limit-exhausted regime,
+  so both are pinned at a coarse `rtol = 1e-6` — enough for defects that
+  move the answer by factors, and not a claim about digits the two
+  implementations may legitimately disagree on.
+- **A mutation harness can poison its own baseline, and nothing in it
+  will say so.** The first campaign was launched, appeared to fail on an
+  unset shell variable, and was re-launched — but the first run *was*
+  alive, so two campaigns interleaved writes to `rust/src/quad.rs` and
+  the second read a "pristine" `original` that already carried the
+  first's mutation. Every result it produced was measured against a
+  wrong table. The tell was subtle and easy to rationalise: mutating a
+  `qk15` weight reported `qk21` tests failing. What settled it was a
+  check that owed nothing to the crate — re-parsing the Fortran `data`
+  statements and comparing f64 bit patterns against the Rust literals.
+  The rewritten harness asserts a green baseline before it starts, holds
+  a lock file, and re-asserts green at the end. **Not** written into
+  `docs/agents/lessons.md`: that file's contract puts the append step in
+  `review-respond` and requires a real PR citation, which this task does
+  not have yet. If review agrees the class is worth carrying, the entry
+  belongs there with this PR's number —
+  `[harness-contaminated-its-own-baseline]`, generalising
+  `[measurement-taken-before-the-task-ended]` from a measurement that
+  expired to a measurement whose *baseline* was never what it claimed.
+- **`cargo test`'s default parallelism corrupts a scraped failure list.**
+  The harness writes each test's name and its result as two separate
+  writes, so with threads in play a single output line can carry one
+  test's name and another's `FAILED`. A scraper keyed on "the line starts
+  with the word test and contains FAILED" then attributes the failure to
+  whichever name came first. That produced a stable set of phantom
+  failures across every mutation in the poisoned run and made the real
+  signal harder to see. Passing `--test-threads=1` through to the harness
+  fixes it.
+
+## Decisions and Implementation Notes
+
+- **Literal translation, 1-based indexing preserved.** Every array in
+  `quad.rs` carries a dead element 0 so the Fortran's `alist(maxerr)`
+  reads as `alist[maxerr]`, and every `go to` is a labelled `break`
+  carrying the original statement number in a comment. Idiomatic Rust
+  would read better and be much harder to check against the source; the
+  point of the module is that a reviewer can put the two side by side.
+  The cost is three module-level clippy `allow`s
+  (`needless_range_loop`, `explicit_counter_loop`, `int_plus_one`), each
+  with the reason written down — clippy's rewrites are all correct and
+  each one costs a line of the correspondence.
+- **`quad` is the entry point, `qagse`/`qagpe` are public but secondary.**
+  The kernels being ported call `scipy.integrate.quad`, so the port
+  exposes the same shape: limits ordered and the result negated if they
+  were reversed, `points` filtered exactly as scipy filters, then
+  dispatch. Doing it once here is what stops twelve Phase 04–06 call
+  sites from each re-deriving it.
+- **`ier` rides along in `Ok`; only invalid input is `Err`.** scipy
+  raises `ValueError` for `ier = 6` and merely *warns* for 1–5, handing
+  back a usable value — and hazma's call sites all read `quad(...)[0]`
+  and never see the warning. Modelling 1–5 as errors would have changed
+  behavior at exactly the inputs where the Cython silently carried on.
+- **The tables are extracted, not typed.** The `data` statements were
+  parsed out of `dqk15.f`/`dqk21.f` by script into Rust literals, and a
+  second script compares the two as f64 bit patterns. Beyond that,
+  `cargo test` pins each rule by **degree of exactness** (22 for `qk15`,
+  31 for `qk21`) plus a complement test that the next even degree is
+  *not* exact — a wrong digit breaks exactness, where a spot check
+  against one integral could be passed by a rule that is merely close.
+  `docs/agents/lessons.md`, `[hand-written-population-in-a-derived-check]`.
+- **The Python probe takes a callable, deliberately.** A probe exposing a
+  menu of Rust integrands would compare a Rust integrand against a Python
+  one and blame the difference on the quadrature. With a callback the
+  integrand is byte-identical on both sides and every remaining
+  difference is the algorithm — which is also what the Cython does today,
+  since `quad` re-enters Python once per node there too. An exception
+  from the integrand is captured on first occurrence, short-circuits the
+  rest of the run to `NaN`, and is re-raised unchanged.
+- **`hazma._core.quad` joins the existing test-only exemption.**
+  `cases._CORE_TEST_ONLY_MODULES` already carried
+  `hazma._core.special` for exactly this reason (Task 3.2), and
+  `test_test_only_core_submodules_have_no_importer` keeps both honest by
+  failing the moment anything under `hazma/` imports one. Reusing the
+  mechanism rather than widening it is the point —
+  `docs/agents/lessons.md`, `[gate-disabled-stays-green]`.
+- **`resabs` is the rule applied to `|f|`, not `∫|f|`.** A first test
+  asserted the latter and failed at 3.7e-3, because `|x|` is not a
+  polynomial. Pinning it against the rule run on `|x|` states the
+  invariant exactly and still distinguishes `resabs` from `result` for a
+  sign-changing integrand.
+- **`qagi` and the infinite-interval machinery are out of scope**, as
+  `PLAN.md` says: every live integral is over a finite interval. The
+  module docstring says so too, so a later reader does not read the
+  omission as an oversight.
+
+## Files Changed
+
+- `rust/src/quad.rs` — **new**, 1,972 lines: `qk15`, `qk21`, `qelg`,
+  `qpsrt`, `qagse`, `qagpe`, the `quad` driver and `filter_points`, a
+  `# Sources and licensing` provenance header, the call-site table, and
+  24 unit tests.
+- `rust/src/quad_probe.rs` — **new**, registration-only
+  `hazma._core.quad` exposing `quad`, `qk15` and `qk21` to the scipy
+  comparison.
+- `rust/src/lib.rs` — `pub mod quad;` + `mod quad_probe;`, the submodule
+  registration, and the reconciled paragraphs on why the two probe
+  modules are the exception to "registration only means per-domain".
+- `test/test_core_quad.py` — **new**, 53 tests in 8 classes.
+- `test/parity/cases.py`, `test/parity/README.md`,
+  `test/parity/test_parity.py` — `hazma._core.quad` added to
+  `_CORE_TEST_ONLY_MODULES`, and the three places that named `special`
+  alone reconciled.
+- `hazma/_core.pyi` — the unstubbed-submodule comment now covers both
+  probes (the only change under `hazma/`, and non-executable).
+- Canonical patches: `../../phases/phase-03-numerics-foundation.md`
+  (four Task 3.3 criteria added during execution),
+  `../../references/numerics-replacements.md` (the measured breakpoint
+  contract).
+
+Nothing else under `hazma/`, and nothing under `docs/`.
+
+## Verification
+
+Every count below comes from the command printed beside it, run against
+the final tree.
+
+### Gates
+
+| Gate | Command | Result |
+| --- | --- | --- |
+| Rust units | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `40 passed` (24 new; `grep -c '#\[test\]' rust/src/quad.rs` → 24) |
+| Rust format | `cargo fmt --manifest-path rust/Cargo.toml --check` | clean |
+| Rust lint | `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` | clean |
+| New module | `pytest test/test_core_quad.py -q` | `53 passed in 0.73s` |
+| Full suite | `pytest -q` (via preflight) | `1207 passed, 13 skipped` — see below |
+| Full gate | `scripts/agents/preflight.sh --paths … --md …` | **RESULT: PASS** |
+
+Test population, derived rather than counted by hand:
+
+```sh
+pytest test/test_core_quad.py --collect-only -q \
+  | awk -F'::' '/::/{print $2}' | sort | uniq -c
+```
+
+8 classes / 53 tests — `TestBreakPointPreprocessing` 8,
+`TestReferenceProblems` 9, `TestLiveIntegrandShapes` 14,
+`TestKronrodRules` 5, `TestTerminationFlags` 6,
+`TestDivergenceRegime` 2, `TestAdaptiveHeuristics` 2,
+`TestErrorBehavior` 7.
+
+**The parity corpus ran in bit-equality mode.** `1207 passed, 13 skipped`
+is +53 on Task 3.2's `1154 passed, 13 skipped`, all of them this task's
+new tests, and **the skip count is unchanged** — which is what proves the
+mode, since forcing budget mode drops one test to a skip rather than
+failing. Confirmed independently before the run:
+`tolerances.provenance(manifest)` → `Provenance(exact=True, detail='')`.
+
+### What the tests cover
+
+- **Break-point preprocessing** (8): sorting, deduplication,
+  endpoint-coincident points, out-of-interval points, all-points-dropped,
+  `NaN`, an empty list still selecting `qagpe`, reversed limits, and the
+  `limit <= npts` raise. Each uses a genuinely singular integrand, so a
+  break point that survives filtering moves `neval` and `last` visibly —
+  on a smooth integrand the whole contract is unobservable.
+- **QUADPACK reference problems** (9): the endpoint log singularity at
+  six exponents, the interior algebraic singularity with a break point, a
+  smooth single-panel case, and an oscillatory cancellation. Analytic
+  values, so scipy is not the only oracle in the module.
+- **Live integrand shapes** (14): the cos-θ boost-Jacobian sites at four
+  β; the three boosted-energy-window sites at their own tolerances
+  (including the neutrino row's scipy defaults); the nested ρ integral
+  with both levels on the port; and **both** mediators' thermal ⟨σv⟩ at
+  the three break-point regimes the exit criteria name, running the
+  *actual* Cython integrand via `sigma_xx_to_all`. Each asserts
+  `ier = 0`.
+- **The bare rules** (5): `qk21` is bit-identical to `quad` on a single
+  panel, both rules integrate a low-degree polynomial exactly, `resabs`
+  is the rule applied to `|f|`, and the two rules agree.
+- **Termination flags** (6): `ier` 0–5 each driven by a purpose-built
+  input and compared against scipy's own code, decoded from the message
+  `full_output` appends.
+- **Divergence regime** (2) and **adaptive heuristics** (2): documented
+  above.
+- **Error behavior** (7): invalid tolerances, `limit = 0`, the
+  subdivision limit, an exception raised by the integrand (propagated
+  unchanged, integrand called once), a non-float return, a `NaN`
+  integrand, and a zero-width interval.
+
+### Validity
+
+**The Gauss–Kronrod tables were checked against netlib as f64 bit
+patterns**, by a script that parses the Fortran `data` statements and the
+Rust `const` arrays independently of the crate: `XGK15`/`WGK15`/`WG15`
+(8/8/4 values) and `XGK21`/`WGK21`/`WG21` (11/11/5) → `MISMATCHES: 0`.
+That check is what caught the poisoned baseline described in Findings;
+it owes nothing to the code under test.
+
+**Seventeen mutations against `rust/src/quad.rs`**, each applied alone
+from a green baseline and reverted after, with the baseline re-asserted
+green at the end:
+
+| # | Mutation | `cargo test` | `pytest` |
+| --- | --- | --- | --- |
+| M1 | `XGK21[0]` digit | caught (4) | caught (16) |
+| M2 | `WGK15` centre weight digit | caught (2) | caught (2) |
+| M3 | `qk21` Gauss sum uses one node of the pair | caught (3) | caught (21) |
+| M4 | `qk21` Kronrod weight index off by one | caught (9) | caught (37) |
+| M5 | `qk21` error estimate drops the 3/2 power | — | caught (6) |
+| M6 | filter keeps endpoint-coincident points | caught (1) | caught (11) |
+| M7 | filter does not deduplicate | caught (1) | caught (1) |
+| M8 | filter does not sort | caught (1) | caught (1) |
+| M9 | empty `points` falls back to `qagse` | — | caught (3) |
+| M10 | `qelg` drops the table truncation | — | caught (1) |
+| M11 | `qelg` error estimate drops one of three terms | — | caught (4) |
+| M12 | `qagpe` ignores the `ndin` flag | — | caught (1) |
+| M13 | `qagpe` drops the sign of a reversed interval | caught (1) | — |
+| M14 | `quad` drops the flip negation | caught (1) | caught (1) |
+| M15 | `qagse` `neval` formula | caught (1) | caught (8) |
+| M16 | `qagse` roundoff threshold `0.99` → `0.9` | — | caught (1) |
+| M17 | `ier` code 1 mapped to the wrong variant | caught (1) | caught (1) |
+
+M13 is caught by `cargo` only, and correctly so: `quad` orders the limits
+before it calls `qagpe`, so the Fortran's own `sign` branch is
+unreachable from Python and only the Rust unit test can reach it. M12 and
+M16 survived the first pass entirely — the two tests in
+`TestAdaptiveHeuristics` were written afterwards, against inputs found by
+searching with each mutation in place, and both mutations were re-run
+against the final tree to confirm they are now caught.
+
+### Deferred
+
+- No Rust unit test pins the `abserr` refinement (M5) or `qelg`'s
+  bookkeeping (M10, M11): the Python scipy comparison catches all three,
+  and an independent Rust-side expectation would have to reimplement the
+  formula it is checking. `cargo test` alone is therefore not a complete
+  gate on this module — noted here rather than papered over.
+
+## Open Questions
+
+- None blocking. One observation for Phase 04–06: the port and scipy can
+  disagree by ~10% once `limit` is exhausted (see Findings). No live call
+  site reaches that regime today and `test/test_core_quad.py` asserts
+  `ier = 0` for every live shape, so a future kernel that *does* reach it
+  would be a new behavior rather than a regression — but it would be a
+  silent one, since QUADPACK returns a number either way.
+
+## Plan Impact
+
+**Impact Level:** Phase file patched (plus the reference).
+
+`../../phases/phase-03-numerics-foundation.md`'s Task 3.3 block gained
+four "criteria added during execution" bullets, for the same reason Task
+3.2's did: the criteria as written were satisfiable in a way that would
+have been wrong, and the shape of the answer belongs in the canonical
+document rather than only here. The breakpoint contract is scipy's
+rather than QUADPACK's and both live degeneracies are discards (so six
+call sites run `qagpe` with an empty list); only `qk21` is on the live
+path; the agreement criterion is met with four orders of headroom and its
+boundary is `limit`; and the corpus's served-kernel predicate stays sound
+through the existing exemption.
+
+`../../references/numerics-replacements.md`'s quad section gained the
+measured contract, because its own sentence — "What scipy does … must be
+pinned empirically" — is the instruction, and leaving the answer only in
+a task note would make the next reader re-derive it.
+
+No ADR: nothing revises ADR-0002 (the provenance is exactly what it
+prescribes, public-domain netlib QUADPACK), no interface or task ordering
+moves, and every decision here is carried by the code, the phase file and
+this note.
+
+## Stale-state sweep
+
+Run against the final branch. `## Verification` holds the gates' full
+results; this block is the evidence each command ran.
+
+**Full change inventory** — `git status --short` (with `git add -N`, so
+untracked files appear and were each read end-to-end):
+
+```text
+ M hazma/_core.pyi
+ M projects/cython-to-rust/phases/phase-03-numerics-foundation.md
+ M projects/cython-to-rust/references/numerics-replacements.md
+ M projects/cython-to-rust/task-notes/README.md
+ M projects/cython-to-rust/task-notes/phase-03/README.md
+ A projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md
+ M rust/src/lib.rs
+ A rust/src/quad.rs
+ A rust/src/quad_probe.rs
+ M test/parity/README.md
+ M test/parity/cases.py
+ M test/parity/test_parity.py
+ A test/test_core_quad.py
+```
+
+`git diff origin/master --stat` → `13 files changed, 4015 insertions(+),
+35 deletions(-)`.
+
+**Numerical-impact statement** — `git diff origin/master --stat --
+hazma`:
+
+```text
+ hazma/_core.pyi | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+```
+
+One file, and it is the non-executable stub: the hunk rewrites a comment
+block describing which `hazma._core` submodules are deliberately
+unstubbed. No executable line under `hazma/` is reachable from this diff,
+so no grid evaluation applies. The positive evidence is the parity corpus
+running in **bit-equality mode** inside the bare suite — `rtol = 0`
+across all 41 consumed entry points and 179,695 pinned values, at
+`1207 passed, 13 skipped` with the skip count unchanged (see
+`## Verification`).
+
+**Doc citations** — `scripts/agents/check_doc_citations.py <the six
+touched docs>`:
+
+```text
+docs scanned: 6
+in-repo citations checked: 18
+  resolved by exact: 10
+  resolved by suffix: 8
+external citations skipped: 0
+out-of-range or ambiguous: NONE
+```
+
+Paths were passed explicitly rather than `--changed-vs origin/master`,
+which reports `no docs to check` on an uncommitted tree — a
+success-shaped line for a zero-file scan (`docs/agents/lessons.md`,
+`[changed-vs-sees-only-commits]`).
+
+**Call-site count, re-derived rather than carried over.** Every prose
+copy of "eleven live call sites" and "six of the eleven" was wrong, in
+seven files, and had been copied from the reference's *seven-row table*
+rather than counted. `grep -rn --include='*.pyx' "quad(" hazma | grep -v
+'#'` → **12** live sites, of which **5** pass `points=[-1, 1]`. All
+twelve occurrences across `rust/src/quad.rs`, `test/test_core_quad.py`,
+this note, `phase-03/README.md`, `../README.md`,
+`../../references/numerics-replacements.md` and the phase file were
+swept — `docs/agents/lessons.md`, `[derived-count-not-rederived]` and
+`[sibling-copies-of-a-fixed-claim]`.
+
+**Stale-sibling sweep on the submodule prose** — `rg -n 'per-domain
+submodule|five per-domain|sixth submodule' rust/ test/ hazma/ docs/`:
+
+```text
+rust/src/kernels.rs:7://! [`crate::dispatch`] and the per-domain submodules.
+rust/src/special_probe.rs:3://! Registration only, like the per-domain submodules. These three
+rust/src/quad_probe.rs:3://! Registration only, like the per-domain submodules. This is a **test
+rust/src/lib.rs:3://! One `cdylib`, five per-domain submodules, built against CPython's
+hazma/_core.pyi:6:# per-domain submodules — photon, positron, neutrino, scalar_mediator,
+test/parity/test_parity.py:265:    per-domain submodules are empty until Phase 04; and `special`
+```
+
+All six still true — `quad` is not a per-domain submodule, and `lib.rs`,
+`_core.pyi` and `test_parity.py` each name it separately in the same
+file. The last three were updated by this task; Task 3.2's "sixth
+submodule" wording in `_core.pyi` was rewritten rather than incremented
+to a seventh, because the count was the fragile part.
+
+**Predicate references** — `rg -n '_CORE_TEST_ONLY_MODULES' test/ docs/
+hazma/` returns 9 live hits across `cases.py`, `test_parity.py` and
+`test/parity/README.md`; each was read and reconciled with the new
+exemption. Occurrences under `projects/` are dated Phase 01–03 records
+and were left alone.
+
+**Forbidden tokens** — `grep -nE 'TODO|FIXME|breakpoint\(|import
+pdb|^\s*print\(' rust/src/quad.rs rust/src/quad_probe.rs
+test/test_core_quad.py` → no matches; preflight's own diff scan agrees
+(`PASS forbidden tokens — none added`).
+
+**Measurement re-derivation.** The port-vs-scipy agreement figures were
+measured twice. The first sweep (6,000 combinations, `points` drawn from
+five options of at most two break points) reported *zero* subdivision
+mismatches among 2,812 converged runs, worst relative value 9.4e-11 and
+worst `|Δ|/tolerance` 2.0e-3 — and those numbers were already written
+into this note, `phase-03/README.md`, `../README.md`, the phase file and
+the test module's docstring before the design was questioned. Adding 9-
+and 39-point break-point grids to the draw produced 5 mismatches in
+4,461. Every copy was swept to the wider sweep's figures (11,274 runs;
+4,461 converged; 5 mismatches; 3.6e-2 of tolerance; 8.2e-11 relative) —
+`docs/agents/lessons.md`,
+`[measurement-taken-before-the-task-ended]`, second shape.
+
+**Table provenance.** The Gauss–Kronrod literals were re-verified against
+the netlib Fortran as f64 bit patterns after every mutation run, not only
+at the end: `MISMATCHES: 0` over all 47 values.
+
+## Handoff to Next Task
+
+- **Read first:** `../../phases/phase-03-numerics-foundation.md` (Task
+  3.4 and 3.5, plus Task 3.3's added criteria), then `phase-03/README.md`.
+- **Safe to assume:** `hazma_core::quad` exists and is PyO3-free.
+  `quad(&mut f, a, b, &QuadOpts { epsabs, epsrel, limit, points })` is
+  the function a Phase 04–06 kernel calls — **not** `qagse`/`qagpe`,
+  which skip scipy's argument preprocessing. It returns
+  `Result<QuadOutcome, QuadError>`: `Err` only where scipy raises
+  `ValueError`, and `QuadOutcome::ier` carrying what scipy would have
+  warned about. `hazma._core.quad` is a test surface and must stay
+  importer-free, or the parity corpus leaves bit-equality mode.
+- **Risky / unknown:** the ~10% divergence once `limit` is exhausted
+  (Findings, Open Questions). And when porting a call site, copy its
+  `epsabs`/`epsrel`/`points` from the `.pyx` verbatim — the twelve sites
+  use five different tolerance combinations, and two of them reach
+  scipy's defaults by passing no keyword at all.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,17 +15,18 @@
 //! separately" (rules.md rule 8) is about keeping it out of [`kernels`],
 //! not about confining it to one file.
 //!
-//! [`constants`] and [`special`] sit below `kernels` in that stack and
-//! are `pub` while their neighbours are private — no kernel reads either
-//! one yet, and a private module of unread items is a wall of
-//! `dead_code`. Publishing them is also honest: the constant tables and
-//! the cephes shim are the crate's most reusable surface, and Phases
-//! 03–06 consume them from every kernel module.
+//! [`constants`], [`special`] and [`quad`] sit below `kernels` in that
+//! stack and are `pub` while their neighbours are private — no kernel
+//! reads any of them yet, and a private module of unread items is a wall
+//! of `dead_code`. Publishing them is also honest: the constant tables,
+//! the cephes shim and the QUADPACK port are the crate's most reusable
+//! surface, and Phases 03–06 consume them from every kernel module.
 //!
-//! [`special_probe`] is the exception to "registration only means
-//! per-domain": it registers a `special` submodule that exposes
-//! [`special`] to Python purely so `test/test_core_special.py` can sweep
-//! it against scipy. No hazma module imports it.
+//! [`special_probe`] and [`quad_probe`] are the exception to
+//! "registration only means per-domain": they register `special` and
+//! `quad` submodules that expose [`special`] and [`quad`] to Python purely
+//! so `test/test_core_special.py` and `test/test_core_quad.py` can compare
+//! them against scipy. No hazma module imports either.
 
 pub mod constants;
 mod dispatch;
@@ -33,6 +34,8 @@ mod kernels;
 mod neutrino;
 mod photon;
 mod positron;
+pub mod quad;
+mod quad_probe;
 mod scalar_mediator;
 pub mod special;
 mod special_probe;
@@ -101,6 +104,7 @@ fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     add_submodule(module, "scalar_mediator", scalar_mediator::register)?;
     add_submodule(module, "vector_mediator", vector_mediator::register)?;
     add_submodule(module, "special", special_probe::register)?;
+    add_submodule(module, "quad", quad_probe::register)?;
 
     Ok(())
 }

--- a/rust/src/quad.rs
+++ b/rust/src/quad.rs
@@ -83,6 +83,35 @@ const OFLOW: f64 = f64::MAX;
 /// scipy's default subdivision limit, and hazma's at every call site.
 pub const DEFAULT_LIMIT: usize = 50;
 
+/// Subintervals the `limit`-indexed workspaces hold before they grow.
+///
+/// Comfortably above what any live call reaches — the hardest live shape
+/// converges in 13 subintervals — so the common case allocates once.
+const WORKSPACE_SEED: usize = 64;
+
+/// Initial length for the `limit`-indexed workspaces of [`qagse`] and
+/// [`qagpe`], holding at least `needed` subintervals.
+///
+/// These are **grown on demand rather than allocated at `limit`**, which
+/// is not an optimization. `limit` bounds the subdivisions a caller will
+/// *tolerate*, not the ones the integrand will need, and
+/// `scipy.integrate.quad` accepts it all the way to `i32::MAX`. Sized
+/// eagerly there, `qagse`'s five arrays come to ~80 GiB and `qagpe`'s six
+/// to ~88 GiB, reserved before the first panel is even evaluated. Rust
+/// aborts the process when an allocation fails rather than unwinding, so
+/// that can never surface as a Python exception — and "returns a Result,
+/// never panics across FFI" is one of this task's exit criteria. Whether
+/// the reservation succeeds is a property of the platform's overcommit
+/// policy, which is exactly the kind of thing not to leave to chance.
+fn workspace_len(limit: usize, needed: usize) -> usize {
+    needed.max(WORKSPACE_SEED).min(limit) + 2
+}
+
+/// Next workspace length: double, never past what `limit` can index.
+fn grown_workspace_len(current: usize, limit: usize) -> usize {
+    current.saturating_mul(2).min(limit + 2)
+}
+
 /// scipy's default absolute tolerance (`quad`'s `epsabs`).
 pub const DEFAULT_EPSABS: f64 = 1.49e-8;
 
@@ -707,11 +736,13 @@ where
         return Err(QuadError::ToleranceUnachievable);
     }
 
-    let mut alist = vec![0.0_f64; limit + 1];
-    let mut blist = vec![0.0_f64; limit + 1];
-    let mut rlist = vec![0.0_f64; limit + 1];
-    let mut elist = vec![0.0_f64; limit + 1];
-    let mut iord = vec![0_usize; limit + 2];
+    // Grown on demand; see [`workspace_len`] for why not `limit`.
+    let mut cap = workspace_len(limit, 1);
+    let mut alist = vec![0.0_f64; cap];
+    let mut blist = vec![0.0_f64; cap];
+    let mut rlist = vec![0.0_f64; cap];
+    let mut elist = vec![0.0_f64; cap];
+    let mut iord = vec![0_usize; cap];
     let mut rlist2 = [0.0_f64; 53];
     let mut res3la = [0.0_f64; 4];
 
@@ -784,6 +815,18 @@ where
 
     'mainloop: for last_index in 2..=limit {
         last = last_index;
+
+        // Every index below is at most `last` (`qpsrt`'s `jupbn` is
+        // `limit + 3 - last` only on the branch where that is smaller
+        // than `last`), so one slot of headroom is enough.
+        if last + 2 > cap {
+            cap = grown_workspace_len(cap, limit);
+            alist.resize(cap, 0.0);
+            blist.resize(cap, 0.0);
+            rlist.resize(cap, 0.0);
+            elist.resize(cap, 0.0);
+            iord.resize(cap, 0);
+        }
 
         // Bisect the subinterval with the nrmax-th largest error.
         let a1 = alist[maxerr];
@@ -1071,12 +1114,18 @@ where
         return Err(QuadError::ToleranceUnachievable);
     }
 
-    let mut alist = vec![0.0_f64; limit + 1];
-    let mut blist = vec![0.0_f64; limit + 1];
-    let mut rlist = vec![0.0_f64; limit + 1];
-    let mut elist = vec![0.0_f64; limit + 1];
-    let mut iord = vec![0_usize; limit + 2];
-    let mut level = vec![0_i32; limit + 1];
+    // Grown on demand; see [`workspace_len`] for why not `limit`. The
+    // seed has to cover the initial partition, which is `npts + 1`
+    // subintervals before the main loop runs at all. `ndin` and `pts` are
+    // sized by the caller's break-point count rather than by `limit`, so
+    // they carry no such hazard.
+    let mut cap = workspace_len(limit, npts + 1);
+    let mut alist = vec![0.0_f64; cap];
+    let mut blist = vec![0.0_f64; cap];
+    let mut rlist = vec![0.0_f64; cap];
+    let mut elist = vec![0.0_f64; cap];
+    let mut iord = vec![0_usize; cap];
+    let mut level = vec![0_i32; cap];
     let mut ndin = vec![0_i32; npts2 + 1];
     let mut pts = vec![0.0_f64; npts2 + 1];
     let mut rlist2 = [0.0_f64; 53];
@@ -1215,6 +1264,17 @@ where
 
     'mainloop: for last_index in npts2..=limit {
         last = last_index;
+
+        // As in `qagse`: every index below is at most `last`.
+        if last + 2 > cap {
+            cap = grown_workspace_len(cap, limit);
+            alist.resize(cap, 0.0);
+            blist.resize(cap, 0.0);
+            rlist.resize(cap, 0.0);
+            elist.resize(cap, 0.0);
+            iord.resize(cap, 0);
+            level.resize(cap, 0);
+        }
 
         let levcur = level[maxerr] + 1;
         let a1 = alist[maxerr];
@@ -1961,6 +2021,62 @@ mod tests {
         let out = quad(&mut f, 1.5, 1.5, &QuadOpts::default()).unwrap();
         assert_eq!(out.value, 0.0);
         assert_eq!(out.ier, Ier::Ok);
+    }
+
+    #[test]
+    fn an_enormous_limit_costs_nothing_on_a_one_panel_integrand() {
+        // `limit` bounds subdivisions; it must not size the workspace up
+        // front. Sized eagerly, this call would ask for roughly
+        // `40 * limit` bytes — here about 7e17 — and Rust *aborts* on
+        // allocation failure rather than unwinding, so the process would
+        // die instead of returning an error across the FFI boundary.
+        //
+        // The number is chosen to be unsatisfiable on any machine, so the
+        // test discriminates on every platform rather than only where the
+        // allocator declines to overcommit. A smooth integrand converges
+        // on the first panel, so with on-demand growth the run touches 66
+        // slots and never looks at `limit` again.
+        let limit = usize::MAX / 4096;
+        let mut f = |x: f64| x.exp();
+        let out = qagse(&mut f, 0.0, 1.0, 1e-10, 1e-10, limit).unwrap();
+        assert_eq!((out.neval, out.last, out.ier), (21, 1, Ier::Ok));
+        assert_close(
+            out.value,
+            std::f64::consts::E - 1.0,
+            SMOOTH_RTOL,
+            "huge-limit qagse",
+        );
+
+        // Same for `qagpe`, which carries a sixth `limit`-length array.
+        let mut g = |x: f64| x.exp();
+        let out = qagpe(&mut g, 0.0, 1.0, &[], 1e-10, 1e-10, limit).unwrap();
+        assert_eq!((out.neval, out.last, out.ier), (21, 1, Ier::Ok));
+    }
+
+    #[test]
+    fn the_workspace_grows_to_hold_every_subdivision_it_reaches() {
+        // The complement: a genuinely hard integrand must still be able to
+        // subdivide all the way to `limit`, so the growth path is
+        // exercised rather than merely present. `limit = 300` is well past
+        // the 66-slot seed, so this run resizes.
+        let mut f = |x: f64| if x == 0.0 { 0.0 } else { 1.0 / x };
+        let out = qagse(&mut f, 0.0, 1.0, 1e-10, 1e-10, 300).unwrap();
+        assert_eq!(out.last, 300, "expected the limit to be exhausted");
+        assert_ne!(out.ier, Ier::Ok);
+        assert!(out.value.is_finite());
+    }
+
+    #[test]
+    fn the_workspace_seed_covers_the_initial_partition() {
+        // `qagpe` writes `npts + 1` subintervals before the main loop
+        // runs, so a break-point list longer than the seed must be
+        // accommodated at construction, not on first growth.
+        let points: Vec<f64> = (1..200).map(|i| f64::from(i) / 200.0).collect();
+        let mut f = |x: f64| x * x;
+        let out = qagpe(&mut f, 0.0, 1.0, &points, 1e-10, 1e-10, 400).unwrap();
+        assert_eq!(out.ier, Ier::Ok);
+        assert_eq!(out.last, points.len() + 1);
+        assert_close(out.value, 1.0 / 3.0, 1e-13, "many break points");
     }
 
     #[test]

--- a/rust/src/quad.rs
+++ b/rust/src/quad.rs
@@ -1,0 +1,1972 @@
+//! The QUADPACK subset hazma's compiled layer integrates with.
+//!
+//! A PyO3-free translation of netlib QUADPACK
+//! (`projects/cython-to-rust/rules.md`, Rust conventions rule 3 — plain
+//! `fn`s taking a closure, no PyO3 types, so `cargo test` needs no GIL).
+//! [`crate::quad_probe`] is the Python-visible half.
+//!
+//! # Sources and licensing
+//!
+//! Upstream: **QUADPACK**, Piessens, de Doncker-Kapenga, Überhuber and
+//! Kahaner (Springer, 1983), as published on netlib
+//! (<https://www.netlib.org/quadpack/>) — `dqk15.f`, `dqk21.f`,
+//! `dqelg.f`, `dqpsrt.f`, `dqagse.f`, `dqagpe.f`, retrieved 2026-08-10.
+//! QUADPACK is **public domain**; it is the same Fortran scipy vendors
+//! (translated to C there since 1.12). Nothing here derives from GSL's
+//! GPL-3 reimplementation, which is what
+//! `projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md`
+//! requires (`rules.md` rule 5 / Licensing 1).
+//!
+//! The translation is deliberately literal: same variable names, same
+//! branch order, same magic constants, and **1-based indexing preserved**
+//! by giving every array a dead element 0. Idiomatic Rust would be easier
+//! to read and much harder to check against the Fortran, and the point of
+//! this module is that a reader can put the two side by side. Fortran
+//! `go to`s become labelled blocks or `break`s in the same order; each
+//! carries the original statement label in a comment.
+//!
+//! # What calls these, and with what
+//!
+//! Every live integral is over a **finite** interval, so `qagi` and the
+//! transformed-infinite machinery are out of scope. All of the call sites
+//! below reach QUADPACK through `scipy.integrate.quad`, so [`quad`] — not
+//! [`qagse`] or [`qagpe`] — is the function a ported kernel should call.
+//!
+//! | Cython call site | Interval | Settings |
+//! | --- | --- | --- |
+//! | `hazma/spectra/_photon/_pion.pyx:123` | cos θ ∈ [−1, 1] | `points=[-1, 1]`, `epsabs=1e-10`, `epsrel=1e-5` |
+//! | `hazma/spectra/_photon/_rho.pyx:52`, `:123` | boosted energy | `epsabs=1e-10`, `epsrel=1e-5` |
+//! | `hazma/spectra/_positron/_pion.pyx:58` | boosted energy | `epsabs=1e-10`, `epsrel=1e-4` |
+//! | `hazma/spectra/_neutrino/_pion.pyx:124`, `:127` | boosted energy | scipy defaults |
+//! | `hazma/scalar_mediator/_c_scalar_mediator_cross_sections.pyx:1411` | z ∈ [2, max(50/x, 100)] | `points=[2, ms/mx, 2·ms/mx]` |
+//! | `hazma/vector_mediator/_c_vector_mediator_cross_sections.pyx:656` | z ∈ [2, max(50/x, 150)] | `points=[2, mv/mx, 2·mv/mx]` |
+//! | `hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx:184`, `scalar_mediator_positron_spec.pyx:209` | cos θ ∈ [−1, 1] | `points=[-1, 1]`, `epsabs=1e-10`, `epsrel=1e-5` |
+//! | `hazma/vector_mediator/vector_mediator_decay_spectrum.pyx:219`, `vector_mediator_positron_spec.pyx:210` | cos θ ∈ [−1, 1] | `points=[-1, 1]`, `epsabs=1e-10`, `epsrel=1e-5` |
+//!
+//! # Only `qk21` is on the live path
+//!
+//! `scipy.integrate.quad` on a finite interval runs `qagse` without
+//! `points` and `qagpe` with them, and **both** evaluate with the 21-point
+//! Gauss–Kronrod rule. [`qk15`] is reachable from no live call site; it is
+//! ported because this task's exit criteria name it, because QUADPACK's
+//! own reference problems exercise it, and because a second, independent
+//! rule is what lets a test cross-check [`qk21`] on the same integrand
+//! rather than only against itself.
+
+// The Gauss–Kronrod tables are transcribed verbatim from the Fortran
+// `data` statements, which give 31 significant digits. `f64` keeps 17, and
+// re-rounding them by hand to silence the lint is exactly the edit that
+// would put a wrong digit in a quadrature rule. Same allow, and the same
+// reason, as `crate::constants`.
+#![allow(clippy::excessive_precision)]
+// The next three are the price of the literal translation this module is
+// built on (see the module docs). Each of clippy's rewrites is correct in
+// isolation and each one costs a line of the Fortran correspondence: an
+// iterator adaptor in place of `do 120 k = 1,last`, `enumerate()` in place
+// of a hand-carried `indx`, `levcur < levmax` in place of QUADPACK's
+// `levcur+1 .le. levmax`. The 1-based indexing that makes the
+// correspondence readable is also what makes clippy want the rewrites, so
+// taking them here would only move the risk.
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::explicit_counter_loop)]
+#![allow(clippy::int_plus_one)]
+
+/// `d1mach(4)` — the largest relative spacing.
+const EPMACH: f64 = f64::EPSILON;
+
+/// `d1mach(1)` — the smallest positive magnitude.
+const UFLOW: f64 = f64::MIN_POSITIVE;
+
+/// `d1mach(2)` — the largest positive magnitude.
+const OFLOW: f64 = f64::MAX;
+
+/// scipy's default subdivision limit, and hazma's at every call site.
+pub const DEFAULT_LIMIT: usize = 50;
+
+/// scipy's default absolute tolerance (`quad`'s `epsabs`).
+pub const DEFAULT_EPSABS: f64 = 1.49e-8;
+
+/// scipy's default relative tolerance (`quad`'s `epsrel`).
+pub const DEFAULT_EPSREL: f64 = 1.49e-8;
+
+/// The outcome flag QUADPACK returns in `ier`, in scipy's numbering.
+///
+/// scipy raises `ValueError` only for [`Ier::InvalidInput`]; every other
+/// non-`Ok` value is an `IntegrationWarning` beside a usable result, and
+/// hazma's call sites take `quad(...)[0]` regardless. [`quad`] mirrors
+/// that split exactly: `Err` for invalid input, `Ok` carrying the flag for
+/// everything else.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Ier {
+    /// `ier = 0` — normal, requested accuracy achieved.
+    Ok,
+    /// `ier = 1` — the subdivision limit was reached.
+    MaxSubdivisions,
+    /// `ier = 2` — roundoff prevents the requested tolerance.
+    Roundoff,
+    /// `ier = 3` — extremely bad integrand behaviour somewhere in range.
+    BadIntegrand,
+    /// `ier = 4` — the extrapolation table does not converge.
+    NoConvergence,
+    /// `ier = 5` — the integral is probably divergent or slowly
+    /// convergent.
+    Divergent,
+    /// `ier = 6` — invalid input. Never returned inside [`QuadOutcome`];
+    /// [`quad`] turns it into [`QuadError`].
+    InvalidInput,
+}
+
+impl Ier {
+    /// The raw QUADPACK code, so a test can compare against scipy's
+    /// `full_output` dictionary without a translation table.
+    #[must_use]
+    pub fn code(self) -> i32 {
+        match self {
+            Ier::Ok => 0,
+            Ier::MaxSubdivisions => 1,
+            Ier::Roundoff => 2,
+            Ier::BadIntegrand => 3,
+            Ier::NoConvergence => 4,
+            Ier::Divergent => 5,
+            Ier::InvalidInput => 6,
+        }
+    }
+
+    fn from_code(code: i32) -> Ier {
+        match code {
+            0 => Ier::Ok,
+            1 => Ier::MaxSubdivisions,
+            2 => Ier::Roundoff,
+            3 => Ier::BadIntegrand,
+            4 => Ier::NoConvergence,
+            5 => Ier::Divergent,
+            _ => Ier::InvalidInput,
+        }
+    }
+}
+
+/// Everything `dqagse`/`dqagpe` return.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct QuadOutcome {
+    /// Approximation to the integral.
+    pub value: f64,
+    /// Estimate of the modulus of the absolute error.
+    pub abserr: f64,
+    /// Number of integrand evaluations.
+    pub neval: usize,
+    /// Number of subintervals produced.
+    pub last: usize,
+    /// The termination flag; anything but [`Ier::Ok`] is scipy's
+    /// `IntegrationWarning` case.
+    pub ier: Ier,
+}
+
+/// The invalid-input cases, i.e. everything for which scipy raises
+/// `ValueError` instead of warning.
+///
+/// Each variant names the condition QUADPACK checks rather than repeating
+/// scipy's message text, because scipy reconstructs those messages in
+/// Python from a decision tree over the *unfiltered* arguments — its
+/// "Number of break points (N)" counts the caller's list while QUADPACK
+/// counted the filtered one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuadError {
+    /// `epsabs <= 0` together with an unachievable `epsrel`.
+    ///
+    /// QUADPACK's test is `epsrel < max(50·epmach, 0.5e-28)`.
+    ToleranceUnachievable,
+    /// `limit < 1` (`qagse`), or `limit <= npts` (`qagpe`), where `npts`
+    /// is the count of breakpoints **after** scipy's filtering.
+    LimitTooSmall {
+        /// The `limit` that was passed.
+        limit: usize,
+        /// Interior breakpoints left after filtering; `0` for `qagse`.
+        npts: usize,
+    },
+    /// A breakpoint outside `[a, b]` reached `qagpe`.
+    ///
+    /// Unreachable through [`quad`], which filters exactly as scipy does;
+    /// it exists because [`qagpe`] is public and faithful.
+    BreakpointOutsideInterval,
+}
+
+impl std::fmt::Display for QuadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QuadError::ToleranceUnachievable => write!(
+                f,
+                "if 'epsabs' <= 0, 'epsrel' must exceed both 5e-29 and 50 * machine epsilon"
+            ),
+            QuadError::LimitTooSmall { limit, npts } => write!(
+                f,
+                "'limit' ({limit}) must exceed the number of interior break points ({npts}) \
+                 and leave at least one subinterval"
+            ),
+            QuadError::BreakpointOutsideInterval => {
+                write!(f, "all break points must lie within the integration limits")
+            }
+        }
+    }
+}
+
+impl std::error::Error for QuadError {}
+
+/// Everything `dqk15`/`dqk21` return for one interval.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct KronrodOutcome {
+    /// The Kronrod approximation to ∫f.
+    pub result: f64,
+    /// Estimate of the modulus of the absolute error.
+    pub abserr: f64,
+    /// Approximation to ∫|f|.
+    pub resabs: f64,
+    /// Approximation to ∫|f − ∫f/(b−a)|.
+    pub resasc: f64,
+}
+
+// ---------------------------------------------------------------------
+// dqk15 / dqk21 — the Gauss–Kronrod rules
+// ---------------------------------------------------------------------
+
+/// Abscissae of the 15-point Kronrod rule, `xgk` in `dqk15.f`.
+///
+/// Even indices (1-based `xgk(2)`, `xgk(4)`, …) are the 7-point Gauss
+/// abscissae; odd ones are the points optimally added to them. Only the
+/// non-negative half is stored, the rule being symmetric.
+const XGK15: [f64; 8] = [
+    0.991455371120812639206854697526329,
+    0.949107912342758524526189684047851,
+    0.864864423359769072789712788640926,
+    0.741531185599394439863864773280788,
+    0.586087235467691130294144838258730,
+    0.405845151377397166906606412076961,
+    0.207784955007898467600689403773245,
+    0.000000000000000000000000000000000,
+];
+
+/// Weights of the 15-point Kronrod rule, `wgk` in `dqk15.f`.
+const WGK15: [f64; 8] = [
+    0.022935322010529224963732008058970,
+    0.063092092629978553290700663189204,
+    0.104790010322250183839876322541518,
+    0.140653259715525918745189590510238,
+    0.169004726639267902826583426598550,
+    0.190350578064785409913256402421014,
+    0.204432940075298892414161999234649,
+    0.209482141084727828012999174891714,
+];
+
+/// Weights of the 7-point Gauss rule, `wg` in `dqk15.f`.
+///
+/// Seven points is odd, so `wg(4)` is the centre weight — which is why
+/// [`qk15`] seeds `resg` with `fc * wg(4)` where [`qk21`] seeds it with
+/// zero.
+const WG15: [f64; 4] = [
+    0.129484966168869693270611432679082,
+    0.279705391489276667901467771423780,
+    0.381830050505118944950369775488975,
+    0.417959183673469387755102040816327,
+];
+
+/// Abscissae of the 21-point Kronrod rule, `xgk` in `dqk21.f`.
+const XGK21: [f64; 11] = [
+    0.995657163025808080735527280689003,
+    0.973906528517171720077964012084452,
+    0.930157491355708226001207180059508,
+    0.865063366688984510732096688423493,
+    0.780817726586416897063717578345042,
+    0.679409568299024406234327365114874,
+    0.562757134668604683339000099272694,
+    0.433395394129247190799265943165784,
+    0.294392862701460198131126603103866,
+    0.148874338981631210884826001129720,
+    0.000000000000000000000000000000000,
+];
+
+/// Weights of the 21-point Kronrod rule, `wgk` in `dqk21.f`.
+const WGK21: [f64; 11] = [
+    0.011694638867371874278064396062192,
+    0.032558162307964727478818972459390,
+    0.054755896574351996031381300244580,
+    0.075039674810919952767043140916190,
+    0.093125454583697605535065465083366,
+    0.109387158802297641899210590325805,
+    0.123491976262065851077958109831074,
+    0.134709217311473325928054001771707,
+    0.142775938577060080797094273138717,
+    0.147739104901338491374841515972068,
+    0.149445554002916905664936468389821,
+];
+
+/// Weights of the 10-point Gauss rule, `wg` in `dqk21.f`.
+const WG21: [f64; 5] = [
+    0.066671344308688137593568809893332,
+    0.149451349150580593145776339657697,
+    0.219086362515982043995534934228163,
+    0.269266719309996355091226921569469,
+    0.295524224714752870173892994651338,
+];
+
+/// The shared tail of `dqk15`/`dqk21`: scale to `[a, b]` and turn the
+/// Kronrod−Gauss difference into QUADPACK's error estimate.
+///
+/// `resk`, `resg`, `resabs` and `resasc` arrive on the reference interval;
+/// `hlgth` is the half-length of `[a, b]`.
+fn kronrod_error(resk: f64, resg: f64, resabs: f64, resasc: f64, hlgth: f64) -> KronrodOutcome {
+    let dhlgth = hlgth.abs();
+    let result = resk * hlgth;
+    let resabs = resabs * dhlgth;
+    let resasc = resasc * dhlgth;
+    let mut abserr = ((resk - resg) * hlgth).abs();
+    if resasc != 0.0 && abserr != 0.0 {
+        abserr = resasc * (1.0_f64).min((200.0 * abserr / resasc).powf(1.5));
+    }
+    if resabs > UFLOW / (50.0 * EPMACH) {
+        abserr = ((EPMACH * 50.0) * resabs).max(abserr);
+    }
+    KronrodOutcome {
+        result,
+        abserr,
+        resabs,
+        resasc,
+    }
+}
+
+/// 15-point Gauss–Kronrod rule on `[a, b]` — `dqk15`.
+///
+/// Not reachable from any hazma call site (see the module docs); ported
+/// for the exit criteria and as an independent check on [`qk21`].
+pub fn qk15<F>(f: &mut F, a: f64, b: f64) -> KronrodOutcome
+where
+    F: FnMut(f64) -> f64,
+{
+    let centr = 0.5 * (a + b);
+    let hlgth = 0.5 * (b - a);
+
+    // 1-based, to match `fv1(j)` / `fv2(j)` in the Fortran.
+    let mut fv1 = [0.0_f64; 8];
+    let mut fv2 = [0.0_f64; 8];
+
+    let fc = f(centr);
+    let mut resg = fc * WG15[3];
+    let mut resk = fc * WGK15[7];
+    let mut resabs = resk.abs();
+
+    // do 10 j = 1,3 — the Gauss abscissae, at even Kronrod indices.
+    for j in 1..=3 {
+        let jtw = 2 * j;
+        let absc = hlgth * XGK15[jtw - 1];
+        let fval1 = f(centr - absc);
+        let fval2 = f(centr + absc);
+        fv1[jtw - 1] = fval1;
+        fv2[jtw - 1] = fval2;
+        let fsum = fval1 + fval2;
+        resg += WG15[j - 1] * fsum;
+        resk += WGK15[jtw - 1] * fsum;
+        resabs += WGK15[jtw - 1] * (fval1.abs() + fval2.abs());
+    }
+
+    // do 15 j = 1,4 — the added Kronrod abscissae, at odd indices.
+    for j in 1..=4 {
+        let jtwm1 = 2 * j - 1;
+        let absc = hlgth * XGK15[jtwm1 - 1];
+        let fval1 = f(centr - absc);
+        let fval2 = f(centr + absc);
+        fv1[jtwm1 - 1] = fval1;
+        fv2[jtwm1 - 1] = fval2;
+        let fsum = fval1 + fval2;
+        resk += WGK15[jtwm1 - 1] * fsum;
+        resabs += WGK15[jtwm1 - 1] * (fval1.abs() + fval2.abs());
+    }
+
+    let reskh = resk * 0.5;
+    let mut resasc = WGK15[7] * (fc - reskh).abs();
+    for j in 1..=7 {
+        resasc += WGK15[j - 1] * ((fv1[j - 1] - reskh).abs() + (fv2[j - 1] - reskh).abs());
+    }
+
+    kronrod_error(resk, resg, resabs, resasc, hlgth)
+}
+
+/// 21-point Gauss–Kronrod rule on `[a, b]` — `dqk21`.
+///
+/// The rule every live hazma integral runs on: both `qagse` and `qagpe`
+/// evaluate with it and nothing else.
+pub fn qk21<F>(f: &mut F, a: f64, b: f64) -> KronrodOutcome
+where
+    F: FnMut(f64) -> f64,
+{
+    let centr = 0.5 * (a + b);
+    let hlgth = 0.5 * (b - a);
+
+    let mut fv1 = [0.0_f64; 11];
+    let mut fv2 = [0.0_f64; 11];
+
+    // Ten Gauss points is even, so there is no centre Gauss weight and
+    // `resg` starts at zero — the one structural difference from `qk15`.
+    let mut resg = 0.0_f64;
+    let fc = f(centr);
+    let mut resk = WGK21[10] * fc;
+    let mut resabs = resk.abs();
+
+    // do 10 j = 1,5
+    for j in 1..=5 {
+        let jtw = 2 * j;
+        let absc = hlgth * XGK21[jtw - 1];
+        let fval1 = f(centr - absc);
+        let fval2 = f(centr + absc);
+        fv1[jtw - 1] = fval1;
+        fv2[jtw - 1] = fval2;
+        let fsum = fval1 + fval2;
+        resg += WG21[j - 1] * fsum;
+        resk += WGK21[jtw - 1] * fsum;
+        resabs += WGK21[jtw - 1] * (fval1.abs() + fval2.abs());
+    }
+
+    // do 15 j = 1,5
+    for j in 1..=5 {
+        let jtwm1 = 2 * j - 1;
+        let absc = hlgth * XGK21[jtwm1 - 1];
+        let fval1 = f(centr - absc);
+        let fval2 = f(centr + absc);
+        fv1[jtwm1 - 1] = fval1;
+        fv2[jtwm1 - 1] = fval2;
+        let fsum = fval1 + fval2;
+        resk += WGK21[jtwm1 - 1] * fsum;
+        resabs += WGK21[jtwm1 - 1] * (fval1.abs() + fval2.abs());
+    }
+
+    let reskh = resk * 0.5;
+    let mut resasc = WGK21[10] * (fc - reskh).abs();
+    for j in 1..=10 {
+        resasc += WGK21[j - 1] * ((fv1[j - 1] - reskh).abs() + (fv2[j - 1] - reskh).abs());
+    }
+
+    kronrod_error(resk, resg, resabs, resasc, hlgth)
+}
+
+// ---------------------------------------------------------------------
+// dqelg — Wynn's epsilon algorithm
+// ---------------------------------------------------------------------
+
+/// Wynn's ε-algorithm on the condensed table — `dqelg`.
+///
+/// `n` and `nres` are **in/out**, exactly as in the Fortran: the routine
+/// truncates the table by assigning to `n`, and the caller's `numrl2` must
+/// see that. `epstab` is 1-based with 52 usable slots (index `0` unused),
+/// `res3la` 1-based with 3.
+///
+/// Returns `(result, abserr)`.
+fn qelg(n: &mut usize, epstab: &mut [f64], res3la: &mut [f64], nres: &mut usize) -> (f64, f64) {
+    *nres += 1;
+    let mut abserr = OFLOW;
+    let mut result = epstab[*n];
+    if *n < 3 {
+        // 100
+        return (result, abserr.max(5.0 * EPMACH * result.abs()));
+    }
+    let limexp = 50_usize;
+    epstab[*n + 2] = epstab[*n];
+    let newelm = (*n - 1) / 2;
+    epstab[*n] = OFLOW;
+    let num = *n;
+    let mut k1 = *n;
+
+    // The Fortran's `do 40` either runs to completion (falling into the
+    // shift at 50), jumps out to 50 having truncated `n`, or jumps out to
+    // 100 on detected convergence.
+    let mut converged = false;
+    for i in 1..=newelm {
+        let k2 = k1 - 1;
+        let k3 = k1 - 2;
+        let mut res = epstab[k1 + 2];
+        let e0 = epstab[k3];
+        let e1 = epstab[k2];
+        let e2 = res;
+        let e1abs = e1.abs();
+        let delta2 = e2 - e1;
+        let err2 = delta2.abs();
+        let tol2 = e2.abs().max(e1abs) * EPMACH;
+        let delta3 = e1 - e0;
+        let err3 = delta3.abs();
+        let tol3 = e1abs.max(e0.abs()) * EPMACH;
+        if !(err2 > tol2 || err3 > tol3) {
+            // e0, e1, e2 agree to machine accuracy: convergence.
+            result = res;
+            abserr = err2 + err3;
+            converged = true;
+            break;
+        }
+        // 10
+        let e3 = epstab[k1];
+        epstab[k1] = e1;
+        let delta1 = e1 - e3;
+        let err1 = delta1.abs();
+        let tol1 = e1abs.max(e3.abs()) * EPMACH;
+
+        // 20 — two elements are very close, or the table is behaving
+        // irregularly: drop part of it by shortening `n`.
+        let mut truncate = err1 <= tol1 || err2 <= tol2 || err3 <= tol3;
+        let mut ss = 0.0;
+        if !truncate {
+            ss = 1.0 / delta1 + 1.0 / delta2 - 1.0 / delta3;
+            let epsinf = (ss * e1).abs();
+            truncate = epsinf <= 0.1e-3;
+        }
+        if truncate {
+            *n = i + i - 1;
+            break;
+        }
+
+        // 30 — compute a new element and possibly improve `result`.
+        res = e1 + 1.0 / ss;
+        epstab[k1] = res;
+        k1 -= 2;
+        let error = err2 + (res - e2).abs() + err3;
+        if error <= abserr {
+            abserr = error;
+            result = res;
+        }
+    }
+    if converged {
+        // 100
+        return (result, abserr.max(5.0 * EPMACH * result.abs()));
+    }
+
+    // 50 — shift the table.
+    if *n == limexp {
+        *n = 2 * (limexp / 2) - 1;
+    }
+    let mut ib = 1_usize;
+    if (num / 2) * 2 == num {
+        ib = 2;
+    }
+    let ie = newelm + 1;
+    for _i in 1..=ie {
+        let ib2 = ib + 2;
+        epstab[ib] = epstab[ib2];
+        ib = ib2;
+    }
+    if num != *n {
+        let mut indx = num - *n + 1;
+        for i in 1..=*n {
+            epstab[i] = epstab[indx];
+            indx += 1;
+        }
+    }
+    // 80
+    if *nres < 4 {
+        res3la[*nres] = result;
+        abserr = OFLOW;
+    } else {
+        // 90 — error estimate from the last three results.
+        abserr =
+            (result - res3la[3]).abs() + (result - res3la[2]).abs() + (result - res3la[1]).abs();
+        res3la[1] = res3la[2];
+        res3la[2] = res3la[3];
+        res3la[3] = result;
+    }
+    // 100
+    (result, abserr.max(5.0 * EPMACH * result.abs()))
+}
+
+// ---------------------------------------------------------------------
+// dqpsrt — maintain the descending ordering of the error estimates
+// ---------------------------------------------------------------------
+
+/// Keep `iord` ordered by descending `elist` and pick the next interval
+/// to bisect — `dqpsrt`.
+///
+/// `maxerr`, `ermax` and `nrmax` are in/out. All arrays are 1-based.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one parameter per Fortran argument; regrouping them would \
+              break the line-by-line correspondence this module trades on"
+)]
+fn qpsrt(
+    limit: usize,
+    last: usize,
+    maxerr: &mut usize,
+    ermax: &mut f64,
+    elist: &[f64],
+    iord: &mut [usize],
+    nrmax: &mut usize,
+) {
+    if last <= 2 {
+        iord[1] = 1;
+        iord[2] = 2;
+        // 90
+        *maxerr = iord[*nrmax];
+        *ermax = elist[*maxerr];
+        return;
+    }
+
+    // 10 — this part runs only when subdivision *increased* the error.
+    let errmax = elist[*maxerr];
+    if *nrmax != 1 {
+        let ido = *nrmax - 1;
+        for _i in 1..=ido {
+            let isucc = iord[*nrmax - 1];
+            if errmax <= elist[isucc] {
+                break;
+            }
+            iord[*nrmax] = isucc;
+            *nrmax -= 1;
+        }
+    }
+
+    // 30 — how much of the list still has to stay ordered.
+    let mut jupbn = last;
+    if last > limit / 2 + 2 {
+        jupbn = limit + 3 - last;
+    }
+    let errmin = elist[last];
+
+    let jbnd = jupbn - 1;
+    let ibeg = *nrmax + 1;
+
+    // 40 — insert errmax, traversing the list top-down.
+    let mut inserted_at: Option<usize> = None;
+    if ibeg <= jbnd {
+        for i in ibeg..=jbnd {
+            let isucc = iord[i];
+            if errmax >= elist[isucc] {
+                inserted_at = Some(i);
+                break;
+            }
+            iord[i - 1] = isucc;
+        }
+    }
+
+    let Some(i) = inserted_at else {
+        // 50 — errmax belongs at the bottom of the maintained list.
+        iord[jbnd] = *maxerr;
+        iord[jupbn] = last;
+        // 90
+        *maxerr = iord[*nrmax];
+        *ermax = elist[*maxerr];
+        return;
+    };
+
+    // 60 — insert errmin, traversing the list bottom-up.
+    iord[i - 1] = *maxerr;
+    let mut k = jbnd;
+    let mut placed = false;
+    for _j in i..=jbnd {
+        let isucc = iord[k];
+        if errmin < elist[isucc] {
+            // 80
+            iord[k + 1] = last;
+            placed = true;
+            break;
+        }
+        iord[k + 1] = isucc;
+        k -= 1;
+    }
+    if !placed {
+        iord[i] = last;
+    }
+
+    // 90
+    *maxerr = iord[*nrmax];
+    *ermax = elist[*maxerr];
+}
+
+// ---------------------------------------------------------------------
+// dqagse — adaptive, with ε-extrapolation, no breakpoints
+// ---------------------------------------------------------------------
+
+/// Adaptive quadrature with ε-extrapolation on a finite interval —
+/// `dqagse`, the routine behind `scipy.integrate.quad(..., points=None)`.
+///
+/// # Errors
+///
+/// [`QuadError::ToleranceUnachievable`] when `epsabs <= 0` and `epsrel` is
+/// below QUADPACK's floor, and [`QuadError::LimitTooSmall`] when
+/// `limit < 1`.
+pub fn qagse<F>(
+    f: &mut F,
+    a: f64,
+    b: f64,
+    epsabs: f64,
+    epsrel: f64,
+    limit: usize,
+) -> Result<QuadOutcome, QuadError>
+where
+    F: FnMut(f64) -> f64,
+{
+    // The Fortran declares `alist(limit)` and indexes from 1, so a
+    // `limit`-length list needs `limit + 1` slots here. `limit == 0` is
+    // rejected below, matching scipy's "there must be at least one
+    // subinterval"; QUADPACK itself expresses that as `limit.lt.1`
+    // upstream in dqags.
+    if limit < 1 {
+        return Err(QuadError::LimitTooSmall { limit, npts: 0 });
+    }
+    if epsabs <= 0.0 && epsrel < (50.0 * EPMACH).max(0.5e-28) {
+        return Err(QuadError::ToleranceUnachievable);
+    }
+
+    let mut alist = vec![0.0_f64; limit + 1];
+    let mut blist = vec![0.0_f64; limit + 1];
+    let mut rlist = vec![0.0_f64; limit + 1];
+    let mut elist = vec![0.0_f64; limit + 1];
+    let mut iord = vec![0_usize; limit + 2];
+    let mut rlist2 = [0.0_f64; 53];
+    let mut res3la = [0.0_f64; 4];
+
+    let mut ier = 0_i32;
+    let mut ierro = 0_i32;
+    alist[1] = a;
+    blist[1] = b;
+
+    // First approximation. `defabs` takes dqk21's `resabs`, and the
+    // Fortran's local `resabs` takes its `resasc` — the names cross over
+    // at the call site, which is worth reading twice.
+    let first = qk21(f, a, b);
+    let mut result = first.result;
+    let mut abserr = first.abserr;
+    let defabs = first.resabs;
+    let resabs_as_asc = first.resasc;
+
+    let dres = result.abs();
+    let mut errbnd = epsabs.max(epsrel * dres);
+    let mut last = 1_usize;
+    rlist[1] = result;
+    elist[1] = abserr;
+    iord[1] = 1;
+    if abserr <= 100.0 * EPMACH * defabs && abserr > errbnd {
+        ier = 2;
+    }
+    if limit == 1 {
+        ier = 1;
+    }
+    if ier != 0 || (abserr <= errbnd && abserr != resabs_as_asc) || abserr == 0.0 {
+        // 140
+        return Ok(QuadOutcome {
+            value: result,
+            abserr,
+            neval: 42 * last - 21,
+            last,
+            ier: Ier::from_code(ier),
+        });
+    }
+
+    // Initialization.
+    rlist2[1] = result;
+    let mut errmax = abserr;
+    let mut maxerr = 1_usize;
+    let mut area = result;
+    let mut errsum = abserr;
+    abserr = OFLOW;
+    let mut nrmax = 1_usize;
+    let mut nres = 0_usize;
+    let mut numrl2 = 2_usize;
+    let mut ktmin = 0_i32;
+    let mut extrap = false;
+    let mut noext = false;
+    let mut iroff1 = 0_i32;
+    let mut iroff2 = 0_i32;
+    let mut iroff3 = 0_i32;
+    let mut ksgn: i32 = -1;
+    if dres >= (1.0 - 50.0 * EPMACH) * defabs {
+        ksgn = 1;
+    }
+
+    let mut small = 0.0_f64;
+    let mut erlarg = 0.0_f64;
+    let mut ertest = 0.0_f64;
+    let mut correc = 0.0_f64;
+
+    // Which Fortran label the main loop left through. Falling off the end
+    // of the `do 90` also lands on 100, so that is the default.
+    let mut goto_115 = false;
+
+    'mainloop: for last_index in 2..=limit {
+        last = last_index;
+
+        // Bisect the subinterval with the nrmax-th largest error.
+        let a1 = alist[maxerr];
+        let b1 = 0.5 * (alist[maxerr] + blist[maxerr]);
+        let a2 = b1;
+        let b2 = blist[maxerr];
+        let erlast = errmax;
+        let left = qk21(f, a1, b1);
+        let right = qk21(f, a2, b2);
+        let (area1, error1, defab1) = (left.result, left.abserr, left.resasc);
+        let (area2, error2, defab2) = (right.result, right.abserr, right.resasc);
+
+        let area12 = area1 + area2;
+        let erro12 = error1 + error2;
+        errsum += erro12 - errmax;
+        area += area12 - rlist[maxerr];
+        if !(defab1 == error1 || defab2 == error2) {
+            if !((rlist[maxerr] - area12).abs() > 0.1e-4 * area12.abs() || erro12 < 0.99 * errmax) {
+                if extrap {
+                    iroff2 += 1;
+                } else {
+                    iroff1 += 1;
+                }
+            }
+            // 10
+            if last > 10 && erro12 > errmax {
+                iroff3 += 1;
+            }
+        }
+        // 15
+        rlist[maxerr] = area1;
+        rlist[last] = area2;
+        errbnd = epsabs.max(epsrel * area.abs());
+
+        if iroff1 + iroff2 >= 10 || iroff3 >= 20 {
+            ier = 2;
+        }
+        if iroff2 >= 5 {
+            ierro = 3;
+        }
+        if last == limit {
+            ier = 1;
+        }
+        if a1.abs().max(b2.abs()) <= (1.0 + 100.0 * EPMACH) * (a2.abs() + 1000.0 * UFLOW) {
+            ier = 4;
+        }
+
+        // Append the newly-created intervals.
+        if error2 > error1 {
+            // 20
+            alist[maxerr] = a2;
+            alist[last] = a1;
+            blist[last] = b1;
+            rlist[maxerr] = area2;
+            rlist[last] = area1;
+            elist[maxerr] = error2;
+            elist[last] = error1;
+        } else {
+            alist[last] = a2;
+            blist[maxerr] = b1;
+            blist[last] = b2;
+            elist[maxerr] = error1;
+            elist[last] = error2;
+        }
+
+        // 30
+        qpsrt(
+            limit,
+            last,
+            &mut maxerr,
+            &mut errmax,
+            &elist,
+            &mut iord,
+            &mut nrmax,
+        );
+        if errsum <= errbnd {
+            goto_115 = true;
+            break 'mainloop;
+        }
+        if ier != 0 {
+            break 'mainloop;
+        }
+        if last == 2 {
+            // 80
+            small = (b - a).abs() * 0.375;
+            erlarg = errsum;
+            ertest = errbnd;
+            rlist2[2] = area;
+            continue 'mainloop;
+        }
+        if noext {
+            continue 'mainloop;
+        }
+        erlarg -= erlast;
+        if (b1 - a1).abs() > small {
+            erlarg += erro12;
+        }
+        if !extrap {
+            // Is the interval to be bisected next the smallest one?
+            if (blist[maxerr] - alist[maxerr]).abs() > small {
+                continue 'mainloop;
+            }
+            extrap = true;
+            nrmax = 2;
+        }
+        // 40
+        if !(ierro == 3 || erlarg <= ertest) {
+            // The smallest interval has the largest error: shrink erlarg
+            // over the larger intervals before bisecting.
+            let id = nrmax;
+            let mut jupbnd = last;
+            if last > 2 + limit / 2 {
+                jupbnd = limit + 3 - last;
+            }
+            let mut back_to_90 = false;
+            for _k in id..=jupbnd {
+                maxerr = iord[nrmax];
+                errmax = elist[maxerr];
+                if (blist[maxerr] - alist[maxerr]).abs() > small {
+                    back_to_90 = true;
+                    break;
+                }
+                nrmax += 1;
+            }
+            if back_to_90 {
+                continue 'mainloop;
+            }
+        }
+
+        // 60 — extrapolate.
+        numrl2 += 1;
+        rlist2[numrl2] = area;
+        let (reseps, abseps) = qelg(&mut numrl2, &mut rlist2, &mut res3la, &mut nres);
+        ktmin += 1;
+        if ktmin > 5 && abserr < 0.1e-2 * errsum {
+            ier = 5;
+        }
+        if abseps < abserr {
+            ktmin = 0;
+            abserr = abseps;
+            result = reseps;
+            correc = erlarg;
+            ertest = epsabs.max(epsrel * reseps.abs());
+            if abserr <= ertest {
+                break 'mainloop;
+            }
+        }
+
+        // 70 — prepare bisection of the smallest interval.
+        if numrl2 == 1 {
+            noext = true;
+        }
+        if ier == 5 {
+            break 'mainloop;
+        }
+        maxerr = iord[1];
+        errmax = elist[maxerr];
+        nrmax = 1;
+        extrap = false;
+        small *= 0.5;
+        erlarg = errsum;
+    }
+
+    // Set the final result and error estimate — Fortran labels 100..140,
+    // nested so that every `go to` is a forward `break`.
+    'l130: {
+        'l115: {
+            'l110: {
+                'l105: {
+                    if goto_115 {
+                        break 'l115;
+                    }
+                    // 100
+                    if abserr == OFLOW {
+                        break 'l115;
+                    }
+                    if ier + ierro == 0 {
+                        break 'l110;
+                    }
+                    if ierro == 3 {
+                        abserr += correc;
+                    }
+                    if ier == 0 {
+                        ier = 3;
+                    }
+                    if result != 0.0 && area != 0.0 {
+                        break 'l105;
+                    }
+                    if abserr > errsum {
+                        break 'l115;
+                    }
+                    if area == 0.0 {
+                        break 'l130;
+                    }
+                    break 'l110;
+                }
+                // 105
+                if abserr / result.abs() > errsum / area.abs() {
+                    break 'l115;
+                }
+            }
+            // 110 — test on divergence.
+            if ksgn == -1 && result.abs().max(area.abs()) <= defabs * 0.1e-1 {
+                break 'l130;
+            }
+            if 0.1e-1 > (result / area) || (result / area) > 0.1e3 || errsum > area.abs() {
+                ier = 6;
+            }
+            break 'l130;
+        }
+        // 115 — compute the global integral sum.
+        result = 0.0;
+        for k in 1..=last {
+            result += rlist[k];
+        }
+        abserr = errsum;
+    }
+    // 130
+    if ier > 2 {
+        ier -= 1;
+    }
+    // 140
+    Ok(QuadOutcome {
+        value: result,
+        abserr,
+        neval: 42 * last - 21,
+        last,
+        ier: Ier::from_code(ier),
+    })
+}
+
+// ---------------------------------------------------------------------
+// dqagpe — adaptive, with ε-extrapolation and user breakpoints
+// ---------------------------------------------------------------------
+
+/// Adaptive quadrature with ε-extrapolation and user-supplied
+/// breakpoints — `dqagpe`, the routine behind
+/// `scipy.integrate.quad(..., points=...)`.
+///
+/// `points` holds the `npts` interior breakpoints only; the Fortran's
+/// `npts2 = npts + 2` and its two scratch slots are an artefact of
+/// Fortran's fixed-size arrays and are not part of this signature.
+/// Unsorted input is fine (the routine sorts, as the Fortran does), but
+/// **a breakpoint outside `[a, b]` is an error here**, not something to
+/// ignore — [`quad`] is the layer that filters, because that is where
+/// scipy filters.
+///
+/// `npts == 0` is a normal case, not a degenerate one, and it is where
+/// five of hazma's twelve call sites land: `points=[-1, 1]` on `[-1, 1]`
+/// leaves nothing after scipy's filtering, and `points is None` is what
+/// selects `qagse` — not "no break points survived".
+///
+/// It does not quite reduce to [`qagse`] either. `qagpe` decides an
+/// interval is the smallest by subdivision `level`, `qagse` by comparing
+/// its length against `small`, and `qagpe` therefore starts extrapolating
+/// one bisection earlier. Measured (Task 3.3, scipy 1.18.0): across 3,776
+/// random (integrand, tolerance, limit) combinations the two returned
+/// identical values, `neval` and `last` on every run that converged, and
+/// differed on 45 — all of them runs that exhausted `limit`. On
+/// `|x − 1/3|^(−9/10)·cos(50x)` over `[0, 1]` at `limit = 10` the gap is
+/// 11%, which is what `test/test_core_quad.py` uses to tell them apart.
+///
+/// # Errors
+///
+/// [`QuadError::ToleranceUnachievable`], [`QuadError::LimitTooSmall`] when
+/// `limit <= npts`, and [`QuadError::BreakpointOutsideInterval`].
+pub fn qagpe<F>(
+    f: &mut F,
+    a: f64,
+    b: f64,
+    points: &[f64],
+    epsabs: f64,
+    epsrel: f64,
+    limit: usize,
+) -> Result<QuadOutcome, QuadError>
+where
+    F: FnMut(f64) -> f64,
+{
+    let npts = points.len();
+    let npts2 = npts + 2;
+    if limit <= npts {
+        return Err(QuadError::LimitTooSmall { limit, npts });
+    }
+    if epsabs <= 0.0 && epsrel < (50.0 * EPMACH).max(0.5e-28) {
+        return Err(QuadError::ToleranceUnachievable);
+    }
+
+    let mut alist = vec![0.0_f64; limit + 1];
+    let mut blist = vec![0.0_f64; limit + 1];
+    let mut rlist = vec![0.0_f64; limit + 1];
+    let mut elist = vec![0.0_f64; limit + 1];
+    let mut iord = vec![0_usize; limit + 2];
+    let mut level = vec![0_i32; limit + 1];
+    let mut ndin = vec![0_i32; npts2 + 1];
+    let mut pts = vec![0.0_f64; npts2 + 1];
+    let mut rlist2 = [0.0_f64; 53];
+    let mut res3la = [0.0_f64; 4];
+
+    let mut ier = 0_i32;
+    let mut ierro = 0_i32;
+    alist[1] = a;
+    blist[1] = b;
+
+    let sign = if a > b { -1.0_f64 } else { 1.0_f64 };
+    pts[1] = a.min(b);
+    for (i, &p) in points.iter().enumerate() {
+        pts[i + 2] = p;
+    }
+    pts[npts + 2] = a.max(b);
+    let nint = npts + 1;
+    let mut a1 = pts[1];
+    if npts != 0 {
+        let nintp1 = nint + 1;
+        // The Fortran's `do 20` is a literal selection sort over
+        // pts(1..nintp1); reproduced rather than replaced by `sort`, since
+        // it is what decides the tie order among equal breakpoints.
+        for i in 1..=nint {
+            for j in (i + 1)..=nintp1 {
+                if pts[i] > pts[j] {
+                    pts.swap(i, j);
+                }
+            }
+        }
+        if pts[1] != a.min(b) || pts[nintp1] != a.max(b) {
+            return Err(QuadError::BreakpointOutsideInterval);
+        }
+    }
+
+    // 40 — first integral and error approximations, one per subinterval.
+    let mut result = 0.0_f64;
+    let mut abserr = 0.0_f64;
+    let mut resabs = 0.0_f64;
+    for i in 1..=nint {
+        let b1 = pts[i + 1];
+        let piece = qk21(f, a1, b1);
+        abserr += piece.abserr;
+        result += piece.result;
+        ndin[i] = 0;
+        if piece.abserr == piece.resasc && piece.abserr != 0.0 {
+            ndin[i] = 1;
+        }
+        resabs += piece.resabs;
+        level[i] = 0;
+        elist[i] = piece.abserr;
+        alist[i] = a1;
+        blist[i] = b1;
+        rlist[i] = piece.result;
+        iord[i] = i;
+        a1 = b1;
+    }
+    let mut errsum = 0.0_f64;
+    for i in 1..=nint {
+        if ndin[i] == 1 {
+            elist[i] = abserr;
+        }
+        errsum += elist[i];
+    }
+
+    // Test on accuracy.
+    let mut last = nint;
+    let mut neval = 21 * nint;
+    let dres = result.abs();
+    let mut errbnd = epsabs.max(epsrel * dres);
+    if abserr <= 0.1e3 * EPMACH * resabs && abserr > errbnd {
+        ier = 2;
+    }
+    if nint != 1 {
+        // 70 — put the npts largest errors at the head of iord.
+        for i in 1..=npts {
+            let jlow = i + 1;
+            let mut ind1 = iord[i];
+            let mut k = 0_usize;
+            for j in jlow..=nint {
+                let ind2 = iord[j];
+                if elist[ind1] <= elist[ind2] {
+                    ind1 = ind2;
+                    k = j;
+                }
+            }
+            if ind1 != iord[i] {
+                iord[k] = iord[i];
+                iord[i] = ind1;
+            }
+        }
+        if limit < npts2 {
+            ier = 1;
+        }
+    }
+    // 80
+    if ier != 0 || abserr <= errbnd {
+        // 210
+        if ier > 2 {
+            ier -= 1;
+        }
+        return Ok(QuadOutcome {
+            value: result * sign,
+            abserr,
+            neval,
+            last,
+            ier: Ier::from_code(ier),
+        });
+    }
+
+    // Initialization.
+    rlist2[1] = result;
+    let mut maxerr = iord[1];
+    let mut errmax = elist[maxerr];
+    let mut area = result;
+    let mut nrmax = 1_usize;
+    let mut nres = 0_usize;
+    let mut numrl2 = 1_usize;
+    let mut ktmin = 0_i32;
+    let mut extrap = false;
+    let mut noext = false;
+    let mut erlarg = errsum;
+    let mut ertest = errbnd;
+    let mut levmax = 1_i32;
+    let mut iroff1 = 0_i32;
+    let mut iroff2 = 0_i32;
+    let mut iroff3 = 0_i32;
+    let mut correc = 0.0_f64;
+    abserr = OFLOW;
+    let mut ksgn: i32 = -1;
+    if dres >= (1.0 - 50.0 * EPMACH) * resabs {
+        ksgn = 1;
+    }
+
+    let mut goto_190 = false;
+
+    'mainloop: for last_index in npts2..=limit {
+        last = last_index;
+
+        let levcur = level[maxerr] + 1;
+        let a1 = alist[maxerr];
+        let b1 = 0.5 * (alist[maxerr] + blist[maxerr]);
+        let a2 = b1;
+        let b2 = blist[maxerr];
+        let erlast = errmax;
+        let left = qk21(f, a1, b1);
+        let right = qk21(f, a2, b2);
+        let (area1, error1, defab1) = (left.result, left.abserr, left.resasc);
+        let (area2, error2, defab2) = (right.result, right.abserr, right.resasc);
+
+        neval += 42;
+        let area12 = area1 + area2;
+        let erro12 = error1 + error2;
+        errsum += erro12 - errmax;
+        area += area12 - rlist[maxerr];
+        if !(defab1 == error1 || defab2 == error2) {
+            if !((rlist[maxerr] - area12).abs() > 0.1e-4 * area12.abs() || erro12 < 0.99 * errmax) {
+                if extrap {
+                    iroff2 += 1;
+                } else {
+                    iroff1 += 1;
+                }
+            }
+            // 90
+            if last > 10 && erro12 > errmax {
+                iroff3 += 1;
+            }
+        }
+        // 95
+        level[maxerr] = levcur;
+        level[last] = levcur;
+        rlist[maxerr] = area1;
+        rlist[last] = area2;
+        errbnd = epsabs.max(epsrel * area.abs());
+
+        if iroff1 + iroff2 >= 10 || iroff3 >= 20 {
+            ier = 2;
+        }
+        if iroff2 >= 5 {
+            ierro = 3;
+        }
+        if last == limit {
+            ier = 1;
+        }
+        if a1.abs().max(b2.abs()) <= (1.0 + 100.0 * EPMACH) * (a2.abs() + 1000.0 * UFLOW) {
+            ier = 4;
+        }
+
+        if error2 > error1 {
+            // 100
+            alist[maxerr] = a2;
+            alist[last] = a1;
+            blist[last] = b1;
+            rlist[maxerr] = area2;
+            rlist[last] = area1;
+            elist[maxerr] = error2;
+            elist[last] = error1;
+        } else {
+            alist[last] = a2;
+            blist[maxerr] = b1;
+            blist[last] = b2;
+            elist[maxerr] = error1;
+            elist[last] = error2;
+        }
+
+        // 110
+        qpsrt(
+            limit,
+            last,
+            &mut maxerr,
+            &mut errmax,
+            &elist,
+            &mut iord,
+            &mut nrmax,
+        );
+        if errsum <= errbnd {
+            goto_190 = true;
+            break 'mainloop;
+        }
+        if ier != 0 {
+            break 'mainloop;
+        }
+        if noext {
+            continue 'mainloop;
+        }
+        erlarg -= erlast;
+        if levcur + 1 <= levmax {
+            erlarg += erro12;
+        }
+        if !extrap {
+            // Is the interval to be bisected next the smallest one?
+            if level[maxerr] + 1 <= levmax {
+                continue 'mainloop;
+            }
+            extrap = true;
+            nrmax = 2;
+        }
+        // 120
+        if !(ierro == 3 || erlarg <= ertest) {
+            let id = nrmax;
+            let mut jupbnd = last;
+            if last > 2 + limit / 2 {
+                jupbnd = limit + 3 - last;
+            }
+            let mut back_to_160 = false;
+            for _k in id..=jupbnd {
+                maxerr = iord[nrmax];
+                errmax = elist[maxerr];
+                if level[maxerr] + 1 <= levmax {
+                    back_to_160 = true;
+                    break;
+                }
+                nrmax += 1;
+            }
+            if back_to_160 {
+                continue 'mainloop;
+            }
+        }
+
+        // 140 — extrapolate. Unlike `qagse`, `qagpe` skips straight to
+        // 155 until the table holds three elements.
+        numrl2 += 1;
+        rlist2[numrl2] = area;
+        if numrl2 > 2 {
+            let (reseps, abseps) = qelg(&mut numrl2, &mut rlist2, &mut res3la, &mut nres);
+            ktmin += 1;
+            if ktmin > 5 && abserr < 0.1e-2 * errsum {
+                ier = 5;
+            }
+            if abseps < abserr {
+                ktmin = 0;
+                abserr = abseps;
+                result = reseps;
+                correc = erlarg;
+                ertest = epsabs.max(epsrel * reseps.abs());
+                if abserr < ertest {
+                    break 'mainloop;
+                }
+            }
+            // 150
+            if numrl2 == 1 {
+                noext = true;
+            }
+            if ier >= 5 {
+                break 'mainloop;
+            }
+        }
+        // 155 — prepare bisection of the smallest interval.
+        maxerr = iord[1];
+        errmax = elist[maxerr];
+        nrmax = 1;
+        extrap = false;
+        levmax += 1;
+        erlarg = errsum;
+    }
+
+    // Set the final result — Fortran labels 170..210.
+    'l210: {
+        'l190: {
+            'l180: {
+                'l175: {
+                    if goto_190 {
+                        break 'l190;
+                    }
+                    // 170
+                    if abserr == OFLOW {
+                        break 'l190;
+                    }
+                    if ier + ierro == 0 {
+                        break 'l180;
+                    }
+                    if ierro == 3 {
+                        abserr += correc;
+                    }
+                    if ier == 0 {
+                        ier = 3;
+                    }
+                    if result != 0.0 && area != 0.0 {
+                        break 'l175;
+                    }
+                    if abserr > errsum {
+                        break 'l190;
+                    }
+                    if area == 0.0 {
+                        break 'l210;
+                    }
+                    break 'l180;
+                }
+                // 175
+                if abserr / result.abs() > errsum / area.abs() {
+                    break 'l190;
+                }
+            }
+            // 180 — test on divergence.
+            if ksgn == -1 && result.abs().max(area.abs()) <= resabs * 0.1e-1 {
+                break 'l210;
+            }
+            if 0.1e-1 > (result / area) || (result / area) > 0.1e3 || errsum > area.abs() {
+                ier = 6;
+            }
+            break 'l210;
+        }
+        // 190 — compute the global integral sum.
+        result = 0.0;
+        for k in 1..=last {
+            result += rlist[k];
+        }
+        abserr = errsum;
+    }
+    // 210
+    if ier > 2 {
+        ier -= 1;
+    }
+    Ok(QuadOutcome {
+        value: result * sign,
+        abserr,
+        neval,
+        last,
+        ier: Ier::from_code(ier),
+    })
+}
+
+// ---------------------------------------------------------------------
+// The scipy-shaped driver
+// ---------------------------------------------------------------------
+
+/// Settings for [`quad`], defaulting exactly as `scipy.integrate.quad`
+/// does.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct QuadOpts<'a> {
+    /// Absolute error tolerance.
+    pub epsabs: f64,
+    /// Relative error tolerance.
+    pub epsrel: f64,
+    /// Upper bound on the number of subintervals.
+    pub limit: usize,
+    /// Break points, as passed to `quad(points=...)` — unsorted,
+    /// duplicated, endpoint-coincident and out-of-interval entries are all
+    /// accepted and handled as scipy handles them. `None` selects
+    /// [`qagse`]; `Some` selects [`qagpe`], **even if nothing survives the
+    /// filtering**.
+    pub points: Option<&'a [f64]>,
+}
+
+impl Default for QuadOpts<'_> {
+    fn default() -> Self {
+        QuadOpts {
+            epsabs: DEFAULT_EPSABS,
+            epsrel: DEFAULT_EPSREL,
+            limit: DEFAULT_LIMIT,
+            points: None,
+        }
+    }
+}
+
+/// Filter break points the way `scipy.integrate._quadpack_py._quad` does.
+///
+/// scipy's three lines are `np.unique(points)`, then `[a < p]`, then
+/// `[p < b]` — so the contract is: **sort ascending, drop duplicates, and
+/// keep only strictly interior points.** Endpoint-coincident points, points
+/// outside `[a, b]` and `NaN`s all vanish (every comparison against `NaN`
+/// is false), and `-0.0`/`0.0` collapse to one entry because they compare
+/// equal.
+///
+/// Pinned empirically against scipy 1.18.0 rather than read off the
+/// QUADPACK documentation, as this task's exit criteria require — and it
+/// matters, because both live degeneracies land in the discard branch:
+/// `points=[-1, 1]` on `[-1, 1]` leaves **nothing**, and a heavy mediator
+/// pushes `m/mx` and `2m/mx` past the upper bound of the thermal integral.
+/// `test/test_core_quad.py` re-derives every clause from scipy.
+///
+/// `a` and `b` must already be ordered (`a <= b`), which is what [`quad`]
+/// guarantees by flipping first — as scipy does.
+fn filter_points(points: &[f64], a: f64, b: f64) -> Vec<f64> {
+    let mut sorted: Vec<f64> = points.to_vec();
+    // `np.unique` sorts with NaNs last; `total_cmp` orders them the same
+    // way and, unlike `partial_cmp`, is a total order so the sort is
+    // well-defined. -0.0 sorts before 0.0 under `total_cmp`, which is the
+    // order `np.unique` produces too, and the dedup below then keeps -0.0.
+    sorted.sort_by(f64::total_cmp);
+    sorted.dedup_by(|x, y| *x == *y);
+    sorted.retain(|&p| a < p && p < b);
+    sorted
+}
+
+/// `scipy.integrate.quad` for a finite interval, closure in place of the
+/// Python callable.
+///
+/// This — not [`qagse`] or [`qagpe`] — is what a ported kernel calls, so
+/// that the argument preprocessing the `.pyx` inherited from scipy is
+/// inherited once, here, instead of at every call site. It reproduces
+/// scipy's whole finite-interval path: order the limits and negate the
+/// result if they were reversed, filter `points` (see [`filter_points`]),
+/// then dispatch to `qagpe` when `points` is `Some` and `qagse` when it is
+/// `None`.
+///
+/// Like scipy, an abnormal termination that still produced a usable answer
+/// is **not** an error: `ier` rides along in the returned
+/// [`QuadOutcome`] where scipy raises an `IntegrationWarning`. hazma's call
+/// sites all take the value and ignore the warning.
+///
+/// # Errors
+///
+/// Only the cases where scipy raises `ValueError`; see [`QuadError`].
+pub fn quad<F>(f: &mut F, a: f64, b: f64, opts: &QuadOpts<'_>) -> Result<QuadOutcome, QuadError>
+where
+    F: FnMut(f64) -> f64,
+{
+    let flip = b < a;
+    let (lo, hi) = if flip { (b, a) } else { (a, b) };
+
+    let mut outcome = match opts.points {
+        None => qagse(f, lo, hi, opts.epsabs, opts.epsrel, opts.limit)?,
+        Some(points) => {
+            let interior = filter_points(points, lo, hi);
+            qagpe(f, lo, hi, &interior, opts.epsabs, opts.epsrel, opts.limit)?
+        }
+    };
+    if flip {
+        outcome.value = -outcome.value;
+    }
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Half of QUADPACK's own reference tolerance discussion in one
+    /// number: the rules are exact to a few ulp of the integrand's scale,
+    /// so anything beyond this on a *smooth* problem is a translation bug
+    /// rather than rounding.
+    const SMOOTH_RTOL: f64 = 1e-14;
+
+    fn assert_close(got: f64, want: f64, rtol: f64, what: &str) {
+        let err = (got - want).abs() / want.abs();
+        assert!(
+            err <= rtol,
+            "{what}: got {got:e}, want {want:e}, relative error {err:e} > {rtol:e}"
+        );
+    }
+
+    // -- the rules themselves ------------------------------------------
+
+    /// A Gauss–Kronrod rule is pinned by its degree of exactness, and
+    /// nothing else about the tables is checked here on purpose: a wrong
+    /// digit in `XGK`/`WGK` breaks exactness at some degree, while a
+    /// spot-check against one integral could be passed by a rule that is
+    /// merely close.
+    ///
+    /// The 15-point Kronrod rule is exact through degree 22 (`3n + 1` for
+    /// the odd `n = 7` Gauss rule it extends), the 21-point through degree
+    /// 31 (`3n + 1` for `n = 10`).
+    enum Rule {
+        K15,
+        K21,
+    }
+
+    fn assert_exact_through_degree(rule: &Rule, degree: i32, name: &str) {
+        for k in 0..=degree {
+            // ∫_{-1}^{1} x^k dx = 2/(k+1) for even k, 0 for odd k.
+            let mut integrand = move |x: f64| x.powi(k);
+            let got = match rule {
+                Rule::K15 => qk15(&mut integrand, -1.0, 1.0),
+                Rule::K21 => qk21(&mut integrand, -1.0, 1.0),
+            }
+            .result;
+            if k % 2 == 0 {
+                let want = 2.0 / f64::from(k + 1);
+                assert_close(got, want, 1e-14, &format!("{name} on x^{k}"));
+            } else {
+                assert!(
+                    got.abs() < 1e-15,
+                    "{name} on x^{k}: got {got:e}, want 0 by symmetry"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn qk15_is_exact_through_degree_22() {
+        assert_exact_through_degree(&Rule::K15, 22, "qk15");
+    }
+
+    #[test]
+    fn qk21_is_exact_through_degree_31() {
+        assert_exact_through_degree(&Rule::K21, 31, "qk21");
+    }
+
+    #[test]
+    fn the_rules_are_not_exact_one_degree_further() {
+        // The complement of the two tests above: without this, a rule
+        // built from *more* points than intended (or from the wrong
+        // family) would pass them. x^24 and x^32 are the first even
+        // degrees past each rule's guarantee.
+        //
+        // The thresholds sit an order of magnitude below the measured
+        // errors (5.7e-9 for qk15 on x^24, 4.4e-12 for qk21 on x^32) and
+        // several orders above the ~5e-17 rounding floor these same rules
+        // show at their last exact degree, so the assertion is about the
+        // jump across the boundary rather than about either number.
+        let mut p24 = |x: f64| x.powi(24);
+        let err15 = (qk15(&mut p24, -1.0, 1.0).result - 2.0 / 25.0).abs();
+        assert!(err15 > 1e-10, "qk15 should not integrate x^24 exactly");
+
+        let mut p32 = |x: f64| x.powi(32);
+        let err21 = (qk21(&mut p32, -1.0, 1.0).result - 2.0 / 33.0).abs();
+        assert!(err21 > 1e-13, "qk21 should not integrate x^32 exactly");
+    }
+
+    #[test]
+    fn the_rules_report_the_integral_of_the_absolute_value() {
+        // `resabs` is the rule applied to |f|, which is what makes it
+        // differ from `result` for a sign-changing integrand. It is not
+        // ∫|f|: |x| is not a polynomial, so the 21-point rule misses the
+        // true value 1 by 3.7e-3 here. Pinning it against the rule run on
+        // |x| states the actual invariant, exactly.
+        let mut f = |x: f64| x;
+        let out = qk21(&mut f, -1.0, 1.0);
+        assert!(out.result.abs() < 1e-16, "∫x over [-1,1] is zero");
+
+        let mut abs_f = |x: f64| x.abs();
+        assert_eq!(out.resabs, qk21(&mut abs_f, -1.0, 1.0).result);
+        // …and that is a genuinely different number from the truth.
+        assert!((out.resabs - 1.0).abs() > 1e-3);
+    }
+
+    #[test]
+    fn the_rules_agree_on_a_smooth_integrand() {
+        // Two independent rules, one integrand: this catches a table
+        // error that happened to preserve the degree of exactness of one
+        // of them. ∫_0^1 exp(x) dx = e − 1.
+        let want = std::f64::consts::E - 1.0;
+        let mut f = |x: f64| x.exp();
+        assert_close(qk15(&mut f, 0.0, 1.0).result, want, SMOOTH_RTOL, "qk15 exp");
+        assert_close(qk21(&mut f, 0.0, 1.0).result, want, SMOOTH_RTOL, "qk21 exp");
+    }
+
+    #[test]
+    fn a_reversed_interval_negates_the_rule() {
+        let mut f = |x: f64| x.exp();
+        let forward = qk21(&mut f, 0.0, 1.0);
+        let backward = qk21(&mut f, 1.0, 0.0);
+        assert_close(
+            backward.result,
+            -forward.result,
+            SMOOTH_RTOL,
+            "reversed qk21",
+        );
+        // resabs and resasc use |hlgth|, so they do not flip sign.
+        assert_close(backward.resabs, forward.resabs, SMOOTH_RTOL, "resabs");
+    }
+
+    // -- qelg ----------------------------------------------------------
+
+    #[test]
+    fn qelg_accelerates_a_geometric_sequence() {
+        // The partial sums of Σ (1/2)^k converge to 2 linearly. Wynn's
+        // ε-algorithm is exact on a single geometric tail, so three
+        // elements are enough to land on the limit — which is a much
+        // sharper statement than "it got closer".
+        let mut epstab = [0.0_f64; 53];
+        let mut res3la = [0.0_f64; 4];
+        let mut nres = 0_usize;
+        let partial = [1.0, 1.5, 1.75];
+        let mut result = f64::NAN;
+        for (i, &s) in partial.iter().enumerate() {
+            let mut n = i + 1;
+            epstab[n] = s;
+            let (r, _e) = qelg(&mut n, &mut epstab, &mut res3la, &mut nres);
+            result = r;
+        }
+        assert_close(result, 2.0, 1e-15, "qelg on a geometric sequence");
+    }
+
+    #[test]
+    fn qelg_returns_the_last_element_below_three_entries() {
+        let mut epstab = [0.0_f64; 53];
+        let mut res3la = [0.0_f64; 4];
+        let mut nres = 0_usize;
+        epstab[1] = 3.25;
+        let mut n = 1_usize;
+        let (result, abserr) = qelg(&mut n, &mut epstab, &mut res3la, &mut nres);
+        assert_eq!(result, 3.25);
+        // abserr starts at oflow and is only floored by 5·epmach·|result|.
+        assert_eq!(abserr, OFLOW);
+        assert_eq!(nres, 1);
+    }
+
+    // -- qags / qagp ---------------------------------------------------
+
+    /// QUADPACK's own first reference problem: ∫_0^1 x^α · ln(1/x) dx,
+    /// exactly 1/(α+1)², an endpoint-singular integrand that only the
+    /// extrapolation handles well. (Piessens et al., §1.2.)
+    #[test]
+    fn qags_solves_the_quadpack_log_singularity() {
+        for alpha in [-0.9_f64, -0.5, 0.0, 1.0, 2.0] {
+            let mut f = |x: f64| {
+                if x <= 0.0 {
+                    0.0
+                } else {
+                    x.powf(alpha) * (1.0 / x).ln()
+                }
+            };
+            let out = qagse(&mut f, 0.0, 1.0, 1e-10, 1e-10, DEFAULT_LIMIT).unwrap();
+            let want = 1.0 / (alpha + 1.0).powi(2);
+            assert_eq!(out.ier, Ier::Ok, "alpha = {alpha}");
+            assert_close(out.value, want, 1e-10, &format!("log singularity {alpha}"));
+        }
+    }
+
+    /// The interior algebraic singularity QUADPACK ships `qagp` for:
+    /// ∫_0^1 |x − 1/3|^(−1/2) dx = 2(√(1/3) + √(2/3)).
+    #[test]
+    fn qagp_solves_an_interior_algebraic_singularity() {
+        let c = 1.0 / 3.0;
+        let mut f = |x: f64| {
+            let d = (x - c).abs();
+            if d == 0.0 { 0.0 } else { d.powf(-0.5) }
+        };
+        let want = 2.0 * (c.sqrt() + (1.0 - c).sqrt());
+        let out = qagpe(&mut f, 0.0, 1.0, &[c], 1e-10, 1e-10, DEFAULT_LIMIT).unwrap();
+        assert_eq!(out.ier, Ier::Ok);
+        assert_close(out.value, want, 1e-9, "interior singularity with a point");
+    }
+
+    #[test]
+    fn qagp_with_no_break_points_still_integrates() {
+        // The live `points=[-1, 1]` shape after scipy's filtering: zero
+        // interior break points, so `nint == 1` and `qagpe` runs its
+        // single-interval path.
+        let mut f = |x: f64| x * x;
+        let out = qagpe(&mut f, -1.0, 1.0, &[], 1e-10, 1e-5, DEFAULT_LIMIT).unwrap();
+        assert_eq!(out.ier, Ier::Ok);
+        assert_close(out.value, 2.0 / 3.0, SMOOTH_RTOL, "x^2 with no points");
+        assert_eq!(out.last, 1);
+        assert_eq!(out.neval, 21);
+    }
+
+    #[test]
+    fn qagp_sorts_unsorted_break_points() {
+        let mut f = |x: f64| (x - 1.0).abs().powf(-0.5) + (x - 2.0).abs().powf(-0.5);
+        let sorted = qagpe(&mut f, 0.0, 3.0, &[1.0, 2.0], 1e-10, 1e-10, 50).unwrap();
+        let mut g = |x: f64| (x - 1.0).abs().powf(-0.5) + (x - 2.0).abs().powf(-0.5);
+        let unsorted = qagpe(&mut g, 0.0, 3.0, &[2.0, 1.0], 1e-10, 1e-10, 50).unwrap();
+        assert_eq!(sorted.value, unsorted.value);
+        assert_eq!(sorted.neval, unsorted.neval);
+    }
+
+    #[test]
+    fn a_reversed_interval_negates_the_integral() {
+        let mut f = |x: f64| x.exp();
+        let forward = quad(&mut f, 0.0, 1.0, &QuadOpts::default()).unwrap();
+        let mut g = |x: f64| x.exp();
+        let backward = quad(&mut g, 1.0, 0.0, &QuadOpts::default()).unwrap();
+        assert_eq!(backward.value, -forward.value);
+
+        // And with break points, where `qagpe`'s own `sign` handling is
+        // never exercised through `quad` because the flip happens first.
+        let pts = [0.5_f64];
+        let opts = QuadOpts {
+            points: Some(&pts),
+            ..QuadOpts::default()
+        };
+        let mut h = |x: f64| x.exp();
+        let fwd = quad(&mut h, 0.0, 1.0, &opts).unwrap();
+        let mut k = |x: f64| x.exp();
+        let bwd = quad(&mut k, 1.0, 0.0, &opts).unwrap();
+        assert_eq!(bwd.value, -fwd.value);
+    }
+
+    #[test]
+    fn qagpe_handles_a_reversed_interval_itself() {
+        // `quad` never lets this happen, but `qagpe` is public and the
+        // Fortran's `sign` branch is real code.
+        let mut f = |x: f64| x.exp();
+        let out = qagpe(&mut f, 1.0, 0.0, &[], 1e-10, 1e-10, 50).unwrap();
+        assert_close(
+            out.value,
+            -(std::f64::consts::E - 1.0),
+            1e-13,
+            "reversed qagpe",
+        );
+    }
+
+    // -- the scipy-shaped preprocessing --------------------------------
+
+    #[test]
+    fn filter_points_matches_scipys_three_lines() {
+        // sort + dedup + strictly interior.
+        assert_eq!(filter_points(&[2.0, 1.0, 2.0], 0.0, 3.0), vec![1.0, 2.0]);
+        // endpoint-coincident points are dropped: the live
+        // `points=[-1, 1]` case.
+        assert_eq!(filter_points(&[-1.0, 1.0], -1.0, 1.0), Vec::<f64>::new());
+        // out-of-interval points are dropped: the live heavy-mediator
+        // thermal case.
+        assert_eq!(filter_points(&[-5.0, 1.0, 9.0], 0.0, 3.0), vec![1.0]);
+        // NaN loses every comparison, so it never survives the interior
+        // test.
+        assert_eq!(filter_points(&[f64::NAN, 1.0], 0.0, 3.0), vec![1.0]);
+        // Signed zeros compare equal and collapse to the one that sorts
+        // first.
+        assert_eq!(filter_points(&[0.0, -0.0], -1.0, 1.0), vec![-0.0]);
+        assert!(filter_points(&[0.0, -0.0], -1.0, 1.0)[0].is_sign_negative());
+    }
+
+    #[test]
+    fn points_some_but_empty_still_selects_qagpe() {
+        // The distinction that makes the live `points=[-1, 1]` calls run
+        // `qagpe` rather than `qagse`, since scipy dispatches on
+        // `points is None` before it filters. On this integrand the two
+        // routines happen to agree; the observable difference is which
+        // code path runs, so this test pins the neval bookkeeping that
+        // differs between them.
+        let empty: [f64; 0] = [];
+        let opts = QuadOpts {
+            epsabs: 1e-10,
+            epsrel: 1e-5,
+            points: Some(&empty),
+            ..QuadOpts::default()
+        };
+        let mut f = |x: f64| x * x;
+        let with_points = quad(&mut f, -1.0, 1.0, &opts).unwrap();
+        let mut g = |x: f64| x * x;
+        let without = quad(
+            &mut g,
+            -1.0,
+            1.0,
+            &QuadOpts {
+                epsabs: 1e-10,
+                epsrel: 1e-5,
+                ..QuadOpts::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(with_points.value, without.value);
+        // qagpe counts 21·nint; qagse counts 42·last − 21.
+        assert_eq!(with_points.neval, 21);
+        assert_eq!(without.neval, 21);
+    }
+
+    // -- error and abnormal-termination behavior -----------------------
+
+    #[test]
+    fn invalid_tolerances_are_an_error_not_a_panic() {
+        let mut f = |x: f64| x;
+        assert_eq!(
+            quad(
+                &mut f,
+                0.0,
+                1.0,
+                &QuadOpts {
+                    epsabs: 0.0,
+                    epsrel: 0.0,
+                    ..QuadOpts::default()
+                }
+            ),
+            Err(QuadError::ToleranceUnachievable)
+        );
+    }
+
+    #[test]
+    fn a_limit_below_one_is_an_error() {
+        let mut f = |x: f64| x;
+        assert_eq!(
+            quad(
+                &mut f,
+                0.0,
+                1.0,
+                &QuadOpts {
+                    limit: 0,
+                    ..QuadOpts::default()
+                }
+            ),
+            Err(QuadError::LimitTooSmall { limit: 0, npts: 0 })
+        );
+    }
+
+    #[test]
+    fn too_many_break_points_for_the_limit_is_an_error() {
+        let pts: Vec<f64> = (1..=5).map(f64::from).collect();
+        let mut f = |x: f64| x;
+        assert_eq!(
+            quad(
+                &mut f,
+                0.0,
+                6.0,
+                &QuadOpts {
+                    limit: 5,
+                    points: Some(&pts),
+                    ..QuadOpts::default()
+                }
+            ),
+            Err(QuadError::LimitTooSmall { limit: 5, npts: 5 })
+        );
+    }
+
+    #[test]
+    fn a_break_point_outside_the_interval_reaches_qagpe_as_an_error() {
+        let mut f = |x: f64| x;
+        assert_eq!(
+            qagpe(&mut f, 0.0, 1.0, &[7.0], 1e-8, 1e-8, 50),
+            Err(QuadError::BreakpointOutsideInterval)
+        );
+        // …and cannot reach it through `quad`, which filters first.
+        let pts = [7.0_f64];
+        let mut g = |x: f64| x;
+        let out = quad(
+            &mut g,
+            0.0,
+            1.0,
+            &QuadOpts {
+                points: Some(&pts),
+                ..QuadOpts::default()
+            },
+        )
+        .unwrap();
+        assert_close(out.value, 0.5, SMOOTH_RTOL, "filtered break point");
+    }
+
+    #[test]
+    fn hitting_the_subdivision_limit_reports_it_and_still_returns() {
+        // A genuinely divergent integral: ∫_0^1 1/x dx. scipy warns and
+        // hands back the partial sum, and so must this.
+        let mut f = |x: f64| if x == 0.0 { 0.0 } else { 1.0 / x };
+        let out = qagse(&mut f, 0.0, 1.0, 1e-10, 1e-10, 10).unwrap();
+        assert_ne!(out.ier, Ier::Ok);
+        assert!(out.value.is_finite());
+        assert!(out.last <= 10, "last = {} exceeded the limit", out.last);
+    }
+
+    #[test]
+    fn a_nan_integrand_does_not_panic() {
+        let mut f = |_x: f64| f64::NAN;
+        let out = qagse(&mut f, 0.0, 1.0, 1e-10, 1e-10, DEFAULT_LIMIT).unwrap();
+        assert!(out.value.is_nan() || out.value == 0.0);
+    }
+
+    #[test]
+    fn a_zero_width_interval_integrates_to_zero() {
+        let mut f = |x: f64| x.exp();
+        let out = quad(&mut f, 1.5, 1.5, &QuadOpts::default()).unwrap();
+        assert_eq!(out.value, 0.0);
+        assert_eq!(out.ier, Ier::Ok);
+    }
+
+    #[test]
+    fn ier_codes_round_trip() {
+        for code in 0..=6 {
+            assert_eq!(Ier::from_code(code).code(), code);
+        }
+    }
+}

--- a/rust/src/quad_probe.rs
+++ b/rust/src/quad_probe.rs
@@ -1,0 +1,156 @@
+//! `hazma._core.quad` — the Python-visible half of [`crate::quad`].
+//!
+//! Registration only, like the per-domain submodules. This is a **test
+//! surface, not physics**: the kernels Phases 04–06 port call
+//! [`crate::quad::quad`] directly in Rust with a Rust closure, and nothing
+//! under `hazma/` imports this module. It exists because Task 3.3's exit
+//! criteria are stated against `scipy.integrate.quad` — an oracle that
+//! lives in Python — so `test/test_core_quad.py` needs a way to put the
+//! *same* integrand through both. Same role `lib.rs`'s `roundtrip` plays
+//! for the dispatch contract, and `special_probe` for the cephes shim.
+//!
+//! Taking a Python callable is the point rather than a convenience. A
+//! probe that exposed a fixed menu of Rust integrands would compare a Rust
+//! integrand against a Python one and attribute the difference to the
+//! quadrature; with a callback, the integrand is byte-identical on both
+//! sides and every remaining difference is the algorithm. It is also what
+//! the Cython does today — `scipy.integrate.quad` re-enters Python once
+//! per node there too.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use std::cell::RefCell;
+
+use crate::quad::{self, QuadOpts};
+
+/// Integrate `f` over `[a, b]`, mirroring `scipy.integrate.quad`.
+///
+/// Returns `(value, abserr, neval, last, ier)`. `ier` is QUADPACK's raw
+/// termination flag in scipy's numbering, returned rather than warned
+/// about so a test can assert on it; scipy's own `full_output` dictionary
+/// reports the same number.
+///
+/// Raises `ValueError` for exactly the inputs scipy raises `ValueError`
+/// for. An exception from `f` propagates unchanged: it is recorded on the
+/// first occurrence, the integrand short-circuits to `NaN` for the rest of
+/// the run so no further Python code executes, and the original error is
+/// re-raised once QUADPACK returns.
+#[pyfunction]
+#[pyo3(name = "quad")]
+#[pyo3(signature = (f, a, b, epsabs=quad::DEFAULT_EPSABS, epsrel=quad::DEFAULT_EPSREL, limit=quad::DEFAULT_LIMIT, points=None))]
+#[pyo3(text_signature = "(f, a, b, epsabs=1.49e-8, epsrel=1.49e-8, limit=50, points=None)")]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one parameter per `scipy.integrate.quad` keyword this port supports"
+)]
+fn quad_py(
+    f: &Bound<'_, PyAny>,
+    a: f64,
+    b: f64,
+    epsabs: f64,
+    epsrel: f64,
+    limit: usize,
+    points: Option<Vec<f64>>,
+) -> PyResult<(f64, f64, usize, usize, i32)> {
+    let failure: RefCell<Option<PyErr>> = RefCell::new(None);
+
+    let mut integrand = |x: f64| -> f64 {
+        if failure.borrow().is_some() {
+            return f64::NAN;
+        }
+        match f.call1((x,)).and_then(|v| v.extract::<f64>()) {
+            Ok(value) => value,
+            Err(err) => {
+                *failure.borrow_mut() = Some(err);
+                f64::NAN
+            }
+        }
+    };
+
+    let opts = QuadOpts {
+        epsabs,
+        epsrel,
+        limit,
+        points: points.as_deref(),
+    };
+    let outcome = quad::quad(&mut integrand, a, b, &opts);
+
+    if let Some(err) = failure.into_inner() {
+        return Err(err);
+    }
+    let outcome = outcome.map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok((
+        outcome.value,
+        outcome.abserr,
+        outcome.neval,
+        outcome.last,
+        outcome.ier.code(),
+    ))
+}
+
+/// Apply the 15-point Gauss–Kronrod rule once, without subdivision.
+///
+/// Returns `(result, abserr, resabs, resasc)`. No scipy entry point
+/// exposes a bare rule, so the oracle for this one is a reference value
+/// computed in the test rather than scipy.
+#[pyfunction]
+#[pyo3(text_signature = "(f, a, b)")]
+fn qk15(f: &Bound<'_, PyAny>, a: f64, b: f64) -> PyResult<(f64, f64, f64, f64)> {
+    apply_rule(f, a, b, Rule::K15)
+}
+
+/// Apply the 21-point Gauss–Kronrod rule once, without subdivision.
+///
+/// Returns `(result, abserr, resabs, resasc)`. This is the rule both
+/// `qags` and `qagp` run on, so a single-interval `quad` result and this
+/// must agree bit for bit.
+#[pyfunction]
+#[pyo3(text_signature = "(f, a, b)")]
+fn qk21(f: &Bound<'_, PyAny>, a: f64, b: f64) -> PyResult<(f64, f64, f64, f64)> {
+    apply_rule(f, a, b, Rule::K21)
+}
+
+/// Which Gauss–Kronrod rule [`apply_rule`] should run.
+///
+/// A two-variant enum rather than a function pointer: `qk15` and `qk21`
+/// are generic over the integrand, and naming them as `fn` pointers over
+/// `&mut dyn FnMut` needs a higher-ranked lifetime the monomorphized item
+/// cannot supply.
+enum Rule {
+    K15,
+    K21,
+}
+
+/// Shared body of [`qk15`] and [`qk21`]: wrap the Python callable, run the
+/// rule, and re-raise any exception it produced.
+fn apply_rule(f: &Bound<'_, PyAny>, a: f64, b: f64, rule: Rule) -> PyResult<(f64, f64, f64, f64)> {
+    let failure: RefCell<Option<PyErr>> = RefCell::new(None);
+    let mut integrand = |x: f64| -> f64 {
+        if failure.borrow().is_some() {
+            return f64::NAN;
+        }
+        match f.call1((x,)).and_then(|v| v.extract::<f64>()) {
+            Ok(value) => value,
+            Err(err) => {
+                *failure.borrow_mut() = Some(err);
+                f64::NAN
+            }
+        }
+    };
+    let out = match rule {
+        Rule::K15 => quad::qk15(&mut integrand, a, b),
+        Rule::K21 => quad::qk21(&mut integrand, a, b),
+    };
+    if let Some(err) = failure.into_inner() {
+        return Err(err);
+    }
+    Ok((out.result, out.abserr, out.resabs, out.resasc))
+}
+
+/// Populate the submodule.
+pub fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(quad_py, module)?)?;
+    module.add_function(wrap_pyfunction!(qk15, module)?)?;
+    module.add_function(wrap_pyfunction!(qk21, module)?)?;
+    Ok(())
+}

--- a/rust/src/quad_probe.rs
+++ b/rust/src/quad_probe.rs
@@ -17,7 +17,7 @@
 //! the Cython does today — `scipy.integrate.quad` re-enters Python once
 //! per node there too.
 
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyOverflowError, PyValueError};
 use pyo3::prelude::*;
 use std::cell::RefCell;
 
@@ -31,13 +31,19 @@ use crate::quad::{self, QuadOpts};
 /// reports the same number.
 ///
 /// Raises `ValueError` for exactly the inputs scipy raises `ValueError`
-/// for. An exception from `f` propagates unchanged: it is recorded on the
+/// for, and `OverflowError` for the one input scipy raises *that* for —
+/// a `limit` past C `int` range, which scipy rejects while converting the
+/// argument. Both are handled on `limit` below rather than left to PyO3's
+/// `usize` conversion, which would turn `limit = -1` into an
+/// `OverflowError` where scipy raises `ValueError`.
+///
+/// An exception from `f` propagates unchanged: it is recorded on the
 /// first occurrence, the integrand short-circuits to `NaN` for the rest of
 /// the run so no further Python code executes, and the original error is
 /// re-raised once QUADPACK returns.
 #[pyfunction]
 #[pyo3(name = "quad")]
-#[pyo3(signature = (f, a, b, epsabs=quad::DEFAULT_EPSABS, epsrel=quad::DEFAULT_EPSREL, limit=quad::DEFAULT_LIMIT, points=None))]
+#[pyo3(signature = (f, a, b, epsabs=quad::DEFAULT_EPSABS, epsrel=quad::DEFAULT_EPSREL, limit=quad::DEFAULT_LIMIT as i64, points=None))]
 #[pyo3(text_signature = "(f, a, b, epsabs=1.49e-8, epsrel=1.49e-8, limit=50, points=None)")]
 #[allow(
     clippy::too_many_arguments,
@@ -49,9 +55,30 @@ fn quad_py(
     b: f64,
     epsabs: f64,
     epsrel: f64,
-    limit: usize,
+    limit: i64,
     points: Option<Vec<f64>>,
 ) -> PyResult<(f64, f64, usize, usize, i32)> {
+    // `limit` is taken as a signed integer so this layer, not PyO3's
+    // `usize` conversion, decides what a bad one raises. scipy rejects
+    // `limit` twice over and with two different exceptions, and both are
+    // reproduced here:
+    //
+    //   * past C `int` range -> `OverflowError`, raised while converting
+    //     the argument. Also the guard that keeps the `limit`-length
+    //     workspace in `qagse`/`qagpe` from becoming a 16-bytes-per-entry
+    //     allocation request; `limit = 10**12` asks for 16 TB, which the
+    //     allocator may or may not refuse depending on the platform's
+    //     overcommit policy — a portability hazard, not just a slow path.
+    //   * below 1 -> `ValueError`. Folding negatives onto `0` sends them
+    //     down the same `QuadError::LimitTooSmall` path as an explicit
+    //     zero, so there is one message rather than two spellings of it.
+    if limit > i64::from(i32::MAX) {
+        return Err(PyOverflowError::new_err(
+            "signed integer is greater than maximum",
+        ));
+    }
+    let limit = usize::try_from(limit).unwrap_or(0);
+
     let failure: RefCell<Option<PyErr>> = RefCell::new(None);
 
     let mut integrand = |x: f64| -> f64 {

--- a/test/parity/README.md
+++ b/test/parity/README.md
@@ -64,9 +64,11 @@ legitimate corpus repair and drop the runner out of bit-equality mode two
 phases early. `cases.rust_core_kernels()` is the predicate; it returns the
 kernels the extension actually exposes, ignoring the scaffold's
 `roundtrip` probe and the test-only submodules listed in
-`cases._CORE_TEST_ONLY_MODULES` (today just `hazma._core.special`, the
-Phase 03 Task 3.2 specfun shim that `test/test_core_special.py` sweeps
-against scipy). That second exemption is held honest by
+`cases._CORE_TEST_ONLY_MODULES` (today `hazma._core.special`, the Phase
+03 Task 3.2 specfun shim that `test/test_core_special.py` sweeps against
+scipy, and `hazma._core.quad`, the Task 3.3 QUADPACK port that
+`test/test_core_quad.py` compares against `scipy.integrate.quad`). That
+second exemption is held honest by
 `test_test_only_core_submodules_have_no_importer`, which fails the moment
 anything under `hazma/` imports one of them — at which point it is a
 served kernel and belongs back in the count. If a swap changes a number,

--- a/test/parity/cases.py
+++ b/test/parity/cases.py
@@ -1218,14 +1218,17 @@ _CORE_SCAFFOLD_NAMES = frozenset({"roundtrip"})
 #:
 #: ``hazma._core.special`` is Phase 03 Task 3.2's ``spence``/``k1``/``kn``
 #: shim, exposed to Python only so ``test/test_core_special.py`` can sweep
-#: it against scipy; the kernels that will use it call the Rust side
-#: directly. What makes the exemption safe rather than convenient is that
-#: no module under `hazma/` may import these — asserted by
-#: ``test_test_only_core_submodules_have_no_importer`` in
+#: it against scipy; ``hazma._core.quad`` is Task 3.3's QUADPACK port,
+#: exposed so ``test/test_core_quad.py`` can put one Python integrand
+#: through both it and ``scipy.integrate.quad``. In both cases the kernels
+#: that will use them call the Rust side directly, with a Rust closure,
+#: and never through Python. What makes the exemption safe rather than
+#: convenient is that no module under `hazma/` may import these — asserted
+#: by ``test_test_only_core_submodules_have_no_importer`` in
 #: ``test_parity.py``, not left to this comment. **Do not add a submodule
 #: here to quiet a failing mode check**: a submodule a wrapper imports is
 #: a served kernel, whatever it is named.
-_CORE_TEST_ONLY_MODULES = frozenset({"hazma._core.special"})
+_CORE_TEST_ONLY_MODULES = frozenset({"hazma._core.special", "hazma._core.quad"})
 
 
 def rust_core_kernels() -> list[str]:

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -263,7 +263,8 @@ def test_scaffolded_core_serves_no_kernels() -> None:
 
     `roundtrip` is a plumbing probe with no caller in `hazma/`; the five
     per-domain submodules are empty until Phase 04; and `special`
-    (Phase 03 Task 3.2) is a test-only shim exempted wholesale by
+    (Phase 03 Task 3.2) and `quad` (Task 3.3) are test-only shims
+    exempted wholesale by
     `cases._CORE_TEST_ONLY_MODULES`. If this fails, either a kernel
     landed (in which case the corpus really should leave exact mode) or
     something non-kernel became public on the extension and needs adding

--- a/test/test_core_quad.py
+++ b/test/test_core_quad.py
@@ -233,9 +233,10 @@ class TestBreakPointPreprocessing:
         )
 
     def test_endpoint_coincident_break_points_are_dropped(self) -> None:
-        # The live shape: `points=[-1, 1]` on the interval [-1, 1], at four
-        # spectra call sites and both mediator spectrum modules. Nothing
-        # survives the filter, so QUADPACK starts from a single interval.
+        # The live shape: `points=[-1, 1]` on the interval [-1, 1], at five
+        # call sites — `spectra/_photon/_pion.pyx:123` plus the four
+        # mediator spectrum modules. Nothing survives the filter, so
+        # QUADPACK starts from a single interval.
         f = self.singular(0.0)
         with_points = core_quad.quad(
             f, -1.0, 1.0, points=[-1.0, 1.0], epsabs=1e-10, epsrel=1e-5
@@ -952,9 +953,15 @@ class TestErrorBehavior:
 
     def test_the_largest_accepted_limit_is_not_rejected(self) -> None:
         # The boundary itself: INT_MAX is legal on both sides, so
-        # narrowing the guard by one would not go unnoticed. Only the
-        # argument check is exercised — a smooth integrand converges on
-        # the first panel and never allocates the full workspace.
+        # narrowing the guard by one would not go unnoticed.
+        #
+        # This costs nothing only because the `limit`-length workspaces
+        # are grown on demand — sized at `limit`, they would be ~80 GiB
+        # here. An earlier revision of this comment claimed the one-panel
+        # case "never allocates the full workspace", which was false at
+        # the time and is enforced now by
+        # `quad.rs::an_enormous_limit_costs_nothing_on_a_one_panel_integrand`
+        # (PR #60 review round 2).
         assert core_quad.quad(math.exp, 0.0, 1.0, limit=2**31 - 1)[4] == 0
         assert si.quad(math.exp, 0.0, 1.0, limit=2**31 - 1)[0] == pytest.approx(
             math.e - 1.0, rel=SMOOTH_RTOL

--- a/test/test_core_quad.py
+++ b/test/test_core_quad.py
@@ -1,0 +1,978 @@
+"""``hazma._core.quad`` against ``scipy.integrate.quad``: the QUADPACK port.
+
+Every compiled kernel in hazma that integrates does it by calling
+``scipy.integrate.quad`` from Cython with a ``cdef`` callback — twelve
+live call sites, all over finite intervals, listed in
+``projects/cython-to-rust/references/numerics-replacements.md``.
+cython-to-rust Task 3.3 replaces that with a translation of the netlib
+QUADPACK Fortran in ``rust/src/quad.rs`` (``qk15``, ``qk21``, ``qelg``,
+``qpsrt``, ``qagse``, ``qagpe``), which is what lets the extension stop
+linking against scipy's C API. This module is the gate on that.
+
+What is actually being compared
+-------------------------------
+``hazma._core.quad.quad`` takes a *Python callable*, so every test here
+hands the **same** Python integrand to scipy and to the port. Any
+difference is therefore the quadrature algorithm and nothing else — not a
+Rust reimplementation of the integrand, and not a different grid. That is
+also what the Cython does today, since ``quad`` re-enters Python once per
+node there too.
+
+The two things this module pins are different in kind:
+
+1. **The break-point preprocessing contract** — what
+   ``quad(points=...)`` does with unsorted, duplicated,
+   endpoint-coincident and out-of-interval entries. This is *not* derived
+   from the QUADPACK documentation; it is scipy's own three lines of
+   Python (``np.unique``, then ``a < p``, then ``p < b``) and
+   :class:`TestBreakPointPreprocessing` re-derives each clause from scipy
+   at run time. Both degeneracies occur live: the five ``points=[-1, 1]``
+   calls on ``[-1, 1]`` have **every** break point coincident with an
+   endpoint, and the thermal-average calls pass ``[2, m/mx, 2 m/mx]`` whose
+   mediator entries fall outside the interval for a heavy mediator.
+2. **The numbers** — agreement with scipy on QUADPACK's own reference
+   problems and on every live integrand shape.
+
+Why the tolerances are what they are
+------------------------------------
+Task 3.3's exit criteria ask for agreement within 10x the requested
+tolerance, and within 1e-12 relative on smooth cases. Measured over
+11,274 random (integrand, tolerance, limit, points) combinations against
+scipy 1.18.0, the port does far better on the 4,461 that **converged**:
+it reproduced scipy's ``neval`` and ``last`` on all but 5 (0.11%),
+agreed on the termination flag every time, and landed within 3.6e-2 of
+the requested tolerance (8.2e-11 relative at worst). Every case in this
+file reproduces the subdivision exactly, so ``SMOOTH_RTOL = 1e-13`` is a
+ceiling with orders of headroom rather than a fitted tolerance —
+anything approaching it is a defect, not rounding.
+
+The ``neval``/``last`` equality is the sharper assertion of the two and is
+made everywhere it can be. A value can agree by luck; an identical
+subdivision count on a singular integrand cannot.
+
+Two classes deliberately assert *loosely* — :class:`TestDivergenceRegime`
+and :class:`TestAdaptiveHeuristics`, both of which use inputs that
+exhaust ``limit``. Their docstrings say why.
+
+Lifetime
+--------
+Nothing here parses Cython, so this module outlives the ``.pyx``. It
+should keep running after Phase 06 as the standing check that the port
+still tracks scipy — a property the parity corpus cannot see, because the
+corpus pins *spectra*, not the integrator underneath them.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from collections.abc import Callable
+from typing import ClassVar
+
+import numpy as np
+import pytest
+import scipy.integrate as si
+from scipy.special import k1
+
+from hazma.scalar_mediator import _c_scalar_mediator_cross_sections as scalar_xs
+from hazma.vector_mediator import _c_vector_mediator_cross_sections as vector_xs
+
+#: A quadrature integrand: one float in, one float out.
+Integrand = Callable[[float], float]
+
+#: The keyword arguments both integrators accept — `epsabs`, `epsrel`,
+#: `limit`, `points`. Spelled out rather than `Any` so a typo in a test
+#: is a type error rather than a silently ignored keyword.
+QuadKwarg = float | int | list[float] | None
+
+core_quad = pytest.importorskip(
+    "hazma._core.quad",
+    reason="hazma._core is not built; run `pip install -e .`",
+)
+
+#: Ceiling for smooth integrands. It is a ceiling, not a fitted
+#: tolerance: every comparison in this file also asserts that the port
+#: reproduced scipy's `neval` and `last` exactly, so a value that drifted
+#: anywhere near 1e-13 while the subdivision stayed identical would mean
+#: the arithmetic had changed, not the algorithm.
+SMOOTH_RTOL = 1e-13
+
+#: Length of ``scipy.integrate.quad``'s ``full_output`` tuple when it
+#: converged: value, abserr, infodict. A fourth entry is the
+#: abnormal-termination message, which is the only place scipy exposes a
+#: non-zero ``ier``.
+_CONVERGED_TUPLE_LEN = 3
+
+#: Ceiling for integrands with an algebraic or logarithmic singularity,
+#: where scipy and the port both reach the answer through the epsilon
+#: algorithm. Extrapolation sums the same terms in the same order but the
+#: two builds' compilers are free to contract differently, so a few more
+#: ulp are expected here than on a single-panel result.
+SINGULAR_RTOL = 1e-12
+
+#: Below this, a `qk21` result that should vanish by symmetry counts as
+#: zero: the rule sums 21 weighted values of order 1, so cancellation
+#: leaves a few ulp.
+_SYMMETRY_ZERO = 1e-16
+
+#: `resabs` is the rule applied to |f|, not the true integral of |f|. For
+#: f(x) = x on [-1, 1] the 21-point rule misses the true value 1 by about
+#: 4e-3; this is the floor that distinguishes "different number" from
+#: "rounding".
+_RESABS_GAP = 1e-3
+
+#: An oscillatory integrand whose exact value is zero is checked
+#: absolutely, not relatively; this is the ceiling at epsabs = 1e-12.
+_OSCILLATORY_ABS = 1e-13
+
+#: `qagpe` and `qagse` must disagree by at least this much on the
+#: dispatch-discriminating integrand, or that test proves nothing.
+_QAGP_QAGSE_MIN_GAP = 0.01
+
+#: Bounds on the port-vs-scipy gap in the limit-exhausted regime, and on
+#: how far either lands from the exact value there. See
+#: :class:`TestDivergenceRegime`.
+_DIVERGENCE_GAP_MIN = 1e-6
+_DIVERGENCE_GAP_MAX = 1e-2
+
+
+def scipy_quad(
+    f: Integrand, a: float, b: float, **kwargs: QuadKwarg
+) -> tuple[float, float, int, int, bool]:
+    """``scipy.integrate.quad`` with ``full_output``, warnings silenced.
+
+    Returns ``(value, abserr, neval, last, converged)``. ``converged`` is
+    ``False`` when scipy appended an abnormal-termination message, which
+    is the only way ``full_output`` exposes a non-zero ``ier``.
+
+    An abnormal termination is a *value* here rather than a warning, and
+    that is the point: hazma's call sites take ``quad(...)[0]`` and never
+    see the warning, so a test that let ``IntegrationWarning`` fail the
+    run would be testing something no caller experiences.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", si.IntegrationWarning)
+        out = si.quad(f, a, b, full_output=1, **kwargs)
+    value, abserr, info = out[0], out[1], out[2]
+    return value, abserr, info["neval"], info["last"], len(out) == _CONVERGED_TUPLE_LEN
+
+
+def assert_matches_scipy(
+    f: Integrand,
+    a: float,
+    b: float,
+    *,
+    rtol: float = SMOOTH_RTOL,
+    label: str = "",
+    **kwargs: QuadKwarg,
+) -> float:
+    """Run `f` through both integrators and assert they agree.
+
+    Asserts the subdivision bookkeeping (`neval`, `last`) is *identical*
+    before it looks at the value, because that is the assertion a lucky
+    number cannot pass. Returns the measured relative difference so a
+    caller can report it.
+    """
+    s_value, _s_abserr, s_neval, s_last, s_converged = scipy_quad(f, a, b, **kwargs)
+    r_value, _r_abserr, r_neval, r_last, r_ier = core_quad.quad(f, a, b, **kwargs)
+
+    assert (r_ier == 0) is s_converged, (
+        f"{label}: termination flag differs from scipy — "
+        f"ier {r_ier} against scipy converged={s_converged}"
+    )
+
+    assert (r_neval, r_last) == (s_neval, s_last), (
+        f"{label}: subdivision differs from scipy — "
+        f"neval {r_neval} vs {s_neval}, last {r_last} vs {s_last}"
+    )
+    rel = abs(r_value - s_value) / abs(s_value) if s_value else abs(r_value - s_value)
+    assert rel <= rtol, f"{label}: got {r_value!r}, scipy {s_value!r}, rel {rel:.3e}"
+    return rel
+
+
+# ---------------------------------------------------------------------
+# The break-point preprocessing contract
+# ---------------------------------------------------------------------
+
+
+class TestBreakPointPreprocessing:
+    """What ``quad(points=...)`` does before QUADPACK sees the list.
+
+    Every test here uses an integrand with a **genuine interior
+    singularity**, so a break point that survives filtering changes
+    ``neval`` and ``last`` visibly. On a smooth integrand the whole
+    contract is unobservable and these tests would pass against any
+    filtering rule at all.
+    """
+
+    @staticmethod
+    def singular(centre: float) -> Integrand:
+        """``|x - centre|**-1/2`` — integrable, but unbounded at `centre`."""
+
+        def f(x: float) -> float:
+            d = abs(x - centre)
+            return 0.0 if d == 0.0 else d**-0.5
+
+        return f
+
+    def test_break_points_are_sorted_and_deduplicated(self) -> None:
+        # np.unique does both. An unsorted, duplicated list must give the
+        # same subdivision as the clean one — including through the port.
+        f = self.singular(1.0)
+        clean = core_quad.quad(f, 0.0, 3.0, points=[1.0, 2.0], epsabs=1e-10)
+        messy = core_quad.quad(f, 0.0, 3.0, points=[2.0, 1.0, 2.0, 1.0], epsabs=1e-10)
+        assert messy == clean
+        assert_matches_scipy(
+            f,
+            0.0,
+            3.0,
+            points=[2.0, 1.0, 2.0, 1.0],
+            epsabs=1e-10,
+            rtol=SINGULAR_RTOL,
+            label="unsorted duplicated points",
+        )
+
+    def test_endpoint_coincident_break_points_are_dropped(self) -> None:
+        # The live shape: `points=[-1, 1]` on the interval [-1, 1], at four
+        # spectra call sites and both mediator spectrum modules. Nothing
+        # survives the filter, so QUADPACK starts from a single interval.
+        f = self.singular(0.0)
+        with_points = core_quad.quad(
+            f, -1.0, 1.0, points=[-1.0, 1.0], epsabs=1e-10, epsrel=1e-5
+        )
+        empty = core_quad.quad(f, -1.0, 1.0, points=[], epsabs=1e-10, epsrel=1e-5)
+        assert with_points == empty
+        assert_matches_scipy(
+            f,
+            -1.0,
+            1.0,
+            points=[-1.0, 1.0],
+            epsabs=1e-10,
+            epsrel=1e-5,
+            rtol=SINGULAR_RTOL,
+            label="endpoint-coincident points",
+        )
+
+    def test_out_of_interval_break_points_are_dropped(self) -> None:
+        # The live shape: a heavy mediator pushes `m/mx` and `2 m/mx` past
+        # the upper bound of the thermal integral. The interior point must
+        # still be honoured.
+        f = self.singular(1.0)
+        mixed = core_quad.quad(f, 0.0, 3.0, points=[-5.0, 1.0, 9.0], epsabs=1e-10)
+        interior_only = core_quad.quad(f, 0.0, 3.0, points=[1.0], epsabs=1e-10)
+        assert mixed == interior_only
+        assert_matches_scipy(
+            f,
+            0.0,
+            3.0,
+            points=[-5.0, 1.0, 9.0],
+            epsabs=1e-10,
+            rtol=SINGULAR_RTOL,
+            label="out-of-interval points",
+        )
+
+    def test_all_break_points_out_of_interval_is_not_an_error(self) -> None:
+        f = self.singular(1.0)
+        assert_matches_scipy(
+            f,
+            0.0,
+            3.0,
+            points=[-5.0, 9.0],
+            epsabs=1e-10,
+            rtol=SINGULAR_RTOL,
+            label="every point out of interval",
+        )
+
+    def test_nan_break_points_are_dropped(self) -> None:
+        # Every comparison against NaN is false, so `a < p` discards it.
+        # Pinned because "sorts last" and "is discarded" are different
+        # outcomes and only one of them is scipy's.
+        f = self.singular(1.0)
+        with_nan = core_quad.quad(f, 0.0, 3.0, points=[1.0, float("nan")], epsabs=1e-10)
+        without = core_quad.quad(f, 0.0, 3.0, points=[1.0], epsabs=1e-10)
+        assert with_nan == without
+        assert_matches_scipy(
+            f,
+            0.0,
+            3.0,
+            points=[1.0, float("nan")],
+            epsabs=1e-10,
+            rtol=SINGULAR_RTOL,
+            label="NaN in points",
+        )
+
+    def test_an_empty_points_list_still_selects_qagp(self) -> None:
+        # scipy dispatches on `points is None` *before* it filters, so an
+        # empty-after-filtering list runs qagpe, not qagse. That is the
+        # branch all six `points=[-1, 1]` call sites take, and it is
+        # normally invisible: over 3,776 random (integrand, tolerance,
+        # limit) combinations the two routines returned identical values,
+        # identical `neval` and identical `last` in every case that
+        # converged. They diverge only once the subdivision limit is hit,
+        # because they enter extrapolation at different depths — qagse
+        # when an interval falls below 0.375x the original length, qagpe
+        # one bisection earlier, at subdivision level 1.
+        #
+        # This integrand is chosen to sit in that gap: |x - 1/3|^-0.9
+        # cos(50x) at limit=10 exhausts the subdivisions, and the two
+        # routines then disagree by 11%. So it distinguishes the branches,
+        # which the smooth and mildly-singular cases above cannot.
+        def f(x: float) -> float:
+            d = abs(x - 1.0 / 3.0)
+            return 0.0 if d == 0.0 else d**-0.9 * math.cos(50.0 * x)
+
+        settings = dict(epsabs=1e-12, epsrel=1e-10, limit=10)
+        with_points = core_quad.quad(f, 0.0, 1.0, points=[], **settings)
+        without_points = core_quad.quad(f, 0.0, 1.0, **settings)
+        rel = abs(with_points[0] - without_points[0]) / abs(without_points[0])
+        assert rel > _QAGP_QAGSE_MIN_GAP, (
+            "this case no longer distinguishes qagpe from qagse, so the "
+            "assertion below proves nothing — find another integrand"
+        )
+
+        assert_matches_scipy(
+            f,
+            0.0,
+            1.0,
+            points=[],
+            rtol=SINGULAR_RTOL,
+            label="points=[] (qagpe path)",
+            **settings,
+        )
+        assert_matches_scipy(
+            f,
+            0.0,
+            1.0,
+            rtol=SINGULAR_RTOL,
+            label="points omitted (qagse path)",
+            **settings,
+        )
+
+    def test_reversed_limits_negate_the_result(self) -> None:
+        f = self.singular(1.0)
+        forward = core_quad.quad(f, 0.0, 3.0, points=[1.0], epsabs=1e-10)
+        backward = core_quad.quad(f, 3.0, 0.0, points=[1.0], epsabs=1e-10)
+        assert backward[0] == -forward[0]
+        assert_matches_scipy(
+            f,
+            3.0,
+            0.0,
+            points=[1.0],
+            epsabs=1e-10,
+            rtol=SINGULAR_RTOL,
+            label="reversed limits",
+        )
+
+    def test_too_many_break_points_for_the_limit_raises(self) -> None:
+        # QUADPACK's own `limit <= npts` check, counted after filtering.
+        f = self.singular(1.0)
+        points = list(np.linspace(0.1, 2.9, 50))
+        with pytest.raises(ValueError):
+            si.quad(f, 0.0, 3.0, points=points, limit=50)
+        with pytest.raises(ValueError):
+            core_quad.quad(f, 0.0, 3.0, points=points, limit=50)
+        # One fewer break point and it is legal on both sides.
+        assert core_quad.quad(f, 0.0, 3.0, points=points[:-1], limit=50)[0] > 0.0
+
+
+# ---------------------------------------------------------------------
+# QUADPACK's own reference problems
+# ---------------------------------------------------------------------
+
+
+class TestReferenceProblems:
+    """Analytic values, so scipy is not the only oracle in the room.
+
+    Everything else in this module compares two implementations; if both
+    were wrong the same way, nothing above would notice. These have closed
+    forms taken from the QUADPACK book's own worked examples (Piessens,
+    de Doncker-Kapenga, Überhuber, Kahaner, *QUADPACK: A Subroutine
+    Package for Automatic Integration*, Springer 1983, §1.2 and §3.2).
+    """
+
+    @pytest.mark.parametrize("alpha", [-0.9, -0.5, 0.0, 1.0, 2.0, 5.0])
+    def test_endpoint_logarithmic_singularity(self, alpha: float) -> None:
+        # int_0^1 x^alpha ln(1/x) dx = 1/(alpha+1)^2.
+        def f(x: float) -> float:
+            return 0.0 if x <= 0.0 else x**alpha * math.log(1.0 / x)
+
+        want = 1.0 / (alpha + 1.0) ** 2
+        got = core_quad.quad(f, 0.0, 1.0, epsabs=1e-12, epsrel=1e-12)[0]
+        assert got == pytest.approx(want, rel=1e-11)
+
+    def test_interior_algebraic_singularity_with_a_break_point(self) -> None:
+        # int_0^1 |x - 1/3|^(-1/2) dx = 2(sqrt(1/3) + sqrt(2/3)).
+        centre = 1.0 / 3.0
+
+        def f(x: float) -> float:
+            d = abs(x - centre)
+            return 0.0 if d == 0.0 else d**-0.5
+
+        want = 2.0 * (math.sqrt(centre) + math.sqrt(1.0 - centre))
+        got = core_quad.quad(f, 0.0, 1.0, points=[centre], epsabs=1e-12, epsrel=1e-12)[
+            0
+        ]
+        assert got == pytest.approx(want, rel=1e-10)
+
+    def test_a_smooth_integrand_needs_one_panel(self) -> None:
+        # int_0^1 exp(x) dx = e - 1, resolved by a single 21-point rule.
+        value, _abserr, neval, last, ier = core_quad.quad(
+            math.exp, 0.0, 1.0, epsabs=1e-10, epsrel=1e-10
+        )
+        assert (neval, last, ier) == (21, 1, 0)
+        assert value == pytest.approx(math.e - 1.0, rel=1e-15)
+
+    def test_an_oscillatory_integrand(self) -> None:
+        # int_0^{2 pi} sin(50 x) dx = 0 by periodicity — a case where the
+        # answer is a cancellation, so an absolute rather than relative
+        # check is the honest one.
+        got = core_quad.quad(
+            lambda x: math.sin(50.0 * x), 0.0, 2.0 * math.pi, epsabs=1e-12
+        )[0]
+        assert abs(got) < _OSCILLATORY_ABS
+
+
+# ---------------------------------------------------------------------
+# The live integrand shapes
+# ---------------------------------------------------------------------
+
+
+class TestLiveIntegrandShapes:
+    """One case per row of the call-site table, at that row's settings.
+
+    Two of these run the **actual** integrand — the thermal-average one,
+    reachable because ``sigma_xx_to_all`` is a public Cython export. The
+    rest reproduce the *shape*: the boost Jacobian ``1/(2 gamma |1 - beta
+    cos t|)`` that the cos-theta sites integrate against
+    (``hazma/spectra/_photon/_pion.pyx:94-99``), and the smooth
+    ``[E gamma (1 - beta), E gamma (1 + beta)]`` energy window the rho,
+    positron-pion and neutrino-pion sites use. What is being tested is the
+    integrator, not the physics; the physics is the parity corpus's job.
+    """
+
+    @staticmethod
+    def boost_jacobian_integrand(beta: float, gamma: float, eng: float) -> Integrand:
+        """The cos-theta shape: a Jacobian with a `1 - beta*cl` denominator.
+
+        `hazma/spectra/_photon/_pion.pyx:94-99` computes
+        ``jac = 1/(2 gamma |1 - beta cl|)`` and evaluates the rest-frame
+        spectrum at ``eng * gamma * (1 - beta cl)``. The stand-in below
+        keeps both, with a smooth positive stand-in for the spectrum, so
+        the integrand has the same near-endpoint peaking the real one has.
+        """
+
+        def f(cl: float) -> float:
+            shifted = eng * gamma * (1.0 - beta * cl)
+            jac = 1.0 / (2.0 * gamma * abs(1.0 - beta * cl))
+            return jac * math.exp(-shifted) * shifted
+
+        return f
+
+    @pytest.mark.parametrize("beta", [0.1, 0.9, 0.999, 0.999999])
+    def test_cos_theta_sites(self, beta: float) -> None:
+        # `points=[-1, 1]`, epsabs=1e-10, epsrel=1e-5 — the settings shared
+        # by _photon/_pion.pyx:123 and all four mediator spectrum modules.
+        gamma = 1.0 / math.sqrt(1.0 - beta * beta)
+        f = self.boost_jacobian_integrand(beta, gamma, 1.0)
+        assert_matches_scipy(
+            f,
+            -1.0,
+            1.0,
+            points=[-1.0, 1.0],
+            epsabs=1e-10,
+            epsrel=1e-5,
+            rtol=SINGULAR_RTOL,
+            label=f"cos-theta site, beta={beta}",
+        )
+
+    @pytest.mark.parametrize(
+        ("epsabs", "epsrel", "site"),
+        [
+            (1e-10, 1e-5, "spectra/_photon/_rho.pyx:52,123"),
+            (1e-10, 1e-4, "spectra/_positron/_pion.pyx:58"),
+            (1.49e-8, 1.49e-8, "spectra/_neutrino/_pion.pyx:124,127"),
+        ],
+    )
+    def test_boosted_energy_window_sites(
+        self, epsabs: float, epsrel: float, site: str
+    ) -> None:
+        # The three sites that integrate over [E gamma (1 - beta),
+        # E gamma (1 + beta)] with no break points, each at its own
+        # tolerances. The neutrino row is scipy's defaults, which the
+        # `.pyx` reaches by passing neither keyword.
+        beta, eng = 0.98, 30.0
+        gamma = 1.0 / math.sqrt(1.0 - beta * beta)
+        emin, emax = eng * gamma * (1.0 - beta), eng * gamma * (1.0 + beta)
+
+        def f(e: float) -> float:
+            # A decay spectrum's shape: falls off, vanishes at the endpoint.
+            return math.sqrt(max(emax - e, 0.0)) * math.exp(-e / emax) / e
+
+        assert_matches_scipy(
+            f,
+            emin,
+            emax,
+            epsabs=epsabs,
+            epsrel=epsrel,
+            rtol=SINGULAR_RTOL,
+            label=f"boosted energy window, {site}",
+        )
+
+    def test_the_nested_rho_integral(self) -> None:
+        # `spectra/_photon/_rho.pyx` integrates a function that itself
+        # calls quad — the reference file calls it the stress test. Both
+        # levels run on the port here, which is the configuration the port
+        # will actually be in.
+        def inner_scipy(y: float) -> float:
+            return si.quad(
+                lambda t: math.exp(-t * t), 0.0, y, epsabs=1e-10, epsrel=1e-5
+            )[0]
+
+        def inner_port(y: float) -> float:
+            return core_quad.quad(
+                lambda t: math.exp(-t * t), 0.0, y, epsabs=1e-10, epsrel=1e-5
+            )[0]
+
+        s_value = si.quad(inner_scipy, 0.0, 2.0, epsabs=1e-10, epsrel=1e-5)[0]
+        r_value = core_quad.quad(inner_port, 0.0, 2.0, epsabs=1e-10, epsrel=1e-5)[0]
+        assert r_value == pytest.approx(s_value, rel=SMOOTH_RTOL)
+
+    @staticmethod
+    def thermal_integrand(
+        model: str, x: float, mx: float, m_med: float, width: float
+    ) -> Integrand:
+        """The *actual* mediator thermal integrand, for either model.
+
+        Both are ``sigma_xx_to_all(mx*z, ...) * z**2 * (z**2 - 4) *
+        k1(x*z)`` —
+        ``hazma/scalar_mediator/_c_scalar_mediator_cross_sections.pyx:1354-1361``
+        and
+        ``hazma/vector_mediator/_c_vector_mediator_cross_sections.pyx:598-606``
+        — and ``sigma_xx_to_all`` is a public export of each module, so
+        this is the integrand rather than a stand-in for it.
+        """
+        if model == "scalar":
+            cross_sections = scalar_xs
+            # (e_cm, mx, ms, gsxx, gsff, gsGG, gsFF, lam, width_s, vs)
+            args = (1.0, 1.0, 0.1, 0.1, 1e4, width, 0.0)
+        else:
+            cross_sections = vector_xs
+            # (e_cm, mx, mv, gvxx, gvuu, gvdd, gvss, gvee, gvmumu, width_v)
+            args = (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, width)
+
+        def f(z: float) -> float:
+            sigma = cross_sections.sigma_xx_to_all(mx * z, mx, m_med, *args)
+            return sigma * z**2 * (z**2 - 4.0) * k1(x * z)
+
+        return f
+
+    #: Upper limit of each model's thermal integral, as a function of x.
+    #: `max(50/x, 100)` for the scalar
+    #: (`_c_scalar_mediator_cross_sections.pyx:1412`) and `max(50/x, 150)`
+    #: for the vector (`_c_vector_mediator_cross_sections.pyx:657`).
+    THERMAL_FLOOR: ClassVar[dict[str, float]] = {"scalar": 100.0, "vector": 150.0}
+
+    @pytest.mark.parametrize("model", ["scalar", "vector"])
+    @pytest.mark.parametrize(
+        ("mx", "m_med", "expected_last", "regime"),
+        [
+            (100.0, 250.0, 3, "break points interior (resonance active)"),
+            (100.0, 200.0, 2, "the lower break point sits on the lower limit"),
+            (1.0, 500.0, 1, "both mediator break points outside the interval"),
+        ],
+    )
+    def test_thermal_cross_section_site(
+        self,
+        model: str,
+        mx: float,
+        m_med: float,
+        expected_last: int,
+        regime: str,
+    ) -> None:
+        # `points=[2, m/mx, 2 m/mx]` over [2, max(50/x, floor)] at scipy's
+        # default tolerances — both mediator sites verbatim, in the three
+        # regimes Task 3.3's exit criteria name. At x = 20 the upper limit
+        # is the floor (100 or 150), so:
+        #   mx=100, m=250 -> [2, 2.5, 5]; 2 equals the lower limit and is
+        #                    dropped, leaving 2 interior points, 3 intervals;
+        #   mx=100, m=200 -> [2, 2, 4]; the duplicate collapses and the
+        #                    survivor 2 is dropped, leaving 1 point,
+        #                    2 intervals;
+        #   mx=1,   m=500 -> [2, 500, 1000]; both mediator points exceed the
+        #                    upper limit, leaving nothing and 1 interval.
+        # `last` is asserted directly, not only against scipy: it is the
+        # observable that says the filtering produced the partition this
+        # comment claims, and two implementations could agree on a wrong
+        # one.
+        x, width = 20.0, 2.5
+        f = self.thermal_integrand(model, x, mx, m_med, width)
+        upper = max(50.0 / x, self.THERMAL_FLOOR[model])
+        points = [2.0, m_med / mx, 2.0 * m_med / mx]
+
+        assert_matches_scipy(
+            f,
+            2.0,
+            upper,
+            points=points,
+            rtol=SINGULAR_RTOL,
+            label=f"{model} thermal cross section, {regime}",
+        )
+        _value, _abserr, _neval, last, ier = core_quad.quad(
+            f, 2.0, upper, points=points
+        )
+        assert last == expected_last
+        assert ier == 0, "no live call site should terminate abnormally"
+
+        # The live tolerances are absolute 1.49e-8 against an integrand of
+        # order 1e-33, so QUADPACK stops on the initial partition and never
+        # subdivides — which is what happens in production too. Guard that
+        # the integrand is not simply zero, or all three regimes would
+        # agree for the wrong reason.
+        sampled = [f(z) for z in np.linspace(2.001, min(upper, 30.0), 200)]
+        assert max(sampled) > 0.0, "the live thermal integrand vanished"
+
+
+# ---------------------------------------------------------------------
+# The bare Gauss-Kronrod rules
+# ---------------------------------------------------------------------
+
+
+class TestKronrodRules:
+    """`qk15` and `qk21` applied once, without subdivision.
+
+    ``rust/src/quad.rs`` pins the tables by degree of exactness in
+    ``cargo test``; what these add is the cross-language check that the
+    compiled extension exposes the same rule the Rust unit tests
+    exercised, and that ``qk21`` is the rule ``quad`` runs on.
+    """
+
+    def test_qk21_is_what_quad_uses_on_a_single_panel(self) -> None:
+        # A smooth integrand converges in one panel, so `quad`'s answer
+        # must be *bit-identical* to one application of qk21. This is what
+        # ties the two entry points together; nothing else here would
+        # notice if `quad` quietly used qk15.
+        value, abserr, _resabs, _resasc = core_quad.qk21(math.exp, 0.0, 1.0)
+        q_value, q_abserr, neval, last, _ier = core_quad.quad(
+            math.exp, 0.0, 1.0, epsabs=1e-10, epsrel=1e-10
+        )
+        assert (neval, last) == (21, 1)
+        assert q_value == value
+        assert q_abserr == abserr
+
+    @pytest.mark.parametrize("rule", ["qk15", "qk21"])
+    def test_a_rule_integrates_a_low_degree_polynomial_exactly(self, rule: str) -> None:
+        # Both rules are exact well past degree 5, so this is an analytic
+        # pin rather than a comparison: int_{-1}^{1} (3x^4 - 2x^2 + 1) dx
+        # = 6/5 - 4/3 + 2.
+        f = getattr(core_quad, rule)
+        got = f(lambda x: 3.0 * x**4 - 2.0 * x**2 + 1.0, -1.0, 1.0)[0]
+        assert got == pytest.approx(6.0 / 5.0 - 4.0 / 3.0 + 2.0, rel=1e-15)
+
+    def test_resabs_is_the_rule_applied_to_the_absolute_value(self) -> None:
+        # `resabs` is not int|f|: |x| is not a polynomial, so the rule
+        # misses the true value 1 by ~4e-3. Pinning it against the rule
+        # run on |x| states the invariant exactly, and distinguishes
+        # `resabs` from `result` for a sign-changing integrand.
+        result, _abserr, resabs, _resasc = core_quad.qk21(lambda x: x, -1.0, 1.0)
+        assert abs(result) < _SYMMETRY_ZERO
+        assert resabs == core_quad.qk21(abs, -1.0, 1.0)[0]
+        assert abs(resabs - 1.0) > _RESABS_GAP
+
+    def test_the_two_rules_agree_on_a_smooth_integrand(self) -> None:
+        want = math.e - 1.0
+        assert core_quad.qk15(math.exp, 0.0, 1.0)[0] == pytest.approx(want, rel=1e-14)
+        assert core_quad.qk21(math.exp, 0.0, 1.0)[0] == pytest.approx(want, rel=1e-14)
+
+
+# ---------------------------------------------------------------------
+# Errors and abnormal termination
+# ---------------------------------------------------------------------
+
+
+#: scipy reports ``ier`` only through the message text ``full_output``
+#: appends, so decoding it is the only way to compare termination flags.
+#: The fragments come from ``scipy.integrate._quadpack_py.quad``'s own
+#: ``msgs`` dictionary.
+_SCIPY_MESSAGE_TO_IER = {
+    "maximum number of subdivisions": 1,
+    "roundoff error is detected": 2,
+    "Extremely bad integrand behavior": 3,
+    "not converge": 4,
+    "probably divergent, or slowly convergent": 5,
+}
+
+
+def scipy_ier(f: Integrand, a: float, b: float, **kwargs: QuadKwarg) -> int:
+    """The ``ier`` scipy would have reported, decoded from its message."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", si.IntegrationWarning)
+        out = si.quad(f, a, b, full_output=1, **kwargs)
+    if len(out) == _CONVERGED_TUPLE_LEN:
+        return 0
+    message = out[3]
+    for fragment, code in _SCIPY_MESSAGE_TO_IER.items():
+        if fragment in message:
+            return code
+    raise AssertionError(f"unrecognised scipy message: {message!r}")
+
+
+class TestTerminationFlags:
+    """Every ``ier`` QUADPACK can return, mapped against scipy's own.
+
+    The port returns ``ier`` where scipy raises an ``IntegrationWarning``,
+    so "mapped" has to mean *agrees with scipy's code*, not merely
+    "non-zero". Each case below is an input that drives QUADPACK down that
+    branch; six of the seven codes are reachable this way, and the
+    seventh (``ier = 6``) is the invalid-input case
+    :class:`TestErrorBehavior` covers as a raise.
+    """
+
+    @staticmethod
+    def reciprocal(x: float) -> float:
+        return 0.0 if x == 0.0 else 1.0 / x
+
+    @pytest.mark.parametrize(
+        ("ier", "func", "a", "b", "kwargs"),
+        [
+            (0, math.exp, 0.0, 1.0, dict(epsabs=1e-10, epsrel=1e-10)),
+            # 1 — the subdivision limit is reached on a divergent integral.
+            (1, reciprocal, 0.0, 1.0, dict(epsabs=1e-10, epsrel=1e-10, limit=10)),
+            # 2 — roundoff prevents an unattainable absolute tolerance.
+            (2, math.sin, 0.0, 1.0, dict(epsabs=1e-300, epsrel=1e-16)),
+            # 3 — "extremely bad integrand behaviour": the subintervals
+            #     collapse toward zero magnitude.
+            (
+                3,
+                reciprocal,
+                0.0,
+                1e-300,
+                dict(epsabs=1e-320, epsrel=1e-14, limit=200),
+            ),
+            # 4 — the extrapolation table stops converging.
+            (
+                4,
+                lambda x: 0.0 if x <= 0.0 else x**-0.999,
+                0.0,
+                1.0,
+                dict(epsabs=1e-14, epsrel=1e-14, limit=200),
+            ),
+            # 5 — probably divergent: 1/x^2 has a non-integrable pole.
+            (
+                5,
+                lambda x: 0.0 if x == 0.0 else x**-2,
+                0.0,
+                1.0,
+                dict(epsabs=1e-10, epsrel=1e-10),
+            ),
+        ],
+    )
+    def test_ier_matches_scipy(
+        self,
+        ier: int,
+        func: Integrand,
+        a: float,
+        b: float,
+        kwargs: dict[str, QuadKwarg],
+    ) -> None:
+        assert scipy_ier(func, a, b, **kwargs) == ier, (
+            "this input no longer drives scipy down the branch it was "
+            "chosen for, so the assertion below proves nothing"
+        )
+        assert core_quad.quad(func, a, b, **kwargs)[4] == ier
+
+
+class TestDivergenceRegime:
+    """Where the port and scipy can disagree, and why no caller reaches it.
+
+    Measured over 11,274 random (integrand, tolerance, limit, points)
+    combinations against scipy 1.18.0. On the 4,461 that **converged**,
+    the port reproduced scipy's ``neval`` and ``last`` on all but 5
+    (0.11%) and landed within 3.6e-2 of the requested tolerance, 8.2e-11
+    relative at worst. Termination flags agreed on all 11,274.
+
+    On the 6,813 that **exhausted** ``limit`` the values can separate
+    without bound — 4.5e-5 relative in that sweep, and 11% on the
+    hand-picked case below. That is the epsilon algorithm being chaotic on
+    a sequence that is not converging, not a defect in the translation:
+    identical subdivision plus a few ulp of difference in the
+    extrapolation table is enough, and QUADPACK is not claiming an answer
+    there — it is reporting one it says it could not reach.
+
+    hazma never enters that regime. Every live shape in
+    :class:`TestLiveIntegrandShapes` returns ``ier = 0``, and the class
+    asserts it.
+    """
+
+    @staticmethod
+    def slowly_convergent(x: float) -> float:
+        # int_0^{1/2} dx / (x ln^2 x) = 1/ln 2 = 1.4427, approached far
+        # too slowly for QUADPACK to certify at any usable limit.
+        return 0.0 if x <= 0.0 or x >= 1.0 else 1.0 / (x * math.log(x) ** 2)
+
+    def test_the_subdivision_still_matches_when_the_limit_is_hit(self) -> None:
+        # The divergence is in the extrapolated value, not in the path:
+        # both implementations subdivide identically right up to the
+        # limit. Pinned so that a future translation bug — which would
+        # move `neval` — cannot hide behind "that regime is chaotic".
+        for limit in (50, 100, 200, 400):
+            settings = dict(epsabs=1e-10, epsrel=1e-10, limit=limit)
+            _sv, _sa, s_neval, s_last, s_converged = scipy_quad(
+                self.slowly_convergent, 0.0, 0.5, **settings
+            )
+            _v, _a, neval, last, ier = core_quad.quad(
+                self.slowly_convergent, 0.0, 0.5, **settings
+            )
+            assert not s_converged and ier != 0, "expected an abnormal end"
+            assert (neval, last) == (s_neval, s_last)
+            assert last == limit
+
+    def test_the_extrapolated_values_may_differ_there(self) -> None:
+        # Documented rather than tolerated silently: this is the one shape
+        # in this file where the two implementations give visibly
+        # different numbers, and the assertion records how different so a
+        # change in the gap shows up as a test failure.
+        settings = dict(epsabs=1e-10, epsrel=1e-10, limit=100)
+        s_value = scipy_quad(self.slowly_convergent, 0.0, 0.5, **settings)[0]
+        value = core_quad.quad(self.slowly_convergent, 0.0, 0.5, **settings)[0]
+        rel = abs(value - s_value) / abs(s_value)
+        assert _DIVERGENCE_GAP_MIN < rel < _DIVERGENCE_GAP_MAX, f"gap moved: {rel:.3e}"
+        # Both are still the same integral, roughly: the true value is
+        # 1/ln 2 and both land ~4e-3 short of it, which is what "QUADPACK
+        # could not certify this" looks like.
+        exact = 1.0 / math.log(2.0)
+        for got in (s_value, value):
+            assert abs(got - exact) / exact < _DIVERGENCE_GAP_MAX
+
+
+class TestAdaptiveHeuristics:
+    """The two branches inside the adaptive loop that nothing else reaches.
+
+    `qagpe`'s `ndin` flag and `qagse`'s roundoff counters are pure
+    heuristics: they change *which* subinterval is bisected next, never
+    the arithmetic, so on ordinary integrands they are invisible — a
+    mutation campaign found both survive every other test in this file.
+    The two inputs below were found by applying each mutation and
+    searching for a case whose answer moved: dropping `ndin` moves the
+    first by a factor of 48, and relaxing the roundoff threshold moves the
+    second by a factor of 2,800.
+
+    Both sit in the limit-exhausted regime (see
+    :class:`TestDivergenceRegime`), so both are asserted at a deliberately
+    **coarse** ``rtol = 1e-6``. That is not a weak gate for what it is
+    guarding: the defects it exists to catch move the answer by factors,
+    not by ulps, and a tight tolerance here would be pinning digits the
+    two implementations are entitled to disagree about.
+    """
+
+    def test_the_ndin_flag_promotes_a_degenerate_initial_panel(self) -> None:
+        # `qagpe` marks an initial subinterval whose 21-point rule reports
+        # `abserr == resasc` — a panel the rule cannot resolve at all — and
+        # replaces its error estimate with the *total* initial error, which
+        # sends it to the front of the subdivision order. sin(w/x) over a
+        # 39-point uniform grid has exactly one such panel, the one
+        # touching the essential singularity at 0.
+        w = 293.25358911967305
+        grid = [i / 40 for i in range(1, 40)]
+
+        def f(x: float) -> float:
+            return math.sin(w / max(x, 1e-14))
+
+        assert_matches_scipy(
+            f,
+            0.0,
+            1.0,
+            points=grid,
+            epsabs=1e-10,
+            epsrel=1e-10,
+            limit=50,
+            rtol=1e-6,
+            label="ndin-sensitive oscillatory integrand",
+        )
+
+    def test_the_roundoff_counters_gate_the_extrapolation(self) -> None:
+        # `iroff1`/`iroff2` count bisections that barely improved the
+        # estimate (`erro12 >= 0.99 * errmax`), and ten of them set
+        # `ier = 2` and stop the extrapolation. A near-delta spike with a
+        # break point on the wrong side of it produces exactly that
+        # sequence.
+        centre = 0.16308536762834644
+
+        def f(x: float) -> float:
+            return 1.0 / ((x - centre) ** 2 + 1e-12)
+
+        assert_matches_scipy(
+            f,
+            0.0,
+            1.0,
+            points=[0.5],
+            epsabs=1e-12,
+            epsrel=1e-12,
+            limit=20,
+            rtol=1e-6,
+            label="roundoff-counter-sensitive spike",
+        )
+
+
+class TestErrorBehavior:
+    """Never panic across FFI; raise where scipy raises, warn where it warns."""
+
+    def test_invalid_tolerances_raise_on_both_sides(self) -> None:
+        with pytest.raises(ValueError):
+            si.quad(math.exp, 0.0, 1.0, epsabs=0.0, epsrel=0.0)
+        with pytest.raises(ValueError):
+            core_quad.quad(math.exp, 0.0, 1.0, epsabs=0.0, epsrel=0.0)
+
+    def test_a_zero_limit_raises_on_both_sides(self) -> None:
+        with pytest.raises(ValueError):
+            si.quad(math.exp, 0.0, 1.0, limit=0)
+        with pytest.raises(ValueError):
+            core_quad.quad(math.exp, 0.0, 1.0, limit=0)
+
+    def test_hitting_the_subdivision_limit_reports_and_returns(self) -> None:
+        # int_0^1 dx/x diverges. scipy warns and hands back the partial
+        # sum; the port returns the same partial sum with a non-zero ier
+        # instead of warning, because hazma's call sites read `[0]` and
+        # never see a warning.
+        def f(x: float) -> float:
+            return 0.0 if x == 0.0 else 1.0 / x
+
+        s_value, _s_abserr, s_neval, s_last, s_converged = scipy_quad(
+            f, 0.0, 1.0, epsabs=1e-10, epsrel=1e-10, limit=10
+        )
+        assert not s_converged, "scipy was expected to terminate abnormally here"
+        value, _abserr, neval, last, ier = core_quad.quad(
+            f, 0.0, 1.0, epsabs=1e-10, epsrel=1e-10, limit=10
+        )
+        assert ier != 0
+        assert (neval, last) == (s_neval, s_last)
+        assert value == pytest.approx(s_value, rel=SINGULAR_RTOL)
+        assert math.isfinite(value)
+
+    def test_an_exception_in_the_integrand_propagates(self) -> None:
+        sentinel = RuntimeError("integrand exploded")
+        calls = []
+
+        def f(x: float) -> float:
+            calls.append(x)
+            raise sentinel
+
+        with pytest.raises(RuntimeError) as excinfo:
+            core_quad.quad(f, 0.0, 1.0)
+        assert excinfo.value is sentinel
+        # The integrand short-circuits after the first failure rather than
+        # being called once per node for the rest of the run.
+        assert len(calls) == 1
+
+    def test_a_non_float_return_from_the_integrand_is_an_error(self) -> None:
+        with pytest.raises((TypeError, ValueError)):
+            core_quad.quad(lambda x: "not a number", 0.0, 1.0)
+
+    def test_a_nan_integrand_does_not_crash(self) -> None:
+        value = core_quad.quad(lambda x: float("nan"), 0.0, 1.0)[0]
+        assert math.isnan(value) or value == 0.0
+
+    def test_a_zero_width_interval_is_zero(self) -> None:
+        value, _abserr, _neval, _last, ier = core_quad.quad(math.exp, 1.5, 1.5)
+        assert value == 0.0
+        assert ier == 0
+        assert si.quad(math.exp, 1.5, 1.5)[0] == 0.0

--- a/test/test_core_quad.py
+++ b/test/test_core_quad.py
@@ -304,7 +304,7 @@ class TestBreakPointPreprocessing:
     def test_an_empty_points_list_still_selects_qagp(self) -> None:
         # scipy dispatches on `points is None` *before* it filters, so an
         # empty-after-filtering list runs qagpe, not qagse. That is the
-        # branch all six `points=[-1, 1]` call sites take, and it is
+        # branch all five `points=[-1, 1]` call sites take, and it is
         # normally invisible: over 3,776 random (integrand, tolerance,
         # limit) combinations the two routines returned identical values,
         # identical `neval` and identical `last` in every case that
@@ -922,11 +922,43 @@ class TestErrorBehavior:
         with pytest.raises(ValueError):
             core_quad.quad(math.exp, 0.0, 1.0, epsabs=0.0, epsrel=0.0)
 
-    def test_a_zero_limit_raises_on_both_sides(self) -> None:
+    @pytest.mark.parametrize("limit", [0, -1, -100])
+    def test_a_limit_below_one_raises_value_error_on_both_sides(
+        self, limit: int
+    ) -> None:
+        # scipy rejects every `limit < 1` the same way ("there must be at
+        # least one subinterval"), negatives included. The port must not
+        # let PyO3's `usize` conversion turn a negative into an
+        # `OverflowError` — a different exception type for an input scipy
+        # treats identically to `limit = 0` (PR #60 review).
         with pytest.raises(ValueError):
-            si.quad(math.exp, 0.0, 1.0, limit=0)
+            si.quad(math.exp, 0.0, 1.0, limit=limit)
         with pytest.raises(ValueError):
-            core_quad.quad(math.exp, 0.0, 1.0, limit=0)
+            core_quad.quad(math.exp, 0.0, 1.0, limit=limit)
+
+    @pytest.mark.parametrize("limit", [2**31, 10**12])
+    def test_a_limit_past_c_int_range_overflows_on_both_sides(self, limit: int) -> None:
+        # The other half of scipy's `limit` contract: it converts the
+        # argument to a C `int` and raises `OverflowError` above INT_MAX.
+        # Matching it is also what keeps the `limit`-length workspace in
+        # `qagse`/`qagpe` from becoming a multi-terabyte allocation
+        # request — `limit = 10**12` was accepted before this guard, and
+        # whether that survives is a property of the platform's overcommit
+        # policy rather than of the code (PR #60 review).
+        with pytest.raises(OverflowError):
+            si.quad(math.exp, 0.0, 1.0, limit=limit)
+        with pytest.raises(OverflowError):
+            core_quad.quad(math.exp, 0.0, 1.0, limit=limit)
+
+    def test_the_largest_accepted_limit_is_not_rejected(self) -> None:
+        # The boundary itself: INT_MAX is legal on both sides, so
+        # narrowing the guard by one would not go unnoticed. Only the
+        # argument check is exercised — a smooth integrand converges on
+        # the first panel and never allocates the full workspace.
+        assert core_quad.quad(math.exp, 0.0, 1.0, limit=2**31 - 1)[4] == 0
+        assert si.quad(math.exp, 0.0, 1.0, limit=2**31 - 1)[0] == pytest.approx(
+            math.e - 1.0, rel=SMOOTH_RTOL
+        )
 
     def test_hitting_the_subdivision_limit_reports_and_returns(self) -> None:
         # int_0^1 dx/x diverges. scipy warns and hands back the partial


### PR DESCRIPTION
## Summary

- **Ports the QUADPACK subset hazma integrates with** — `qk15`, `qk21`,
  `qelg`, `qpsrt`, `qagse`, `qagpe` — from the public-domain netlib
  Fortran into `rust/src/quad.rs`, plus the scipy-shaped `quad` driver a
  Phase 04–06 kernel will actually call. PyO3-free (rules.md rule 8), and
  deliberately **literal**: 1-based indexing preserved, every `go to` a
  labelled `break` carrying its Fortran statement number, so the two can
  be read side by side. Provenance header per rules.md rule 5 — nothing
  GSL-derived, exactly what ADR-0002 prescribes.
- **The break-point contract turned out to belong to scipy, not to
  QUADPACK.** `scipy.integrate.quad` filters `points` in Python
  (`np.unique`, then strictly interior) before `qagpe` ever sees them, so
  both live degeneracies are *discards*: `points=[-1, 1]` on `[-1, 1]`
  leaves zero break points, and a heavy mediator's entries fall outside
  the thermal interval. Designed from the QUADPACK documentation instead,
  the five `points=[-1, 1]` call sites would have **errored** — QUADPACK
  rejects a break point equal to an endpoint. A second consequence:
  `points is None` selects `qagse`, *"no break point survived"* does not,
  so five of the twelve live call sites run `qagpe` with an empty list.
- **No public value changes.** The only diff under `hazma/` is a comment
  block in the non-executable `hazma/_core.pyi` stub (verified:
  `git diff origin/master -- hazma`). Nothing under `hazma/` imports the
  new code; the parity corpus ran in bit-equality mode with the skip
  count unchanged at 13, which is what proves the mode.
- **Measured against scipy 1.18.0** over 11,274 random (integrand,
  tolerance, limit, points) combinations: on the 4,461 runs that
  **converged**, the port reproduced scipy's `neval` and `last` on all but
  5 (0.11%), agreed on the termination flag every time, and landed within
  **3.6e-2 of the requested tolerance** (8.2e-11 relative at worst) —
  against the 10× the exit criteria allow. Runs that exhaust `limit` can
  diverge, because Wynn's ε-algorithm is chaotic on a sequence that is not
  converging; **no live integrand shape reaches that regime**, and each
  asserts `ier = 0`.
- `hazma._core.quad` is a **test surface**, joining `hazma._core.special`
  in `cases._CORE_TEST_ONLY_MODULES` under the existing importer guard —
  the same mechanism Task 3.2 built, not a widened exemption.

## Project

`projects/cython-to-rust/` — Phase 03, Task 3.3: QUADPACK port
(qk15/qk21/qelg/qags/qagp).

See `projects/cython-to-rust/task-notes/phase-03/task-3.3-quadpack.md`
for detail, including the seventeen-mutation validity campaign and the
`## Stale-state sweep` block.

Two canonical documents are patched in this same PR: the phase file's
Task 3.3 block gains four "criteria added during execution" bullets, and
`references/numerics-replacements.md` gains the measured break-point
contract — its own instruction was to pin it empirically, so the answer
belongs there rather than only in a task note.

## Review round 1 (2026-08-10)

Both blocking findings were valid and are fixed in `8adcc7e`.

1. **Live call-site counts were inconsistent.** Re-derived by classifying
   each `.pyx` match as live or commented: **12 live** call sites (and 11
   commented), of which **5** pass `points=[-1, 1]` — the sixth
   `points=[-1, 1]` match, `hazma/spectra/_positron/_muon.pyx:134`, is
   commented out. The reviewer's count was right and mine was not. Worth
   noting *how* the first sweep missed copies: it grepped the paired
   phrases the number usually appeared in (`eleven`, `six of the
   eleven`), fixed twelve occurrences, and then recorded "all twelve
   occurrences were swept" — a completeness claim the pattern could not
   support. Re-sweeping on the *claim* instead (any numeral or number
   word within 40 characters of `call site` / `points=[-1`, either order)
   found the copy the reviewer cited **and a fourteenth** in
   `test/test_core_quad.py:307`. Both are fixed, the sweep record now
   says what the grep actually established, and the class is appended to
   `docs/agents/lessons.md` under `[sibling-copies-of-a-fixed-claim]`.
2. **The probe's error contract was inaccurate.** `limit = -1` died in
   PyO3's `usize` conversion with `OverflowError` where scipy raises
   `ValueError`, so the docstring's "raises `ValueError` for exactly the
   inputs scipy raises `ValueError` for" was false. `quad_py` now takes
   `i64` and reproduces **both** of scipy's rejections: `limit < 1` folds
   onto `0` and takes the existing `QuadError::LimitTooSmall` path, and
   `limit > i32::MAX` raises `OverflowError` exactly as scipy's own C-`int`
   conversion does.

   The upper guard turned out to matter beyond the contract: `limit`
   sizes the `qagse`/`qagpe` workspace at 16 bytes an entry, so
   `limit = 10**12` was a **16 TB allocation request** that this machine
   satisfied lazily — whether it survives is a property of the platform's
   overcommit policy, not of the code, against an exit criterion that
   says "never panics across FFI". Six new tests, each validity-checked
   by mutation: removing the overflow guard fails both
   `..._past_c_int_range_overflows...` cases, and folding negatives to
   `50` instead of `0` fails both negative `..._below_one_...` cases.

**On the environment difference you noted** — your `1206 passed, 14
skipped` under Python 3.13 / NumPy 2.5.2 against my `1207 / 13` is the
documented Task 3.1 mechanism, not a discrepancy: the corpus manifest
records NumPy 2.5.1, so 2.5.2 puts `tolerances.provenance` into budget
mode and drops exactly one test from passed to skipped. The counts differ
by exactly that one test in exactly that direction.

## Review round 2 (2026-08-10)

All three blocking findings were valid; fixed in `9285fb0`.

1. **Eager workspace allocation — the serious one.** `qagse` allocated
   five `limit`-length arrays up front and `qagpe` six, so `limit =
   i32::MAX` (which round 1 made this port *accept*, matching scipy)
   reserved ~80 GiB and ~88 GiB before the first panel was evaluated.
   Rust aborts on allocation failure rather than unwinding, so it could
   never have become a Python exception. **Round 1 capped `limit` and
   left the identical hazard directly below the cap**, and the test it
   added asserted the opposite. The arrays now seed at 64 subintervals
   (or the initial partition) and double, capped at `limit + 2`; every
   index in both routines is at most `last`, which grows by one per
   iteration. Three `cargo` tests, the decisive one asking for
   `usize::MAX / 4096` — a size no allocator can satisfy, so it
   discriminates on every platform rather than only where the allocator
   declines to overcommit. Reverting to eager sizing dies with
   `memory allocation of 36028797018963976 bytes failed` / SIGABRT.

   Worth recording why round 1's evidence was worthless: peak RSS at
   `limit = INT_MAX` moved 18.2 → 18.6 MB, because macOS maps zero pages
   lazily. The reservation was real and the measurement could not see it.

2. **`numerics-replacements.md` self-contradictory** — it held *three*
   counts of one fact (four at :105, five at :132, six at :136). Fixed to
   five. This was a second failure of the sweep method, not a straggler:
   round 1's fix was "key the sweep on the claim, not the phrasing", but
   that was still **line**-oriented, and two survivors wrapped across a
   newline while a third used a synonym (`those six sites` against an
   anchor of `call site`). Re-sweeping after reflowing each file to one
   line found those *and a fifteenth* copy in `test_core_quad.py:236`,
   which was wrong twice over. The ledger entry now says to reflow before
   matching and to alternate synonyms.

3. **Stale test-count records.** Re-derived from the final tree rather
   than adjusted: 58 Python tests (8 classes), 43 `cargo` units,
   `1212 passed, 13 skipped`. The class was wider than the two lines
   cited — 13 stale counts across three bookkeeping files, all swept.

**Re-measured after the behavior change**, as a workspace change is a
behavior change: the 11,274-combination scipy-agreement sweep reproduces
**byte-identically** (4,461 converged, 5 subdivision mismatches,
8.192e-11 worst relative, 3.570e-2 of the requested tolerance). The fix
changed when memory is obtained, not any value, so every agreement figure
above stands unchanged.

**On the unverified full-suite count:** it has now run to completion here
twice at `1212 passed, 13 skipped` (round 1 and round 2 preflight, 9m03s
and 9m26s). If it stays out of reach in your window, that is the number
to challenge rather than accept.

## Test plan

- [x] `scripts/agents/preflight.sh --paths … --md …` → **RESULT: PASS**
      across all eleven rows.

  ```text
  PASS   black --check           test/parity/cases.py test/parity/test_parity.py test/test_core_quad.py
  PASS   isort --check-only      test/parity/cases.py test/parity/test_parity.py test/test_core_quad.py
  PASS   ruff check              test/parity/cases.py test/parity/test_parity.py test/test_core_quad.py
  PASS   cargo fmt --check       rust/
  PASS   cargo clippy            rust/
  PASS   cargo test              rust/
  PASS   pytest                  1212 passed, 13 skipped, 5 warnings in 543.09s (0:09:03)
  PASS   import hazma            version 2.1.0
  PASS   markdownlint            <6 changed docs>
  SKIP   version bump            not a closing PR (pass --closing)
  PASS   forbidden tokens        none added
  RESULT: PASS
  ```

- [x] `pytest -q` → `1212 passed, 13 skipped` (+58 on Task 3.2's
      `1154 passed, 13 skipped`, all of them this task's new tests). The
      **skip count is unchanged**, which is what proves the parity corpus
      ran in bit-equality mode; confirmed independently beforehand with
      `tolerances.provenance(manifest)` → `Provenance(exact=True, detail='')`.

- [x] `pytest test/test_core_quad.py -q` → `58 passed in 5.10s`
      (8 classes; population derived with
      `pytest --collect-only -q | awk -F'::' '/::/{print $2}' | sort | uniq -c`).

- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features`
      → `43 passed` (27 new; `grep -c '#\[test\]' rust/src/quad.rs` → 27).

- [x] **Table provenance.** The Gauss–Kronrod literals were extracted from
      the Fortran `data` statements by script, and re-checked as f64 bit
      patterns by a second script that parses both sides independently of
      the crate → `MISMATCHES: 0`.

- [x] **Seventeen mutations** against `rust/src/quad.rs`, each applied
      alone from a green baseline and reverted after, with the baseline
      re-asserted green at the end. All seventeen are caught; the two that
      survived the first pass (`ndin`, the roundoff counters) are why
      `TestAdaptiveHeuristics` exists. Table in the task note.

