### PR TITLE
feat(utils): port the interp and boost kernels to rust

### DIFF
--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -366,3 +366,19 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   survived an edge-case test that checked `+0.0` and `-1.0`). Generalizes
   past zero: any guard the upstream applies *before* its arithmetic has to
   be re-applied by a caller that does arithmetic *after* it.
+- [platform-scoped-oracle-asserted-globally] A test that compares a port
+  against a *locally compiled* oracle — the Cython twin, NumPy, anything
+  the platform's C compiler built — is asserting a property of that
+  build, not only of the port. Fused multiply-add is the usual culprit:
+  `-ffp-contract=on` is the C default, so an oracle compiled for a target
+  with hardware FMA computes different numbers than one without, and a
+  bit-for-bit assertion that is exactly right on the reference platform
+  fails everywhere else (PR #61: 19 assertions in
+  `test/test_core_{interp,boost}.py` passed on macOS/arm64 and failed on
+  Linux/x86-64, where neither NumPy nor the Cython contracts). Measure
+  the platform property at import and skip the comparison where it does
+  not hold, as `test/parity` already does — do not loosen to a tolerance,
+  because the worst relative gap between two roundings lands at whatever
+  cancellation point the domain contains and a tolerance wide enough for
+  that hides real defects. The tell you are about to make this mistake:
+  the oracle is something you compiled rather than something you pinned.

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -32,6 +32,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [parity corpus pins ill-conditioned points](todo/parity-corpus-pins-ill-conditioned-points.md) | 2026-08-07 | cython-to-rust Task 1.3 (PR #52) | project |
 | [model spectrum dicts reject scalar energies](todo/model-spectra-reject-scalar-energies.md) | 2026-08-08 | cython-to-rust Task 1.4 | cross-cutting |
 | [positron spectra return `nan` at the legacy `MASS_E`](todo/positron-spectrum-nan-at-legacy-electron-mass.md) | 2026-08-08 | cython-to-rust Task 1.4 | cross-cutting |
+| [the boost integral mis-covers its window at both ends](todo/boost-integral-drops-last-interior-cell.md) | 2026-08-10 | cython-to-rust Task 3.4 | cross-cutting |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/boost-integral-drops-last-interior-cell.md
+++ b/docs/followups/todo/boost-integral-drops-last-interior-cell.md
@@ -1,0 +1,145 @@
+# The boost integral mis-covers its window at both ends
+
+- **Added:** 2026-08-10
+- **Source:** cython-to-rust Task 3.4 (the interp + boost port)
+- **Scope:** cross-cutting
+- **Status:** open
+- **Triggers / blockers:** must land **after** Phase 06 Task 6.4 (the
+  last Cython deletion). Repairing it before then would put the Rust and
+  the Cython on different answers while both are alive, and the parity
+  corpus — which pins the *current* values — would have to be regenerated
+  in the same change, which `projects/cython-to-rust/rules.md` rule 2
+  forbids for a tree with ported kernels.
+
+## Why
+
+`boost_integrate_linear_interp` sums whole interior cells with
+
+```python
+np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])
+```
+
+(`hazma/_utils/boost.pyx:216`). The slice is exclusive at the top, so the
+sum covers the cells ending at `x[ihigh - 1]` and stops. The upper
+partial-cell term that follows starts at `x[ihigh]`. Nothing covers
+`[x[ihigh - 1], x[ihigh]]`.
+
+The sharpest form: when the boosted window reaches past the table, `ub`
+is clamped to `x[-1]` and `ihigh` becomes the last index, so the upper
+partial-cell term is skipped entirely and **the table's final row
+contributes to no term at all**. Replacing it with a value six orders of
+magnitude larger leaves the answer bit-identical — checked against the
+live Cython, `test/test_core_boost.py::TestDroppedInteriorCell`.
+
+This is a real error in a published number, not a rounding artifact. On a
+hand-computable case (`x = y = [1, 2, 3, 4]`, `beta = 0.6`, `E = 2.2`)
+the routine returns `1.9 / (2γβ)` where the region it claims to integrate
+is worth `2.9 / (2γβ)` — 34% low.
+
+The same off-by-one read from the other side is far worse. When both
+bounds land inside **one** cell, `ilow` is the node above `lb` and
+`ihigh = ilow - 1` is the node below `ub`, so the two partial-cell terms
+integrate `[lb, x[ilow]]` and `[x[ihigh], ub]` — which **overlap**, and
+between them cover about two whole cells instead of the sliver between
+the bounds. The over-count is the ratio of the cell width to the window
+width, and the window width is `2Eγβ`, so it **diverges as the parent
+slows down**. Measured against the live Cython on `x = y = [1..6]`,
+`beta = 0.01`, `E = 3.5`: 53.497 returned against 3.500 intended, a
+factor of 15.3, predicted exactly by the overlap arithmetic.
+
+That regime is not hypothetical — it is the threshold region every model
+spectrum passes through. All seven public tabulated photon spectra
+diverge instead of converging to their own rest-frame spectrum as the
+parent approaches rest. At `E_γ = m/10` and a parent one part in 1e12
+above rest, against the same function evaluated exactly at rest:
+
+| channel | at rest | one part in 1e12 above rest | ratio |
+| --- | --- | --- | --- |
+| `dnde_photon_eta` | 0.02313 | 767.2 | 33,000 |
+| `dnde_photon_eta_prime` | 0.020022 | 130.35 | 6,500 |
+| `dnde_photon_charged_kaon` | 0.0039628 | 38.625 | 9,700 |
+| `dnde_photon_long_kaon` | 0.015173 | 148.6 | 9,800 |
+| `dnde_photon_short_kaon` | 0.0060399 | 59.174 | 9,800 |
+| `dnde_photon_omega` | 0.0089247 | 87.403 | 9,800 |
+| `dnde_photon_phi` | 0.011033 | 71.716 | 6,500 |
+
+(MeV⁻¹; `hazma` 2.1.0, this worktree, 2026-08-10.) The exact-rest column
+is right because the callers short-circuit at `E − M < DBL_EPSILON` and
+return the rest-frame spectrum directly; one ulp above that short circuit
+the integral takes over and is wrong by three to four orders of
+magnitude. Away from threshold the same defect shrinks to the gap case
+above — one cell out of a wide window, systematically low.
+
+The parity corpus pins these values, faithfully: its `rest_plus_eps`
+block sits exactly in the divergent regime. That is the corpus doing its
+job (it records what the Cython returns, not what is correct), and it is
+why the repair has to regenerate the corpus in the same change.
+
+Note `references/cython-inventory.md` already lists "off-by-one index
+pairing in `boost_integrate_linear_interp_massive`" under *dead* code.
+This is the same class in the **live** routine, which that audit did not
+flag.
+
+## What
+
+Change the interior sum to include the cell ending at `ihigh` — most
+directly by slicing `[ilow : ihigh + 1]` — and then re-derive the upper
+partial-cell term so the two do not overlap. Note the lower end is
+already contiguous (`ilow`'s partial cell ends exactly where the sum
+begins), so only the upper end needs the work.
+
+Fix the overlapping single-cell case in the same change: when
+`ilow > ihigh`, neither partial-cell term should run whole — the answer
+is the integral of one linear interpolant over `[lb, ub]`, which is a
+third closed form rather than a repair of the other two. This is the
+larger of the two errors by far and the reason the near-threshold limit
+is wrong; both are the same off-by-one read from different sides and
+neither should be fixed alone.
+
+A cheap regression to add alongside: for each of the seven channels,
+`dnde_photon_X(E, m * (1 + 1e-12))` must approach `dnde_photon_X(E, m)`.
+That identity holds for no channel today and would hold for all seven
+after the repair, so it is the natural acceptance test.
+
+The change moves published numbers for the seven tabulated photon
+spectra — `dnde_photon_{eta, eta_prime, charged_kaon, long_kaon,
+short_kaon, omega, phi}` — and therefore for every model spectrum that
+sums them. Quantify the shift on the corpus grids, state it in the PR
+body and in `CHANGELOG.md`, and regenerate the parity corpus in the same
+change (a deliberate, declared regeneration, which is the only kind rule 2
+allows).
+
+## Entry points
+
+- `hazma/_utils/boost.pyx:206-241` — the interior sum and both partial
+  cells.
+- `rust/src/boost.rs` — `boost_integrate_linear_interp`, where the
+  behavior is reproduced with the reasoning in its
+  `# Faithfulness notes`.
+- `test/test_core_boost.py::TestDroppedInteriorCell` — the pin to invert
+  when this is fixed.
+- `projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md`
+  — how it was found and the numbers above.
+- `test/parity/tolerances.py` — the `TABULATED` budget class, which is
+  what these seven cases are graded against.
+
+## Risks / open questions
+
+- **How big is it away from threshold?** Measured only as a ratio against
+  an independent reference (the linear interpolant integrated on a dense
+  grid), which is not a repair and does not reproduce every branch. Over
+  a sweep of nine boost regimes and 300 energies per table, the returned
+  value lands between 0.02× and 161× the reference, with the extremes at
+  the smallest boosts and the well-boosted regimes close to 1. Redo this
+  properly against the actual repair before quoting a figure in a
+  CHANGELOG.
+- **How far downstream does it reach?** The tabulated spectra feed
+  branching-fraction-weighted sums in `hazma/theory/`, so every model
+  `total_spectrum` inherits whatever these do near threshold — and
+  threshold is exactly where an indirect-detection spectrum is
+  interesting. Check whether any published figure, limit, or notebook in
+  `docs/source/` or `notebooks/` sits in the affected region.
+- **Does anything depend on the current behavior?** The parity corpus
+  does, by construction, and it is regenerated as part of this work. Look
+  for anything else pinned to a near-threshold tabulated spectrum before
+  assuming the corpus is the only consumer.

--- a/hazma/_core.pyi
+++ b/hazma/_core.pyi
@@ -7,17 +7,22 @@ import numpy as np
 # vector_mediator — exist but are empty until Phases 03-06 fill them;
 # each gets its own stub alongside its first kernel.
 #
-# Two further submodules, `special` (cython-to-rust Task 3.2) and `quad`
-# (Task 3.3), are deliberately not stubbed. `special` exposes `spence`,
-# `bessel_k1` and `bessel_kn` only so `test/test_core_special.py` can
-# sweep them against scipy — its three functions follow the same dispatch
-# contract `roundtrip` documents below. `quad` exposes the QUADPACK port
-# only so `test/test_core_quad.py` can put one Python integrand through
-# both it and `scipy.integrate.quad`; it takes a callable rather than an
-# array and so has no dispatch contract to describe. The kernels that
-# will use either call the Rust side directly, and nothing under `hazma/`
-# imports them — a stub would advertise a surface this package does not
-# mean to offer.
+# Four further submodules — `special` (cython-to-rust Task 3.2), `quad`
+# (Task 3.3), and `interp` and `boost` (Task 3.4) — are deliberately not
+# stubbed. `special` exposes `spence`, `bessel_k1` and `bessel_kn` only so
+# `test/test_core_special.py` can sweep them against scipy; `interp` and
+# `boost` expose the interpolation and boost foundation only so
+# `test/test_core_interp.py` can sweep against `np.interp` and
+# `test/test_core_boost.py` against the Cython twin through
+# `hazma._utils.boost.__pyx_capi__`. Those three follow the same dispatch
+# contract `roundtrip` documents below, on the argument their Cython call
+# sites sweep. `quad` exposes the QUADPACK port only so
+# `test/test_core_quad.py` can put one Python integrand through both it
+# and `scipy.integrate.quad`; it takes a callable rather than an array and
+# so has no dispatch contract to describe. The kernels that will use any
+# of them call the Rust side directly, and nothing under `hazma/` imports
+# them — a stub would advertise a surface this package does not mean to
+# offer.
 
 # `roundtrip` is the scaffold's plumbing probe, not physics. It follows
 # the dispatch contract every ported entry point uses: a Python float, a

--- a/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/phases/phase-03-numerics-foundation.md
@@ -182,6 +182,65 @@ reshapes the other three):
   above-table clamp, β→0 guard) pinned against the Cython originals
   via dedicated micro-fixtures captured in Phase 01.
 
+**Criteria added during execution** (2026-08-10; the second bullet's
+"micro-fixtures captured in Phase 01" turned out not to exist, and what
+replaced them changed what the other criteria could be held to):
+
+- **The oracle is the live Cython, not a fixture.** Phase 01's corpus
+  enumerates top-level `def`s in the surviving `.pyx`, and every routine
+  in this task is `cdef` — private to the C level and invisible to the
+  corpus by construction, so no micro-fixture was ever captured and none
+  could have been. `boost.pxd` declares the `cdef`s, which makes Cython
+  export them through `hazma._utils.boost.__pyx_capi__` as capsules, so
+  `test/test_core_boost.py` calls the *live* kernel through `ctypes` at
+  whatever arguments a test picks. Two mechanical constraints, both
+  found the hard way: the shim must use `ctypes.PYFUNCTYPE` rather than
+  `CFUNCTYPE`, because the latter releases the GIL and
+  `boost_integrate_linear_interp` calls `np.trapezoid` (a `CFUNCTYPE`
+  call segfaults); and the capsule's *name* is its C signature, so a
+  changed argument list is checkable rather than a stack corruption
+  waiting to happen.
+- **The port must reproduce the C compiler's fused multiply-adds, and
+  the criterion is bit-equality rather than a tolerance.** Clang
+  contracts `a*b + c` by default and the corpus's capturing platform
+  (macOS/arm64) does so at five sites in `boost.pyx` and one inside
+  NumPy's `arr_interp`. Written the obvious unfused way the port misses
+  the corpus by up to **3.6e-12** relative *on the corpus's own grids*
+  for the seven tabulated photon spectra — past the 1e-12 `TABULATED`
+  budget, so the Phase 04 swap would have failed its own gate. With the
+  contraction reproduced via `f64::mul_add` the port is bit-equal at
+  every one of those points. Each site was established twice, by
+  disassembling the shipped `.so` and by bisecting the 16 combinations
+  against the live kernel. **Where the Cython does not contract, the
+  port must not either:** `boost_beta` spells its square as
+  `(mass/energy) ** 2`, whose rounded product completes before the
+  subtraction, and none of its ten inlining call sites contract it.
+- **The interior sum drops a whole cell, and that is reproduced.**
+  `np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])` is exclusive at the
+  top while the upper partial-cell term starts at `x[ihigh]`, so
+  `[x[ihigh-1], x[ihigh]]` is covered by nothing — and when the window
+  reaches past the table the table's **final row contributes to no term
+  at all**. Systematic and one-signed (the boosted spectrum is always
+  slightly low). Preserved per rules.md rule 1 and pinned in both
+  languages; the repair is
+  [`../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md),
+  blocked until after Phase 06 Task 6.4 because it needs a declared
+  corpus regeneration.
+- **`interp`'s contract is NumPy's, quirks included.** The exit
+  criterion names three behaviors; there are two more that a
+  spec-driven port would miss. A one-point grid answers *everything*
+  with `fp[0]`, NaN included, because NumPy's NaN check lives on the
+  multi-point path only; and duplicate abscissae resolve to the **last**
+  matching node, not the first. Both are pinned against `np.interp` in
+  the same assertion that pins them, so the pin cannot drift from the
+  thing it pins.
+- **The corpus's served-kernel predicate stays sound.** `interp` and
+  `boost` are exposed as `hazma._core.interp` and `hazma._core.boost`
+  because both oracles live in Python, and both join
+  `cases._CORE_TEST_ONLY_MODULES` under the importer guard Task 3.2
+  built — the same mechanism, not a widened exemption. Third instance of
+  `docs/agents/lessons.md` `[gate-disabled-stays-green]` in this project.
+
 ### Task 3.5: Dispatch and error layer
 
 **Task note:** [`../task-notes/phase-03/task-3.5-dispatch.md`](../task-notes/phase-03/task-3.5-dispatch.md)

--- a/projects/cython-to-rust/references/numerics-replacements.md
+++ b/projects/cython-to-rust/references/numerics-replacements.md
@@ -186,6 +186,66 @@ uses a 1e-6 absolute tolerance; `assert 0.0 < beta < 1.0` guards the
 `boost_delta_function` (boosted Dirac δ for two-body lines) is closed
 form: `1/(2γβk₀)` inside the boosted support window, else 0.
 
+### Measured, Task 3.4 (2026-08-10): fused arithmetic, and a dropped cell
+
+Three facts the two sections above are silent about, each of which
+changes what the port has to be. All were measured against the live
+Cython through `hazma._utils.boost.__pyx_capi__` (the `cdef`s are
+declared in `boost.pxd`, so Cython exports them as capsules and `ctypes`
+can call them — with `PYFUNCTYPE`, since `CFUNCTYPE` drops the GIL and
+the integral calls back into NumPy).
+
+**1. The compiler contracts, and the port has to as well.** Clang's
+default is `-ffp-contract=on`, so `a*b + c` becomes a fused
+multiply-add. The corpus's capturing platform (macOS/arm64) contracts
+eight distinct expressions across these routines — `1 - β²` in both the
+integral and the line, `e² - m²` and `e0² - m²` and `e ∓ βk` in the line,
+and `y1 - m·x1`, `0.5·m·(x2 + lb) + b` and the accumulation itself in
+each partial cell (twelve `mul_add` call sites in the Rust) — plus
+`slope·(x - xp[j]) + fp[j]` inside NumPy's own `arr_interp`. Written
+unfused, the Rust port misses the corpus by up to
+**3.6e-12** relative on the corpus's own grids for the seven tabulated
+photon spectra, against the 1e-12 `TABULATED` budget; written with
+`f64::mul_add` at those sites it is **bit-equal at every point**. The
+sites were established twice over — by disassembling the shipped
+`hazma/_utils/boost.cpython-312-darwin.so` for `fmsub`/`fmadd`, and by
+bisecting all 16 on/off combinations against the live kernel (only the
+all-on combination reaches zero mismatches).
+
+The converse matters as much: `boost_beta` spells its square as
+`(mass/energy) ** 2`, whose rounded product completes before the
+subtraction, and **none** of its ten inlining call sites contract
+`1 - t` (checked in `_eta`, `_kaon`, `_positron/_pion`). Fusing it would
+move every boosted spectrum. "The compiler contracts" is a per-expression
+fact, not a per-file one.
+
+**2. `np.trapezoid` reduces pairwise, not sequentially.** The interior
+sum goes through `ndarray.sum`, which runs eight accumulators over
+128-element blocks and recurses above that. A sequential sum in Rust is a
+different number — up to 1.8e-15 relative on the 500-row tables. The port
+mirrors the blocking; the pin is a comparison against the live
+`np.trapezoid` rather than a comment.
+
+**3. The interior sum never covers its last cell.**
+`np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])` is exclusive at the top
+while the upper partial-cell term starts at `x[ihigh]`, so
+`[x[ihigh-1], x[ihigh]]` belongs to no term. When the window reaches past
+the table, `ihigh` is the last index and the upper term is skipped
+entirely, so the table's **final row contributes to nothing** — checked
+by replacing it with a value six orders larger and getting a bit-identical
+answer from both implementations. The error is systematic and one-signed:
+the boosted spectrum is always slightly low. Preserved per `rules.md`
+rule 1; repair tracked in
+[`../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
+
+Two smaller facts for Phase 04. The live tables are rows of a transposed
+`np.loadtxt` result, so they are **strided views, not contiguous
+buffers** — anything taking a `PyReadonlyArray1` must copy rather than
+`as_slice`. And `np.interp` has two behaviors the section above does not
+list: a one-point grid answers everything with `fp[0]`, NaN included
+(NumPy's NaN check lives on the multi-point path only), and duplicate
+abscissae resolve to the *last* matching node.
+
 ## The cyphus crates (assessed 2026-08-03)
 
 Logan's 2020–2022 GSL ports at github.com/rust-cyphus, evaluated for

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -506,6 +506,19 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   *dead* `boost_integrate_linear_interp_massive`; the live twin was never
   flagged, which is worth remembering before trusting that audit's
   coverage of the surviving code.
+- **A test whose oracle is something *you compiled* is scoped to that
+  build** (Task 3.4, PR #61 review round 1). Nineteen bit-equality
+  assertions against the Cython and NumPy passed on macOS/arm64 and failed
+  on Linux/x86-64, because `-ffp-contract=on` is the C default and only a
+  target with hardware FMA actually contracts — so the assertion was a
+  statement about the platform, not about the port. The fix is to measure
+  the property at import and skip where it does not hold, which is what
+  `test/parity` already does (CI: `pytest --ignore=test/parity` off
+  macOS); loosening to a tolerance is wrong, because the worst relative
+  gap between two roundings lands at whatever cancellation point the
+  domain contains. **Every Phase 04–06 kernel test that uses the Cython
+  twin as its oracle inherits this** —
+  `docs/agents/lessons.md` `[platform-scoped-oracle-asserted-globally]`.
 - **A `cdef` declared in a `.pxd` is callable from Python** (Task 3.4).
   Cython exports it through the module's `__pyx_capi__` as a `PyCapsule`,
   so `ctypes` can call the *live* kernel at arbitrary arguments — which
@@ -1082,12 +1095,12 @@ it from memory.)
   gained the measured break-point contract. Full list in
   [phase-03/README.md](phase-03/README.md).
 - **Task 3.4** — new `rust/src/interp.rs` (`np.interp` with NumPy's full
-  contract, a `# Sources and licensing` header and 10 unit tests) and
+  contract, a `# Sources and licensing` header and 11 unit tests) and
   `rust/src/boost.rs` (`boost_beta` / `boost_gamma` /
   `boost_delta_function` / `boost_integrate_linear_interp` plus
   `trapezoid` / `pairwise_sum` and `BoostError`, with the contracted-site
-  rationale, the `# Faithfulness notes` on the preserved defects, and 13
-  unit tests); `rust/src/{interp_probe,boost_probe}.rs` register the two
+  rationale, the `# Faithfulness notes` on the four preserved defects, and
+  13 unit tests); `rust/src/{interp_probe,boost_probe}.rs` register the two
   test-only submodules and `rust/src/lib.rs` admits all four. New
   `test/test_core_interp.py` and `test/test_core_boost.py` (the latter
   carries the `__pyx_capi__` ctypes oracle).

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -463,6 +463,61 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   lines, so a scraped failure list names the wrong tests
   (`-- --test-threads=1`); and a background job reported as failed may
   still be running.
+- **The compiled Cython's arithmetic is fused, and the port had to match
+  it to pass the corpus** (Task 3.4). Clang defaults to
+  `-ffp-contract=on`, so `a*b + c` becomes a fused multiply-add; the
+  corpus's capturing platform (macOS/arm64) does it at eight distinct
+  expressions across `boost.pyx`, and NumPy's `arr_interp` does it too.
+  Written the obvious unfused way, the Rust misses the corpus by up to
+  **3.6e-12** relative *on the corpus's own grids* for the seven
+  tabulated photon spectra — past the 1e-12 `TABULATED` budget, so the
+  Phase 04 swap would have failed its own gate and the only alternatives
+  would have been widening a budget by three decades or shipping a
+  declared drift. With `f64::mul_add` at those sites the port is
+  bit-equal at every one of those points. The sites were established
+  twice over: `fmsub`/`fmadd` in the disassembled `.so`, and a
+  16-combination bisection against the live kernel in which only all-on
+  reaches zero mismatches (the next best leaves 115 of 2,462).
+  **The converse is the trap Phases 04–06 inherit:** `boost_beta` spells
+  its square as `(mass/energy) ** 2`, whose rounded product completes
+  before the subtraction, and *none* of its ten inlining call sites
+  contract it — fusing it would move every boosted spectrum. Contraction
+  is a per-expression fact, so measure each kernel rather than adopting a
+  house style. Same shape as Tasks 3.2 and 3.3: the model of the
+  third-party artifact is a hypothesis, and only the sweep can refute it.
+- **`boost_integrate_linear_interp` mis-covers its window at both ends,
+  and near threshold the public spectra are wrong by four orders of
+  magnitude** (Task 3.4). The interior sum's slice `yy[ilow:ihigh]` is
+  exclusive at the top while the upper partial-cell term starts at
+  `x[ihigh]`, so one cell is covered by nothing; and with both bounds
+  inside a single cell the two partial-cell terms **overlap**,
+  over-counting by (cell width)/(window width), which diverges as
+  `β → 0`. All seven tabulated photon spectra therefore blow up instead
+  of converging to their own rest-frame spectrum as the parent slows —
+  6,500× to 33,000× at one part in 1e12 above rest, measured through the
+  public API. This is a live defect in hazma 2.1.0, not something the
+  port introduced. Reproduced per rule 1, pinned in both languages, and
+  filed as
+  [`../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md)
+  — blocked until after Phase 06 Task 6.4, because the repair needs a
+  declared corpus regeneration. **The corpus pins the wrong values by
+  design**, so a Phase 04 swap that "fixes" this fails the gate.
+  `../references/cython-inventory.md` §Bugs lists the same class in the
+  *dead* `boost_integrate_linear_interp_massive`; the live twin was never
+  flagged, which is worth remembering before trusting that audit's
+  coverage of the surviving code.
+- **A `cdef` declared in a `.pxd` is callable from Python** (Task 3.4).
+  Cython exports it through the module's `__pyx_capi__` as a `PyCapsule`,
+  so `ctypes` can call the *live* kernel at arbitrary arguments — which
+  is what stood in for the "micro-fixtures captured in Phase 01" the
+  phase file's Task 3.4 criterion named and that Phase 01 could never
+  have captured (the corpus enumerates top-level `def`s only). Two
+  constraints: use `ctypes.PYFUNCTYPE`, never `CFUNCTYPE`, because the
+  latter releases the GIL and anything calling back into Python
+  segfaults with no Python-level error; and the capsule's *name* is its C
+  signature string, so assert on it rather than trusting the argument
+  list. **Any later task needing an oracle for `cdef` code should reach
+  for this rather than adding a temporary shim to a `.pyx`.**
 - **A worktree can inherit `.so` files whose source package is gone**
   (Task 1.1): this tree carried `_gamma_ray/` and `_phase_space/`
   extensions deleted in Task 0.2, giving 25 `.so` against `setup.py`'s
@@ -714,6 +769,41 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
   no live call site enters today, asserted in
   `test/test_core_quad.py` rather than assumed.
 
+- **Task 3.4, 2026-08-10 (interpolation + boost kernels): no public value
+  changes** (verified: `git diff origin/master -- hazma` is one file,
+  `hazma/_core.pyi`, and every line of the hunk is comment text — no
+  executable line under `hazma/` is reachable from this diff, on a tree
+  rebuilt before anything was run). The rest is two PyO3-free Rust
+  modules that no Python imports and no Rust kernel yet calls, their
+  registration-only probes, two new test modules, the parity corpus's
+  served-kernel exemption, and one follow-up. Measured rather than only
+  argued: the bare suite ran the parity corpus in **bit-equality mode** —
+  `rtol = 0` across all 41 consumed entry points, 179,695 pinned values —
+  and passed, at `1314 passed, 13 skipped` (+102 on Task 3.3's 1212, all
+  of them this task's tests; skip count unchanged, and
+  `tolerances.provenance` → `exact=True` checked directly rather than
+  inferred).
+
+  What the task *did* produce, numerically, is a foundation that
+  reproduces the Cython **bit-for-bit** where the Cython is what the
+  corpus records: zero mismatches on all seven live tables across six
+  boost regimes × 400 energies, zero across 40,000 delta-function draws,
+  and zero on 20,204 `np.interp` abscissae per table. **Phase 04's
+  kaon/eta/omega/phi swaps are the first whose drift lines are measured
+  against this.**
+
+  **One drift is already known and lands with Phase 04, not here.** The
+  Rust is bit-equal to the *contracted* (macOS/arm64) Cython on every
+  platform, because `f64::mul_add` is fused unconditionally. On a target
+  whose C compiler does not contract — baseline x86-64, which is what the
+  Linux wheels are built for — today's Cython returns the unfused values,
+  which differ from these by up to **3.6e-12** relative on the corpus
+  grids. That is past rule 3's 1e-12 declaration threshold, so the Phase
+  04 swap PR must state it. Nothing moves in this task, because nothing
+  calls the new code. The alternative — plain arithmetic everywhere —
+  was rejected because it misses the corpus by that same 3.6e-12 on
+  *every* platform, which the 1e-12 `TABULATED` budget does not cover.
+
 (Per-function drift lines land here as Phase 04–06 swaps merge; the
 Phase 07 CHANGELOG is assembled from this section — do not reconstruct
 it from memory.)
@@ -803,6 +893,24 @@ it from memory.)
   instruction, and leaving the answer in a task note would make the next
   reader re-derive it. No ADR: nothing revises ADR-0002 (the provenance
   is exactly what it prescribes), and no interface or ordering moves.
+- **Task 3.4 (2026-08-10)** patched the same two canonical documents, for
+  the third time running and for the third distinct reason. The phase-03
+  file's Task 3.4 block gained five "criteria added during execution"
+  bullets: the oracle is the live Cython through `__pyx_capi__` rather
+  than the Phase 01 micro-fixtures the criterion named (they do not exist
+  and could not — the corpus sees only top-level `def`s); the port must
+  reproduce the compiler's fused multiply-adds where they occur and not
+  where they do not, held to bit-equality rather than a tolerance; the
+  interior sum's dropped cell is reproduced and filed; `interp` carries
+  NumPy's undocumented quirks as well as its contract; and the corpus's
+  served-kernel predicate stays sound with two more test-only submodules.
+  `../references/numerics-replacements.md` gained the measured block,
+  because its own three-bullet `np.interp` contract and its boost
+  paragraph are exactly what a next reader would port from, and both are
+  incomplete in ways that change the numbers. No ADR: the provenance is
+  original work plus NumPy's BSD-3-Clause behavior, which ADR-0002
+  permits (its rule is that nothing GSL-derived enters the tree), and no
+  interface or ordering outside Task 3.4 moves.
 - **Plan-review round 2 (2026-08-03)**, two completeness fixes: the
   inventory's boost-retirement claim corrected to Phase 06 Task 6.4
   (capi survivor `hazma/spectra/_positron/_pion.pyx:10` cimports the
@@ -973,11 +1081,49 @@ it from memory.)
   [`../references/numerics-replacements.md`](../references/numerics-replacements.md)
   gained the measured break-point contract. Full list in
   [phase-03/README.md](phase-03/README.md).
+- **Task 3.4** — new `rust/src/interp.rs` (`np.interp` with NumPy's full
+  contract, a `# Sources and licensing` header and 10 unit tests) and
+  `rust/src/boost.rs` (`boost_beta` / `boost_gamma` /
+  `boost_delta_function` / `boost_integrate_linear_interp` plus
+  `trapezoid` / `pairwise_sum` and `BoostError`, with the contracted-site
+  rationale, the `# Faithfulness notes` on the preserved defects, and 13
+  unit tests); `rust/src/{interp_probe,boost_probe}.rs` register the two
+  test-only submodules and `rust/src/lib.rs` admits all four. New
+  `test/test_core_interp.py` and `test/test_core_boost.py` (the latter
+  carries the `__pyx_capi__` ctypes oracle).
+  `test/parity/{cases.py,test_parity.py,README.md}` gain the
+  `hazma._core.{interp,boost}` exemptions. `hazma/_core.pyi` gains a
+  comment — the only change under `hazma/`, and non-executable. One
+  follow-up filed
+  ([the boost integral's window coverage](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md)).
+  **Two canonical patches:** the phase file's Task 3.4 block gained five
+  "criteria added during execution" bullets, and
+  [`../references/numerics-replacements.md`](../references/numerics-replacements.md)
+  gained the measured fused-arithmetic block. Full list in
+  [phase-03/README.md](phase-03/README.md).
 
 ## Verification
 
 - Scaffolding PR: `scripts/agents/preflight.sh` (repo gate; no code
   changes).
+- **Phase 03 Task 3.4 state (2026-08-10):** bare `pytest -q` →
+  `1314 passed, 13 skipped` on the capturing environment, parity suite
+  included and in bit-equality mode (skip count unchanged at 13, and
+  `tolerances.provenance` → `exact=True` checked directly);
+  `pytest test/test_core_interp.py -q` → `33 passed in 0.46s`;
+  `pytest test/test_core_boost.py -q` → `69 passed in 0.91s`;
+  `cargo test --no-default-features` → `67 passed` (24 new); clippy,
+  fmt and `markdownlint --dot` clean; `scripts/agents/preflight.sh`
+  RESULT: PASS. Twenty-one mutations against `rust/src/{interp,boost}.rs`,
+  run sequentially behind a lock with a green baseline asserted before
+  and after — 17 of the first 20 caught, and all 21 after two tests were
+  added. **The three survivors shared one shape**: each moved a *branch
+  boundary* by a single double without touching any value the function
+  returns, so no grid sample could see it. What catches that is
+  bisecting on the bit pattern (`test_the_window_edges_sit_on_the_same
+  _double_as_the_cython`) — and the parameter space matters as much as
+  the sampling, since with `m = 0` the fused and unfused momenta are
+  bit-identical and only massive-product draws can distinguish them.
 - **Phase 03 Task 3.3 state (2026-08-10):** bare `pytest -q` →
   `1212 passed, 13 skipped` on the capturing environment, parity suite
   included and in bit-equality mode (skip count unchanged at 13);
@@ -1129,10 +1275,14 @@ it from memory.)
   2.1; still true after Task 3.2). The crate lives in `rust/`,
   `uv pip install -e .` builds Cython and Rust in one pass, and the tree
   carries 21 `.so`: the 20 Cython extensions plus `hazma/_core.abi3.so`.
-  Its public surface is `roundtrip` — a plumbing probe — plus the
-  `special` submodule Task 3.2 added, which is a test surface reachable
-  only from `test/test_core_special.py`. Neither is a ported kernel, and
-  `cases.rust_core_kernels()` is the predicate that says so.
+  Its public surface is `roundtrip` — a plumbing probe — plus four
+  test-surface submodules: `special` (Task 3.2), `quad` (3.3), and
+  `interp` and `boost` (3.4), each reachable only from its own
+  `test/test_core_*.py`. None is a ported kernel, and
+  `cases.rust_core_kernels()` is the predicate that says so —
+  `_CORE_TEST_ONLY_MODULES` exempts the four submodules, and
+  `test_test_only_core_submodules_have_no_importer` makes that exemption
+  conditional on nothing under `hazma/` importing them.
   `dispatch::map_unary` is the single
   implementation of the entry-point dispatch contract — Phases 03–06 call
   it rather than touching PyO3 inside a kernel (`../rules.md` Rust rule
@@ -1158,9 +1308,9 @@ it from memory.)
   [`../learnings/phase-02-rust-scaffold.md`](../learnings/phase-02-rust-scaffold.md)
   rather than their twelve task notes — the learnings are the
   distillation, the notes are history. **Phase 03 is in progress:
-  Tasks 3.1 and 3.2 landed 2026-08-09 and Task 3.3 on 2026-08-10, so the
-  next task is 3.5 (dependency-free) or 3.4 (unblocked by 3.1).** No
-  phase carries a decision gate.
+  Tasks 3.1 and 3.2 landed 2026-08-09, Tasks 3.3 and 3.4 on 2026-08-10,
+  so only Task 3.5 (dependency-free) remains — and it closes the
+  phase.** No phase carries a decision gate.
 - **`hazma_core::constants` exists and is bit-equal to the Cython**
   (Task 3.1). `constants::pdg` is `hazma/_utils/constants.pxd` (151
   values), `constants::legacy` is `hazma/_utils/legacy_parameters.pxd`
@@ -1198,6 +1348,26 @@ it from memory.)
   defaults by passing no keyword at all. `hazma._core.quad` is a test
   surface and must stay importer-free, or the parity corpus leaves
   bit-equality mode.
+- **Task 3.4 is done, so `hazma_core::{interp, boost}` exist**, and both
+  are bit-equal to what they replace on the capturing platform.
+  `interp::interp(x, xp, fp)` is `np.interp` with NumPy's full contract
+  (clamping, node hits, NaN propagation, the one-point grid's NaN
+  asymmetry, the last-duplicate tie-break);
+  `boost::{boost_beta, boost_gamma, boost_delta_function,
+  boost_integrate_linear_interp}` are the four live routines of
+  `hazma/_utils/boost.pyx`, the last returning `Result<f64, BoostError>`
+  where the Cython asserts. **Two things a Phase 04 kernel must not
+  do.** First, do not touch the `mul_add`s: twelve expressions are fused
+  because the shipped Cython and NumPy contract them, unfusing misses the
+  corpus by up to 3.6e-12 (past the 1e-12 `TABULATED` budget), and
+  `boost_beta` is deliberately *un*fused because none of its ten call
+  sites contract — contraction is a per-expression fact, so measure,
+  don't pattern-match. Second, do not repair
+  `boost_integrate_linear_interp`'s window coverage, however obviously
+  wrong it looks; the corpus pins the wrong values and the repair is
+  [its own follow-up](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
+  Both `hazma._core.interp` and `hazma._core.boost` are test surfaces and
+  must stay importer-free.
 - **The parity corpus is the gate from here on.** `python
   test/parity/generate.py --check` verifies it (still, with `_core`
   present); `test/parity/cases.py` is the single source of every entry
@@ -1218,8 +1388,8 @@ it from memory.)
   it in Phase 07). Neither ships a deleted path; neither ships the agent
   scaffolding any more.
 - **The suites are merged and green on the capturing platform**: bare
-  `pytest -q` → **1212 passed / 13 skipped** as of Task 3.3
-  (2026-08-10), from 1154/13 at Task 3.2, 1088/13 at Task 3.1,
+  `pytest -q` → **1314 passed / 13 skipped** as of Task 3.4
+  (2026-08-10), from 1212/13 at Task 3.3, 1154/13 at Task 3.2, 1088/13 at Task 3.1,
   1063/13 at Phase 02 close,
   1006/13 at Phase 01 close and 935/30 at Task 1.3. The Phase 02 deltas:
   +3 (Task 2.1's scaffold checks), 0 (Task 2.2, byte-identical, which is
@@ -1227,7 +1397,7 @@ it from memory.)
   Phase 03 so far: +25 (Task 3.1's constants), +66 (Task 3.2's specfun
   module plus one corpus guard, of which +12 landed in review round 1),
   +58 (Task 3.3's QUADPACK module, of which +6 landed in review
-  round 1).
+  round 1), +102 (Task 3.4's interpolation and boost modules).
   **The skip count has not moved since
   Phase 01 closed**, and that is the tell: forcing budget mode drops one
   test to a skip rather than failing, so an unchanged 13 is how the
@@ -1298,6 +1468,20 @@ it from memory.)
   **measured in Task 1.3: it is not.** See the "Off macOS the corpus does
   not reproduce" bullet above; the corpus is scoped to its capturing
   platform until its follow-up lands.
+- **The seven tabulated photon spectra are wrong near threshold, by
+  three to four orders of magnitude** (Task 3.4), and the port
+  faithfully reproduces it. `boost_integrate_linear_interp` mis-covers
+  its integration window at both ends; the overlapping single-cell case
+  diverges as `β → 0`, so `dnde_photon_{eta, eta_prime, charged_kaon,
+  long_kaon, short_kaon, omega, phi}` blow up instead of converging to
+  their own rest-frame spectra as the parent slows. This is a live defect
+  in 2.1.0, not something the migration introduced, and the corpus pins
+  it by construction — its `rest_plus_eps` block sits in the divergent
+  regime. **Phases 04–06 must not fix it**; the repair needs a declared
+  corpus regeneration and is blocked until after Phase 06 Task 6.4
+  ([follow-up](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md)).
+  Worth flagging to the maintainer separately from this project's
+  schedule: it affects published numbers today.
 - **Two Task 1.4 follow-ups ripen inside this project.** The
   [`MASS_E` `nan`](../../../docs/followups/todo/positron-spectrum-nan-at-legacy-electron-mass.md)
   before Phases 05/06 — `rules.md` rule 4 makes it a declared numerical

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -316,11 +316,11 @@ foundation.
 ### Task 3.4
 
 - `rust/src/interp.rs` — **new**, `np.interp` with NumPy's full contract,
-  a `# Sources and licensing` header, the `mul_add` rationale and 10 unit
+  a `# Sources and licensing` header, the `mul_add` rationale and 11 unit
   tests.
 - `rust/src/boost.rs` — **new**, the four kernels plus `trapezoid` /
   `pairwise_sum`, `BoostError`, the contracted-site rationale, the
-  `# Faithfulness notes` on the preserved defects and 13 unit tests.
+  `# Faithfulness notes` on the four preserved defects and 13 unit tests.
 - `rust/src/interp_probe.rs`, `rust/src/boost_probe.rs` — **new**,
   registration-only `hazma._core.interp` and `hazma._core.boost`.
 - `rust/src/lib.rs` — four `mod` lines, two `add_submodule` calls, and the
@@ -526,6 +526,16 @@ Phases row.
   coverage **fails the gate**. Repair blocked until after Phase 06
   Task 6.4 —
   [`../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
+- **A test that compares against a *locally compiled* oracle is scoped to
+  that build** (Task 3.4, PR #61 review round 1). Nineteen bit-equality
+  assertions against the Cython and NumPy passed on macOS/arm64 and failed
+  on Linux/x86-64, where neither contracts — the port was right and the
+  tests over-claimed. `CYTHON_CONTRACTS` / `NUMPY_CONTRACTS` are measured
+  at import and the comparisons skip where false, the same scoping
+  `test/parity` already has. **Phases 04–06 inherit this**: any kernel test
+  whose oracle is the Cython twin needs the same guard, and loosening to a
+  tolerance is the wrong fix — the worst relative gap sits at a
+  cancellation point where any admitting tolerance would hide real defects.
 - **An edge that only decides a branch needs a bisection test, not a
   grid** (Task 3.4). Three mutations survived a 40,000-draw sweep because
   they moved a support boundary by one double without touching any

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -3,8 +3,8 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 03
-**Status:** In Progress (Tasks 3.1 and 3.2 complete 2026-08-09; Task 3.3
-complete 2026-08-10)
+**Status:** In Progress (Tasks 3.1 and 3.2 complete 2026-08-09; Tasks 3.3
+and 3.4 complete 2026-08-10)
 **Plan References:** `../../phases/phase-03-numerics-foundation.md`
 **Related ADRs:** ADR-0002 (Accepted 2026-08-04 — governs the
 provenance of Tasks 3.2/3.3, no longer gates them)
@@ -22,7 +22,7 @@ foundation.
 | 3.1 | Constants module | — | **Complete (2026-08-09)** | [task-3.1-constants.md](task-3.1-constants.md) |
 | 3.2 | Special functions | — (ADR-0002 accepted) | **Complete (2026-08-09)** | [task-3.2-specfun.md](task-3.2-specfun.md) |
 | 3.3 | QUADPACK port (qk15/qk21/qelg/qags/qagp) | — (ADR-0002 accepted) | **Complete (2026-08-10)** | [task-3.3-quadpack.md](task-3.3-quadpack.md) |
-| 3.4 | Interpolation + boost kernels | 3.1 | Not started | [task-3.4-interp-boost.md](task-3.4-interp-boost.md) |
+| 3.4 | Interpolation + boost kernels | 3.1 | **Complete (2026-08-10)** | [task-3.4-interp-boost.md](task-3.4-interp-boost.md) |
 | 3.5 | Dispatch and error layer | — | Not started | [task-3.5-dispatch.md](task-3.5-dispatch.md) |
 
 ## Exit Criteria
@@ -169,6 +169,60 @@ foundation.
   `test NAME ... FAILED` lines so a scraped failure list names the wrong
   tests (`-- --test-threads=1`), and a background job reported as failed
   may still be running.
+- **The compiled Cython contracts `a*b + c` into fused multiply-adds, and
+  the port has to as well** (Task 3.4). Clang's default is
+  `-ffp-contract=on`, and the corpus's capturing platform (macOS/arm64)
+  contracts eight distinct expressions across `boost.pyx` — plus
+  `slope·(x − xp[j]) + fp[j]` inside NumPy's own `arr_interp`. Written
+  the obvious unfused way the port misses the corpus by up to **3.6e-12**
+  relative *on the corpus's own grids* for the seven tabulated photon
+  spectra, past the 1e-12 `TABULATED` budget; with `f64::mul_add` at
+  those sites it is bit-equal at every one of those points. The sites
+  were established twice — `fmsub`/`fmadd` in the disassembled `.so`, and
+  a 16-combination bisection against the live kernel in which only
+  all-on reaches zero mismatches. **The converse is the trap:**
+  `boost_beta` spells its square as `(mass/energy) ** 2`, whose rounded
+  product completes before the subtraction, and **none** of its ten
+  inlining call sites contract it. Contraction is a per-expression fact,
+  not a per-file one, and Phases 04–06 must measure each kernel rather
+  than adopting a house style.
+- **`np.trapezoid` reduces pairwise, and `np.interp` has quirks the
+  reference does not list** (Task 3.4). `ndarray.sum` runs eight
+  accumulators over 128-element blocks and recurses; a sequential sum is
+  a different number (1.8e-15 relative on the 500-row tables), so
+  `rust/src/boost.rs` mirrors the blocking. `np.interp`: a one-point grid
+  answers *everything* with `fp[0]` including NaN (the NaN check lives on
+  the multi-point path only), and duplicate abscissae resolve to the
+  **last** matching node. Also: the live tables are rows of a transposed
+  `np.loadtxt` result, so they are **strided views** and
+  `PyReadonlyArray1::as_slice` refuses them.
+- **`boost_integrate_linear_interp` mis-covers its window at both ends,
+  and near threshold it is wrong by four orders of magnitude** (Task
+  3.4). The interior sum's slice is exclusive at the top while the upper
+  partial-cell term starts at `x[ihigh]`, so one cell is covered by
+  nothing — and with both bounds inside a single cell the two partial-cell
+  terms **overlap**, over-counting by (cell width)/(window width), which
+  diverges as `β → 0`. Consequence on the public API: all seven tabulated
+  photon spectra blow up rather than converging to their own rest-frame
+  spectrum as the parent approaches rest (6,500× to 33,000× one part in
+  1e12 above rest). Reproduced per rule 1, pinned in both languages,
+  filed as
+  [`../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
+  The inventory's §Bugs lists the same class in the *dead*
+  `boost_integrate_linear_interp_massive`; the live twin was not flagged.
+  **Phase 04 inherits it unchanged** — the corpus pins these values, so a
+  swap that "fixes" it fails the gate.
+- **A `cdef` with a `.pxd` declaration is callable from Python** (Task
+  3.4), which is what replaced the micro-fixtures the phase file's Task
+  3.4 criterion named and that Phase 01 never captured (the corpus only
+  sees top-level `def`s). Cython exports declared `cdef`s through
+  `__pyx_capi__` as capsules; `ctypes` calls them. Two constraints:
+  `PYFUNCTYPE`, not `CFUNCTYPE` — the latter releases the GIL and
+  anything calling back into NumPy segfaults (exit 139, no Python error);
+  and the capsule's *name* is its C signature string, so the argument
+  list is checkable rather than a silent stack corruption. **Any later
+  task needing a `cdef` oracle should reach for this instead of adding a
+  temporary shim to a `.pyx`.**
 - **A Python-visible test surface on `hazma._core` reads as a started
   port** (Task 3.2). Registering `hazma._core.special` flipped the
   parity corpus straight out of bit-equality mode
@@ -231,6 +285,25 @@ foundation.
   integrand is byte-identical on both sides. Same shape as `special_probe`
   and it inherits the same `_CORE_TEST_ONLY_MODULES` exemption and
   importer guard rather than widening them.
+- **`interp.rs` and `boost.rs` are PyO3-free; `interp_probe.rs` and
+  `boost_probe.rs` are the Python halves** (Task 3.4) — the shape Tasks
+  3.2 and 3.3 set, with two probe modules rather than one because the two
+  oracles are different (NumPy versus the Cython capsules). Both join
+  `cases._CORE_TEST_ONLY_MODULES` under Task 3.2's importer guard; the
+  exemption mechanism is reused, not widened.
+- **The QUADPACK-style literal translation was *not* carried into
+  `boost.rs`** (Task 3.4). Ninety lines of ordinary arithmetic do not
+  need 1-based indexing and labelled `break`s to stay checkable, so the
+  Rust reads as Rust (`Option` for the `-1` index sentinel, a closure for
+  the `y / x` column the Cython materialises) while every branch,
+  tolerance and ordering is preserved verbatim. The literal posture is
+  for Fortran with `go to`, not for a policy.
+- **`interp` asserts its preconditions; the boost integral returns
+  `Result`** (Task 3.4). The Cython's two `assert`s become error returns
+  per rule 9, plus an `EmptyTable` variant for the case it leaves
+  undefined; `interp` keeps a plain `f64` return because the probe raises
+  `ValueError` with NumPy's own wording first, so the assert is
+  unreachable from Python and no Rust call site has to unwrap.
 - **Only `n = 2` is live, but `bessel_kn` carries general `n`**
   (Task 3.2), because the recurrence is general and the order factor
   `2m/x` is *invisible* at n = 2 (it is `2/x` there). Both the ν = 2
@@ -239,6 +312,31 @@ foundation.
   `cargo test` alone missed it.
 
 ## Files Changed
+
+### Task 3.4
+
+- `rust/src/interp.rs` — **new**, `np.interp` with NumPy's full contract,
+  a `# Sources and licensing` header, the `mul_add` rationale and 10 unit
+  tests.
+- `rust/src/boost.rs` — **new**, the four kernels plus `trapezoid` /
+  `pairwise_sum`, `BoostError`, the contracted-site rationale, the
+  `# Faithfulness notes` on the preserved defects and 13 unit tests.
+- `rust/src/interp_probe.rs`, `rust/src/boost_probe.rs` — **new**,
+  registration-only `hazma._core.interp` and `hazma._core.boost`.
+- `rust/src/lib.rs` — four `mod` lines, two `add_submodule` calls, and the
+  reconciled paragraphs on the foundation modules and their probes.
+- `test/test_core_interp.py`, `test/test_core_boost.py` — **new** (the
+  latter carries the `__pyx_capi__` shim).
+- `test/parity/cases.py`, `test/parity/test_parity.py`,
+  `test/parity/README.md` — `hazma._core.{interp,boost}` added to
+  `_CORE_TEST_ONLY_MODULES` and the three prose sites reconciled.
+- `hazma/_core.pyi` — the unstubbed-submodule comment now covers all four
+  probes (the only change under `hazma/`, non-executable).
+- `docs/followups/todo/boost-integral-drops-last-interior-cell.md` +
+  `docs/followups/README.md` — **new**, the preserved defect.
+- **Two canonical patches:** `../../phases/phase-03-numerics-foundation.md`
+  (five Task 3.4 criteria added during execution) and
+  `../../references/numerics-replacements.md` (the measured block).
 
 ### Task 3.1
 
@@ -293,6 +391,26 @@ foundation.
 
 ## Verification
 
+- **Task 3.4 (2026-08-10):** bare `pytest -q` →
+  `1314 passed, 13 skipped` on the capturing environment, parity suite
+  included and in bit-equality mode (skip count unchanged at 13, and
+  `tolerances.provenance` → `exact=True` checked directly; +102 on Task
+  3.3's 1212, all of them this task's new tests).
+  `pytest test/test_core_interp.py -q` → `33 passed in 0.46s` (6
+  classes); `pytest test/test_core_boost.py -q` → `69 passed in 0.91s`
+  (9 classes);
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features` →
+  `67 passed` (24 new); clippy, fmt and `markdownlint --dot` clean;
+  `scripts/agents/preflight.sh` RESULT: PASS. Twenty-one mutations
+  against `interp.rs` and `boost.rs`, sequential behind a lock with a
+  green baseline before and after — **17 of the first 20 caught**, and
+  the three survivors are exactly what
+  `test_an_infinite_node_returns_its_own_value` and
+  `test_the_window_edges_sit_on_the_same_double_as_the_cython` were
+  written for; a third round confirmed all 21 caught. The survivors'
+  shared shape is worth carrying: each moved a *branch boundary* by one
+  double without touching any returned value, so no grid sample could
+  see it. Tables in the task note.
 - **Task 3.3 (2026-08-10):** bare `pytest -q` →
   `1212 passed, 13 skipped` on the capturing environment, parity suite
   included and in bit-equality mode (skip count unchanged at 13, which is
@@ -358,14 +476,24 @@ foundation.
 ## Handoff to Next Task
 
 **For the next agent working in Phase 03:** read `../../PLAN.md`,
-`../README.md`, this file, then the phase file — whose Task 3.2 block
-now carries three criteria added during execution. Tasks 3.3, 3.4 and
-3.5 remain; 3.3 must honor ADR-0002's provenance rule: netlib QUADPACK
-only, nothing GSL-derived in the tree or the dependency graph.
+`../README.md`, this file, then the phase file — whose Tasks 3.2, 3.3
+and 3.4 blocks all now carry criteria added during execution. **Only
+Task 3.5 (dispatch and error layer) remains**, and it closes the phase:
+synthesize `../../learnings/phase-03-numerics-foundation.md`, flip the
+phase file's frontmatter to `status: Complete`, and update the `PLAN.md`
+Phases row.
 
 **Currently safe to assume:**
 
 - Every live integral is finite-interval — `qagi` is out of scope.
+- **Task 3.4 is done, so `hazma_core::{interp, boost}` exist.**
+  `interp::interp` is `np.interp` with NumPy's full contract;
+  `boost::{boost_beta, boost_gamma, boost_delta_function,
+  boost_integrate_linear_interp}` are the four live routines of
+  `hazma/_utils/boost.pyx`. Both are bit-equal to what they replace on
+  the capturing platform, PyO3-free, and already route through
+  `dispatch::map_unary` in their probes — so whatever Task 3.5 settles
+  about the four live dispatch behaviors applies to them for free.
 - **Task 3.1 is done, so `hazma_core::constants` exists and Task 3.4 is
   unblocked.** `constants::{pdg, legacy}` are the two Cython tables and
   `constants::derived::<source_pyx>` the module-local `DEF`s, all
@@ -384,6 +512,27 @@ only, nothing GSL-derived in the tree or the dependency graph.
 
 **Currently risky / unknown:**
 
+- **Do not "clean up" a `mul_add` in `boost.rs` or `interp.rs`, and do
+  not add one where they do not have it** (Task 3.4). Unfusing costs up
+  to 3.6e-12 against the corpus — past the 1e-12 `TABULATED` budget —
+  and fusing `boost_beta`, which the Cython does *not* contract at any
+  of its ten call sites, moves every boosted spectrum. Every Phase 04
+  kernel needs its own disassembly or bisection; there is no house style
+  to apply.
+- **`boost_integrate_linear_interp` is wrong near threshold and stays
+  wrong for now** (Task 3.4): all seven tabulated photon spectra diverge
+  instead of converging to their rest-frame values as the parent slows.
+  The corpus pins those values, so a Phase 04 swap that repairs the
+  coverage **fails the gate**. Repair blocked until after Phase 06
+  Task 6.4 —
+  [`../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
+- **An edge that only decides a branch needs a bisection test, not a
+  grid** (Task 3.4). Three mutations survived a 40,000-draw sweep because
+  they moved a support boundary by one double without touching any
+  returned value. Any Phase 04–06 kernel with a window, threshold or
+  piecewise switch inherits that — and check the sweep's *parameter*
+  space reaches the branch at all (with `m = 0` the fused and unfused
+  momenta are bit-identical, so only massive draws could see it).
 - `qelg` Fortran→Rust translation is the fiddliest item in the project;
   budget review time accordingly.
 - **Task 3.3 inherits Task 3.2's central lesson**: do not design against
@@ -391,6 +540,8 @@ only, nothing GSL-derived in the tree or the dependency graph.
   does. Task 3.2 found `scipy.special.kn` is `kv` rather than cephes
   only by running the sweep, and 3.3's breakpoint-preprocessing
   criterion already says the same thing about `quad(points=...)`.
+  **Task 3.4 makes it three for three**, and widens it past scipy: the
+  compiled artifact's own arithmetic is a hypothesis too.
 - **Do not "simplify" `special::bessel_kn` to `spec_math`'s** — a
   5.1e-9 miss that the corpus's 1e-8 `thermal_cross_section` budget
   would absorb. `test_beats_cephes_kn_at_its_worst_argument` names the

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
@@ -39,6 +39,8 @@ added there during execution:
 - `interp` carries NumPy's quirks (one-point-grid NaN, duplicate-node
   tie-break) as well as its documented contract.
 - The parity corpus's served-kernel predicate stays sound.
+- The bit-equality comparisons are scoped to a platform whose references
+  contract, and the suite is green where they do not (added in review).
 
 ## Inputs Reviewed
 
@@ -182,6 +184,22 @@ added there during execution:
   assert is unreachable from Python and every Rust call site keeps a plain
   `f64` return. Panicking across FFI is what Task 3.3 ruled out; this
   cannot reach FFI.
+- **The cross-implementation comparisons are scoped to a contracting
+  platform** (added in PR #61 review round 1, after CI caught it). Whether
+  the local Cython and NumPy fuse their multiply-adds is a property of the
+  compiler that built *them*, so on Linux/x86-64 the references compute the
+  unfused values and 19 bit-equality assertions failed — the port was
+  right, the tests over-claimed. `CYTHON_CONTRACTS` / `NUMPY_CONTRACTS` are
+  now measured at import and those comparisons skip where false, which is
+  the scoping the parity corpus already has (CI runs
+  `pytest --ignore=test/parity` off macOS for the same reason). Loosening
+  to a tolerance was rejected: the worst *relative* gap between the two
+  forms sits at a catastrophic-cancellation point (the eta tail, where the
+  interpolant is 2.4e-26 against a table of scale 0.2 — an absolute gap of
+  1.4e-30), so a tolerance admitting it would hide real defects. The
+  per-branch tests keep their platform-independent halves running
+  everywhere and route only the bit-equality claim through
+  `assert_matches_cython`, which skips mid-test *after* those have run.
 - **The QUADPACK-style literal-translation posture does not apply here.**
   `boost.pyx` is 90 lines of ordinary arithmetic, so the Rust reads as
   Rust (`Option` for the `-1` index sentinel, a closure for the `y / x`
@@ -191,11 +209,11 @@ added there during execution:
 ## Files Changed
 
 - `rust/src/interp.rs` — **new**, `np.interp` with NumPy's full contract,
-  a `# Sources and licensing` header, the `mul_add` rationale, and 10
+  a `# Sources and licensing` header, the `mul_add` rationale, and 11
   unit tests.
 - `rust/src/boost.rs` — **new**, the four kernels plus `trapezoid` /
   `pairwise_sum`, `BoostError`, the contracted-site rationale, the
-  `# Faithfulness notes` on the three preserved defects, and 13 unit
+  `# Faithfulness notes` on the four preserved defects, and 13 unit
   tests.
 - `rust/src/interp_probe.rs`, `rust/src/boost_probe.rs` — **new**,
   registration-only `hazma._core.interp` and `hazma._core.boost`.
@@ -228,7 +246,7 @@ anything was run:
 | `pytest -q` (bare, the gate) | `1314 passed, 13 skipped, 5 warnings in 596.25s` |
 | `pytest test/test_core_interp.py -q` | `33 passed in 0.46s` (6 classes) |
 | `pytest test/test_core_boost.py -q` | `69 passed in 0.91s` (9 classes) |
-| `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `67 passed` (24 new: 10 in `interp`, 14 in `boost`) |
+| `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `67 passed` (24 new: 11 in `interp`, 13 in `boost`) |
 | `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` | clean |
 | `markdownlint --dot` over the eight changed `.md` | clean |
 | `scripts/agents/preflight.sh --paths "…"` | **RESULT: PASS** |
@@ -361,11 +379,14 @@ Nothing moves in *this* task, because nothing calls the new code.
 Each command run against this branch on 2026-08-10.
 
 **Full change inventory** — `git status --short` plus
-`git diff origin/master --stat` after `git add -N .` (18 files,
-+3,265 / −49): four new `rust/src/*.rs`, `rust/src/lib.rs`, two new
-`test/test_core_*.py`, three `test/parity/*` sites, `hazma/_core.pyi`,
-two canonical patches, one follow-up + its index row, and three
-bookkeeping files. No untracked file is unaccounted for.
+`git diff origin/master --stat` after `git add -N .`, re-derived after
+the review round: **19 files, +3,539 / −49**. Four new `rust/src/*.rs`,
+`rust/src/lib.rs`, two new `test/test_core_*.py`, three `test/parity/*`
+sites, `hazma/_core.pyi`, two canonical patches, one follow-up + its
+index row, `docs/agents/lessons.md`, and three bookkeeping files. No
+untracked file is unaccounted for. (Round 1 recorded `18 files,
++3,265 / −49`, which was measured before the last documentation edits of
+that round — the number is now taken after every edit, not during.)
 
 **Numerical-impact statement** — `git diff origin/master -- hazma` is one
 file, `hazma/_core.pyi`, comment-only. Corpus in bit-equality mode:

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
@@ -1,0 +1,479 @@
+# Task 3.4: Interpolation + boost kernels
+
+**Date:** 2026-08-10
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-03-numerics-foundation.md` (Task
+3.4); `../../references/numerics-replacements.md` (§`np.interp`
+semantics, §`boost_integrate_linear_interp`); `../../rules.md` rules 1, 3,
+8, 9
+**Related ADRs:** none (nothing revises ADR-0001 or ADR-0002; the
+provenance here is original work plus NumPy's BSD-3-Clause behavior)
+**Depends On:** Task 3.1 (`hazma_core::constants`)
+
+## Objective
+
+Port `np.interp` and the four live routines of `hazma/_utils/boost.pyx`
+to PyO3-free Rust, with per-branch tests pinned against the
+implementations they replace, so Phase 04's tabulated photon spectra have
+a foundation that reproduces the parity corpus.
+
+## Exit Criteria
+
+From the phase file's Task 3.4 block, plus the five criteria this task
+added there during execution:
+
+- `interp` replicating `np.interp` exactly (ascending grid, edge
+  clamping, node hits) — property-tested against NumPy over random grids.
+- `boost_beta` / `boost_gamma` / `boost_delta_function` /
+  `boost_integrate_linear_interp` ported with per-branch unit tests
+  (interior, both partial edge cells, below-table `1/E` tail, above-table
+  clamp, β→0 guard) pinned against the Cython originals.
+- The oracle is the live Cython through `__pyx_capi__`, not the
+  "micro-fixtures captured in Phase 01" the criterion names — they do not
+  exist and could not (see Findings).
+- The port reproduces the shipped Cython's fused multiply-adds where they
+  occur and **not** where they do not, held to bit-equality rather than a
+  tolerance.
+- The dropped interior cell is reproduced, not repaired, and filed.
+- `interp` carries NumPy's quirks (one-point-grid NaN, duplicate-node
+  tie-break) as well as its documented contract.
+- The parity corpus's served-kernel predicate stays sound.
+
+## Inputs Reviewed
+
+- `../../PLAN.md`; `../README.md`; `README.md` (phase working memory);
+  `../../phases/phase-03-numerics-foundation.md`; `../../rules.md`.
+- `../../references/numerics-replacements.md` §§ `np.interp`,
+  `boost_integrate_linear_interp`; `../../references/cython-inventory.md`
+  §Bugs.
+- `hazma/_utils/boost.pyx`, `hazma/_utils/boost.pxd`, and the twelve
+  `.pyx` call sites (`rg` over `hazma/`).
+- `rust/src/{lib,dispatch,special,special_probe,quad,quad_probe}.rs` for
+  the conventions this task follows.
+- `test/parity/{cases,tolerances,test_parity}.py`, `test/parity/README.md`.
+- The generated `hazma/_utils/boost.c` and the compiled
+  `hazma/_utils/boost.cpython-312-darwin.so` (disassembly).
+- `docs/agents/lessons.md`, `docs/agents/environment.md`.
+
+## Findings
+
+- **The oracle the exit criterion names does not exist, and a better one
+  does.** Phase 01's corpus enumerates top-level `def`s in the surviving
+  `.pyx`; every routine here is `cdef`, so no micro-fixture was captured
+  and none could have been. But `boost.pxd` *declares* the `cdef`s, which
+  makes Cython export them through `hazma._utils.boost.__pyx_capi__` as
+  capsules — so `ctypes` can call the live kernel at whatever arguments a
+  test picks, which is strictly stronger than a frozen sample. Two
+  mechanical constraints, both hit: the shim must use
+  `ctypes.PYFUNCTYPE`, since `CFUNCTYPE` releases the GIL and
+  `boost_integrate_linear_interp` calls `np.trapezoid` (`CFUNCTYPE`
+  segfaults, exit 139, with no Python-level error); and the capsule's
+  *name* is its C signature string, so a changed argument list is
+  checkable rather than a silent stack corruption.
+- **The shipped Cython's arithmetic is fused, and reproducing that is
+  what makes the port pass the corpus.** Clang defaults to
+  `-ffp-contract=on`. Written the obvious unfused way, the port misses
+  the corpus by up to **3.6e-12** relative *on the corpus's own grids*
+  for the seven tabulated photon spectra — past the 1e-12 `TABULATED`
+  budget in `test/parity/tolerances.py`, so the Phase 04 swap would have
+  failed its own gate and the only alternatives would have been widening
+  a budget by three decades or shipping a declared drift. With
+  `f64::mul_add` at the contracted sites the port is **bit-equal at every
+  one of those points** (0.000e+00, all seven tables).
+- **Which sites contract is a per-expression fact, established twice.**
+  Disassembling `hazma/_utils/boost.cpython-312-darwin.so` shows
+  `fmsub`/`fmadd` at `1 - β·β` (both routines), `e·e - m·m` and
+  `e0·e0 - m·m` and `e ∓ β·k` (the line), and `y1 - m·x1`,
+  `0.5·m·(x2 + lb) + b` and the accumulation itself (each partial cell).
+  Independently, bisecting all 16 on/off combinations of the integral's
+  four sites against the live kernel over 2,462 corpus-grid points found
+  exactly one combination at zero mismatches — all four on; the next best
+  left 115. NumPy's `arr_interp` contracts too: unfused, `interp` misses
+  `np.interp` at 1,549 of 20,204 eta-table points by up to 1.1e-13.
+- **`boost_beta` must *not* be fused, and that is not symmetry-breaking
+  for its own sake.** The Cython spells it `(mass / energy) ** 2`, whose
+  rounded product completes before the subtraction; disassembling the
+  inlined copies in `_eta`, `_kaon` and `_positron/_pion` shows
+  `fdiv / fmul / fsub / fsqrt` with no contraction at any of them.
+  Fusing it would move every boosted spectrum for no reason. "The
+  compiler contracts" is a claim about an expression, not about a file.
+- **`np.trapezoid` reduces pairwise, not sequentially.** `ndarray.sum`
+  runs eight accumulators over 128-element blocks and recurses above
+  that; a left-to-right sum is a different number, up to 1.8e-15 relative
+  on the 500-row tables. Reproducing the blocking is the only way the
+  interior sum is bit-equal. A Python transcription of the blocking
+  matched `np.sum` on 3 random arrays at each of 306 lengths from 0 to
+  5,000 with zero mismatches, which is what justified writing it in Rust.
+- **The live tables are strided views, not contiguous buffers.** They are
+  rows of a transposed `np.loadtxt` result, so `PyReadonlyArray1::as_slice`
+  raises `TypeError: The given array is not contiguous or is misaligned`.
+  Both probes copy with `as_array().to_vec()`. Phase 04 kernels own their
+  tables in Rust and never see the stride, but any future probe taking a
+  live table inherits this.
+- **`boost_integrate_linear_interp` mis-covers its window at both ends,
+  and near threshold it is wrong by four orders of magnitude.** The
+  interior sum's slice `yy[ilow:ihigh]` is exclusive at the top while the
+  upper partial-cell term starts at `x[ihigh]`, so
+  `[x[ihigh-1], x[ihigh]]` is covered by nothing — and when the window is
+  clamped, the table's final row contributes to no term at all. The
+  mirror-image case is worse: with both bounds inside one cell,
+  `ihigh = ilow - 1` and the two partial-cell terms **overlap**, covering
+  ~two whole cells instead of the sliver between the bounds, over-counting
+  by (cell width)/(window width) — which diverges as `β → 0`. Consequence
+  on the public API: all seven tabulated photon spectra blow up instead of
+  converging to their own rest-frame spectrum as the parent approaches
+  rest (ratios 6,500× to 33,000× one part in 1e12 above rest; table in the
+  follow-up). Reproduced per rule 1, pinned in both languages, filed as
+  [`../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
+  `../../references/cython-inventory.md` §Bugs lists the same class in the
+  *dead* `boost_integrate_linear_interp_massive`; the live twin was not
+  flagged.
+- **`np.interp` has two behaviors the reference's three-bullet contract
+  omits.** A one-point grid answers *everything* with `fp[0]`, NaN
+  included, because NumPy's NaN check sits on the multi-point path only;
+  and duplicate abscissae resolve to the **last** matching node, because
+  its bisection walks past equal keys. A port written from the reference
+  alone would have got both backwards.
+- **`boost_jac` and `boost_eng` are exported and called by nothing.**
+  `rg` over the tree at execution time finds no consumer; they are out of
+  this port's scope and Phase 06 Task 6.4 deletes the extension. They are
+  not dead weight for the tests, though — `boost_eng(ep, mp, 1, 0, 0)`
+  reduces to `γ` exactly and is used as the Cython-side oracle for
+  `boost_gamma`.
+
+## Decisions and Implementation Notes
+
+- **`f64::mul_add` at exactly the contracted sites, and nowhere else.**
+  The alternative — plain arithmetic plus a widened budget — was rejected
+  because it costs three decades of resolution on the class of error the
+  corpus exists to catch, and because the fused form is *more* portable
+  rather than less: the Rust returns the same numbers on x86-64 and
+  arm64, while the Cython's answer depends on whether its target has FMA.
+  Stated as a consequence rather than hidden: on a platform whose C
+  compiler does not contract, hazma today returns the unfused values, and
+  the Phase 04 swap will move them by up to that same 3.6e-12.
+- **`pairwise_sum` mirrors a NumPy implementation detail, deliberately.**
+  Mimicking a documented contract is faithfulness; mimicking a
+  compiler's instruction selection would not be — except that here the
+  compiler's choice is what the corpus records, which is why both end up
+  in. The cost is a coupling to NumPy's reduction, and the mitigation is
+  that `TestTrapezoidSummation` compares against the live `np.trapezoid`,
+  so a future NumPy change is a red test rather than a silent drift.
+- **Two probe submodules, not one.** `hazma._core.interp` and
+  `hazma._core.boost` are separate because their oracles are (NumPy
+  versus the Cython capsules), and both join
+  `cases._CORE_TEST_ONLY_MODULES` under the importer guard Task 3.2
+  built — the same mechanism, not a widened exemption. Third instance of
+  `docs/agents/lessons.md` `[gate-disabled-stays-green]` in this project.
+- **`interp` is scalar-in, scalar-out; the array form lives in the
+  probe.** Every Cython call site passes a scalar. The probe routes the
+  abscissa through `dispatch::map_unary` so a 20,000-point sweep against
+  NumPy is one call rather than a Python loop — the kind of test that
+  otherwise gets trimmed later.
+- **`boost_integrate_linear_interp` returns `Result`, and the probe
+  validates once.** Rule 9 turns the Cython's two `assert`s into error
+  returns, and adds `EmptyTable` for the case the Cython leaves undefined
+  (`x[npts - 1]` with `wraparound(False)` and no bounds check). The guards
+  depend only on `beta` and the table, so the probe checks them once
+  before mapping rather than deciding what value a failed element takes.
+- **`interp` asserts its preconditions rather than returning `Result`.**
+  The probe raises `ValueError` with NumPy's own wording first, so the
+  assert is unreachable from Python and every Rust call site keeps a plain
+  `f64` return. Panicking across FFI is what Task 3.3 ruled out; this
+  cannot reach FFI.
+- **The QUADPACK-style literal-translation posture does not apply here.**
+  `boost.pyx` is 90 lines of ordinary arithmetic, so the Rust reads as
+  Rust (`Option` for the `-1` index sentinel, a closure for the `y / x`
+  column the Cython materialises) while every branch, tolerance and
+  ordering is preserved.
+
+## Files Changed
+
+- `rust/src/interp.rs` — **new**, `np.interp` with NumPy's full contract,
+  a `# Sources and licensing` header, the `mul_add` rationale, and 10
+  unit tests.
+- `rust/src/boost.rs` — **new**, the four kernels plus `trapezoid` /
+  `pairwise_sum`, `BoostError`, the contracted-site rationale, the
+  `# Faithfulness notes` on the three preserved defects, and 13 unit
+  tests.
+- `rust/src/interp_probe.rs`, `rust/src/boost_probe.rs` — **new**,
+  registration-only `hazma._core.interp` and `hazma._core.boost`.
+- `rust/src/lib.rs` — the four `mod` lines, two `add_submodule` calls, and
+  the reconciled paragraphs on the foundation modules and their probes.
+- `test/test_core_interp.py` — **new**.
+- `test/test_core_boost.py` — **new**, including the `__pyx_capi__` shim.
+- `test/parity/cases.py`, `test/parity/test_parity.py`,
+  `test/parity/README.md` — `hazma._core.{interp,boost}` added to
+  `_CORE_TEST_ONLY_MODULES`, and the three places naming the exempted
+  submodules reconciled.
+- `hazma/_core.pyi` — the unstubbed-submodule comment now covers all four
+  probes (the only change under `hazma/`, non-executable).
+- `docs/followups/todo/boost-integral-drops-last-interior-cell.md` +
+  `docs/followups/README.md` — the preserved defect.
+- **Two canonical patches:**
+  `../../phases/phase-03-numerics-foundation.md` (five Task 3.4 criteria
+  added during execution) and
+  `../../references/numerics-replacements.md` (the measured block).
+
+## Verification
+
+**Commands and their real summary lines**, all on the corpus's capturing
+environment (CPython 3.12.12, NumPy 2.5.1, SciPy 1.18.0, macOS/arm64), on
+a tree rebuilt with `uv pip install -e . --no-build-isolation` before
+anything was run:
+
+| Command | Result |
+| --- | --- |
+| `pytest -q` (bare, the gate) | `1314 passed, 13 skipped, 5 warnings in 596.25s` |
+| `pytest test/test_core_interp.py -q` | `33 passed in 0.46s` (6 classes) |
+| `pytest test/test_core_boost.py -q` | `69 passed in 0.91s` (9 classes) |
+| `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `67 passed` (24 new: 10 in `interp`, 14 in `boost`) |
+| `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` | clean |
+| `markdownlint --dot` over the eight changed `.md` | clean |
+| `scripts/agents/preflight.sh --paths "…"` | **RESULT: PASS** |
+
+`+102` on Task 3.3's `1212 passed, 13 skipped`, and all 102 are this
+task's tests. **The skip count is unchanged at 13, which is what proves
+the parity corpus ran in bit-equality mode**; confirmed directly rather
+than inferred —
+`tolerances.provenance(manifest)` → `Provenance(exact=True, detail='')`.
+
+**What the tests cover**, by class rather than by count:
+
+*`test/test_core_interp.py`* — `TestAgainstNumpy` (bit-equality with
+`np.interp` on all seven live tables over 20,204 abscissae each: 20,000
+random interior points, every node, every node nudged ±1e-13, and four
+out-of-range; plus 50 random grids with cells of wildly unequal width);
+`TestFusedArithmetic` (the fused and unfused forms are shown to differ
+somewhere before the Rust is asserted to side with NumPy, so the test
+cannot pass vacuously on a non-contracting platform);
+`TestClamping`; `TestQuirks` (NaN propagation, the one-point grid's NaN
+asymmetry, the duplicate-node tie-break, both infinite-cell rescues, and
+the infinite-node short circuit); `TestErrors` (both `ValueError`s, each
+asserted against NumPy's own message); `TestDispatch`.
+
+*`test/test_core_boost.py`* — `TestOracle` (the `__pyx_capi__` shim is
+the Cython: the export set, every capsule's C signature string, and a
+closed form `boost_eng` must reproduce); `TestBoostParameters`;
+`TestBoostDeltaFunction` (40,000 random draws at both live product masses
+bit-for-bit against the Cython, the window edges located **to the last
+bit** by bisection over 400 more draws, unit normalisation, and seven
+unphysical or out-of-window argument sets);
+`TestBoostIntegrateLinearInterp` (one test per branch — above-table
+clamp, below-table tail, straddling the floor, straddling the ceiling,
+both partial cells, the interior sum — each pinned by a closed form or by
+a sensitivity check on a table entry only that branch reads, and each
+bit-equal to the Cython; plus all seven live tables over six boost
+regimes × 400 energies); `TestFusedArithmetic` (an independent unfused
+reference, used as a discriminator); `TestDroppedInteriorCell`;
+`TestTrapezoidSummation` (five table sizes spanning NumPy's pairwise
+blocking, plus a check that a sequential sum really would differ);
+`TestErrors`; `TestDispatch`.
+
+**Numerical impact:** no public value changes — see the section below.
+
+**Test validity (mutation campaign).** 21 distinct mutations, run
+strictly sequentially behind a lock file, with a green baseline asserted
+before the campaign and again after it (Task 3.3's
+`[poisoned-baseline]` lesson). Round 1: 20 mutations, **17 caught**.
+The three survivors were real gaps, and each named the test that was
+missing:
+
+| Survivor | Why it survived | Test added |
+| --- | --- | --- |
+| `interp`: drop the exact-node short circuit | At an ordinary node the interpolation returns `fp[j]` anyway, so the guard is unobservable except on an infinitely wide cell | `TestQuirks::test_an_infinite_node_returns_its_own_value` |
+| `boost`: unfuse the delta window bounds | `eminus`/`eplus` never reach the return value — they move the support edge by one double, and no grid sample lands there | `TestBoostDeltaFunction::test_the_window_edges_sit_on_the_same_double_as_the_cython` (bisection on the bit pattern) |
+| `boost`: unfuse `k = sqrt(e² − m²)` | Same, and with `m = 0` the two forms are *identical*, so only massive-product draws can see it — three fixed parameter sets saw nothing | the same sweep, widened to 400 random draws over both product masses. An offline search over 4,000 draws found 708 edges that move when `k` is unfused, which is why 400 is enough |
+
+Round 2 re-ran the three survivors plus a new mutation on the line
+height (`k0`): 3 of 4 caught, `k` still surviving because the first
+version of the edge test used three fixed parameter sets. Round 3, after
+widening that test to the random sweep: **1 mutation, 0 survived.**
+Final state: all 21 caught, baseline restored green
+(`RESTORED BASELINE: GREEN — 102 passed`).
+
+**Deferred:** nothing. Two things are deliberately *not* done rather than
+deferred — the boost integral's window-coverage defect is preserved under
+rule 1 and filed as a follow-up, and `boost_jac` / `boost_eng` are not
+ported because nothing calls them (`rg` at execution time) and Phase 06
+Task 6.4 deletes the extension.
+
+## Open Questions
+
+- **Does the fused-arithmetic decision need to be revisited for the
+  mediator spectrum tables?** Phase 06's `.pyx` call `np.interp` on their
+  own tables and do their own arithmetic around it; whether *those*
+  expressions contract is a separate measurement, and this task did not
+  make it.
+
+## Plan Impact
+
+**Impact Level:** Phase file patched + reference patched.
+
+No ADR. Nothing revises ADR-0001 or ADR-0002 — the provenance here is
+original work plus NumPy's documented behavior (BSD-3-Clause, which
+ADR-0002 permits; its rule is that nothing GSL-derived enters the tree),
+and no interface, ordering or acceptance criterion outside Task 3.4
+moves. The phase file's Task 3.4 block gained five "criteria added during
+execution" bullets, because the criterion it shipped with named an oracle
+that does not exist and set a bar (per-branch tests) that turned out to be
+achievable at bit-equality only by reproducing the compiler's contraction.
+`../../references/numerics-replacements.md` gained the measured block for
+the same reason Tasks 3.2 and 3.3 patched it: its own prose is what would
+lead the next reader to the wrong port.
+
+## Numerical impact
+
+**No public value changes** (verified: `git diff origin/master -- hazma`
+is one file, `hazma/_core.pyi`, and every line of the hunk is comment
+text — no executable line under `hazma/` is reachable from this diff, on
+a tree rebuilt before anything was run). The rest is two PyO3-free Rust
+modules that no Python imports and no Rust kernel yet calls, their
+registration-only probes, two new test modules, the parity corpus's
+served-kernel exemption, and project bookkeeping.
+
+Measured rather than only argued: the bare suite ran the parity corpus in
+**bit-equality mode** — `rtol = 0` across all 41 consumed entry points,
+179,695 pinned values — and passed, at `1314 passed, 13 skipped`
+(`provenance` → `exact=True`).
+
+What the task *did* produce numerically is a foundation that reproduces
+the Cython **bit-for-bit** where the Cython is what the corpus records:
+zero mismatches on all seven live tables across six boost regimes × 400
+energies, zero across 40,000 delta-function draws, and zero on 20,204
+`np.interp` abscissae per table. **The Phase 04 drift line for the
+kaon/eta/omega/phi family will be measured against these**, so a wrong
+choice here would surface as a kernel bug rather than a foundation bug.
+
+**One consequence to declare when Phase 04 lands, not now.** The Rust is
+bit-equal to the *contracted* (macOS/arm64) Cython on every platform,
+because `f64::mul_add` is fused everywhere. On a target whose C compiler
+does not contract — baseline x86-64 is the case that matters, since that
+is what the Linux wheels are built for — today's Cython returns the
+unfused values, which differ from these by up to **3.6e-12** relative on
+the corpus grids. The Phase 04 swap therefore moves those users' numbers
+by that much, one-time, and past rule 3's 1e-12 declaration threshold.
+Nothing moves in *this* task, because nothing calls the new code.
+
+## Stale-state sweep
+
+Each command run against this branch on 2026-08-10.
+
+**Full change inventory** — `git status --short` plus
+`git diff origin/master --stat` after `git add -N .` (18 files,
++3,265 / −49): four new `rust/src/*.rs`, `rust/src/lib.rs`, two new
+`test/test_core_*.py`, three `test/parity/*` sites, `hazma/_core.pyi`,
+two canonical patches, one follow-up + its index row, and three
+bookkeeping files. No untracked file is unaccounted for.
+
+**Numerical-impact statement** — `git diff origin/master -- hazma` is one
+file, `hazma/_core.pyi`, comment-only. Corpus in bit-equality mode:
+
+```text
+$ python -c "...tolerances.provenance(manifest)..."
+Provenance(exact=True, detail='')
+$ python -c "...cases.rust_core_kernels()..."
+[]
+```
+
+**The port is not yet served, and the exemption is honest:**
+
+```text
+registered: ['boost', 'interp', 'neutrino', 'photon', 'positron',
+             'quad', 'scalar_mediator', 'special', 'vector_mediator']
+exempted  : ['boost', 'interp', 'quad', 'special']
+$ rg -n 'hazma\._core\.(interp|boost|special|quad)' hazma/
+none
+```
+
+**The tree under test is this worktree** —
+`python -c "import hazma._core; print(hazma._core.__file__)"` →
+`…/.claude/worktrees/cython-to-rust-96ef8d/hazma/_core.abi3.so`.
+
+**Stale-sibling sweep** —
+`rg -n 'hazma._core.special|_CORE_TEST_ONLY_MODULES'` over the tree finds
+four live prose sites naming the exempted set (`test/parity/cases.py`,
+`test/parity/README.md`, `test/parity/test_parity.py`,
+`hazma/_core.pyi`); **all four now say four submodules**. `rg -n 'Two
+further submodules'` → no occurrences. Every other hit is a dated
+per-task record (the Task 3.2 and 3.3 notes), which is history rather
+than a live claim.
+
+**Citations** —
+`scripts/agents/check_doc_citations.py <8 changed .md>` →
+`docs scanned: 8; in-repo citations checked: 20; out-of-range or
+ambiguous: NONE`.
+
+**Introduced-token scan** — `grep -rnE 'TODO|FIXME|breakpoint\(\)|pdb|^\s*print\('`
+over the six new source files → none. Preflight's own
+`forbidden tokens` gate agrees.
+
+**Bookkeeping consistency** — this note's `**Status:** Complete`, the
+phase README's Tasks-table cell for 3.4, its `**Status:**` header line,
+and the project README's Phases row all agree that 3.4 is complete and
+3.5 is the only task left in Phase 03. The phase file's frontmatter
+stays `status: Not started` because that field is two-state in this
+project (every completed phase file flips straight to `Complete`), and
+flipping it is Task 3.5's closure step, not this task's.
+
+**Gates** — `scripts/agents/preflight.sh --paths "…" --md "…"` →
+`RESULT: PASS`: ten rows PASS (including `markdownlint` over all eight
+changed `.md`) and one expected SKIP (`version bump`, not a closing PR).
+
+## Handoff to Next Task
+
+**For the next agent in Phase 03:** only Task 3.5 (dispatch and error
+layer) remains. Read `../../PLAN.md`, `../README.md`, `README.md`, then
+the phase file — whose Tasks 3.2, 3.3 and 3.4 blocks all now carry
+"criteria added during execution".
+
+**Currently safe to assume:**
+
+- **`hazma_core::interp` and `hazma_core::boost` exist and are
+  bit-equal to what they replace**, on the corpus's capturing platform.
+  `interp::interp(x, xp, fp)` is `np.interp` with NumPy's full contract;
+  `boost::{boost_beta, boost_gamma, boost_delta_function,
+  boost_integrate_linear_interp}` are the four live routines of
+  `hazma/_utils/boost.pyx`. All PyO3-free; the two `hazma._core`
+  submodules are test surfaces and must stay importer-free or the parity
+  corpus leaves bit-equality mode.
+- Task 3.5's dispatch work does not touch either — both already route
+  through `dispatch::map_unary` in their probes, so whatever 3.5 decides
+  about the four live-behavior questions applies to them for free.
+
+**Currently risky / unknown, for Phases 04–06:**
+
+- **Do not "clean up" a `mul_add` into `a * b + c`, and do not add one
+  where this module does not have one.** Both directions move published
+  numbers: unfusing costs up to 3.6e-12 against the corpus (past the
+  1e-12 `TABULATED` budget), and fusing `boost_beta` — which the Cython
+  does *not* contract at any of its ten call sites — moves every boosted
+  spectrum. Every Phase 04 kernel needs its own disassembly or bisection;
+  there is no house style to apply.
+- **`boost_integrate_linear_interp` is wrong near threshold and is
+  supposed to stay wrong for now.** All seven tabulated photon spectra
+  diverge instead of converging to their rest-frame values as the parent
+  slows (6,500×–33,000× one part in 1e12 above rest). The corpus pins
+  those values, so a Phase 04 swap that repairs the coverage **fails the
+  gate**. The repair is
+  [`../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md`](../../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md),
+  blocked until after Phase 06 Task 6.4.
+- **The live tables are strided views**, not contiguous buffers
+  (`np.loadtxt(...).T` rows), so `PyReadonlyArray1::as_slice` refuses
+  them. A Phase 04 kernel should own its table in Rust; anything that
+  takes one from Python must copy.
+- **A `cdef` with a `.pxd` declaration is callable from Python** through
+  `__pyx_capi__` + `ctypes` (`PYFUNCTYPE`, never `CFUNCTYPE`). Reach for
+  that rather than adding a temporary shim to a `.pyx` when a
+  C-level-only routine needs an oracle. `test/test_core_boost.py`'s
+  `cython_boost` is the working example, and it dies with the `.pyx` in
+  Phase 06 Task 6.4 — the classes that outlive it are named in that
+  module's docstring.
+- **An edge that only decides a branch needs a bisection test, not a
+  grid.** Three of this task's mutations survived a 40,000-draw sweep
+  because they moved a support boundary by one double. Any Phase 04–06
+  kernel with a window, a threshold, or a piecewise switch inherits that:
+  sample the boundary by bisecting on the bit pattern, and make sure the
+  sweep's *parameter* space reaches the branch (with `m = 0` the fused
+  and unfused momenta are identical, so only massive draws could see it).

--- a/rust/src/boost.rs
+++ b/rust/src/boost.rs
@@ -1,0 +1,614 @@
+//! The boost kernels of `hazma/_utils/boost.pyx`, ported.
+//!
+//! PyO3-free (`projects/cython-to-rust/rules.md`, Rust conventions
+//! rule 3); [`crate::boost_probe`] is the Python-visible half.
+//!
+//! Four routines, in the order the spectra call them: [`boost_gamma`]
+//! and [`boost_beta`] turn a parent's energy and mass into boost
+//! parameters, [`boost_delta_function`] boosts a two-body line, and
+//! [`boost_integrate_linear_interp`] boosts a tabulated continuum. The
+//! `.pyx` also carries `boost_jac` and `boost_eng`; both are exported
+//! through `__pyx_capi__` and called by nothing in the tree (checked with
+//! `rg` at execution time, 2026-08-10), so they are out of this port's
+//! scope — Phase 06 Task 6.4 deletes the extension outright.
+//!
+//! # What calls these, and with what
+//!
+//! | Function | Cython call sites |
+//! | --- | --- |
+//! | [`boost_beta`] / [`boost_gamma`] | every `_photon`, `_positron` and `_neutrino` kernel that boosts out of a rest frame — `_photon/{_eta,_eta_prime,_kaon,_omega,_phi,_pion,_rho}.pyx`, `_positron/{_muon,_pion}.pyx`, `_neutrino/_pion.pyx` |
+//! | [`boost_delta_function`] | `_photon/{_eta,_eta_prime,_kaon,_omega,_phi}.pyx` (the `→ γγ` lines), `_positron/_pion.pyx`, `_neutrino/_pion.pyx` |
+//! | [`boost_integrate_linear_interp`] | `_photon/{_eta,_eta_prime,_kaon,_omega,_phi}.pyx` — seven tabulated spectra over 100- or 500-row CSVs |
+//!
+//! # Why `mul_add`, and where it is *not* used
+//!
+//! Twelve multiply-adds in this module are written `a.mul_add(b, c)`
+//! instead of `a * b + c` — eight distinct expressions in the `.pyx`,
+//! three of which appear once per partial cell. That is not a rewrite:
+//! it is what the shipped Cython computes. C compilers contract
+//! `a * b + c` into a fused multiply-add by default
+//! (`-ffp-contract=on`), and the parity corpus was captured from a
+//! macOS/arm64 build that does. Each site below was
+//! confirmed by disassembling the shipped
+//! `hazma/_utils/boost.cpython-312-darwin.so` (`fmsub` / `fmadd`
+//! instructions) *and* by bisection against the live kernel through
+//! `__pyx_capi__`; both records are in
+//! `projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md`.
+//!
+//! The measurement that makes this load-bearing rather than pedantic:
+//! evaluated on the parity corpus's own grids for all seven tabulated
+//! photon spectra, the unfused arithmetic misses the corpus by up to
+//! **3.6e-12** relative, against the 1e-12 `TABULATED` budget in
+//! `test/parity/tolerances.py`. The fused form is bit-equal at every one
+//! of those points. A Phase 04 swap written the obvious way would have
+//! failed its own gate, and widening the budget instead would have hidden
+//! a three-decade-wider class of real errors.
+//!
+//! Where the Cython does *not* contract, neither does this module.
+//! [`boost_beta`] is the case that matters: `(mass / energy) ** 2` is a
+//! rounded product before the subtraction, and none of the ten inlining
+//! call sites contract `1.0 - t` (checked by disassembly in `_eta`,
+//! `_kaon` and `_positron/_pion`). Writing it fused would move every
+//! boosted spectrum for no reason.
+
+/// Errors [`boost_integrate_linear_interp`] returns instead of panicking.
+///
+/// The Cython twin states two of these as `assert`s and leaves the third
+/// undefined; `projects/cython-to-rust/rules.md` rule 9 (Rust conventions
+/// 4) makes every such guard an unconditional error return.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BoostError {
+    /// `beta` outside `(0, 1)` — the Cython's `assert 0.0 < beta < 1.0`.
+    ///
+    /// The integral divides by `beta` and by `sqrt(1 - beta^2)`, so both
+    /// endpoints are singular. Callers short-circuit to the rest-frame
+    /// value when the parent is within one epsilon of rest, which is why
+    /// the live path never reaches this.
+    BetaOutOfRange {
+        /// The `beta` that was passed.
+        beta: f64,
+    },
+    /// The table's two columns have different lengths — the Cython's
+    /// `assert npts == len(y)`.
+    LengthMismatch {
+        /// Length of the abscissa column.
+        x: usize,
+        /// Length of the ordinate column.
+        y: usize,
+    },
+    /// The table is empty.
+    ///
+    /// New in the port. The Cython reads `x[npts - 1]` with
+    /// `wraparound(False)` and no bounds check, so an empty table is
+    /// undefined behavior there rather than an error.
+    EmptyTable,
+}
+
+impl std::fmt::Display for BoostError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BoostError::BetaOutOfRange { beta } => {
+                write!(f, "boost velocity must satisfy 0 < beta < 1; got {beta}")
+            }
+            BoostError::LengthMismatch { x, y } => write!(
+                f,
+                "spectrum table columns must have equal length; got {x} energies and {y} values"
+            ),
+            BoostError::EmptyTable => write!(f, "spectrum table must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for BoostError {}
+
+/// The Lorentz factor of a particle — `γ = E / m`.
+///
+/// # Parameters
+///
+/// * `energy` — the particle's energy, MeV.
+/// * `mass` — the particle's mass, MeV.
+///
+/// # Returns
+///
+/// The dimensionless `γ`. No guard: `mass = 0` gives `±∞` here exactly as
+/// in the Cython, and every call site passes a hadron or lepton mass.
+pub fn boost_gamma(energy: f64, mass: f64) -> f64 {
+    energy / mass
+}
+
+/// The velocity of a particle — `β = sqrt(1 − (m/E)²)`, in units of `c`.
+///
+/// # Parameters
+///
+/// * `energy` — the particle's energy, MeV.
+/// * `mass` — the particle's mass, MeV.
+///
+/// # Returns
+///
+/// The dimensionless `β`. `energy < mass` gives `NaN`, as in the Cython;
+/// callers guard the near-rest region themselves with an
+/// `E − m < DBL_EPSILON` short circuit.
+///
+/// Deliberately **not** fused — see the module docs. The Cython spells
+/// this `(mass / energy) ** 2`, whose rounded product is complete before
+/// the subtraction, and no call site's generated code contracts it.
+pub fn boost_beta(energy: f64, mass: f64) -> f64 {
+    let ratio = mass / energy;
+    (1.0 - ratio * ratio).sqrt()
+}
+
+/// Boost a rest-frame line `δ(E − e0)` into the lab frame.
+///
+/// The boosted line is flat in energy across the window the boost opens,
+/// `[γ(e − βk), γ(e + βk)]`, with height `1 / (2 γ β k₀)` where
+/// `k₀ = sqrt(e0² − m²)` is the product's rest-frame momentum.
+///
+/// # Parameters
+///
+/// * `e0` — the line's rest-frame energy, MeV.
+/// * `e` — the product's lab-frame energy, MeV.
+/// * `m` — the product's mass, MeV (`0` for a photon or neutrino).
+/// * `beta` — the parent's boost velocity, in units of `c`.
+///
+/// # Returns
+///
+/// `dN/dE` in MeV⁻¹ inside the window, and `0` outside it. `0` is also
+/// what an unphysical argument gives — `beta > 1`, `beta <= 0`, or
+/// `e < m` — reproducing the Cython's guard rather than raising, because
+/// callers sum this term into a spectrum and rely on it vanishing.
+pub fn boost_delta_function(e0: f64, e: f64, m: f64, beta: f64) -> f64 {
+    if beta > 1.0 || beta <= 0.0 || e < m {
+        return 0.0;
+    }
+
+    let gamma = 1.0 / (-beta).mul_add(beta, 1.0).sqrt();
+    let k = e.mul_add(e, -(m * m)).sqrt();
+    let eminus = gamma * (-beta).mul_add(k, e);
+    let eplus = gamma * beta.mul_add(k, e);
+
+    if eminus < e0 && e0 < eplus {
+        let k0 = e0.mul_add(e0, -(m * m)).sqrt();
+        return 1.0 / (2.0 * gamma * beta * k0);
+    }
+
+    0.0
+}
+
+/// Boost a tabulated rest-frame spectrum into the lab frame.
+///
+/// Evaluates
+///
+/// ```text
+///   dN            1     ⌠ ub  y(x)
+///   ──(E, β)  =  ────   ⎮     ──── dx ,
+///   dE           2 γ β  ⌡ lb    x
+/// ```
+///
+/// with `lb = E γ (1 − β)` and `ub = E γ (1 + β)`, over the rest-frame
+/// spectrum tabulated as `(x, y)`. The integral is the trapezoidal rule
+/// across whole interior cells, plus a closed-form correction on each
+/// partial cell at the two ends, plus an analytic `1/E` tail when `lb`
+/// falls below the table.
+///
+/// # Parameters
+///
+/// * `photon_energy` — the lab-frame energy to evaluate at, MeV. (The
+///   Cython's name; the routine is energy-agnostic and the positron and
+///   neutrino families would use it the same way.)
+/// * `beta` — the parent's boost velocity, in units of `c`, in `(0, 1)`.
+/// * `x` — the table's rest-frame energies, MeV, ascending.
+/// * `y` — the table's `dN/dE` values, MeV⁻¹.
+///
+/// # Returns
+///
+/// The boosted `dN/dE` in MeV⁻¹, or a [`BoostError`] for the guards the
+/// Cython asserts.
+///
+/// # Faithfulness notes
+///
+/// Four details are reproduced rather than repaired, per
+/// `projects/cython-to-rust/rules.md` rule 1 — the corpus pins what the
+/// Cython returns, and a repair is a separate declared change. The first
+/// two are the same off-by-one read from opposite sides and are a real
+/// defect, tracked in
+/// `docs/followups/todo/boost-integral-drops-last-interior-cell.md`:
+///
+/// * the trapezoid runs over `x[ilow..ihigh]`, an **exclusive** upper
+///   bound, while the upper partial-cell term starts at `x[ihigh]` — so
+///   `[x[ihigh - 1], x[ihigh]]` is covered by *nothing*. When `ub` is
+///   clamped, `ihigh` is the last index and the upper term is skipped
+///   too, so the table's final row contributes to no term at all;
+/// * when both bounds fall inside one cell, `ihigh = ilow - 1` and the
+///   two partial-cell terms **overlap** instead, covering about two whole
+///   cells rather than the sliver between the bounds. The over-count is
+///   `cell width / window width`, which diverges as `β → 0` — which is
+///   why all seven tabulated photon spectra blow up near threshold
+///   rather than converging to their rest-frame values;
+/// * cell membership is decided with a **1e-6 absolute** tolerance on
+///   energies that span six decades, so "the bound sits on a node" means
+///   something different at 0.005 MeV than at 1000 MeV;
+/// * the below-table tail assumes `y ∝ 1/E` and is added whole, even when
+///   `ub` also falls below the table (that case returns earlier).
+pub fn boost_integrate_linear_interp(
+    photon_energy: f64,
+    beta: f64,
+    x: &[f64],
+    y: &[f64],
+) -> Result<f64, BoostError> {
+    if !(0.0 < beta && beta < 1.0) {
+        return Err(BoostError::BetaOutOfRange { beta });
+    }
+    if x.len() != y.len() {
+        return Err(BoostError::LengthMismatch {
+            x: x.len(),
+            y: y.len(),
+        });
+    }
+    let npts = x.len();
+    if npts == 0 {
+        return Err(BoostError::EmptyTable);
+    }
+
+    let xmax = x[npts - 1];
+    let x0 = x[0];
+    let y0 = y[0];
+
+    // Fused: the Cython's `1.0 - beta * beta` contracts to `fmsub`.
+    let gamma = 1.0 / (-beta).mul_add(beta, 1.0).sqrt();
+    let mut lb = photon_energy * gamma * (1.0 - beta);
+    let mut ub = photon_energy * gamma * (1.0 + beta);
+
+    // The whole boosted window sits above the table: nothing to integrate.
+    if lb > xmax {
+        return Ok(0.0);
+    }
+    // The whole window sits below it: only the analytic 1/E tail survives,
+    // and it integrates to the closed form below.
+    if ub < x0 {
+        return Ok(y0 * x0 / photon_energy);
+    }
+
+    let mut integral = 0.0;
+    // `-1` is the Cython's "not yet decided" sentinel for both indices;
+    // `Option` carries it here without a magic value.
+    let mut ilow: Option<usize> = None;
+    let mut ihigh: Option<usize> = None;
+
+    if ub > xmax {
+        ub = xmax;
+        ihigh = Some(npts - 1);
+    }
+
+    if lb < x0 {
+        let rat = (1.0 - beta) * photon_energy * gamma / x0;
+        integral += y0 * (1.0 - rat) / rat;
+        lb = x0;
+        ilow = Some(0);
+    }
+
+    // `yy[i] = y[i] / x[i]` — the Cython materialises the whole column;
+    // reading it pointwise gives the same values without the allocation.
+    let yy = |i: usize| y[i] / x[i];
+
+    // `np.flatnonzero(bound <= x)[0]`: the first index at or above the
+    // bound. Both bounds are inside the table by the early returns above,
+    // so both scans find one.
+    let ilow = ilow.unwrap_or_else(|| {
+        (0..npts)
+            .find(|&i| lb <= x[i])
+            .expect("lb <= xmax, so some node is at or above it")
+    });
+    let ihigh = ihigh.unwrap_or_else(|| {
+        let first = (0..npts)
+            .find(|&i| ub <= x[i])
+            .expect("ub <= xmax, so some node is at or above it");
+        // Step back unless that node *is* the bound, so the interior sum
+        // never reaches past `ub`. The 1e-6 is absolute and the Cython's.
+        if (x[first] - ub).abs() > 1e-6 {
+            first - 1
+        } else {
+            first
+        }
+    });
+
+    if ilow < ihigh {
+        integral += trapezoid(&x[ilow..ihigh], ilow, &yy);
+    }
+
+    // Partial cell at the lower bound: integrate the linear interpolant
+    // of `y/x` across `[lb, x[ilow]]`.
+    if ilow > 0 && (x[ilow] - lb).abs() > 1e-6 {
+        let x2 = x[ilow];
+        let x1 = x[ilow - 1];
+        let m = (yy(ilow) - yy(ilow - 1)) / (x2 - x1);
+        // Fused: `y1 - m * x1`, then `0.5 * m * (x2 + lb) + b`, then the
+        // accumulation itself — three `fmsub`/`fmadd` in the Cython.
+        let b = (-m).mul_add(x1, yy(ilow - 1));
+        let inner = (0.5 * m).mul_add(x2 + lb, b);
+        integral = (x2 - lb).mul_add(inner, integral);
+    }
+
+    // Partial cell at the upper bound, same shape anchored on `x[ihigh]`.
+    if ihigh < npts - 1 && (ub - x[ihigh]).abs() > 1e-6 {
+        let x2 = x[ihigh + 1];
+        let x1 = x[ihigh];
+        let m = (yy(ihigh + 1) - yy(ihigh)) / (x2 - x1);
+        let b = (-m).mul_add(x1, yy(ihigh));
+        let inner = (0.5 * m).mul_add(ub + x1, b);
+        integral = (ub - x1).mul_add(inner, integral);
+    }
+
+    Ok(integral / (2.0 * gamma * beta))
+}
+
+/// `np.trapezoid(yy[offset..offset + xs.len()], x=xs)`.
+///
+/// `xs` is the abscissa slice and `yy` reads the ordinate by *absolute*
+/// index, so the caller does not have to materialise the `y / x` column
+/// the Cython builds. `offset` is the absolute index of `xs[0]`.
+///
+/// NumPy forms the per-cell terms as one array and reduces it with
+/// `ndarray.sum`, which is pairwise rather than sequential — see
+/// [`pairwise_sum`]. Reproducing that is what makes this function
+/// bit-equal to the call it replaces.
+fn trapezoid<F>(xs: &[f64], offset: usize, yy: &F) -> f64
+where
+    F: Fn(usize) -> f64,
+{
+    if xs.len() < 2 {
+        return 0.0;
+    }
+    let terms: Vec<f64> = (0..xs.len() - 1)
+        .map(|i| ((xs[i + 1] - xs[i]) * (yy(offset + i + 1) + yy(offset + i))) / 2.0)
+        .collect();
+    pairwise_sum(&terms)
+}
+
+/// NumPy's pairwise summation for `float64`, reproduced.
+///
+/// `ndarray.sum` is not a sequential accumulation: below 8 elements it is
+/// sequential, up to a 128-element block it runs eight independent
+/// accumulators and combines them as a balanced tree, and above that it
+/// splits in half on a multiple of 8 and recurses. The order is what the
+/// result depends on, so a sequential sum here would be a different
+/// number — up to 1.8e-15 relative on the 500-row tables, measured.
+///
+/// This mirrors an implementation detail rather than a documented
+/// contract, which is a real cost: a future NumPy could reduce
+/// differently. `test/test_core_boost.py::TestTrapezoid` compares against
+/// the live `np.trapezoid`, so the day that happens the test says so
+/// instead of the number drifting quietly.
+fn pairwise_sum(values: &[f64]) -> f64 {
+    /// NumPy's `PW_BLOCKSIZE`.
+    const BLOCK: usize = 128;
+
+    let n = values.len();
+    if n < 8 {
+        return values.iter().fold(0.0, |acc, &v| acc + v);
+    }
+    if n <= BLOCK {
+        let mut r = [
+            values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7],
+        ];
+        let unrolled = n - (n % 8);
+        let mut i = 8;
+        while i < unrolled {
+            for (k, slot) in r.iter_mut().enumerate() {
+                *slot += values[i + k];
+            }
+            i += 8;
+        }
+        let mut res = ((r[0] + r[1]) + (r[2] + r[3])) + ((r[4] + r[5]) + (r[6] + r[7]));
+        while i < n {
+            res += values[i];
+            i += 1;
+        }
+        return res;
+    }
+    let half = (n / 2) - (n / 2) % 8;
+    pairwise_sum(&values[..half]) + pairwise_sum(&values[half..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `γ = E/m` and `β = sqrt(1 − 1/γ²)` are the same boost, so the two
+    /// helpers must satisfy `γ = 1/sqrt(1 − β²)`.
+    ///
+    /// The tolerance is derived rather than chosen. Recovering `γ` from
+    /// `β` evaluates `1 − β²`, whose true value is `1/γ²`; the rounding
+    /// of `β²` is absolute at the `eps` level, so the subtraction's
+    /// relative error is `~eps·γ²` and the square root halves it. `4 eps
+    /// γ²` therefore covers every case with margin — and it is the
+    /// cancellation that sets it, not the implementation, which is why
+    /// the ultrarelativistic electron below is allowed nearly a part in
+    /// 1e5 while the near-rest eta is held to a part in 1e15.
+    #[test]
+    fn beta_and_gamma_describe_the_same_boost() {
+        for &(energy, mass) in &[(1000.0, 139.57039), (547.9, 547.862), (5e4, 0.5109989461)] {
+            let beta = boost_beta(energy, mass);
+            let gamma = boost_gamma(energy, mass);
+            let from_beta = 1.0 / (1.0 - beta * beta).sqrt();
+            let tol = 4.0 * f64::EPSILON * gamma * gamma;
+            assert!(
+                (gamma - from_beta).abs() <= tol * gamma,
+                "gamma {gamma} vs {from_beta} at E = {energy}, m = {mass} (rtol {tol:.3e})"
+            );
+        }
+    }
+
+    #[test]
+    fn a_particle_at_rest_has_zero_velocity_and_unit_gamma() {
+        assert_eq!(boost_beta(139.57039, 139.57039), 0.0);
+        assert_eq!(boost_gamma(139.57039, 139.57039), 1.0);
+    }
+
+    #[test]
+    fn below_rest_energy_beta_is_nan() {
+        assert!(boost_beta(100.0, 139.57039).is_nan());
+    }
+
+    /// The boosted line integrates back to 1 over its own window: it is a
+    /// normalised δ that the boost only spreads out.
+    #[test]
+    fn the_boosted_line_carries_unit_normalisation() {
+        let (e0, m, beta): (f64, f64, f64) = (200.0, 0.0, 0.6);
+        let gamma = 1.0 / (1.0 - beta * beta).sqrt();
+        let k0 = e0;
+        let lo = gamma * (e0 - beta * k0);
+        let hi = gamma * (e0 + beta * k0);
+        let height = boost_delta_function(e0, 0.5 * (lo + hi), m, beta);
+        let integral = height * (hi - lo);
+        assert!(
+            (integral - 1.0).abs() < 1e-12,
+            "normalisation {integral} != 1"
+        );
+    }
+
+    #[test]
+    fn the_boosted_line_vanishes_outside_its_window() {
+        let (e0, m, beta): (f64, f64, f64) = (200.0, 0.0, 0.6);
+        let gamma = 1.0 / (1.0 - beta * beta).sqrt();
+        // Just outside each edge of [γ(e0 − βe0), γ(e0 + βe0)].
+        assert_eq!(
+            boost_delta_function(e0, gamma * e0 * (1.0 - beta) * 0.99, m, beta),
+            0.0
+        );
+        assert_eq!(
+            boost_delta_function(e0, gamma * e0 * (1.0 + beta) * 1.01, m, beta),
+            0.0
+        );
+    }
+
+    #[test]
+    fn the_boosted_line_rejects_unphysical_arguments() {
+        assert_eq!(boost_delta_function(200.0, 200.0, 0.0, 1.5), 0.0);
+        assert_eq!(boost_delta_function(200.0, 200.0, 0.0, 0.0), 0.0);
+        assert_eq!(boost_delta_function(200.0, 200.0, 0.0, -0.3), 0.0);
+        // Product below its own mass.
+        assert_eq!(boost_delta_function(200.0, 0.1, 0.5109989461, 0.6), 0.0);
+    }
+
+    /// A flat rest-frame spectrum `y = c` boosts to `c ln(ub/lb)/(2γβ)`
+    /// when the window sits inside the table.
+    ///
+    /// The tolerance is set by the dropped interior cell, not by the
+    /// quadrature: at cell width `h` the missing cell is `h·c/ub` out of
+    /// `c·ln(ub/lb)`, which at `h = 1e-3` here is 2.6e-5 of the answer,
+    /// while the trapezoidal error on `c/x` over the same cells is
+    /// `~1e-10`. See [`the_last_interior_cell_is_dropped`] for the pin on
+    /// the drop itself; this test only has to stay loose enough to let it
+    /// through.
+    #[test]
+    fn a_flat_table_boosts_to_the_log_of_the_window() {
+        let x: Vec<f64> = (0..40_001).map(|i| 1.0 + f64::from(i) * 1e-3).collect();
+        let y = vec![2.0; x.len()];
+        let beta: f64 = 0.5;
+        let gamma = 1.0 / (1.0 - beta * beta).sqrt();
+        let energy = 20.0;
+        let (lb, ub) = (energy * gamma * (1.0 - beta), energy * gamma * (1.0 + beta));
+        let want = 2.0 * (ub / lb).ln() / (2.0 * gamma * beta);
+        let got = boost_integrate_linear_interp(energy, beta, &x, &y).unwrap();
+        assert!(
+            (got - want).abs() < 1e-4 * want,
+            "boosted flat spectrum {got} vs {want}"
+        );
+    }
+
+    /// The interior sum stops one cell short of `ihigh`, so the cell
+    /// `[x[ihigh - 1], x[ihigh]]` is covered by nothing.
+    ///
+    /// Reproduced, not repaired — `projects/cython-to-rust/rules.md`
+    /// rule 1, and
+    /// `docs/followups/todo/boost-integral-drops-last-interior-cell.md`.
+    /// The numbers are hand-computable: with `y = x` the integrand `y/x`
+    /// is 1, `beta = 0.6` gives `gamma = 1.25`, and `E = 2.2` gives
+    /// `lb = 1.1` and `ub = 4.4`, clamped to `xmax = 4`. The Cython then
+    /// covers `[1.1, 2]` (lower partial cell) and `[2, 3]` (the interior
+    /// sum) and nothing else, for `1.9 / (2γβ) = 1.9 / 1.5`. The true
+    /// integral over `[1.1, 4]` would be `2.9 / 1.5`.
+    ///
+    /// Checked against the live Cython through `__pyx_capi__`, which
+    /// returns this same 1.2666666666666666 (Task 3.4 task note).
+    #[test]
+    fn the_last_interior_cell_is_dropped() {
+        let x = [1.0, 2.0, 3.0, 4.0];
+        let y = x;
+        let got = boost_integrate_linear_interp(2.2, 0.6, &x, &y).unwrap();
+        assert_eq!(got, 1.9 / 1.5);
+        assert_ne!(got, 2.9 / 1.5);
+    }
+
+    #[test]
+    fn a_window_entirely_above_the_table_is_zero() {
+        let x = [1.0, 2.0, 3.0];
+        let y = [1.0, 1.0, 1.0];
+        // lb = E γ (1 − β) > 3 for a large enough E.
+        assert_eq!(
+            boost_integrate_linear_interp(1e6, 0.5, &x, &y).unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn a_window_entirely_below_the_table_is_the_analytic_tail() {
+        let x = [1.0, 2.0, 3.0];
+        let y = [7.0, 1.0, 1.0];
+        let energy = 1e-6;
+        let got = boost_integrate_linear_interp(energy, 0.5, &x, &y).unwrap();
+        assert_eq!(got, 7.0 * 1.0 / energy);
+    }
+
+    #[test]
+    fn the_guards_return_errors_rather_than_panicking() {
+        let x = [1.0, 2.0];
+        let y = [1.0, 1.0];
+        assert_eq!(
+            boost_integrate_linear_interp(1.0, 0.0, &x, &y),
+            Err(BoostError::BetaOutOfRange { beta: 0.0 })
+        );
+        assert_eq!(
+            boost_integrate_linear_interp(1.0, 1.0, &x, &y),
+            Err(BoostError::BetaOutOfRange { beta: 1.0 })
+        );
+        assert!(matches!(
+            boost_integrate_linear_interp(1.0, f64::NAN, &x, &y),
+            Err(BoostError::BetaOutOfRange { .. })
+        ));
+        assert_eq!(
+            boost_integrate_linear_interp(1.0, 0.5, &x, &[1.0]),
+            Err(BoostError::LengthMismatch { x: 2, y: 1 })
+        );
+        assert_eq!(
+            boost_integrate_linear_interp(1.0, 0.5, &[], &[]),
+            Err(BoostError::EmptyTable)
+        );
+    }
+
+    /// Every branch of [`pairwise_sum`]'s length dispatch, against a
+    /// sequential sum on values that make the two agree exactly (powers
+    /// of two lose nothing to reassociation).
+    #[test]
+    fn pairwise_sum_totals_exactly_representable_values() {
+        for n in [0usize, 1, 7, 8, 9, 128, 129, 300, 1000] {
+            let values: Vec<f64> = (0..n).map(|i| f64::from(i as u32 % 8) * 0.25).collect();
+            let want: f64 = values.iter().sum();
+            assert_eq!(pairwise_sum(&values), want, "n = {n}");
+        }
+    }
+
+    /// The trapezoidal rule is exact on a straight line, whatever the
+    /// cell widths.
+    #[test]
+    fn trapezoid_is_exact_on_a_linear_integrand() {
+        let xs: Vec<f64> = vec![0.5, 1.0, 2.5, 3.0, 7.0, 11.5];
+        // yy(i) must return 3 * xs[i] + 1, and `trapezoid` indexes it
+        // absolutely from `offset`.
+        let yy = |i: usize| 3.0f64.mul_add(xs[i], 1.0);
+        let got = trapezoid(&xs, 0, &yy);
+        let (a, b) = (xs[0], xs[xs.len() - 1]);
+        let want = 1.5 * (b * b - a * a) + (b - a);
+        assert!((got - want).abs() < 1e-12 * want, "{got} vs {want}");
+    }
+}

--- a/rust/src/boost_probe.rs
+++ b/rust/src/boost_probe.rs
@@ -1,0 +1,107 @@
+//! `hazma._core.boost` — the Python-visible half of [`crate::boost`].
+//!
+//! Registration only, like the per-domain submodules. This is a **test
+//! surface, not physics**: the kernels Phase 04 ports call
+//! [`crate::boost`] directly in Rust, and nothing under `hazma/` imports
+//! this module. It exists because Task 3.4's oracle is the Cython twin
+//! itself, reached from Python through `hazma._utils.boost.__pyx_capi__`
+//! — so `test/test_core_boost.py` needs a way to put the same arguments
+//! through both. Same role `special_probe` plays for the cephes shim and
+//! `quad_probe` for the QUADPACK port, and it joins them in
+//! `test/parity/cases.py`'s `_CORE_TEST_ONLY_MODULES` rather than
+//! widening that exemption.
+//!
+//! Each wrapper maps over the argument its Cython call sites sweep — the
+//! parent energy for the boost parameters, the product energy for the
+//! line, the lab-frame energy for the tabulated integral — through
+//! [`crate::dispatch::map_unary`], so a sweep is one array call rather
+//! than a Python loop.
+
+use numpy::PyReadonlyArray1;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::boost;
+use crate::dispatch::map_unary;
+
+/// The velocity of a particle — `β = sqrt(1 − (m/E)²)`, in units of `c`.
+///
+/// `energy` is the mapped argument and `mass` a scalar, matching how the
+/// spectra sweep a parent energy at fixed mass.
+#[pyfunction]
+#[pyo3(text_signature = "(energy, mass)")]
+fn boost_beta(energy: &Bound<'_, PyAny>, mass: f64) -> PyResult<Py<PyAny>> {
+    map_unary(energy, "Parent energies", |value| {
+        boost::boost_beta(value, mass)
+    })
+}
+
+/// The Lorentz factor of a particle — `γ = E / m`.
+#[pyfunction]
+#[pyo3(text_signature = "(energy, mass)")]
+fn boost_gamma(energy: &Bound<'_, PyAny>, mass: f64) -> PyResult<Py<PyAny>> {
+    map_unary(energy, "Parent energies", |value| {
+        boost::boost_gamma(value, mass)
+    })
+}
+
+/// Boost a rest-frame line `δ(E − e0)` into the lab frame, in MeV⁻¹.
+///
+/// `e` — the product's lab-frame energy — is the mapped argument, which
+/// is the argument every call site sweeps. The parameter order matches
+/// the Cython's `boost_delta_function(e0, e, m, beta)`.
+#[pyfunction]
+#[pyo3(text_signature = "(e0, e, m, beta)")]
+fn boost_delta_function(e0: f64, e: &Bound<'_, PyAny>, m: f64, beta: f64) -> PyResult<Py<PyAny>> {
+    map_unary(e, "Product energies", |value| {
+        boost::boost_delta_function(e0, value, m, beta)
+    })
+}
+
+/// Boost a tabulated rest-frame spectrum into the lab frame, in MeV⁻¹.
+///
+/// `photon_energy` is the mapped argument; `x` and `y` are the table's
+/// 1-D `float64` columns.
+///
+/// # Errors
+///
+/// Raises `ValueError` for the guards the Cython states as `assert`s —
+/// `beta` outside `(0, 1)` and columns of different lengths — plus the
+/// empty table the Cython leaves undefined
+/// (`projects/cython-to-rust/rules.md` rule 9).
+#[pyfunction]
+#[pyo3(text_signature = "(photon_energy, beta, x, y)")]
+fn boost_integrate_linear_interp(
+    photon_energy: &Bound<'_, PyAny>,
+    beta: f64,
+    x: PyReadonlyArray1<'_, f64>,
+    y: PyReadonlyArray1<'_, f64>,
+) -> PyResult<Py<PyAny>> {
+    // `to_vec`, not `as_slice`: the live tables are rows of a transposed
+    // `np.loadtxt` result, so they are strided views rather than
+    // contiguous buffers and `as_slice` refuses them. Copying is the
+    // right answer for a test surface — a Phase 04 kernel owns its table
+    // in Rust and never sees a NumPy stride at all.
+    let x = x.as_array().to_vec();
+    let y = y.as_array().to_vec();
+    // Validate once here rather than per element: the guards depend only
+    // on `beta` and the table, so a swept array either fails everywhere
+    // or nowhere, and mapping the error out of the kernel would mean
+    // deciding what value a failed element takes.
+    if let Err(err) = boost::boost_integrate_linear_interp(1.0, beta, &x, &y) {
+        return Err(PyValueError::new_err(err.to_string()));
+    }
+    map_unary(photon_energy, "Photon energies", |value| {
+        boost::boost_integrate_linear_interp(value, beta, &x, &y)
+            .expect("the guards depend only on beta and the table, both just checked")
+    })
+}
+
+/// Populate the submodule.
+pub fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(boost_beta, module)?)?;
+    module.add_function(wrap_pyfunction!(boost_gamma, module)?)?;
+    module.add_function(wrap_pyfunction!(boost_delta_function, module)?)?;
+    module.add_function(wrap_pyfunction!(boost_integrate_linear_interp, module)?)?;
+    Ok(())
+}

--- a/rust/src/interp.rs
+++ b/rust/src/interp.rs
@@ -1,0 +1,264 @@
+//! `np.interp`, reproduced exactly.
+//!
+//! PyO3-free (`projects/cython-to-rust/rules.md`, Rust conventions
+//! rule 3); [`crate::interp_probe`] is the Python-visible half.
+//!
+//! # Sources and licensing
+//!
+//! This is an independent Rust implementation of the behavior of
+//! `numpy.interp`, written against NumPy's documented contract and the
+//! observable behavior of the shipped binary, then pinned against it by
+//! exhaustive comparison in `test/test_core_interp.py`. No NumPy source
+//! is transcribed. NumPy is BSD-3-Clause, which
+//! `projects/cython-to-rust/adrs/ADR-0002-license-clean-numerics.md`
+//! permits in any case — the rule it enforces is that nothing
+//! GSL-derived (GPL-3) enters the tree, and nothing here is.
+//!
+//! # What calls this, and with what
+//!
+//! Five rest-frame photon spectra reach `np.interp` inside `cdef`
+//! functions, always as `np.interp(energy, table_energies, table_dnde)`
+//! on an ascending 100- or 500-row table read from a shipped CSV:
+//! `hazma/spectra/_photon/_eta.pyx:44`, `_eta_prime.pyx:48`,
+//! `_kaon.pyx:127`, `_omega.pyx:48`, `_phi.pyx:47`. The four mediator
+//! spectrum modules call it the same way on their own tables
+//! (`hazma/{scalar,vector}_mediator/*_decay_spectrum.pyx`,
+//! `*_positron_spec.pyx`). Every call site passes a scalar `x`, so the
+//! signature here is scalar-in / scalar-out and the array form lives in
+//! the probe.
+//!
+//! # Why `mul_add`
+//!
+//! The interpolation step is written `slope.mul_add(x - xp[j], fp[j])`
+//! rather than `slope * (x - xp[j]) + fp[j]`, because that is what the
+//! shipped NumPy computes. C compilers contract `a * b + c` into a fused
+//! multiply-add by default (`-ffp-contract=on`), and on the corpus's
+//! capturing platform — macOS/arm64 — NumPy's `arr_interp` does exactly
+//! that. Measured on the eta and charged-kaon tables over 20,000 random
+//! abscissae plus every node and every node nudged by one part in 1e13:
+//! the fused form is **bit-equal to `np.interp` at every point**, and the
+//! unfused form misses it at 1,549 of 20,204 points, by up to 1.1e-13
+//! relative (`test/test_core_interp.py::TestAgainstNumpy`).
+//!
+//! That trade is worth stating, because it is not free. `mul_add` is a
+//! single instruction only where the target has hardware FMA; elsewhere
+//! it lowers to a libm `fma()` call. And a NumPy built for a target
+//! *without* FMA does not contract, so on such a platform this function
+//! would differ from its `np.interp` by that same ≤1.1e-13 — an order
+//! inside the 1e-12 budget `test/parity/tolerances.py` sets for the
+//! tabulated spectra, where the unfused form's error against the corpus
+//! is not (see [`crate::boost`]).
+
+/// Linear interpolation on an ascending grid — `numpy.interp(x, xp, fp)`.
+///
+/// Reproduces NumPy's full contract for the three-argument form:
+///
+/// * outside the grid the result is **clamped**, not extrapolated:
+///   `fp[0]` below `xp[0]`, `fp[len - 1]` above `xp[len - 1]`;
+/// * an exact node hit returns that node's value, which is also NumPy's
+///   guard against a non-finite interpolation at a node;
+/// * `NaN` propagates — except on a one-point grid, where NumPy has no
+///   `NaN` check and every argument returns `fp[0]`. That asymmetry is
+///   NumPy's, reproduced deliberately and pinned by test.
+///
+/// # Parameters
+///
+/// * `x` — the abscissa to evaluate at, in the grid's units.
+/// * `xp` — grid abscissae, **ascending**. NumPy does not check this and
+///   neither does this function; an unsorted grid gives NumPy's own
+///   (meaningless) answer.
+/// * `fp` — grid ordinates, same length as `xp`.
+///
+/// # Panics
+///
+/// Panics if `xp` is empty or `xp.len() != fp.len()`. NumPy raises
+/// `ValueError` for both; [`crate::interp_probe`] raises it with NumPy's
+/// wording before this function is reached, so the panic is a
+/// caller-side bug rather than a reachable path from Python.
+pub fn interp(x: f64, xp: &[f64], fp: &[f64]) -> f64 {
+    assert!(!xp.is_empty(), "interp: the grid must not be empty");
+    assert!(
+        xp.len() == fp.len(),
+        "interp: xp and fp must have the same length"
+    );
+
+    let n = xp.len();
+
+    // NumPy's one-point branch, which runs *before* its NaN check and so
+    // returns `fp[0]` for every argument including NaN.
+    if n == 1 {
+        return fp[0];
+    }
+
+    if x.is_nan() {
+        return x;
+    }
+
+    match search(x, xp) {
+        Slot::Below => fp[0],
+        Slot::Above => fp[n - 1],
+        Slot::Cell(j) if j == n - 1 => fp[j],
+        // A node hit takes the node's value rather than interpolating,
+        // so a zero-width or non-finite cell cannot turn an exact
+        // abscissa into a NaN.
+        Slot::Cell(j) if xp[j] == x => fp[j],
+        Slot::Cell(j) => {
+            let slope = (fp[j + 1] - fp[j]) / (xp[j + 1] - xp[j]);
+            // Fused, to match the shipped NumPy — see the module docs.
+            let value = slope.mul_add(x - xp[j], fp[j]);
+            if !value.is_nan() {
+                return value;
+            }
+            // NumPy's two-step NaN rescue: try the cell's other end, and
+            // if that fails too fall back to the node value when the cell
+            // is flat. Reachable when a cell edge is infinite.
+            let from_right = slope.mul_add(x - xp[j + 1], fp[j + 1]);
+            if !from_right.is_nan() {
+                from_right
+            } else if fp[j] == fp[j + 1] {
+                fp[j]
+            } else {
+                from_right
+            }
+        }
+    }
+}
+
+/// Where `x` sits relative to an ascending grid.
+enum Slot {
+    /// Strictly below `xp[0]`.
+    Below,
+    /// Strictly above `xp[len - 1]`.
+    Above,
+    /// In the grid: the largest `j` with `xp[j] <= x`.
+    Cell(usize),
+}
+
+/// NumPy's `binary_search_with_guess`, without the guess.
+///
+/// Returns the largest index `j` with `xp[j] <= x`, or [`Slot::Below`] /
+/// [`Slot::Above`] outside the grid. NumPy's version starts from the
+/// previous result and expands outwards before bisecting, which is a
+/// speedup for a sorted query array and cannot change the index it
+/// returns; this one bisects immediately.
+fn search(x: f64, xp: &[f64]) -> Slot {
+    let n = xp.len();
+    if x > xp[n - 1] {
+        return Slot::Above;
+    }
+    if x < xp[0] {
+        return Slot::Below;
+    }
+
+    // `x >= xp[0]` here, so `imin` ends at 1 or more and the subtraction
+    // cannot underflow. Ties resolve to the *last* matching index,
+    // matching NumPy.
+    let mut imin = 0usize;
+    let mut imax = n;
+    while imin < imax {
+        let imid = imin + ((imax - imin) >> 1);
+        if x >= xp[imid] {
+            imin = imid + 1;
+        } else {
+            imax = imid;
+        }
+    }
+    Slot::Cell(imin - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A grid with unequal cells, so a wrong cell index cannot pass by
+    /// symmetry.
+    const XP: [f64; 5] = [0.0, 1.0, 3.0, 4.0, 8.0];
+    const FP: [f64; 5] = [10.0, 20.0, 0.0, -5.0, 15.0];
+
+    #[test]
+    fn clamps_outside_the_grid() {
+        assert_eq!(interp(-1.0, &XP, &FP), 10.0);
+        assert_eq!(interp(-1e300, &XP, &FP), 10.0);
+        assert_eq!(interp(9.0, &XP, &FP), 15.0);
+        assert_eq!(interp(f64::INFINITY, &XP, &FP), 15.0);
+        assert_eq!(interp(f64::NEG_INFINITY, &XP, &FP), 10.0);
+    }
+
+    #[test]
+    fn returns_node_values_at_nodes() {
+        for (&x, &f) in XP.iter().zip(FP.iter()) {
+            assert_eq!(interp(x, &XP, &FP), f);
+        }
+    }
+
+    #[test]
+    fn interpolates_linearly_inside_a_cell() {
+        // Midpoint of [1, 3] with values 20 -> 0.
+        assert_eq!(interp(2.0, &XP, &FP), 10.0);
+        // Quarter point of [4, 8] with values -5 -> 15.
+        assert_eq!(interp(5.0, &XP, &FP), 0.0);
+    }
+
+    #[test]
+    fn propagates_nan_on_a_multi_point_grid() {
+        assert!(interp(f64::NAN, &XP, &FP).is_nan());
+    }
+
+    #[test]
+    fn a_one_point_grid_never_propagates_nan() {
+        // NumPy checks for NaN only on the multi-point path, so its
+        // one-point branch answers `fp[0]` to everything.
+        assert_eq!(interp(f64::NAN, &[2.0], &[7.0]), 7.0);
+        assert_eq!(interp(-1.0, &[2.0], &[7.0]), 7.0);
+        assert_eq!(interp(5.0, &[2.0], &[7.0]), 7.0);
+    }
+
+    #[test]
+    fn duplicate_nodes_resolve_to_the_last_match() {
+        // NumPy's bisection walks past equal keys, so `x = 1` lands on
+        // the *second* copy and returns its value.
+        let xp = [0.0, 1.0, 1.0, 2.0];
+        let fp = [0.0, 5.0, 9.0, 9.0];
+        assert_eq!(interp(1.0, &xp, &fp), 9.0);
+    }
+
+    #[test]
+    fn the_last_cell_index_short_circuits_to_the_node() {
+        // `x == xp[n - 1]` reaches `Slot::Cell(n - 1)`, where there is no
+        // cell to the right; NumPy returns the node rather than reading
+        // past the end.
+        assert_eq!(interp(8.0, &XP, &FP), 15.0);
+    }
+
+    #[test]
+    fn an_infinite_ordinate_falls_back_to_the_other_end() {
+        // The slope is -inf, so the left-anchored form is
+        // `fma(-inf, 0.5, inf)` = NaN; NumPy retries anchored on the
+        // right node, where `fma(-inf, -0.5, 0)` = +inf.
+        let xp = [0.0, 1.0];
+        let fp = [f64::INFINITY, 0.0];
+        assert_eq!(interp(0.0, &xp, &fp), f64::INFINITY);
+        assert_eq!(interp(0.5, &xp, &fp), f64::INFINITY);
+    }
+
+    #[test]
+    fn a_nan_from_both_ends_survives_unless_the_cell_is_flat() {
+        // Both anchors give NaN when the cell is infinitely wide. NumPy
+        // rescues the flat case and leaves the rest NaN.
+        let flat = [f64::NEG_INFINITY, f64::INFINITY];
+        assert_eq!(interp(0.0, &flat, &[3.0, 3.0]), 3.0);
+        assert!(interp(0.0, &flat, &[3.0, 4.0]).is_nan());
+    }
+
+    #[test]
+    #[should_panic(expected = "must not be empty")]
+    fn rejects_an_empty_grid() {
+        interp(0.0, &[], &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "same length")]
+    fn rejects_mismatched_lengths() {
+        interp(0.0, &[0.0, 1.0], &[0.0]);
+    }
+}

--- a/rust/src/interp_probe.rs
+++ b/rust/src/interp_probe.rs
@@ -1,0 +1,69 @@
+//! `hazma._core.interp` — the Python-visible half of [`crate::interp`].
+//!
+//! Registration only, like the per-domain submodules. This is a **test
+//! surface, not physics**: the kernels Phase 04 ports call
+//! [`crate::interp::interp`] directly in Rust, and nothing under `hazma/`
+//! imports this module. It exists because Task 3.4's exit criterion is
+//! stated against `np.interp` — an oracle that lives in Python — so
+//! `test/test_core_interp.py` needs a way to put the same abscissae
+//! through both. Same role `special_probe` plays for the cephes shim and
+//! `quad_probe` for the QUADPACK port, and it joins them in
+//! `test/parity/cases.py`'s `_CORE_TEST_ONLY_MODULES` rather than
+//! widening that exemption.
+//!
+//! The abscissa goes through [`crate::dispatch::map_unary`], so a sweep
+//! runs as one array call rather than a Python loop over tens of
+//! thousands of points — the kind of test that otherwise gets quietly
+//! trimmed later.
+
+use numpy::PyReadonlyArray1;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::dispatch::map_unary;
+use crate::interp;
+
+/// Linear interpolation on an ascending grid — `numpy.interp(x, xp, fp)`.
+///
+/// `x` follows the usual dispatch contract (scalar or 1-D `float64`
+/// array); `xp` and `fp` must both be 1-D `float64` arrays.
+///
+/// # Errors
+///
+/// Raises `ValueError`, with NumPy's own wording, for an empty grid or
+/// for `xp` and `fp` of different lengths. Doing it here rather than in
+/// the kernel keeps [`crate::interp::interp`]'s asserts unreachable from
+/// Python.
+#[pyfunction]
+#[pyo3(name = "interp")]
+#[pyo3(text_signature = "(x, xp, fp)")]
+fn interp_py(
+    x: &Bound<'_, PyAny>,
+    xp: PyReadonlyArray1<'_, f64>,
+    fp: PyReadonlyArray1<'_, f64>,
+) -> PyResult<Py<PyAny>> {
+    // `to_vec`, not `as_slice`: the live tables are rows of a transposed
+    // `np.loadtxt` result, so they are strided views rather than
+    // contiguous buffers and `as_slice` refuses them. Copying is the
+    // right answer for a test surface — a Phase 04 kernel owns its table
+    // in Rust and never sees a NumPy stride at all.
+    let xp = xp.as_array().to_vec();
+    let fp = fp.as_array().to_vec();
+    if xp.is_empty() {
+        return Err(PyValueError::new_err("array of sample points is empty"));
+    }
+    if xp.len() != fp.len() {
+        return Err(PyValueError::new_err(
+            "fp and xp are not of the same length.",
+        ));
+    }
+    map_unary(x, "Interpolation abscissae", |value| {
+        interp::interp(value, &xp, &fp)
+    })
+}
+
+/// Populate the submodule.
+pub fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(interp_py, module)?)?;
+    Ok(())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,21 +15,29 @@
 //! separately" (rules.md rule 8) is about keeping it out of [`kernels`],
 //! not about confining it to one file.
 //!
-//! [`constants`], [`special`] and [`quad`] sit below `kernels` in that
-//! stack and are `pub` while their neighbours are private — no kernel
-//! reads any of them yet, and a private module of unread items is a wall
-//! of `dead_code`. Publishing them is also honest: the constant tables,
-//! the cephes shim and the QUADPACK port are the crate's most reusable
-//! surface, and Phases 03–06 consume them from every kernel module.
+//! [`constants`], [`special`], [`quad`], [`interp`] and [`boost`] sit
+//! below `kernels` in that stack and are `pub` while their neighbours are
+//! private — no kernel reads any of them yet, and a private module of
+//! unread items is a wall of `dead_code`. Publishing them is also honest:
+//! the constant tables, the cephes shim, the QUADPACK port and the
+//! interpolation/boost foundation are the crate's most reusable surface,
+//! and Phases 03–06 consume them from every kernel module.
 //!
-//! [`special_probe`] and [`quad_probe`] are the exception to
-//! "registration only means per-domain": they register `special` and
-//! `quad` submodules that expose [`special`] and [`quad`] to Python purely
-//! so `test/test_core_special.py` and `test/test_core_quad.py` can compare
-//! them against scipy. No hazma module imports either.
+//! [`special_probe`], [`quad_probe`], [`interp_probe`] and [`boost_probe`]
+//! are the exception to "registration only means per-domain": they
+//! register `special`, `quad`, `interp` and `boost` submodules that expose
+//! the four foundation modules to Python purely so
+//! `test/test_core_special.py`, `test/test_core_quad.py`,
+//! `test/test_core_interp.py` and `test/test_core_boost.py` can compare
+//! them against their oracles — scipy, NumPy, and the Cython twin itself
+//! through `__pyx_capi__`. No hazma module imports any of them.
 
+pub mod boost;
+mod boost_probe;
 pub mod constants;
 mod dispatch;
+pub mod interp;
+mod interp_probe;
 mod kernels;
 mod neutrino;
 mod photon;
@@ -105,6 +113,8 @@ fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     add_submodule(module, "vector_mediator", vector_mediator::register)?;
     add_submodule(module, "special", special_probe::register)?;
     add_submodule(module, "quad", quad_probe::register)?;
+    add_submodule(module, "interp", interp_probe::register)?;
+    add_submodule(module, "boost", boost_probe::register)?;
 
     Ok(())
 }

--- a/test/parity/README.md
+++ b/test/parity/README.md
@@ -64,10 +64,14 @@ legitimate corpus repair and drop the runner out of bit-equality mode two
 phases early. `cases.rust_core_kernels()` is the predicate; it returns the
 kernels the extension actually exposes, ignoring the scaffold's
 `roundtrip` probe and the test-only submodules listed in
-`cases._CORE_TEST_ONLY_MODULES` (today `hazma._core.special`, the Phase
-03 Task 3.2 specfun shim that `test/test_core_special.py` sweeps against
-scipy, and `hazma._core.quad`, the Task 3.3 QUADPACK port that
-`test/test_core_quad.py` compares against `scipy.integrate.quad`). That
+`cases._CORE_TEST_ONLY_MODULES` (today four: `hazma._core.special`, the
+Phase 03 Task 3.2 specfun shim that `test/test_core_special.py` sweeps
+against scipy; `hazma._core.quad`, the Task 3.3 QUADPACK port that
+`test/test_core_quad.py` compares against `scipy.integrate.quad`; and
+`hazma._core.interp` and `hazma._core.boost`, the Task 3.4 interpolation
+and boost foundation, swept by `test/test_core_interp.py` against
+`np.interp` and by `test/test_core_boost.py` against the Cython twin
+itself through `hazma._utils.boost.__pyx_capi__`). That
 second exemption is held honest by
 `test_test_only_core_submodules_have_no_importer`, which fails the moment
 anything under `hazma/` imports one of them — at which point it is a

--- a/test/parity/cases.py
+++ b/test/parity/cases.py
@@ -1220,15 +1220,26 @@ _CORE_SCAFFOLD_NAMES = frozenset({"roundtrip"})
 #: shim, exposed to Python only so ``test/test_core_special.py`` can sweep
 #: it against scipy; ``hazma._core.quad`` is Task 3.3's QUADPACK port,
 #: exposed so ``test/test_core_quad.py`` can put one Python integrand
-#: through both it and ``scipy.integrate.quad``. In both cases the kernels
-#: that will use them call the Rust side directly, with a Rust closure,
-#: and never through Python. What makes the exemption safe rather than
+#: through both it and ``scipy.integrate.quad``; ``hazma._core.interp``
+#: and ``hazma._core.boost`` are Task 3.4's interpolation and boost
+#: foundation, exposed so ``test/test_core_interp.py`` can sweep against
+#: ``np.interp`` and ``test/test_core_boost.py`` against the Cython twin
+#: itself through ``hazma._utils.boost.__pyx_capi__``. In every case the
+#: kernels that will use them call the Rust side directly, in Rust, and
+#: never through Python. What makes the exemption safe rather than
 #: convenient is that no module under `hazma/` may import these — asserted
 #: by ``test_test_only_core_submodules_have_no_importer`` in
 #: ``test_parity.py``, not left to this comment. **Do not add a submodule
 #: here to quiet a failing mode check**: a submodule a wrapper imports is
 #: a served kernel, whatever it is named.
-_CORE_TEST_ONLY_MODULES = frozenset({"hazma._core.special", "hazma._core.quad"})
+_CORE_TEST_ONLY_MODULES = frozenset(
+    {
+        "hazma._core.special",
+        "hazma._core.quad",
+        "hazma._core.interp",
+        "hazma._core.boost",
+    }
+)
 
 
 def rust_core_kernels() -> list[str]:

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -263,8 +263,8 @@ def test_scaffolded_core_serves_no_kernels() -> None:
 
     `roundtrip` is a plumbing probe with no caller in `hazma/`; the five
     per-domain submodules are empty until Phase 04; and `special`
-    (Phase 03 Task 3.2) and `quad` (Task 3.3) are test-only shims
-    exempted wholesale by
+    (Phase 03 Task 3.2), `quad` (Task 3.3), `interp` and `boost`
+    (Task 3.4) are test-only shims exempted wholesale by
     `cases._CORE_TEST_ONLY_MODULES`. If this fails, either a kernel
     landed (in which case the corpus really should leave exact mode) or
     something non-kernel became public on the extension and needs adding

--- a/test/test_core_boost.py
+++ b/test/test_core_boost.py
@@ -1,0 +1,801 @@
+r"""``hazma._core.boost`` against the Cython it replaces.
+
+``hazma/_utils/boost.pyx`` is the only compiled module the spectra share:
+:func:`boost_beta` and :func:`boost_gamma` turn a parent's energy and mass
+into boost parameters, ``boost_delta_function`` boosts a two-body line,
+and ``boost_integrate_linear_interp`` boosts a tabulated continuum.
+cython-to-rust Task 3.4 reimplements all four in ``rust/src/boost.rs``.
+
+The oracle is the Cython itself
+-------------------------------
+The phase file asked for "micro-fixtures captured in Phase 01". There are
+none: the parity corpus enumerates top-level ``def``\ s in the surviving
+``.pyx``, and every routine here is ``cdef`` -- private to the C level and
+invisible to the corpus by construction. What exists instead is stronger.
+``boost.pxd`` declares the ``cdef``\ s, which makes Cython export them
+through ``hazma._utils.boost.__pyx_capi__`` as ``PyCapsule``\ s, and
+:func:`cython_boost` calls them through ``ctypes``. So the comparisons
+below are against the *live* kernel at whatever arguments the test picks,
+rather than against a frozen sample of it.
+
+Two mechanical points about that shim. It must use ``ctypes.PYFUNCTYPE``
+rather than ``CFUNCTYPE``: the latter releases the GIL, and
+``boost_integrate_linear_interp`` touches Python objects (it calls
+``np.trapezoid``), so a ``CFUNCTYPE`` call segfaults. And the capsule
+name *is* the C signature, so :class:`TestOracle` checks it rather than
+trusting that the argument list has not changed.
+
+The bar is bit-equality
+-----------------------
+Not a tolerance. ``rust/src/boost.rs`` reproduces the shipped Cython's
+arithmetic exactly, fused multiply-adds included --
+:class:`TestFusedArithmetic` is the measurement that made that mandatory:
+written the obvious unfused way, the boost integral misses the corpus by
+up to 3.6e-12 relative on the corpus's own grids, against the 1e-12
+``TABULATED`` budget in ``test/parity/tolerances.py``.
+
+Lifetime
+--------
+Everything comparing against ``__pyx_capi__`` dies with the ``.pyx`` in
+Phase 06 Task 6.4. :class:`TestTrapezoidSummation`,
+:class:`TestDroppedInteriorCell`, :class:`TestErrors` and
+:class:`TestDispatch` do not, and are what remains as the standing check
+afterwards.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import math
+from collections.abc import Callable
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+from hazma._core import boost as core_boost
+from hazma._utils import boost as cython_module
+from hazma.parameters import (
+    charged_kaon_mass,
+    eta_mass,
+    eta_prime_mass,
+    neutral_kaon_mass,
+    omega_mass,
+    phi_mass,
+)
+from hazma.spectra._photon import _eta, _eta_prime, _kaon, _omega, _phi
+
+boost_beta = core_boost.boost_beta
+boost_gamma = core_boost.boost_gamma
+boost_delta_function = core_boost.boost_delta_function
+boost_integrate_linear_interp = core_boost.boost_integrate_linear_interp
+
+
+# --------------------------------------------------------------------------
+# The Cython oracle
+# --------------------------------------------------------------------------
+
+_SIGNATURES = {
+    "boost_integrate_linear_interp": (
+        b"double (double, double, PyArrayObject *, PyArrayObject *)"
+    ),
+    "boost_delta_function": b"double (double, double, double, double)",
+    "boost_eng": b"double (double, double, double, double, double)",
+    "boost_jac": b"double (double, double, double, double, double)",
+}
+
+_ARGTYPES: dict[str, tuple[type, ...]] = {
+    "boost_integrate_linear_interp": (
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.py_object,
+        ctypes.py_object,
+    ),
+    "boost_delta_function": (ctypes.c_double,) * 4,
+    "boost_eng": (ctypes.c_double,) * 5,
+    "boost_jac": (ctypes.c_double,) * 5,
+}
+
+
+def cython_boost(name: str) -> Callable[..., float]:
+    """The live Cython ``cdef`` of that name, callable from Python.
+
+    Parameters
+    ----------
+    name : str
+        A key of ``hazma._utils.boost.__pyx_capi__``.
+
+    Returns
+    -------
+    callable
+        Returns a ``float``. ``PYFUNCTYPE``, not ``CFUNCTYPE`` -- see the
+        module docstring.
+    """
+    get_pointer = ctypes.pythonapi.PyCapsule_GetPointer
+    get_pointer.restype = ctypes.c_void_p
+    get_pointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+    capsule = cython_module.__pyx_capi__[name]
+    address = get_pointer(capsule, _SIGNATURES[name])
+    prototype = ctypes.PYFUNCTYPE(ctypes.c_double, *_ARGTYPES[name])
+    return prototype(address)
+
+
+def fma(a: float, b: float, c: float) -> float:
+    """``a * b + c`` with a single rounding, without ``math.fma``.
+
+    ``math.fma`` arrived in Python 3.13 and this suite supports 3.10, so
+    the fused product is computed exactly as a rational and rounded once
+    by ``float()``, which rounds to nearest. Used to reproduce the
+    compiler's contraction when a test needs to predict a bound.
+    """
+    return float(Fraction(a) * Fraction(b) + Fraction(c))
+
+
+def rust_gamma(beta: float) -> float:
+    """``1 / sqrt(1 - beta**2)`` as ``rust/src/boost.rs`` computes it."""
+    return 1.0 / math.sqrt(fma(-beta, beta, 1.0))
+
+
+def photon_tables() -> dict[str, tuple[np.ndarray, np.ndarray, float]]:
+    """The seven live ``(energies, dnde, parent_mass)`` triples."""
+    return {
+        "eta": (_eta.eta_data_energies, _eta.eta_data_dnde, eta_mass),
+        "eta_prime": (
+            _eta_prime.eta_prime_data_energies,
+            _eta_prime.eta_prime_data_dnde,
+            eta_prime_mass,
+        ),
+        "charged_kaon": (
+            _kaon.charged_kaon_data_energies,
+            _kaon.charged_kaon_data_dnde,
+            charged_kaon_mass,
+        ),
+        "long_kaon": (
+            _kaon.long_kaon_data_energies,
+            _kaon.long_kaon_data_dnde,
+            neutral_kaon_mass,
+        ),
+        "short_kaon": (
+            _kaon.short_kaon_data_energies,
+            _kaon.short_kaon_data_dnde,
+            neutral_kaon_mass,
+        ),
+        "omega": (_omega.omega_data_energies, _omega.omega_data_dnde, omega_mass),
+        "phi": (_phi.phi_data_energies, _phi.phi_data_dnde, phi_mass),
+    }
+
+
+#: Parent-energy multiples spanning the regimes the parity corpus uses --
+#: just off rest, near rest, mildly boosted, strongly boosted.
+BOOST_REGIMES = (1.000_000_001, 1.05, 1.5, 2.0, 3.0, 10.0)
+
+#: A flat toy table with ``y / x == 1`` everywhere, so every branch's
+#: contribution is a length and can be predicted by hand.
+FLAT_X = np.arange(1.0, 9.0)
+FLAT_Y = FLAT_X.copy()
+
+#: The Cython's absolute tolerance for "this bound sits on a node"
+#: (``hazma/_utils/boost.pyx:212``), reused where a test has to predict
+#: which branch fires.
+EDGE_ATOL = 1e-6
+#: Enough bracketed window edges for the sweep to mean something.
+MIN_EDGES_CHECKED = 100
+#: The smallest miss the unfused arithmetic is recorded as producing; a
+#: smaller one means the platform stopped contracting.
+MIN_RECORDED_UNFUSED_MISS = 1e-13
+
+
+class TestOracle:
+    """The shim really is the Cython, and calls it correctly."""
+
+    def test_every_cdef_is_exported(self) -> None:
+        assert set(cython_module.__pyx_capi__) == set(_SIGNATURES)
+
+    @pytest.mark.parametrize("name", sorted(_SIGNATURES))
+    def test_the_capsule_signature_is_the_one_the_shim_assumes(self, name: str) -> None:
+        """A changed argument list would otherwise corrupt the stack."""
+        get_name = ctypes.pythonapi.PyCapsule_GetName
+        get_name.restype = ctypes.c_char_p
+        get_name.argtypes = [ctypes.py_object]
+        assert get_name(cython_module.__pyx_capi__[name]) == _SIGNATURES[name]
+
+    def test_the_shim_returns_the_documented_closed_form(self) -> None:
+        """``boost_eng(ep, mp, 1, 0, 0)`` is ``gamma`` and nothing else.
+
+        With ``md = 0`` and ``ed = 1`` the transverse factor is 1 and the
+        angular factor is ``1 + 0``, so the Cython computes ``g * 1 * 1``.
+        That makes it an exact readout of the inlined ``boost_gamma``,
+        which is what :class:`TestBoostParameters` uses it for.
+        """
+        eng = cython_boost("boost_eng")
+        assert eng(1000.0, 139.57039, 1.0, 0.0, 0.0) == 1000.0 / 139.57039
+
+
+class TestBoostParameters:
+    """``boost_beta`` and ``boost_gamma``."""
+
+    CASES = (
+        (1000.0, 139.57039),
+        (547.9, 547.862),
+        (5e4, 0.510_998_946_1),
+        (1200.0, 493.677),
+        (139.570_390_000_001, 139.57039),
+    )
+
+    @pytest.mark.parametrize(("energy", "mass"), CASES)
+    def test_gamma_matches_the_cython_bit_for_bit(
+        self, energy: float, mass: float
+    ) -> None:
+        eng = cython_boost("boost_eng")
+        assert boost_gamma(energy, mass) == eng(energy, mass, 1.0, 0.0, 0.0)
+
+    @pytest.mark.parametrize(("energy", "mass"), CASES)
+    def test_beta_matches_the_unfused_closed_form_bit_for_bit(
+        self, energy: float, mass: float
+    ) -> None:
+        """The definition, evaluated in Python's (never-fused) arithmetic.
+
+        This is the pin on the *absence* of a fused multiply-add in
+        ``boost_beta``: the Cython spells it ``(mass / energy) ** 2``,
+        whose rounded product completes before the subtraction, and none
+        of its ten inlining call sites contract it (checked by
+        disassembly, Task 3.4 task note). Writing it fused would move
+        every boosted spectrum, and this assertion is what fails if
+        someone does.
+        """
+        ratio = mass / energy
+        assert boost_beta(energy, mass) == math.sqrt(1.0 - ratio * ratio)
+
+    @pytest.mark.parametrize(("energy", "mass"), CASES)
+    def test_beta_agrees_with_what_the_cython_can_be_asked_for(
+        self, energy: float, mass: float
+    ) -> None:
+        """Cross-check through ``boost_eng``, at the precision it allows.
+
+        ``boost_eng(ep, mp, 1, 0, 1) = gamma * (1 + beta)``, so dividing
+        out ``gamma`` and subtracting 1 recovers ``beta`` -- but the
+        subtraction cancels, leaving an absolute error of order ``eps``
+        rather than a relative one. The tolerance says exactly that: a few
+        ulp of 1, loosened by nothing else.
+        """
+        eng = cython_boost("boost_eng")
+        gamma = eng(energy, mass, 1.0, 0.0, 0.0)
+        recovered = eng(energy, mass, 1.0, 0.0, 1.0) / gamma - 1.0
+        assert boost_beta(energy, mass) == pytest.approx(
+            recovered, abs=4.0 * np.finfo(np.float64).eps, rel=0.0
+        )
+
+    def test_a_particle_at_rest_has_zero_velocity_and_unit_gamma(self) -> None:
+        assert boost_beta(139.57039, 139.57039) == 0.0
+        assert boost_gamma(139.57039, 139.57039) == 1.0
+
+    def test_below_rest_energy_beta_is_nan(self) -> None:
+        assert np.isnan(boost_beta(100.0, 139.57039))
+
+
+class TestBoostDeltaFunction:
+    """The boosted two-body line, branch by branch."""
+
+    def test_matches_the_cython_over_a_random_sweep(self) -> None:
+        """40,000 draws at both live product masses, bit for bit.
+
+        ``m = 0`` is the photon and neutrino case; ``m = MASS_E`` is
+        ``hazma/spectra/_positron/_pion.pyx``. The product energy is drawn
+        within a factor of 2.5 of the line, which straddles both window
+        edges at every boost.
+        """
+        cython = cython_boost("boost_delta_function")
+        rng = np.random.default_rng(20_260_810)
+        masses = [0.0, 0.510_998_928]
+        mismatched = 0
+        total = 0
+        for _ in range(40_000):
+            m = float(rng.choice(masses))
+            beta = float(rng.uniform(1e-6, 1.0 - 1e-9))
+            e0 = float(10.0 ** rng.uniform(-1.0, 3.0))
+            e = float(e0 * 10.0 ** rng.uniform(-0.4, 0.4))
+            total += 1
+            if boost_delta_function(e0, e, m, beta) != cython(e0, e, m, beta):
+                mismatched += 1
+        assert mismatched == 0, f"{mismatched} of {total} draws differ from the Cython"
+
+    def test_the_window_edges_agree_with_the_cython(self) -> None:
+        """Both edges, sampled just inside and just outside.
+
+        A one-ulp difference in the bound flips the answer between a
+        finite value and zero rather than moving it slightly.
+        """
+        cython = cython_boost("boost_delta_function")
+        e0, m, beta = 200.0, 0.0, 0.6
+        gamma = rust_gamma(beta)
+        for edge in (gamma * e0 * (1.0 - beta), gamma * e0 * (1.0 + beta)):
+            for scale in (1.0 - 1e-15, 1.0, 1.0 + 1e-15, 0.99, 1.01):
+                e = edge * scale
+                assert boost_delta_function(e0, e, m, beta) == cython(e0, e, m, beta)
+
+    @staticmethod
+    def _window_edges(
+        cython: Callable[..., float], e0: float, m: float, beta: float
+    ) -> list[tuple[float, float]]:
+        """The adjacent doubles the Cython's support starts and ends between.
+
+        Returns one `(below, above)` pair per edge that could be
+        bracketed — at most two, and possibly none if the analytic
+        brackets do not straddle a transition for these parameters.
+        """
+
+        def bisect(lo: float, hi: float) -> tuple[float, float]:
+            lo_bits = int(np.float64(lo).view(np.int64))
+            hi_bits = int(np.float64(hi).view(np.int64))
+            lo_zero = cython(e0, lo, m, beta) == 0.0
+            while hi_bits - lo_bits > 1:
+                mid_bits = (lo_bits + hi_bits) // 2
+                mid = float(np.int64(mid_bits).view(np.float64))
+                if (cython(e0, mid, m, beta) == 0.0) == lo_zero:
+                    lo_bits = mid_bits
+                else:
+                    hi_bits = mid_bits
+            return (
+                float(np.int64(lo_bits).view(np.float64)),
+                float(np.int64(hi_bits).view(np.float64)),
+            )
+
+        gamma = rust_gamma(beta)
+        span = 4.0 * gamma * (1.0 + beta)
+        brackets = [(max(m, e0 / span), e0), (e0, e0 * span)]
+        return [
+            bisect(lo, hi)
+            for lo, hi in brackets
+            if (cython(e0, lo, m, beta) == 0.0) != (cython(e0, hi, m, beta) == 0.0)
+        ]
+
+    def test_the_window_edges_sit_on_the_same_double_as_the_cython(self) -> None:
+        """Both edges of the support, located to the last bit, 400 times.
+
+        ``eminus`` and ``eplus`` never appear in the returned value —
+        they only decide whether it is ``1/(2 gamma beta k0)`` or zero.
+        So a one-ulp change in how they are computed is invisible to any
+        test that samples ``e`` on a grid: it moves the edge by a single
+        double, and no random draw lands there. Bisecting on the bit
+        pattern does land there.
+
+        The sweep is what makes this a pin rather than an anecdote, and
+        the massive product is the half that matters: with ``m = 0`` the
+        fused and unfused ``k = sqrt(e^2 - m^2)`` agree identically, so
+        only the ``m = MASS_E`` draws can catch a change in it. An
+        earlier version of this test used three fixed parameter sets and
+        missed an unfused ``k`` entirely; the random sweep catches it
+        (Task 3.4's mutation campaign, round 3).
+        """
+        cython = cython_boost("boost_delta_function")
+        rng = np.random.default_rng(20_260_810)
+        checked = 0
+        for _ in range(400):
+            m = float(rng.choice([0.0, 0.510_998_928]))
+            e0 = float(10.0 ** rng.uniform(0.0, 3.0))
+            beta = float(rng.uniform(0.02, 0.999))
+            if cython(e0, e0, m, beta) == 0.0:
+                continue
+            for below, above in self._window_edges(cython, e0, m, beta):
+                # A flip, so the assertions below compare a zero against a
+                # non-zero rather than two zeros.
+                assert (cython(e0, below, m, beta) == 0.0) != (
+                    cython(e0, above, m, beta) == 0.0
+                )
+                for e in (below, above):
+                    assert boost_delta_function(e0, e, m, beta) == cython(
+                        e0, e, m, beta
+                    ), f"edge differs at e0={e0!r}, e={e!r}, m={m!r}, beta={beta!r}"
+                checked += 1
+        assert (
+            checked > MIN_EDGES_CHECKED
+        ), f"only {checked} edges were bracketed; the sweep is thin"
+
+    def test_the_line_integrates_to_one_across_its_window(self) -> None:
+        """The boost spreads a normalised delta; it does not renormalise it.
+
+        Tolerance is the arithmetic's, not the method's: the height and
+        the width are each a handful of roundings, so a part in 1e-13 is
+        already three orders of headroom.
+        """
+        e0, m, beta = 200.0, 0.0, 0.6
+        gamma = rust_gamma(beta)
+        lo, hi = gamma * e0 * (1.0 - beta), gamma * e0 * (1.0 + beta)
+        height = boost_delta_function(e0, 0.5 * (lo + hi), m, beta)
+        assert height * (hi - lo) == pytest.approx(1.0, rel=1e-13)
+
+    @pytest.mark.parametrize(
+        ("e0", "e", "m", "beta"),
+        [
+            (200.0, 200.0, 0.0, 1.5),  # beta > 1
+            (200.0, 200.0, 0.0, 1.0),  # beta == 1
+            (200.0, 200.0, 0.0, 0.0),  # beta == 0, the singular guard
+            (200.0, 200.0, 0.0, -0.3),  # beta < 0
+            (200.0, 0.1, 0.510_998_946_1, 0.6),  # product below its own mass
+            (200.0, 1e9, 0.0, 0.6),  # far above the window
+            (200.0, 1e-9, 0.0, 0.6),  # far below the window
+        ],
+    )
+    def test_unphysical_and_outside_arguments_return_zero(
+        self, e0: float, e: float, m: float, beta: float
+    ) -> None:
+        cython = cython_boost("boost_delta_function")
+        assert boost_delta_function(e0, e, m, beta) == 0.0
+        assert cython(e0, e, m, beta) == 0.0
+
+
+class TestBoostIntegrateLinearInterp:
+    """The tabulated continuum boost, branch by branch.
+
+    Every case asserts bit-equality with the Cython *and* pins the branch
+    that fired -- either by a closed form the branch alone can produce, or
+    by a sensitivity check on a table entry only that branch reads.
+    """
+
+    def test_the_whole_window_above_the_table_is_zero(self) -> None:
+        cython = cython_boost("boost_integrate_linear_interp")
+        energy, beta = 1e6, 0.5
+        assert boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y) == 0.0
+        assert cython(energy, beta, FLAT_X, FLAT_Y) == 0.0
+
+    def test_the_whole_window_below_the_table_is_the_analytic_tail(self) -> None:
+        """``y0 * x0 / E``, a closed form no other branch can produce."""
+        cython = cython_boost("boost_integrate_linear_interp")
+        energy, beta = 1e-6, 0.5
+        got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
+        assert got == FLAT_Y[0] * FLAT_X[0] / energy
+        assert got == cython(energy, beta, FLAT_X, FLAT_Y)
+
+    def test_a_window_straddling_the_table_floor_adds_the_tail(self) -> None:
+        """`lb` below the table, `ub` inside it.
+
+        Pinned by sensitivity: only the tail term reads ``y[0]`` when
+        ``ilow`` is 0, and only through the ``y0 * (1 - rat) / rat``
+        factor, so scaling ``y[0]`` must scale the tail's contribution.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        energy, beta = 1.4, 0.6
+        base = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
+        assert base == cython(energy, beta, FLAT_X, FLAT_Y)
+
+        bumped = FLAT_Y.copy()
+        bumped[0] *= 2.0
+        moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
+        assert moved != base
+        assert moved == cython(energy, beta, FLAT_X, bumped)
+
+    def test_a_window_above_the_table_ceiling_clamps(self) -> None:
+        """`ub` past the table's top, but `lb` inside it.
+
+        The clamp is what keeps this from returning zero, and the value
+        matches the Cython. That the clamp *also* skips the upper
+        partial-cell term — and with it the table's last row — is pinned
+        separately in :class:`TestDroppedInteriorCell`.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        energy, beta = 5.0, 0.6
+        got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
+        assert got != 0.0
+        assert got == cython(energy, beta, FLAT_X, FLAT_Y)
+
+    @pytest.mark.parametrize("index", [0, 7])
+    def test_both_partial_cells_are_integrated(self, index: int) -> None:
+        """`lb` and `ub` both strictly inside cells.
+
+        ``y[0]`` is read only by the lower partial cell here (``ilow`` is
+        1, so the tail does not fire) and ``y[7]`` only by the upper one
+        (``ihigh`` is 6). Perturbing either must move the answer, and the
+        Cython must move with it.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        energy, beta = 3.7, 0.6
+        base = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
+        assert base == cython(energy, beta, FLAT_X, FLAT_Y)
+
+        bumped = FLAT_Y.copy()
+        bumped[index] += 1.0
+        moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
+        assert moved != base
+        assert moved == cython(energy, beta, FLAT_X, bumped)
+
+    def test_the_interior_sum_is_integrated(self) -> None:
+        """The trapezoidal sum contributes.
+
+        ``y[3]`` is read by that sum and by nothing else at these bounds.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        energy, beta = 3.7, 0.6
+        base = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
+        bumped = FLAT_Y.copy()
+        bumped[3] += 1.0
+        moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
+        assert moved != base
+        assert moved == cython(energy, beta, FLAT_X, bumped)
+
+    @pytest.mark.parametrize("name", list(photon_tables()))
+    def test_matches_the_cython_on_the_live_tables(self, name: str) -> None:
+        """The seven shipped tables, bit for bit.
+
+        Six boost regimes and 400 energies each -- the sweep Phase 04's
+        swap will be graded on.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        x, y, mass = photon_tables()[name]
+        energies = np.geomspace(1e-3, 1e4, 400)
+        mismatched = 0
+        total = 0
+        for multiple in BOOST_REGIMES:
+            beta = boost_beta(mass * multiple, mass)
+            got = boost_integrate_linear_interp(energies, beta, x, y)
+            want = np.array([cython(float(e), beta, x, y) for e in energies])
+            total += energies.size
+            mismatched += int(np.count_nonzero(got != want))
+        assert (
+            mismatched == 0
+        ), f"{name}: {mismatched} of {total} points differ from the Cython"
+
+
+class TestFusedArithmetic:
+    """The fused multiply-adds are load-bearing, and this is the proof.
+
+    :func:`unfused_reference` is the same algorithm written the obvious
+    way -- ``a * b + c``, as Rust would compile it without ``mul_add``.
+    It is an independent implementation as well as a discriminator: it
+    reproduces the Cython everywhere the contraction does not bite.
+    """
+
+    @staticmethod
+    def unfused_reference(
+        photon_energy: float, beta: float, x: np.ndarray, y: np.ndarray
+    ) -> float:
+        """``boost_integrate_linear_interp`` with no contraction anywhere."""
+        npts = len(x)
+        xmax, x0, y0 = float(x[-1]), float(x[0]), float(y[0])
+        gamma = 1.0 / math.sqrt(1.0 - beta * beta)
+        lb = photon_energy * gamma * (1.0 - beta)
+        ub = photon_energy * gamma * (1.0 + beta)
+        if lb > xmax:
+            return 0.0
+        if ub < x0:
+            return y0 * x0 / photon_energy
+
+        integral = 0.0
+        ilow = ihigh = -1
+        if ub > xmax:
+            ub, ihigh = xmax, npts - 1
+        if lb < x0:
+            rat = (1.0 - beta) * photon_energy * gamma / x0
+            integral += y0 * (1.0 - rat) / rat
+            lb, ilow = x0, 0
+        yy = y / x
+        if ilow == -1:
+            ilow = int(np.flatnonzero(lb <= x)[0])
+        if ihigh == -1:
+            ihigh = int(np.flatnonzero(ub <= x)[0])
+            if abs(float(x[ihigh]) - ub) > EDGE_ATOL:
+                ihigh -= 1
+        if ilow < ihigh:
+            integral += float(np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh]))
+        if ilow > 0 and abs(float(x[ilow]) - lb) > EDGE_ATOL:
+            x2, x1 = float(x[ilow]), float(x[ilow - 1])
+            m = (float(yy[ilow]) - float(yy[ilow - 1])) / (x2 - x1)
+            b = float(yy[ilow - 1]) - m * x1
+            integral += (x2 - lb) * (0.5 * m * (x2 + lb) + b)
+        if ihigh < npts - 1 and abs(ub - float(x[ihigh])) > EDGE_ATOL:
+            x1 = float(x[ihigh])
+            m = (float(yy[ihigh + 1]) - float(yy[ihigh])) / (float(x[ihigh + 1]) - x1)
+            b = float(yy[ihigh]) - m * x1
+            integral += (ub - x1) * (0.5 * m * (ub + x1) + b)
+        return integral / (2.0 * gamma * beta)
+
+    def test_the_unfused_form_misses_the_cython_and_the_rust_does_not(self) -> None:
+        """On the eta table, over the corpus's boost regimes.
+
+        The recorded figure is the point of this test: writing the port
+        without ``mul_add`` costs up to a few parts in 1e12, which the
+        1e-12 ``TABULATED`` budget does not cover. If a future platform
+        stops contracting, ``differ`` goes empty and the assertion says so
+        rather than passing silently.
+        """
+        x, y, mass = photon_tables()["eta"]
+        energies = np.geomspace(1e-2, 1e3, 300)
+        cython = cython_boost("boost_integrate_linear_interp")
+
+        worst = 0.0
+        differ = 0
+        for multiple in BOOST_REGIMES:
+            beta = boost_beta(mass * multiple, mass)
+            for energy in energies:
+                want = cython(float(energy), beta, x, y)
+                assert boost_integrate_linear_interp(float(energy), beta, x, y) == want
+                unfused = self.unfused_reference(float(energy), beta, x, y)
+                if want not in (unfused, 0.0):
+                    differ += 1
+                    worst = max(worst, abs(unfused - want) / abs(want))
+        assert differ > 0, (
+            "the unfused form matched the Cython everywhere, so this "
+            "platform does not contract and the test proves nothing here"
+        )
+        assert (
+            worst > MIN_RECORDED_UNFUSED_MISS
+        ), f"unfused worst miss {worst:.3e} is smaller than recorded"
+
+
+class TestDroppedInteriorCell:
+    """The interior sum stops one cell short, and the port keeps it that way.
+
+    ``np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])`` has an exclusive
+    upper bound, so the cell ``[x[ihigh - 1], x[ihigh]]`` is covered by
+    neither the sum nor the upper partial-cell term. Reproduced rather
+    than repaired (``projects/cython-to-rust/rules.md`` rule 1); the
+    repair is tracked in
+    ``docs/followups/todo/boost-integral-drops-last-interior-cell.md``.
+    """
+
+    X = np.array([1.0, 2.0, 3.0, 4.0])
+    Y = np.array([1.0, 2.0, 3.0, 4.0])  # y / x == 1, so integrals are lengths
+
+    def test_the_hand_computed_value_omits_one_cell(self) -> None:
+        """``E = 2.2``, ``beta = 0.6``: ``lb = 1.1``, ``ub`` clamped to 4.
+
+        The Cython covers ``[1.1, 2]`` (lower partial cell) and ``[2, 3]``
+        (the interior sum) for ``1.9 / (2 gamma beta)``. Covering
+        ``[1.1, 4]`` as intended would give ``2.9`` -- a 53% difference,
+        far too large to be roundoff.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        got = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
+        assert got == cython(2.2, 0.6, self.X, self.Y)
+        assert got == pytest.approx(1.9 / 1.5, rel=1e-15)
+        assert got != pytest.approx(2.9 / 1.5, rel=1e-3)
+
+    def test_a_clamped_window_never_reads_the_tables_last_row(self) -> None:
+        """The sharpest form of the drop.
+
+        When the window reaches past the table, ``ihigh`` is the last
+        index, the upper partial-cell term is skipped, and the interior
+        sum stops one short -- so the final row contributes to nothing.
+        Replacing it with a value six orders larger leaves the answer
+        bit-identical, in the port and in the Cython alike.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        spoiled = self.Y.copy()
+        spoiled[-1] = 1e6
+        base = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
+        assert boost_integrate_linear_interp(2.2, 0.6, self.X, spoiled) == base
+        assert cython(2.2, 0.6, self.X, spoiled) == base
+
+
+class TestTrapezoidSummation:
+    """The interior sum reproduces ``np.trapezoid``, reduction order included.
+
+    ``ndarray.sum`` is pairwise, not sequential, so a left-to-right
+    accumulation in Rust would be a different number -- up to 1.8e-15
+    relative on the 500-row tables. ``rust/src/boost.rs`` mirrors NumPy's
+    blocking; this is the pin, and it survives the ``.pyx``'s deletion.
+
+    The construction puts both bounds exactly on nodes, which switches off
+    the tail, the clamp and both partial-cell terms, leaving the interior
+    sum as the whole answer.
+    """
+
+    @pytest.mark.parametrize("nodes", [12, 41, 130, 260, 1001])
+    def test_the_interior_sum_is_numpys_trapezoid(self, nodes: int) -> None:
+        beta = 0.6
+        gamma = rust_gamma(beta)
+        energy = 40.0
+        lb = energy * gamma * (1.0 - beta)
+        ub = energy * gamma * (1.0 + beta)
+
+        # A table whose nodes include `lb` and `ub` exactly, with a node
+        # outside each bound so neither the tail nor the clamp fires.
+        interior = np.linspace(lb, ub, nodes)
+        x = np.concatenate([[lb * 0.5], interior, [ub * 1.5]])
+        rng = np.random.default_rng(nodes)
+        y = rng.uniform(0.1, 10.0, x.size) * x
+
+        got = boost_integrate_linear_interp(energy, beta, x, y)
+        yy = y / x
+        # `ilow` is 1 (the node at `lb`), `ihigh` the node at `ub`; the
+        # Cython's slice stops one short of `ihigh`.
+        ihigh = x.size - 2
+        want = np.trapezoid(yy[1:ihigh], x=x[1:ihigh]) / (2.0 * gamma * beta)
+        assert got == want
+
+    def test_a_sequential_sum_would_be_a_different_number(self) -> None:
+        """Otherwise the test above would pass against either reduction."""
+        rng = np.random.default_rng(11)
+        values = rng.standard_normal(500) * 10.0 ** rng.uniform(-6, 6, 500)
+        sequential = 0.0
+        for value in values:
+            sequential += float(value)
+        assert sequential != float(values.sum())
+
+
+class TestErrors:
+    """Guards the Cython states as ``assert`` become raises (rule 9)."""
+
+    def test_beta_outside_the_open_unit_interval_raises(self) -> None:
+        for beta in (0.0, 1.0, -0.5, 1.5, float("nan")):
+            with pytest.raises(ValueError, match="0 < beta < 1"):
+                boost_integrate_linear_interp(1.0, beta, FLAT_X, FLAT_Y)
+
+    def test_the_cython_also_refuses_those_betas(self) -> None:
+        """The port tightens an ``assert`` into a raise.
+
+        It does not invent a restriction the Cython does not have.
+        """
+        cython = cython_boost("boost_integrate_linear_interp")
+        for beta in (0.0, 1.0, -0.5, 1.5):
+            with pytest.raises(AssertionError):
+                cython(1.0, beta, FLAT_X, FLAT_Y)
+
+    def test_mismatched_columns_raise(self) -> None:
+        with pytest.raises(ValueError, match="equal length"):
+            boost_integrate_linear_interp(1.0, 0.5, FLAT_X, FLAT_Y[:-1])
+
+    def test_an_empty_table_raises(self) -> None:
+        """New in the port.
+
+        The Cython reads ``x[npts - 1]`` unchecked, so an empty table is
+        undefined behavior there rather than an error.
+        """
+        empty = np.array([], dtype=np.float64)
+        with pytest.raises(ValueError, match="must not be empty"):
+            boost_integrate_linear_interp(1.0, 0.5, empty, empty)
+
+
+class TestDispatch:
+    """The swept argument follows the usual scalar-or-1-D contract.
+
+    ``test/test_core_dispatch.py`` pins that contract branch by branch;
+    this only checks the three wrappers are wired into it.
+    """
+
+    @pytest.mark.parametrize(
+        ("call", "scalar"),
+        [
+            (lambda x: boost_beta(x, 139.57039), 1000.0),
+            (lambda x: boost_gamma(x, 139.57039), 1000.0),
+            (lambda x: boost_delta_function(200.0, x, 0.0, 0.6), 220.0),
+            (
+                lambda x: boost_integrate_linear_interp(x, 0.6, FLAT_X, FLAT_Y),
+                3.7,
+            ),
+        ],
+        ids=["beta", "gamma", "delta", "integral"],
+    )
+    def test_scalar_and_array_paths_agree(
+        self, call: Callable[[object], object], scalar: float
+    ) -> None:
+        grid = np.array([scalar, scalar * 1.3, scalar * 0.7])
+        single = call(scalar)
+        assert isinstance(single, float)
+        swept = call(grid)
+        assert isinstance(swept, np.ndarray)
+        assert swept.dtype == np.float64
+        assert swept[0] == single
+        assert np.array_equal(swept, [call(float(v)) for v in grid])
+
+    @pytest.mark.parametrize(
+        ("call", "scalar"),
+        [
+            (lambda x: boost_beta(x, 139.57039), 1000.0),
+            (lambda x: boost_gamma(x, 139.57039), 1000.0),
+            (lambda x: boost_delta_function(200.0, x, 0.0, 0.6), 220.0),
+            (
+                lambda x: boost_integrate_linear_interp(x, 0.6, FLAT_X, FLAT_Y),
+                3.7,
+            ),
+        ],
+        ids=["beta", "gamma", "delta", "integral"],
+    )
+    def test_bad_shapes_and_dtypes_raise(
+        self, call: Callable[[object], object], scalar: float
+    ) -> None:
+        del scalar
+        with pytest.raises(ValueError, match="0 or 1-dimensional"):
+            call(np.zeros((2, 2)))
+        with pytest.raises(ValueError, match="float64 array"):
+            call(np.array([1, 2], dtype=np.int64))

--- a/test/test_core_boost.py
+++ b/test/test_core_boost.py
@@ -25,14 +25,30 @@ rather than ``CFUNCTYPE``: the latter releases the GIL, and
 name *is* the C signature, so :class:`TestOracle` checks it rather than
 trusting that the argument list has not changed.
 
-The bar is bit-equality
------------------------
+The bar is bit-equality, on a contracting platform
+--------------------------------------------------
 Not a tolerance. ``rust/src/boost.rs`` reproduces the shipped Cython's
 arithmetic exactly, fused multiply-adds included --
 :class:`TestFusedArithmetic` is the measurement that made that mandatory:
 written the obvious unfused way, the boost integral misses the corpus by
 up to 3.6e-12 relative on the corpus's own grids, against the 1e-12
 ``TABULATED`` budget in ``test/parity/tolerances.py``.
+
+But *whether* the Cython contracts is a property of the C compiler that
+built it, not of this port. On macOS/arm64 -- the platform the parity
+corpus was captured on, and whose numbers this port targets -- it does,
+and every comparison below is bit-exact. On a target without hardware
+FMA (baseline x86-64, which is what the Linux wheels are built for) the
+Cython computes the unfused values instead: measured here, that moves
+``boost_delta_function`` by up to 1.9e-13 relative and the tabulated
+integral by up to 9.9e-13, with no branch flip in 40,000 draws. So
+:data:`CYTHON_CONTRACTS` is measured at import and the
+cross-implementation tests skip where it is false -- the same scoping
+the parity corpus already has (CI runs ``pytest --ignore=test/parity``
+off macOS for the same reason). Everything platform-independent --
+the closed forms, the per-branch sensitivity checks, the dropped-cell
+pins, the trapezoid reduction, the error paths, dispatch -- runs
+everywhere.
 
 Lifetime
 --------
@@ -170,6 +186,74 @@ def photon_tables() -> dict[str, tuple[np.ndarray, np.ndarray, float]]:
 #: just off rest, near rest, mildly boosted, strongly boosted.
 BOOST_REGIMES = (1.000_000_001, 1.05, 1.5, 2.0, 3.0, 10.0)
 
+
+def unfused_delta_function(e0: float, e: float, m: float, beta: float) -> float:
+    """``boost_delta_function`` with no contraction anywhere.
+
+    Only used to decide whether the local Cython contracts; the port's
+    own reference implementation is
+    :meth:`TestFusedArithmetic.unfused_reference`.
+    """
+    if beta > 1.0 or beta <= 0.0 or e < m:
+        return 0.0
+    gamma = 1.0 / math.sqrt(1.0 - beta * beta)
+    k = math.sqrt(e * e - m * m)
+    if gamma * (e - beta * k) < e0 < gamma * (e + beta * k):
+        return 1.0 / (2.0 * gamma * beta * math.sqrt(e0 * e0 - m * m))
+    return 0.0
+
+
+def cython_contracts() -> bool:
+    """Whether the compiled Cython fuses its multiply-adds.
+
+    Draws until the two forms are distinguishable rather than trusting a
+    single point: most arguments round the same either way.
+    """
+    cython = cython_boost("boost_delta_function")
+    rng = np.random.default_rng(0)
+    for _ in range(2048):
+        beta = float(rng.uniform(0.05, 0.95))
+        e0 = float(10.0 ** rng.uniform(0.0, 3.0))
+        e = float(e0 * 10.0 ** rng.uniform(-0.2, 0.2))
+        m = 0.510_998_928
+        if cython(e0, e, m, beta) != unfused_delta_function(e0, e, m, beta):
+            return True
+    return False
+
+
+#: True where the compiled Cython contracts, i.e. where a bit-for-bit
+#: comparison against it is a statement about this port rather than
+#: about the platform's instruction selection.
+CYTHON_CONTRACTS = cython_contracts()
+
+
+def assert_matches_cython(got: float, want: float, what: str) -> None:
+    """Assert bit-equality with the Cython, where that means anything.
+
+    Where the local Cython does not contract it computes different
+    numbers than the build this port targets, so the claim is skipped
+    rather than weakened. Called *after* a test's platform-independent
+    assertions so those still run everywhere; the skip is visible in the
+    report rather than silently passing.
+    """
+    if not CYTHON_CONTRACTS:
+        pytest.skip(
+            f"{what}: this Cython build does not contract, so a bit-for-bit "
+            "comparison against it is not a statement about the port"
+        )
+    assert got == want, what
+
+
+requires_a_contracting_cython = pytest.mark.skipif(
+    not CYTHON_CONTRACTS,
+    reason=(
+        "this Cython build does not fuse its multiply-adds, so it computes "
+        "different values than the macOS/arm64 build this port targets; the "
+        "bit-for-bit comparison is scoped to a contracting platform exactly "
+        "as the parity corpus is"
+    ),
+)
+
 #: A flat toy table with ``y / x == 1`` everywhere, so every branch's
 #: contribution is a length and can be predicted by hand.
 FLAT_X = np.arange(1.0, 9.0)
@@ -277,6 +361,7 @@ class TestBoostParameters:
 class TestBoostDeltaFunction:
     """The boosted two-body line, branch by branch."""
 
+    @requires_a_contracting_cython
     def test_matches_the_cython_over_a_random_sweep(self) -> None:
         """40,000 draws at both live product masses, bit for bit.
 
@@ -300,6 +385,7 @@ class TestBoostDeltaFunction:
                 mismatched += 1
         assert mismatched == 0, f"{mismatched} of {total} draws differ from the Cython"
 
+    @requires_a_contracting_cython
     def test_the_window_edges_agree_with_the_cython(self) -> None:
         """Both edges, sampled just inside and just outside.
 
@@ -350,6 +436,7 @@ class TestBoostDeltaFunction:
             if (cython(e0, lo, m, beta) == 0.0) != (cython(e0, hi, m, beta) == 0.0)
         ]
 
+    @requires_a_contracting_cython
     def test_the_window_edges_sit_on_the_same_double_as_the_cython(self) -> None:
         """Both edges of the support, located to the last bit, 400 times.
 
@@ -436,8 +523,9 @@ class TestBoostIntegrateLinearInterp:
     def test_the_whole_window_above_the_table_is_zero(self) -> None:
         cython = cython_boost("boost_integrate_linear_interp")
         energy, beta = 1e6, 0.5
-        assert boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y) == 0.0
-        assert cython(energy, beta, FLAT_X, FLAT_Y) == 0.0
+        got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
+        assert got == 0.0
+        assert_matches_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "clamp")
 
     def test_the_whole_window_below_the_table_is_the_analytic_tail(self) -> None:
         """``y0 * x0 / E``, a closed form no other branch can produce."""
@@ -445,7 +533,7 @@ class TestBoostIntegrateLinearInterp:
         energy, beta = 1e-6, 0.5
         got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
         assert got == FLAT_Y[0] * FLAT_X[0] / energy
-        assert got == cython(energy, beta, FLAT_X, FLAT_Y)
+        assert_matches_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "tail")
 
     def test_a_window_straddling_the_table_floor_adds_the_tail(self) -> None:
         """`lb` below the table, `ub` inside it.
@@ -457,13 +545,14 @@ class TestBoostIntegrateLinearInterp:
         cython = cython_boost("boost_integrate_linear_interp")
         energy, beta = 1.4, 0.6
         base = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
-        assert base == cython(energy, beta, FLAT_X, FLAT_Y)
-
         bumped = FLAT_Y.copy()
         bumped[0] *= 2.0
         moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
         assert moved != base
-        assert moved == cython(energy, beta, FLAT_X, bumped)
+        assert_matches_cython(base, cython(energy, beta, FLAT_X, FLAT_Y), "tail base")
+        assert_matches_cython(
+            moved, cython(energy, beta, FLAT_X, bumped), "tail bumped"
+        )
 
     def test_a_window_above_the_table_ceiling_clamps(self) -> None:
         """`ub` past the table's top, but `lb` inside it.
@@ -477,7 +566,7 @@ class TestBoostIntegrateLinearInterp:
         energy, beta = 5.0, 0.6
         got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
         assert got != 0.0
-        assert got == cython(energy, beta, FLAT_X, FLAT_Y)
+        assert_matches_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "ceiling")
 
     @pytest.mark.parametrize("index", [0, 7])
     def test_both_partial_cells_are_integrated(self, index: int) -> None:
@@ -491,13 +580,14 @@ class TestBoostIntegrateLinearInterp:
         cython = cython_boost("boost_integrate_linear_interp")
         energy, beta = 3.7, 0.6
         base = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
-        assert base == cython(energy, beta, FLAT_X, FLAT_Y)
-
         bumped = FLAT_Y.copy()
         bumped[index] += 1.0
         moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
         assert moved != base
-        assert moved == cython(energy, beta, FLAT_X, bumped)
+        assert_matches_cython(base, cython(energy, beta, FLAT_X, FLAT_Y), "edge base")
+        assert_matches_cython(
+            moved, cython(energy, beta, FLAT_X, bumped), "edge bumped"
+        )
 
     def test_the_interior_sum_is_integrated(self) -> None:
         """The trapezoidal sum contributes.
@@ -511,8 +601,11 @@ class TestBoostIntegrateLinearInterp:
         bumped[3] += 1.0
         moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
         assert moved != base
-        assert moved == cython(energy, beta, FLAT_X, bumped)
+        assert_matches_cython(
+            moved, cython(energy, beta, FLAT_X, bumped), "interior sum"
+        )
 
+    @requires_a_contracting_cython
     @pytest.mark.parametrize("name", list(photon_tables()))
     def test_matches_the_cython_on_the_live_tables(self, name: str) -> None:
         """The seven shipped tables, bit for bit.
@@ -536,6 +629,7 @@ class TestBoostIntegrateLinearInterp:
         ), f"{name}: {mismatched} of {total} points differ from the Cython"
 
 
+@requires_a_contracting_cython
 class TestFusedArithmetic:
     """The fused multiply-adds are load-bearing, and this is the proof.
 
@@ -614,8 +708,9 @@ class TestFusedArithmetic:
                     differ += 1
                     worst = max(worst, abs(unfused - want) / abs(want))
         assert differ > 0, (
-            "the unfused form matched the Cython everywhere, so this "
-            "platform does not contract and the test proves nothing here"
+            "the unfused form matched the Cython everywhere; the class "
+            "guard says this platform contracts, so that is a contradiction "
+            "rather than a platform difference"
         )
         assert (
             worst > MIN_RECORDED_UNFUSED_MISS
@@ -646,9 +741,9 @@ class TestDroppedInteriorCell:
         """
         cython = cython_boost("boost_integrate_linear_interp")
         got = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
-        assert got == cython(2.2, 0.6, self.X, self.Y)
         assert got == pytest.approx(1.9 / 1.5, rel=1e-15)
         assert got != pytest.approx(2.9 / 1.5, rel=1e-3)
+        assert_matches_cython(got, cython(2.2, 0.6, self.X, self.Y), "dropped cell")
 
     def test_a_clamped_window_never_reads_the_tables_last_row(self) -> None:
         """The sharpest form of the drop.
@@ -664,7 +759,7 @@ class TestDroppedInteriorCell:
         spoiled[-1] = 1e6
         base = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
         assert boost_integrate_linear_interp(2.2, 0.6, self.X, spoiled) == base
-        assert cython(2.2, 0.6, self.X, spoiled) == base
+        assert cython(2.2, 0.6, self.X, spoiled) == cython(2.2, 0.6, self.X, self.Y)
 
 
 class TestTrapezoidSummation:

--- a/test/test_core_interp.py
+++ b/test/test_core_interp.py
@@ -1,0 +1,318 @@
+"""``hazma._core.interp`` against ``numpy.interp``.
+
+Twelve ``cdef`` functions in the compiled layer call ``np.interp`` on a
+shipped table: the five rest-frame photon spectra
+(``hazma/spectra/_photon/{_eta,_eta_prime,_kaon,_omega,_phi}.pyx``) and
+the four mediator spectrum modules. cython-to-rust Task 3.4 reimplements
+it in ``rust/src/interp.rs``, and this module is the gate on that.
+
+The oracle is ``numpy.interp`` itself, and the bar is **bit-equality**,
+not a tolerance. That is achievable because the Rust reproduces NumPy's
+arithmetic exactly, fused multiply-add included -- see
+:class:`TestFusedArithmetic` for the measurement that made the fused form
+mandatory rather than stylistic.
+
+Why bit-equality and not ``rtol``
+---------------------------------
+``test/parity/tolerances.py`` budgets the tabulated spectra at 1e-12
+relative, and the unfused form's worst miss against NumPy measured here
+is 1.1e-13 -- inside that. It is the *boost integral* built on the same
+arithmetic that is not (3.6e-12, see ``test/test_core_boost.py``), and
+having one of the two hold to a tolerance while the other holds to the
+bit would make the pair impossible to reason about. Both are pinned at
+the bit, and any drift is a fact to explain rather than a budget to
+spend.
+
+Lifetime
+--------
+Nothing here parses Cython, so this module outlives the ``.pyx``. After
+Phase 06 it remains the standing check that the Rust interpolation still
+tracks NumPy -- a property the parity corpus cannot see, because the
+corpus pins spectra rather than the routines underneath them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from hazma._core import interp as core_interp
+from hazma.spectra._photon import _eta, _eta_prime, _kaon, _omega, _phi
+
+interp = core_interp.interp
+
+#: The smallest grid the multi-point path handles; below it NumPy takes
+#: its one-point branch, whose behavior differs (see :class:`TestQuirks`).
+MULTI_POINT = 2
+
+
+def photon_tables() -> dict[str, tuple[np.ndarray, np.ndarray]]:
+    """The live tables ``np.interp`` is called on, keyed by kernel."""
+    return {
+        "eta": (_eta.eta_data_energies, _eta.eta_data_dnde),
+        "eta_prime": (
+            _eta_prime.eta_prime_data_energies,
+            _eta_prime.eta_prime_data_dnde,
+        ),
+        "charged_kaon": (
+            _kaon.charged_kaon_data_energies,
+            _kaon.charged_kaon_data_dnde,
+        ),
+        "long_kaon": (_kaon.long_kaon_data_energies, _kaon.long_kaon_data_dnde),
+        "short_kaon": (_kaon.short_kaon_data_energies, _kaon.short_kaon_data_dnde),
+        "omega": (_omega.omega_data_energies, _omega.omega_data_dnde),
+        "phi": (_phi.phi_data_energies, _phi.phi_data_dnde),
+    }
+
+
+def sweep_abscissae(xp: np.ndarray, seed: int) -> np.ndarray:
+    """Abscissae covering every branch of the interpolation.
+
+    Random interior points find generic cells; the nodes themselves hit
+    the exact-node short circuit; the nodes nudged by one part in 1e13
+    land just inside the cells on either side of a node, which is where a
+    wrong cell index shows up; and the four out-of-range points exercise
+    the clamps.
+    """
+    rng = np.random.default_rng(seed)
+    return np.concatenate(
+        [
+            rng.uniform(xp[0], xp[-1], 20_000),
+            xp,
+            xp * (1.0 + 1e-13),
+            xp * (1.0 - 1e-13),
+            [xp[0] - 1.0, xp[-1] + 1.0, xp[0], xp[-1]],
+        ]
+    )
+
+
+class TestAgainstNumpy:
+    """Bit-equality with ``np.interp`` on every live table."""
+
+    @pytest.mark.parametrize("name", list(photon_tables()))
+    def test_matches_numpy_bit_for_bit(self, name: str) -> None:
+        xp, fp = photon_tables()[name]
+        x = sweep_abscissae(xp, seed=hash(name) % 2**32)
+        got = interp(x, xp, fp)
+        want = np.interp(x, xp, fp)
+        mismatched = int(np.count_nonzero(got != want))
+        assert mismatched == 0, (
+            f"{name}: {mismatched} of {x.size} points differ from np.interp; "
+            f"worst relative {np.max(np.abs(got - want) / np.abs(want)):.3e}"
+        )
+
+    def test_matches_numpy_on_a_random_grid(self) -> None:
+        """A grid NumPy has never seen, with cells of wildly unequal width.
+
+        The live tables are smooth and near-geometric; this one is not,
+        so a cell-index or slope error that the tables happen to forgive
+        has somewhere to show.
+        """
+        rng = np.random.default_rng(20260810)
+        for _ in range(50):
+            n = int(rng.integers(2, 60))
+            xp = np.sort(rng.uniform(-1e3, 1e3, n) * 10.0 ** rng.uniform(-6, 6, n))
+            xp = np.unique(xp)
+            if xp.size < MULTI_POINT:
+                continue
+            fp = rng.standard_normal(xp.size) * 10.0 ** rng.uniform(-8, 8, xp.size)
+            x = sweep_abscissae(xp, seed=int(rng.integers(2**31)))
+            assert np.array_equal(interp(x, xp, fp), np.interp(x, xp, fp))
+
+
+class TestFusedArithmetic:
+    """The interpolation step is fused, and it has to be.
+
+    NumPy computes ``slope * (x - xp[j]) + fp[j]`` in C, where the
+    default ``-ffp-contract=on`` lets the compiler emit a fused
+    multiply-add -- and on this project's reference platform
+    (macOS/arm64) it does. Rust never contracts on its own, so
+    ``rust/src/interp.rs`` spells the fusion out with ``mul_add``.
+
+    This class does not assume the platform: it computes the unfused
+    value in Python and asserts that where the two forms differ, the Rust
+    sides with NumPy. On a platform whose NumPy is *not* contracted the
+    two forms agree everywhere and the test passes trivially, which is
+    the correct outcome rather than a false green -- :class:`TestAgainstNumpy`
+    is what would fail there.
+    """
+
+    def test_the_rust_sides_with_numpy_where_the_forms_differ(self) -> None:
+        xp, fp = photon_tables()["eta"]
+        rng = np.random.default_rng(4)
+        x = rng.uniform(xp[0], xp[-1], 20_000)
+
+        j = np.searchsorted(xp, x, side="right") - 1
+        j = np.clip(j, 0, xp.size - 2)
+        slope = (fp[j + 1] - fp[j]) / (xp[j + 1] - xp[j])
+        unfused = slope * (x - xp[j]) + fp[j]
+
+        want = np.interp(x, xp, fp)
+        differ = unfused != want
+        assert differ.any(), (
+            "no point distinguishes the fused and unfused forms on this "
+            "platform, so this test proves nothing here"
+        )
+        assert np.array_equal(interp(x, xp, fp), want)
+
+
+#: A three-node toy grid with cells of unequal width, shared by the
+#: contract tests below. The names let the assertions say *which* node
+#: they expect rather than repeating its value.
+TOY_XP = np.array([1.0, 2.0, 4.0])
+TOY_FP = np.array([10.0, 20.0, -5.0])
+TOY_FIRST, TOY_MIDDLE, TOY_LAST = (float(value) for value in TOY_FP)
+#: Midpoints of the two cells: (10 + 20)/2 and (20 - 5)/2.
+TOY_FIRST_CELL_MID = 15.0
+TOY_SECOND_CELL_MID = 7.5
+
+
+class TestClamping:
+    """Outside the grid ``np.interp`` clamps; it never extrapolates."""
+
+    XP = TOY_XP
+    FP = TOY_FP
+
+    @pytest.mark.parametrize("x", [0.0, -1e300, -np.inf, 0.999_999])
+    def test_below_the_grid_returns_the_first_value(self, x: float) -> None:
+        assert interp(x, self.XP, self.FP) == TOY_FIRST
+
+    @pytest.mark.parametrize("x", [5.0, 1e300, np.inf, 4.000_001])
+    def test_above_the_grid_returns_the_last_value(self, x: float) -> None:
+        assert interp(x, self.XP, self.FP) == TOY_LAST
+
+    def test_nodes_return_their_own_values(self) -> None:
+        assert np.array_equal(interp(self.XP, self.XP, self.FP), self.FP)
+
+    def test_the_midpoint_of_a_cell_is_the_mean_of_its_ends(self) -> None:
+        assert interp(1.5, self.XP, self.FP) == TOY_FIRST_CELL_MID
+        assert interp(3.0, self.XP, self.FP) == TOY_SECOND_CELL_MID
+
+
+#: Values the quirk tests assert on by name.
+ONE_POINT_VALUE = 7.0
+LAST_DUPLICATE = 9.0
+INFINITE_NODE_VALUE = 1.0
+FLAT_CELL_VALUE = 3.0
+
+
+class TestQuirks:
+    """Behaviors that are NumPy's rather than linear interpolation's.
+
+    Each is reproduced deliberately and checked against NumPy in the same
+    assertion, so the pin cannot drift away from the thing it pins.
+    """
+
+    def test_nan_propagates_on_a_multi_point_grid(self) -> None:
+        xp, fp = np.array([1.0, 2.0]), np.array([ONE_POINT_VALUE, 8.0])
+        assert np.isnan(interp(np.nan, xp, fp))
+        assert np.isnan(np.interp(np.nan, xp, fp))
+
+    def test_a_one_point_grid_answers_everything_with_its_one_value(self) -> None:
+        """NumPy's one-point branch runs before its NaN check.
+
+        So a NaN abscissa returns ``fp[0]`` there while it returns NaN on
+        any longer grid -- an asymmetry with no principle behind it,
+        carried because the corpus is pinned to what NumPy does.
+        """
+        xp, fp = np.array([2.0]), np.array([ONE_POINT_VALUE])
+        for x in (np.nan, -1.0, 2.0, 5.0):
+            assert interp(x, xp, fp) == ONE_POINT_VALUE
+            assert np.interp(x, xp, fp) == ONE_POINT_VALUE
+
+    def test_duplicate_nodes_resolve_to_the_last_copy(self) -> None:
+        xp = np.array([0.0, 1.0, 1.0, 2.0])
+        fp = np.array([0.0, 5.0, LAST_DUPLICATE, LAST_DUPLICATE])
+        assert interp(1.0, xp, fp) == np.interp(1.0, xp, fp) == LAST_DUPLICATE
+
+    def test_an_infinite_ordinate_falls_back_to_the_cells_other_end(self) -> None:
+        xp, fp = np.array([0.0, 1.0]), np.array([np.inf, 0.0])
+        assert interp(0.5, xp, fp) == np.interp(0.5, xp, fp) == np.inf
+
+    def test_an_infinite_node_returns_its_own_value(self) -> None:
+        """The exact-node short circuit, in the only place it is visible.
+
+        At an ordinary node the interpolation gives ``slope * 0 + fp[j]``
+        = ``fp[j]`` anyway, so the guard NumPy carries to "avoid potential
+        non-finite interpolation" is unobservable — until the cell is
+        infinitely wide. Here ``slope`` is 0 and ``x - xp[j]`` is
+        ``-inf - -inf`` = NaN, so the product is NaN and both NaN rescues
+        fail; only the short circuit returns a number.
+        """
+        xp = np.array([-np.inf, 0.0, 1.0])
+        fp = np.array([INFINITE_NODE_VALUE, 2.0, 3.0])
+        assert interp(-np.inf, xp, fp) == INFINITE_NODE_VALUE
+        assert np.interp(-np.inf, xp, fp) == INFINITE_NODE_VALUE
+
+    def test_an_infinitely_wide_cell_is_rescued_only_when_flat(self) -> None:
+        xp = np.array([-np.inf, np.inf])
+        flat = np.array([FLAT_CELL_VALUE, FLAT_CELL_VALUE])
+        sloped = np.array([FLAT_CELL_VALUE, FLAT_CELL_VALUE + 1.0])
+        assert interp(0.0, xp, flat) == FLAT_CELL_VALUE
+        assert np.interp(0.0, xp, flat) == FLAT_CELL_VALUE
+        assert np.isnan(interp(0.0, xp, sloped))
+        assert np.isnan(np.interp(0.0, xp, sloped))
+
+
+class TestErrors:
+    """The two grids NumPy refuses, refused with NumPy's own wording."""
+
+    def test_an_empty_grid_raises(self) -> None:
+        empty = np.array([], dtype=np.float64)
+        with pytest.raises(ValueError, match="array of sample points is empty"):
+            interp(1.0, empty, empty)
+        with pytest.raises(ValueError, match="array of sample points is empty"):
+            np.interp(1.0, empty, empty)
+
+    def test_mismatched_lengths_raise(self) -> None:
+        xp = np.array([1.0, 2.0])
+        fp = np.array([1.0])
+        with pytest.raises(ValueError, match="not of the same length"):
+            interp(1.0, xp, fp)
+        with pytest.raises(ValueError, match="not of the same length"):
+            np.interp(1.0, xp, fp)
+
+
+class TestDispatch:
+    """The abscissa follows the contract every ported entry point uses.
+
+    The full branch-by-branch pinning lives in
+    ``test/test_core_dispatch.py``; this only checks that ``interp`` is
+    wired into it rather than re-deriving it.
+    """
+
+    XP = TOY_XP
+    FP = TOY_FP
+
+    def test_scalar_in_float_out(self) -> None:
+        got = interp(1.5, self.XP, self.FP)
+        assert isinstance(got, float)
+        assert got == TOY_FIRST_CELL_MID
+
+    def test_array_in_fresh_array_out(self) -> None:
+        x = np.array([1.5, 3.0])
+        got = interp(x, self.XP, self.FP)
+        assert isinstance(got, np.ndarray)
+        assert got.dtype == np.float64
+        assert np.array_equal(got, [TOY_FIRST_CELL_MID, TOY_SECOND_CELL_MID])
+        assert not np.shares_memory(got, x)
+
+    def test_array_path_equals_the_scalar_path(self) -> None:
+        x = np.linspace(0.5, 4.5, 101)
+        assert np.array_equal(
+            interp(x, self.XP, self.FP),
+            [interp(float(v), self.XP, self.FP) for v in x],
+        )
+
+    def test_empty_array_round_trips(self) -> None:
+        got = interp(np.array([]), self.XP, self.FP)
+        assert isinstance(got, np.ndarray)
+        assert got.size == 0
+
+    def test_two_dimensional_abscissae_raise(self) -> None:
+        with pytest.raises(ValueError, match="0 or 1-dimensional"):
+            interp(np.zeros((2, 2)), self.XP, self.FP)
+
+    def test_non_float64_abscissae_raise(self) -> None:
+        with pytest.raises(ValueError, match="float64 array"):
+            interp(np.array([1, 2], dtype=np.int64), self.XP, self.FP)

--- a/test/test_core_interp.py
+++ b/test/test_core_interp.py
@@ -12,16 +12,29 @@ arithmetic exactly, fused multiply-add included -- see
 :class:`TestFusedArithmetic` for the measurement that made the fused form
 mandatory rather than stylistic.
 
-Why bit-equality and not ``rtol``
----------------------------------
-``test/parity/tolerances.py`` budgets the tabulated spectra at 1e-12
-relative, and the unfused form's worst miss against NumPy measured here
-is 1.1e-13 -- inside that. It is the *boost integral* built on the same
-arithmetic that is not (3.6e-12, see ``test/test_core_boost.py``), and
-having one of the two hold to a tolerance while the other holds to the
-bit would make the pair impossible to reason about. Both are pinned at
-the bit, and any drift is a fact to explain rather than a budget to
-spend.
+The comparison is scoped to a contracting platform
+--------------------------------------------------
+Whether ``np.interp`` fuses ``slope * (x - xp[j]) + fp[j]`` is a property
+of *the NumPy binary that happens to be installed*, not of this port. On
+macOS/arm64 -- the platform the parity corpus was captured on, and whose
+numbers this port targets -- the C compiler contracts it and the
+comparison is bit-exact. On a target built without hardware FMA
+(baseline x86-64, which is what the Linux wheels are built for) NumPy
+computes the unfused values instead, and "does the Rust match the local
+NumPy bit-for-bit" stops being a question about the port.
+
+So :data:`NUMPY_CONTRACTS` is *measured at import* and the
+cross-implementation tests skip where it is false. That is the same
+scoping the parity corpus already has -- CI runs
+``pytest --ignore=test/parity`` off macOS for the same reason -- and it
+is preferred over loosening the assertion to a tolerance, because the
+worst *relative* gap between the two forms lands at a catastrophic
+cancellation point (the eta table's tail, where the interpolant is
+``2.4e-26`` against a table whose scale is ``0.2``, an absolute gap of
+``1.4e-30``). A tolerance wide enough to admit that point would be wide
+enough to hide a real defect. Everything platform-independent -- the
+clamping contract, NumPy's quirks, the error paths, dispatch -- runs
+everywhere.
 
 Lifetime
 --------
@@ -65,6 +78,38 @@ def photon_tables() -> dict[str, tuple[np.ndarray, np.ndarray]]:
     }
 
 
+def numpy_contracts() -> bool:
+    """Whether the installed NumPy fuses the interpolation step.
+
+    Compares ``np.interp`` against the unfused form on interior points
+    only, where the cell index is unambiguous and no clamp or node
+    short circuit is in play -- so a disagreement can only be the
+    contraction.
+    """
+    xp, fp = photon_tables()["eta"]
+    rng = np.random.default_rng(0)
+    x = rng.uniform(xp[0], xp[-1], 4096)
+    j = np.clip(np.searchsorted(xp, x, side="right") - 1, 0, xp.size - 2)
+    slope = (fp[j + 1] - fp[j]) / (xp[j + 1] - xp[j])
+    return bool(np.any(slope * (x - xp[j]) + fp[j] != np.interp(x, xp, fp)))
+
+
+#: True where the installed NumPy contracts, i.e. where a bit-for-bit
+#: comparison against it is a statement about this port rather than
+#: about the platform's instruction selection.
+NUMPY_CONTRACTS = numpy_contracts()
+
+requires_a_contracting_numpy = pytest.mark.skipif(
+    not NUMPY_CONTRACTS,
+    reason=(
+        "this NumPy does not fuse the interpolation step, so it computes "
+        "different values than the macOS/arm64 build this port targets; "
+        "the bit-for-bit comparison is scoped to a contracting platform "
+        "exactly as the parity corpus is"
+    ),
+)
+
+
 def sweep_abscissae(xp: np.ndarray, seed: int) -> np.ndarray:
     """Abscissae covering every branch of the interpolation.
 
@@ -86,8 +131,12 @@ def sweep_abscissae(xp: np.ndarray, seed: int) -> np.ndarray:
     )
 
 
+@requires_a_contracting_numpy
 class TestAgainstNumpy:
-    """Bit-equality with ``np.interp`` on every live table."""
+    """Bit-equality with ``np.interp`` on every live table.
+
+    Scoped to a contracting NumPy -- see the module docstring.
+    """
 
     @pytest.mark.parametrize("name", list(photon_tables()))
     def test_matches_numpy_bit_for_bit(self, name: str) -> None:
@@ -96,9 +145,14 @@ class TestAgainstNumpy:
         got = interp(x, xp, fp)
         want = np.interp(x, xp, fp)
         mismatched = int(np.count_nonzero(got != want))
+        # `want` is exactly zero past the spectrum endpoint, so the
+        # relative gap is reported against a floor rather than dividing
+        # by it -- otherwise the diagnostic reads `nan` precisely when
+        # it is needed.
+        scale = np.where(want == 0.0, 1.0, np.abs(want))
         assert mismatched == 0, (
             f"{name}: {mismatched} of {x.size} points differ from np.interp; "
-            f"worst relative {np.max(np.abs(got - want) / np.abs(want)):.3e}"
+            f"worst relative {np.max(np.abs(got - want) / scale):.3e}"
         )
 
     def test_matches_numpy_on_a_random_grid(self) -> None:
@@ -120,21 +174,20 @@ class TestAgainstNumpy:
             assert np.array_equal(interp(x, xp, fp), np.interp(x, xp, fp))
 
 
+@requires_a_contracting_numpy
 class TestFusedArithmetic:
     """The interpolation step is fused, and it has to be.
 
-    NumPy computes ``slope * (x - xp[j]) + fp[j]`` in C, where the
-    default ``-ffp-contract=on`` lets the compiler emit a fused
-    multiply-add -- and on this project's reference platform
-    (macOS/arm64) it does. Rust never contracts on its own, so
-    ``rust/src/interp.rs`` spells the fusion out with ``mul_add``.
+        NumPy computes ``slope * (x - xp[j]) + fp[j]`` in C, where the
+        default ``-ffp-contract=on`` lets the compiler emit a fused
+        multiply-add -- and on this project's reference platform
+        (macOS/arm64) it does. Rust never contracts on its own, so
+        ``rust/src/interp.rs`` spells the fusion out with ``mul_add``.
 
-    This class does not assume the platform: it computes the unfused
-    value in Python and asserts that where the two forms differ, the Rust
-    sides with NumPy. On a platform whose NumPy is *not* contracted the
-    two forms agree everywhere and the test passes trivially, which is
-    the correct outcome rather than a false green -- :class:`TestAgainstNumpy`
-    is what would fail there.
+    It computes the unfused value in Python and asserts that where the
+        two forms differ, the Rust sides with NumPy. The class only runs
+        where :data:`NUMPY_CONTRACTS`, so "the forms differ somewhere" is a
+        precondition rather than a hope.
     """
 
     def test_the_rust_sides_with_numpy_where_the_forms_differ(self) -> None:


### PR DESCRIPTION
## Summary

- Ports `np.interp` and the four live routines of `hazma/_utils/boost.pyx` — `boost_beta`, `boost_gamma`, `boost_delta_function`, `boost_integrate_linear_interp` — to PyO3-free Rust (`rust/src/{interp,boost}.rs`), with `hazma._core.{interp,boost}` registration-only probes so the tests can reach them. **No kernel is swapped:** nothing under `hazma/` imports either module, the only change under `hazma/` is a comment in `hazma/_core.pyi`, and the parity corpus still runs in bit-equality mode (`rtol = 0`, `provenance → exact=True`).
- **The port reproduces the shipped Cython's fused multiply-adds, and that is load-bearing rather than pedantic.** Clang defaults to `-ffp-contract=on`; the corpus's capturing platform (macOS/arm64) contracts eight distinct expressions across `boost.pyx`, and NumPy's `arr_interp` contracts too. Written the obvious unfused way the port misses the corpus by up to **3.6e-12** relative *on the corpus's own grids* — past the 1e-12 `TABULATED` budget in `test/parity/tolerances.py` — so the Phase 04 swap would have failed its own gate. With `f64::mul_add` at those sites it is bit-equal at every one of those points. The converse is the trap: `boost_beta` is deliberately **not** fused, because none of its ten inlining call sites contract `1 - (m/E)**2`. Each site was established twice, by disassembling the shipped `.so` and by bisecting all 16 on/off combinations against the live kernel.
- **No values move in this PR**, but one drift is now known and lands with the Phase 04 swap: the Rust returns the *contracted* (arm64) numbers on every platform, so on a target whose C compiler does not contract — baseline x86-64, which is what the Linux wheels are built for — today's Cython returns values up to 3.6e-12 relative away from these. Past `rules.md` rule 3's 1e-12 threshold, so it is recorded in the project's "Numerical impact so far" for the Phase 04 PR to declare. The alternative, plain arithmetic, misses the corpus by that same amount on *every* platform.
- **Found while porting: `boost_integrate_linear_interp` is wrong near threshold, in released hazma.** Its interior sum stops one cell short of the upper partial cell, and when both integration bounds fall inside one cell the two partial-cell terms overlap instead — an over-count of `cell width / window width`, which diverges as `beta → 0`. All seven tabulated photon spectra therefore blow up instead of converging to their own rest-frame spectrum as the parent slows: `dnde_photon_eta(54.79, m_eta)` is `0.02313` MeV⁻¹ at rest against `767.2` one part in 1e12 above it, a factor of 33,000; the other six run 6,500×–9,800×. **This PR reproduces the behavior rather than repairing it** (`rules.md` rule 1 — the corpus pins these values, so a fix here would fail the gate), pins it in both languages, and files [the repair](docs/followups/todo/boost-integral-drops-last-interior-cell.md), blocked until after Phase 06 Task 6.4 because it needs a declared corpus regeneration. Worth a look independently of this project's schedule.
- Two canonical patches, in the same PR as the code: the phase file's Task 3.4 block gains five "criteria added during execution" bullets (the oracle it named does not exist — Phase 01 captures top-level `def`s and these are all `cdef`, so the tests call the live Cython through `__pyx_capi__` with `ctypes` instead), and `references/numerics-replacements.md` gains the measured block, since its own `np.interp` and boost prose is what a next reader would port from and both are incomplete in ways that change the numbers.

## Project

`projects/cython-to-rust/` — Task 3.4: Interpolation + boost kernels.

See `projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md`
for implementation detail, decisions, the mutation tables, and verification.

## Test plan

- [x] `scripts/agents/preflight.sh --paths "…" --md "…"` → **RESULT: PASS** (ten rows PASS, one expected SKIP for the version bump)

```text
PASS   black --check / isort --check-only / ruff check
PASS   cargo fmt --check / cargo clippy / cargo test        rust/
PASS   pytest                  1314 passed, 13 skipped, 5 warnings in 566.77s (0:09:26)
PASS   import hazma            version 2.1.0
PASS   markdownlint            (8 changed .md)
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
RESULT: PASS
```

- [x] `+102` on Task 3.3's `1212 passed, 13 skipped`, all of them this task's tests. **The skip count is unchanged at 13**, which is how the parity suite reports it is still in bit-equality mode — confirmed directly rather than inferred:

```text
$ python -c "...tolerances.provenance(manifest)..."
Provenance(exact=True, detail='')
$ python -c "...cases.rust_core_kernels()..."
[]
```

- [x] `pytest test/test_core_interp.py -q` → `33 passed in 0.46s` (6 classes); `pytest test/test_core_boost.py -q` → `69 passed in 0.91s` (9 classes)
- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features` → `67 passed` (24 new)
- [x] Bit-equality against the oracles, not a tolerance: zero mismatches on all seven live tables across six boost regimes × 400 energies, zero across 40,000 `boost_delta_function` draws at both live product masses, and zero on 20,204 `np.interp` abscissae per table.
- [x] **Test validity — 21 mutations**, run sequentially behind a lock with a green baseline asserted before and after. 17 of the first 20 caught; all 21 after two tests were added. The three survivors shared one shape — each moved a *branch boundary* by a single double without touching any returned value, which no grid sample can see. The tests written for them bisect on the bit pattern. Tables in the task note.
- [x] No public value changes: `git diff origin/master -- hazma` is one file, `hazma/_core.pyi`, and every line of the hunk is comment text.