### PR TITLE
test(suite): declare the boost oracle's platform scope

### DIFF
--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -82,7 +82,27 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   venv was rebuilt on the corpus's capturing interpreter partway through).
   When a measured artifact carries the environment in its name, record the
   invariant and the mechanism (`cp<XY>`, never `abi3`, because a Cython
-  extension remains) rather than one run's value.
+  extension remains) rather than one run's value. A third shape, and the
+  cheapest to hit: the number is a count of *your own* tests, taken while
+  the diff was still moving. PR #64 recorded a re-measured
+  `test/test_core_boost.py` at `81 passed` in a durable note, then dropped
+  two tests and added one during a later self-review pass and shipped 80 —
+  the note was written once and never re-derived, and review caught it.
+  Re-derive every count you wrote *after* your last code edit, not after
+  the edit that motivated the count.
+- [partial-historical-labeling] Annotating **one** measurement in a dated
+  section as historical silently upgrades every unlabeled measurement
+  beside it into a claim about the current tree. Label the *section*, not
+  the line. PR #64 footnoted a single row of a task note's `## Verification`
+  table as "left as taken" while the same section's mutation-campaign
+  baseline (`102 passed`) sat sixty lines below with no such marker, and
+  review read it as a live figure — correctly, because the neighbouring
+  footnote implied it. The reverse error is just as easy: a number that
+  looks stale can be *right* for what it claims, and blind number-chasing
+  breaks it — the same PR's `cargo test` "69 units" describes the
+  **foundation's** units, so "fixing" it to the current 80 would have
+  folded in a later phase's kernel and made a true sentence false. Decide
+  per claim what it is a statement *about*, then date the block.
 - [flat-vs-sectioned-numbering] A document whose items restart numbering in
   each section, cited elsewhere by a flat index, has two schemes and no key —
   so a correct citation reads as a dangling one and a reviewer's "fix" breaks

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -384,13 +384,30 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   bit-for-bit assertion that is exactly right on the reference platform
   fails everywhere else (PR #61: 19 assertions in
   `test/test_core_{interp,boost}.py` passed on macOS/arm64 and failed on
-  Linux/x86-64, where neither NumPy nor the Cython contracts). Measure
-  the platform property at import and skip the comparison where it does
-  not hold, as `test/parity` already does — do not loosen to a tolerance,
-  because the worst relative gap between two roundings lands at whatever
-  cancellation point the domain contains and a tolerance wide enough for
-  that hides real defects. The tell you are about to make this mistake:
-  the oracle is something you compiled rather than something you pinned.
+  Linux/x86-64, where neither NumPy nor the Cython contracts). **Declare
+  the scope from the platform; do not probe for it.** Read the capturing
+  platform out of `test/parity/data/manifest.json` so the scope cannot
+  drift from the corpus's, compare bit-for-bit there, and hold a measured
+  budget everywhere else. Probing — evaluate the compiled oracle against
+  an unfused transcription, conclude "this build contracts", skip where it
+  does not — is the trap this lesson used to recommend, and it fails in
+  both directions: a probe sees one contraction mechanism and is blind to
+  the rest, so it claims bit-equality on a build that diverges for another
+  reason (PR #63, `test_core_positron_muon.py`, twice) *and* silently
+  voids the whole comparison when the one mechanism it knows is absent
+  (`test_core_boost.py`, 19 claims skipped on every non-macOS CI entry
+  from PR #61 until 2026-08-12 — and the capturing platform cannot see
+  either failure, because there the probe answers correctly by accident).
+  Scale the off-platform budget to the **peak** of the compared array
+  rather than applying a pointwise `rtol`: the worst relative gap between
+  two roundings lands at whatever cancellation point the domain contains,
+  and an `rtol` wide enough for that hides real defects, while against the
+  peak a wrong branch or dropped term still lands at O(1). Measure the
+  budget — build the tree for the other platform and compare — rather than
+  guessing it, and give it a test that proves it still rejects a real
+  error, since on the capturing platform nothing else exercises it. The
+  tell you are about to make this mistake: the oracle is something you
+  compiled rather than something you pinned.
 - [settling-a-deferral-has-two-sweeps] When a task *settles* something an
   earlier task deferred, the stale text lives in two disjoint populations
   and grepping one feels like finishing. The **pointers** say "Task N

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -34,6 +34,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [positron spectra return `nan` at the legacy `MASS_E`](todo/positron-spectrum-nan-at-legacy-electron-mass.md) | 2026-08-08 | cython-to-rust Task 1.4 | cross-cutting |
 | [the boost integral mis-covers its window at both ends](todo/boost-integral-drops-last-interior-cell.md) | 2026-08-10 | cython-to-rust Task 3.4 | cross-cutting |
 | [the muon positron spectrum divides by its normalization](todo/positron-muon-spectrum-normalization-inverted.md) | 2026-08-11 | cython-to-rust Task 4.1 | cross-cutting |
+| [`test_core_interp.py` still scopes its NumPy oracle with a probe](todo/interp-oracle-scoped-by-an-unsound-probe.md) | 2026-08-12 | cython-to-rust — the `test_core_boost.py` probe removal | cross-cutting |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/interp-oracle-scoped-by-an-unsound-probe.md
+++ b/docs/followups/todo/interp-oracle-scoped-by-an-unsound-probe.md
@@ -1,0 +1,104 @@
+# `test_core_interp.py` still scopes its NumPy oracle with a probe
+
+- **Added:** 2026-08-12
+- **Source:** cython-to-rust — carved out of the `test/test_core_boost.py`
+  probe removal (the same mechanism, the other module)
+- **Scope:** cross-cutting
+- **Status:** open
+- **Triggers / blockers:** none. Independent of the Phase 04–06 kernel
+  swaps; `hazma._core.interp` is a foundation module those swaps consume
+  but do not change.
+
+## Why
+
+`test/test_core_interp.py` decides whether to compare `hazma._core.interp`
+against `np.interp` bit-for-bit by *measuring* whether the installed NumPy
+fuses its interpolation step — `numpy_contracts()` at
+`test/test_core_interp.py:81`, cached in `NUMPY_CONTRACTS` and applied as
+`requires_a_contracting_numpy` to `TestAgainstNumpy` and
+`TestFusedArithmetic`.
+
+That is the mechanism cython-to-rust Task 4.1 retired in
+`test/test_core_positron_muon.py` and the 2026-08-12 rewrite retired in
+`test/test_core_boost.py`, for a reason that applies unchanged here: a
+probe tests **one** contraction mechanism, so it is blind to every other
+way two builds can disagree. It fails in both directions — claiming
+bit-equality on a build that diverges for a reason it cannot see (PR #63,
+runs 31562223329 and 31564747071), and voiding the comparison outright
+when its own mechanism is absent.
+
+The interp module is resolving the second way, and it is measurable:
+building this worktree for linux/amd64 (Debian, gcc, glibc, CPython
+3.12.13, NumPy 2.5.1) and running the module gives **24 passed, 9
+skipped** — every comparison against `np.interp` is skipped. Those nine
+are the whole of the module's cross-implementation gate: seven
+parametrised `test_matches_numpy_bit_for_bit` cases over the live photon
+tables, `test_matches_numpy_on_a_random_grid`, and
+`test_the_rust_sides_with_numpy_where_the_forms_differ`. On every CI entry
+but macOS, `hazma._core.interp` is checked against nothing but its own
+clamping contract, quirks, and error paths.
+
+This is latent rather than breaking — the module is green — which is
+exactly why it needs tracking: nothing will surface it.
+
+## What
+
+Apply the shape `test/test_core_boost.py` and
+`test/test_core_positron_muon.py` now share:
+
+1. Replace `numpy_contracts()` / `NUMPY_CONTRACTS` /
+   `requires_a_contracting_numpy` with `ON_THE_CAPTURING_PLATFORM`,
+   derived from `test/parity/data/manifest.json`'s
+   `environment.machine`, so this module's scope cannot drift from
+   `test/parity`'s.
+2. Give the comparison two declared modes — bit-equality on the capturing
+   platform, a budget elsewhere — behind an
+   `assert_matches_numpy(got, want, context)` helper.
+3. **Measure the off-platform divergence before choosing the budget.**
+   Build the tree for linux/amd64 and compare directly; do not infer the
+   figure from a local fused-versus-unfused proxy, which is the reasoning
+   PR #63 refuted.
+4. Scale the budget to the **peak** of the compared array
+   (`atol = BUDGET * peak`, `rtol = BUDGET`), not pointwise. This module
+   is the sharpest case for that: Task 3.4 rejected a tolerance precisely
+   because the worst relative gap sits at the eta tail, where the
+   interpolant is 2.4e-26 against a table of scale 0.2 — an absolute gap
+   of 1.4e-30, invisible against the peak and catastrophic as an `rtol`.
+   Peak scaling is what makes a budget viable where a pointwise one is
+   not.
+5. Add a guard that the budget still rejects a real error, since on the
+   capturing platform nothing else exercises the tolerance branch.
+
+`TestFusedArithmetic` deserves the treatment its boost counterpart got
+rather than a budget: rewrite it to discriminate against a **fused Python
+reference** (`fma` at the interpolation step, via the `Fraction`-based
+helper — `math.fma` needs 3.13 and the suite supports 3.10) instead of
+against NumPy. `f64::mul_add` is correctly rounded on every target Rust
+supports, so "the port fuses here" becomes a platform-independent claim
+and the class stops needing a scope at all.
+
+## Entry points
+
+- `test/test_core_interp.py:81` — `numpy_contracts()`
+- `test/test_core_interp.py:100` — `NUMPY_CONTRACTS`
+- `test/test_core_interp.py:102` — `requires_a_contracting_numpy`
+- `test/test_core_interp.py:134`, `:177` — the two scoped classes
+- `test/test_core_boost.py` — the pattern to copy, including the
+  measured budget, the ulp budget for support edges, and
+  `TestOffPlatformBudgets`
+- `test/test_core_positron_muon.py` — the per-kernel template it came from
+- `projects/cython-to-rust/task-notes/phase-04/task-4.1-positron-muon.md`
+  §Findings — why the probe is unsound
+- `docs/agents/lessons.md` `[platform-scoped-oracle-asserted-globally]`
+
+## Risks / open questions
+
+- **`np.interp` is a weaker oracle than a Cython twin in one respect:** it
+  is not the implementation being replaced, it is an independent one, so
+  the budget is a statement about two independent implementations rather
+  than about one compiler's contraction choices. The figure may need to be
+  looser than boost's `1e-10`; measure it rather than reusing that number.
+- **The quirk tests must stay exact.** NaN propagation, the one-point
+  grid's asymmetry, the duplicate-node tie-break and both infinite-cell
+  rescues are structural, not numerical, and already run everywhere; a
+  budget must not be extended over them.

--- a/projects/cython-to-rust/learnings/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/learnings/phase-03-numerics-foundation.md
@@ -146,13 +146,20 @@ transcription, and it will survive contact with the artifact.**
 ## 4. Test Infrastructure State
 
 - **Five Python test modules, all against a live oracle**, none of them
-  duplicating the parity corpus: `test/test_core_constants.py` (25 tests,
-  source-to-source text comparison, no build needed, 0.03s),
-  `test_core_special.py` (65, scipy), `test_core_quad.py` (58,
-  `scipy.integrate.quad` through a Python-callable probe),
-  `test_core_interp.py` (33, `np.interp`), `test_core_boost.py` (69, the
-  Cython twin via `__pyx_capi__`), `test_core_dispatch.py` (118, the
-  `.pyx` sources' own error strings). `cargo test` carries 69 units.
+  duplicating the parity corpus. Counts are **as Phase 03 closed**, which
+  is what this document records; later phases add to them.
+  `test/test_core_constants.py` (25 tests, source-to-source text
+  comparison, no build needed, 0.03s), `test_core_special.py` (65,
+  scipy), `test_core_quad.py` (58, `scipy.integrate.quad` through a
+  Python-callable probe), `test_core_interp.py` (33, `np.interp`),
+  `test_core_boost.py` (69, the Cython twin via `__pyx_capi__`),
+  `test_core_dispatch.py` (118, the `.pyx` sources' own error strings).
+  `cargo test` carries 69 units — the foundation's, GIL-free.
+  **Since phase close:** `test_core_boost.py` is **80**, the 2026-08-12
+  rescoping of its platform guard (+11, derived in that task note); and
+  `cargo test` is **80**, Task 4.1's `positron_muon` kernel (+11), which
+  are *not* foundation units and are why the 69 above is left as it
+  stands. Every other count still reproduces on the current tree.
 - **`test_core_dispatch.py` is the template Phases 04–06 copy** for a
   kernel swap: keep every test, swap the probe and the quantity wording,
   add the kernel's numerical tests *beside* rather than merged in.

--- a/projects/cython-to-rust/learnings/phase-03-numerics-foundation.md
+++ b/projects/cython-to-rust/learnings/phase-03-numerics-foundation.md
@@ -159,11 +159,17 @@ transcription, and it will survive contact with the artifact.**
 - **A test whose oracle is something you compiled is scoped to that
   build.** Nineteen bit-equality assertions against the Cython and NumPy
   passed on macOS/arm64 and failed on Linux/x86-64, because
-  `-ffp-contract=on` only bites on a target with hardware FMA. Measure the
-  property at import (`CYTHON_CONTRACTS`, `NUMPY_CONTRACTS`) and skip
-  where it does not hold; loosening to a tolerance is the wrong fix, since
-  the worst relative gap sits at a cancellation point where any admitting
-  tolerance would hide real defects
+  `-ffp-contract=on` only bites on a target with hardware FMA. **Declare
+  that scope from the platform and hold a measured budget off it** —
+  `ON_THE_CAPTURING_PLATFORM`, read from the corpus manifest, plus an
+  `assert_allclose` whose `atol` is scaled by the peak of the compared
+  array so the cancellation points do not force a loose pointwise `rtol`.
+  This phase's original remedy — probe the property at import
+  (`CYTHON_CONTRACTS`, `NUMPY_CONTRACTS`) and skip where false — is
+  retired: a probe sees one contraction mechanism and no others, so it
+  claims bit-equality where none holds *and* voids the comparison where it
+  does. `test_core_boost.py` was doing the latter on every non-macOS CI
+  entry until 2026-08-12
   (`docs/agents/lessons.md` `[platform-scoped-oracle-asserted-globally]`).
 - **Mutation campaigns are this phase's standard gate** — 13 mutations in
   3.1, 11 in 3.2, 17 in 3.3, 21 in 3.4, 14 in 3.5, each run sequentially

--- a/projects/cython-to-rust/task-notes/phase-03/README.md
+++ b/projects/cython-to-rust/task-notes/phase-03/README.md
@@ -629,9 +629,16 @@ parallel.
   wrong for now** — the corpus pins those values, so a swap that repairs
   the coverage **fails the gate**. Blocked until after Phase 06 Task 6.4.
 - **A test whose oracle is something you compiled is scoped to that
-  build.** Any kernel test using the Cython twin as its oracle needs the
-  `CYTHON_CONTRACTS`-style import-time guard; loosening to a tolerance is
-  the wrong fix.
+  build.** Any kernel test using the Cython twin as its oracle needs that
+  scope **declared from the platform**, not probed for: read
+  `test/parity/data/manifest.json`'s `environment.machine`, compare
+  bit-for-bit there, and hold a **measured** budget elsewhere — the shape
+  `test/test_core_positron_muon.py` and `test/test_core_boost.py` both
+  carry. The `CYTHON_CONTRACTS`-style import-time guard this line used to
+  prescribe is retired: it probes one contraction mechanism and is blind
+  to the others, so it both over- and under-claims (Task 4.1 Findings; the
+  boost module was silently skipping all 19 of its claims off macOS until
+  2026-08-12).
 - **An edge that only decides a branch needs a bisection test, not a
   grid** — and check the sweep's parameter space reaches the branch at all.
 - **The two `thermal_cross_section` implementations disagree above

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
@@ -200,6 +200,35 @@ added there during execution:
   per-branch tests keep their platform-independent halves running
   everywhere and route only the bit-equality claim through
   `assert_matches_cython`, which skips mid-test *after* those have run.
+
+  > **Superseded for `test/test_core_boost.py` on 2026-08-12.** The
+  > *diagnosis* above holds; the *remedy* does not. Task 4.1 showed the
+  > probe to be unsound (PR #63, runs 31562223329 and 31564747071): it
+  > tests one contraction mechanism and is therefore blind to the others,
+  > so it answers "contracts" where nothing does — and, as measured here,
+  > can answer "does not contract" and void the comparison entirely.
+  > `test/test_core_boost.py` was resolving the second way: the probe
+  > returned `False` on Linux/x86-64 and **all 19 of the module's
+  > cross-implementation claims skipped**, so that gate had been vacuous on
+  > every CI entry but macOS since PR #61. (19 = 11 tests carrying
+  > `requires_a_contracting_cython` + 8 reaching a mid-test
+  > `assert_matches_cython`. Confirmed two ways: directly, by building this
+  > worktree for linux/amd64 and reading `-rs`; and from CI, where the
+  > 2026-08-12 master run 31619425557 reports `767 passed, 41 skipped` on
+  > Linux against `1424 passed, 14 skipped` on macOS — a 28-skip excess
+  > once the corpus's own skip drops out with `--ignore=test/parity`, which
+  > is exactly this module's 19 plus `test_core_interp.py`'s 9. Do not read
+  > this 19 as the same 19 in the bullet above: that one is PR #61's count
+  > of *failing assertions* across both modules.) It
+  > now declares the mode from the platform (`ON_THE_CAPTURING_PLATFORM`,
+  > read from the corpus manifest) and applies a **measured** budget off
+  > it, exactly as `test/test_core_positron_muon.py` does. The
+  > cancellation-point argument above is why that budget is scaled to the
+  > *peak* of the compared array rather than applied pointwise — it is the
+  > reason the two-mode design works, not a reason to skip. `NUMPY_CONTRACTS`
+  > in `test/test_core_interp.py` still carries the retired mechanism and 9
+  > of its claims still skip off macOS; that is tracked in
+  > [`interp-oracle-scoped-by-an-unsound-probe.md`](../../../../docs/followups/todo/interp-oracle-scoped-by-an-unsound-probe.md).
 - **The QUADPACK-style literal-translation posture does not apply here.**
   `boost.pyx` is 90 lines of ordinary arithmetic, so the Rust reads as
   Rust (`Option` for the `-1` index sentinel, a closure for the `y / x`
@@ -251,6 +280,11 @@ anything was run:
 | `markdownlint --dot` over the eight changed `.md` | clean |
 | `scripts/agents/preflight.sh --paths "…"` | **RESULT: PASS** |
 
+The table is this task's measurement and is left as taken. Re-running it
+today gives `81 passed` for `test/test_core_boost.py`, not 69: the
+2026-08-12 rewrite of its platform scoping (see §Findings) replaced 19
+probe-gated claims with two declared modes and added the budget guards.
+
 `+102` on Task 3.3's `1212 passed, 13 skipped`, and all 102 are this
 task's tests. **The skip count is unchanged at 13, which is what proves
 the parity corpus ran in bit-equality mode**; confirmed directly rather
@@ -264,8 +298,11 @@ than inferred —
 random interior points, every node, every node nudged ±1e-13, and four
 out-of-range; plus 50 random grids with cells of wildly unequal width);
 `TestFusedArithmetic` (the fused and unfused forms are shown to differ
-somewhere before the Rust is asserted to side with NumPy, so the test
-cannot pass vacuously on a non-contracting platform);
+somewhere before the Rust is asserted to side with NumPy — but that
+premise is false wherever NumPy does not contract, so the class is
+skipped rather than run there, and on Linux/x86-64 it always is; see the
+superseding note in §Findings and
+[`interp-oracle-scoped-by-an-unsound-probe.md`](../../../../docs/followups/todo/interp-oracle-scoped-by-an-unsound-probe.md));
 `TestClamping`; `TestQuirks` (NaN propagation, the one-point grid's NaN
 asymmetry, the duplicate-node tie-break, both infinite-cell rescues, and
 the infinite-node short circuit); `TestErrors` (both `ValueError`s, each
@@ -284,7 +321,10 @@ both partial cells, the interior sum — each pinned by a closed form or by
 a sensitivity check on a table entry only that branch reads, and each
 bit-equal to the Cython; plus all seven live tables over six boost
 regimes × 400 energies); `TestFusedArithmetic` (an independent unfused
-reference, used as a discriminator); `TestDroppedInteriorCell`;
+reference, used as a discriminator — **rewritten on 2026-08-12** to
+discriminate against a *fused* Python reference instead of against the
+Cython, which makes the claim platform-independent and drops its skip);
+`TestDroppedInteriorCell`;
 `TestTrapezoidSummation` (five table sizes spanning NumPy's pairwise
 blocking, plus a check that a sequential sum really would differ);
 `TestErrors`; `TestDispatch`.

--- a/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
+++ b/projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md
@@ -265,6 +265,16 @@ added there during execution:
 
 ## Verification
 
+> **Everything in this section is a dated record of what this task
+> measured on 2026-08-10, not a claim about the current tree**, and it is
+> left as taken. Two of its numbers have since moved and are reconciled
+> where they appear: `test/test_core_boost.py` (69 → 80, the 2026-08-12
+> rescoping in §Findings) and the mutation campaign's restored baseline
+> (102 → 113, the same 11 tests). Everything else — the bare-suite line,
+> `test_core_interp.py`, the `cargo test` count, the mutation tables —
+> reproduces only against this task's commit, which is the point of
+> recording it.
+
 **Commands and their real summary lines**, all on the corpus's capturing
 environment (CPython 3.12.12, NumPy 2.5.1, SciPy 1.18.0, macOS/arm64), on
 a tree rebuilt with `uv pip install -e . --no-build-isolation` before
@@ -280,10 +290,28 @@ anything was run:
 | `markdownlint --dot` over the eight changed `.md` | clean |
 | `scripts/agents/preflight.sh --paths "…"` | **RESULT: PASS** |
 
-The table is this task's measurement and is left as taken. Re-running it
-today gives `81 passed` for `test/test_core_boost.py`, not 69: the
-2026-08-12 rewrite of its platform scoping (see §Findings) replaced 19
-probe-gated claims with two declared modes and added the budget guards.
+Re-running the `test_core_boost.py` row against the 2026-08-12 rescoping
+(§Findings) gives **`80 passed`**, not 69. The `+11` is not the 19
+rescoped claims — those were re-gated, not added or removed — and comes
+entirely from two other changes, derived by diffing collected test ids
+rather than counted by hand:
+
+- `TestFusedArithmetic` 1 test → 9 (**+8**). It stopped discriminating
+  against the Cython and now discriminates against a *fused* Python
+  reference, which is a per-table claim:
+  - `test_the_tabulated_port_is_the_fused_reference`, parametrised over
+    all seven photon tables (**+7**);
+  - `test_the_delta_function_port_is_the_fused_reference` and
+    `test_the_unfused_tabulated_form_would_be_a_different_number`,
+    replacing the single
+    `test_the_unfused_form_misses_the_cython_and_the_rust_does_not`
+    (**+2 −1**).
+- `TestOffPlatformBudgets` is new (**+3**): one guard per budget plus the
+  mode-dispatch guard.
+
+`+12 −1 = +11`, and `69 + 11 = 80`. The five
+`test_gamma_matches_the_cython_bit_for_bit` ids and two window-edge ids
+also changed name, which moves no count.
 
 `+102` on Task 3.3's `1212 passed, 13 skipped`, and all 102 are this
 task's tests. **The skip count is unchanged at 13, which is what proves
@@ -349,7 +377,9 @@ height (`k0`): 3 of 4 caught, `k` still surviving because the first
 version of the edge test used three fixed parameter sets. Round 3, after
 widening that test to the random sweep: **1 mutation, 0 survived.**
 Final state: all 21 caught, baseline restored green
-(`RESTORED BASELINE: GREEN — 102 passed`).
+(`RESTORED BASELINE: GREEN — 102 passed`, this task's two modules as they
+stood on 2026-08-10; the same pair is `113 passed` today — see the note at
+the head of this section).
 
 **Deferred:** nothing. Two things are deliberately *not* done rather than
 deferred — the boost integral's window-coverage defect is preserved under

--- a/test/test_core_boost.py
+++ b/test/test_core_boost.py
@@ -25,46 +25,110 @@ rather than ``CFUNCTYPE``: the latter releases the GIL, and
 name *is* the C signature, so :class:`TestOracle` checks it rather than
 trusting that the argument list has not changed.
 
-The bar is bit-equality, on a contracting platform
---------------------------------------------------
-Not a tolerance. ``rust/src/boost.rs`` reproduces the shipped Cython's
-arithmetic exactly, fused multiply-adds included --
-:class:`TestFusedArithmetic` is the measurement that made that mandatory:
-written the obvious unfused way, the boost integral misses the corpus by
-up to 3.6e-12 relative on the corpus's own grids, against the 1e-12
-``TABULATED`` budget in ``test/parity/tolerances.py``.
+Why the comparison has two modes
+--------------------------------
+Bit-equality against a *compiled* twin is a statement about the build that
+produced it, not about this port. Until 2026-08-12 this module tried to
+*detect* that condition instead of declaring it: ``cython_contracts()``
+compared the compiled ``boost_delta_function`` against an unfused Python
+transcription and skipped every claim against the Cython where the two
+agreed, on the theory that a build which does not fuse its multiply-adds
+is simply a different arithmetic. Task 4.1 showed the same mechanism to be
+unsound in ``test/test_core_positron_muon.py`` (PR #63, runs 31562223329
+and 31564747071): a probe over one mechanism cannot see the others, so it
+answers "contracts" on platforms where nothing does and the bit-equality
+assertions then fail, or answers "does not contract" and silently voids
+the whole comparison. **This module was resolving the second way.** On
+Linux/x86-64 the probe returned ``False``, all 19 of its
+cross-implementation claims skipped, and that gate had been vacuous on
+every CI entry but macOS since PR #61 -- measured directly, and
+corroborated by the skip counts of master run 31619425557
+(``projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md``
+carries the arithmetic).
 
-But *whether* the Cython contracts is a property of the C compiler that
-built it, not of this port. On macOS/arm64 -- the platform the parity
-corpus was captured on, and whose numbers this port targets -- it does,
-and every comparison below is bit-exact. On a target without hardware
-FMA (baseline x86-64, which is what the Linux wheels are built for) the
-Cython computes the unfused values instead: measured here, that moves
-``boost_delta_function`` by up to 1.9e-13 relative and the tabulated
-integral by up to 9.9e-13, with no branch flip in 40,000 draws. So
-:data:`CYTHON_CONTRACTS` is measured at import and the
-cross-implementation tests skip where it is false -- the same scoping
-the parity corpus already has (CI runs ``pytest --ignore=test/parity``
-off macOS for the same reason). Everything platform-independent --
-the closed forms, the per-branch sensitivity checks, the dropped-cell
-pins, the trapezoid reduction, the error paths, dispatch -- runs
-everywhere.
+So the *mode* is declared from the platform, and the divergence off it was
+**measured rather than assumed** -- by building this worktree for
+linux/amd64 (Debian, gcc, glibc, CPython 3.12.13, NumPy 2.5.1) and
+comparing the two implementations directly:
+
+============================== ============= ================
+comparison                     max relative  max ``|Δ|``/peak
+============================== ============= ================
+``boost_delta_function``       1.9e-13       7.3e-17
+``…_interp``, eta              9.9e-13       1.2e-15
+``…_interp``, eta_prime        6.3e-13       7.2e-16
+``…_interp``, charged_kaon     3.6e-13       3.2e-15
+``…_interp``, long_kaon        1.3e-13       3.1e-15
+``…_interp``, short_kaon       1.2e-13       3.4e-15
+``…_interp``, omega            2.6e-13       3.3e-15
+``…_interp``, phi              9.1e-14       5.9e-16
+============================== ============= ================
+
+Over 40,000 delta-function draws and 16,800 tabulated points: no sign
+flip, no NaN, and -- the statement rounding cannot excuse -- **no
+disagreement anywhere about which energies are zero**. The magnitudes are
+what the unfused arithmetic costs, which is the expected finding here:
+baseline x86-64 has no hardware FMA, and the worst delta-function
+disagreement measured against the Linux Cython (1.8683e-13) is the number
+:meth:`TestFusedArithmetic.test_the_delta_function_port_is_the_fused_reference`
+recovers from an unfused Python reference, on any platform, over the same
+40,000 draws.
+
+:data:`OFF_PLATFORM_BUDGET` is scaled to the **peak of the compared
+array** rather than applied pointwise, and the two columns above are why:
+they differ by three orders of magnitude, because the worst *relative*
+disagreements land where the integrand cancels. On the eta table the two
+maxima together bound the value carrying the worst relative gap at
+1.2e-3 of the peak -- so a pointwise ``rtol`` wide enough to admit it
+would be a thousand times wider than what the spectrum actually is, which
+is the shape Task 3.4 rejected a tolerance over. Against the peak -- what
+a downstream integral or limit sees -- the whole population fits in
+3.4e-15. Both arms are asserted (``atol = BUDGET * peak`` with
+``rtol = BUDGET``), and the figure is set from the tighter reading: 1e-10
+is 100x the worst measured relative disagreement and 2.9e4x the worst
+measured peak-relative one. A wrong branch, a dropped term or a bad
+constant lands at O(1) against that -- :class:`TestDroppedInteriorCell`
+measures the one defect this module knows the size of at 53%.
+
+Support edges get their own budget, in ulps
+-------------------------------------------
+``eminus`` and ``eplus`` never appear in a returned value; they only
+decide whether it is ``1/(2 gamma beta k0)`` or zero. So the port's agreement
+with the Cython about *where* the window ends cannot be expressed as a
+tolerance on the output -- one implementation returns a finite number and
+the other returns zero. It is expressed instead as a distance in ulps
+between the two support boundaries, located by bisection on the bit
+pattern. Same two modes: the same double on the capturing platform, and
+within :data:`OFF_PLATFORM_EDGE_ULPS` elsewhere.
+
+The parity corpus (``test/parity/``) is scoped by platform the same way
+(``.github/workflows/ci.yml`` passes ``--ignore=test/parity`` off the
+capturing platform), and :data:`CAPTURE_MACHINE` is read out of its
+manifest so the two scopes cannot drift apart.
 
 Lifetime
 --------
 Everything comparing against ``__pyx_capi__`` dies with the ``.pyx`` in
-Phase 06 Task 6.4. :class:`TestTrapezoidSummation`,
-:class:`TestDroppedInteriorCell`, :class:`TestErrors` and
-:class:`TestDispatch` do not, and are what remains as the standing check
-afterwards.
+Phase 06 Task 6.4. :class:`TestFusedArithmetic`,
+:class:`TestTrapezoidSummation`, :class:`TestDroppedInteriorCell`,
+:class:`TestErrors` and :class:`TestDispatch` do not, and are what remains
+as the standing check afterwards. :class:`TestFusedArithmetic` earns that
+by comparing the port against a Python reference rather than against the
+Cython: ``rust/src/boost.rs``'s twelve ``mul_add`` sites are pinned in
+both directions on every platform, which is the claim the old
+Cython-versus-unfused form could only make on one.
 """
 
 from __future__ import annotations
 
 import ctypes
+import json
 import math
+import platform
+import sys
 from collections.abc import Callable
 from fractions import Fraction
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -85,6 +149,8 @@ boost_beta = core_boost.boost_beta
 boost_gamma = core_boost.boost_gamma
 boost_delta_function = core_boost.boost_delta_function
 boost_integrate_linear_interp = core_boost.boost_integrate_linear_interp
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 # --------------------------------------------------------------------------
@@ -137,20 +203,263 @@ def cython_boost(name: str) -> Callable[..., float]:
     return prototype(address)
 
 
+# --------------------------------------------------------------------------
+# Which platform this is, and what the comparison costs off it
+# --------------------------------------------------------------------------
+
+#: The platform the parity corpus was captured on, read from its own
+#: manifest so the two can never drift apart. `test/parity` is scoped to
+#: this platform for exactly the reason in the module docstring, and CI
+#: enforces it with `--ignore=test/parity` everywhere else
+#: (`.github/workflows/ci.yml`); this module is the same kind of oracle and
+#: carries the same scope.
+CAPTURE_MACHINE = json.loads(
+    (REPO_ROOT / "test" / "parity" / "data" / "manifest.json").read_text()
+)["environment"]["machine"]
+
+ON_THE_CAPTURING_PLATFORM = (
+    sys.platform == "darwin" and platform.machine() == CAPTURE_MACHINE
+)
+
+#: The off-platform budget, as a fraction of the peak of the array being
+#: compared. Set from the linux/amd64 measurement in the module docstring:
+#: 100x the worst *relative* disagreement observed there (9.9e-13, the eta
+#: table at the strongest boost) and 2.9e4x the worst peak-relative one
+#: (3.4e-15). The relative reading is the tighter of the two and is what
+#: chose the figure; the peak scaling is what keeps the tolerance from
+#: having to admit the catastrophic-cancellation points. Applied as
+#: `assert_allclose`'s `atol` scaled by the peak, with `rtol` at the same
+#: figure so a large value is held to the same standard.
+OFF_PLATFORM_BUDGET = 1e-10
+
+#: How far the two implementations' support boundaries may sit apart off
+#: the capturing platform, in ulps of the boundary itself. Measured at
+#: **55 ulps worst** over 800 bracketed edges on linux/amd64 (547 of them
+#: on the identical double); 4096 leaves 74x headroom and still corresponds
+#: to a relative displacement of 9.1e-13, eleven orders below anything a
+#: wrong edge formula would produce.
+OFF_PLATFORM_EDGE_ULPS = 4096
+
+
+def _as_array(values: object) -> np.ndarray:
+    """A 1-D float64 view of a scalar or array, for the comparisons below."""
+    return np.atleast_1d(np.asarray(values, dtype=np.float64))
+
+
+def assert_within_the_off_platform_budget(
+    got: object, want: object, context: str
+) -> None:
+    """Assert two results agree to :data:`OFF_PLATFORM_BUDGET` of the peak.
+
+    Split out from :func:`assert_matches_the_cython` so the budget can be
+    exercised on *every* platform, including the one where the caller would
+    otherwise take the bit-equality branch and leave this untested --
+    :meth:`TestOffPlatformBudgets.test_the_value_budget_rejects_a_real_error`.
+
+    ``atol`` is scaled by the peak rather than left at zero because the
+    relative error is unbounded where the integrand cancels: see "Why the
+    comparison has two modes".
+    """
+    got, want = _as_array(got), _as_array(want)
+    finite = np.isfinite(want)
+    peak = float(np.abs(want[finite]).max()) if finite.any() else 0.0
+    np.testing.assert_allclose(
+        got,
+        want,
+        rtol=OFF_PLATFORM_BUDGET,
+        atol=OFF_PLATFORM_BUDGET * peak,
+        err_msg=(
+            f"{context}: the port left the Cython's budget of "
+            f"{OFF_PLATFORM_BUDGET:.0e} x the peak ({peak:.6e}). Rounding "
+            f"between two builds was measured at 3.4e-15 x peak, so this is "
+            f"a defect, not a platform difference."
+        ),
+    )
+
+
+def assert_matches_the_cython(got: object, want: object, context: str) -> None:
+    """The oracle, in whichever of its two modes this platform gets.
+
+    Bit-for-bit where the corpus was captured -- the port was written
+    against *this* build's arithmetic and reproduces it exactly, which is a
+    far stronger statement than any tolerance. A budget elsewhere, because
+    off it the comparison measures the C compiler rather than the port.
+    """
+    if ON_THE_CAPTURING_PLATFORM:
+        assert _as_array(got).tobytes() == _as_array(want).tobytes(), (
+            f"{context}: not bit-equal to the Cython on the platform the "
+            f"corpus was captured on, where the port is written to reproduce "
+            f"it exactly"
+        )
+        return
+    assert_within_the_off_platform_budget(got, want, context)
+
+
+def ulps_between(a: float, b: float) -> int:
+    """How many doubles separate ``a`` and ``b``, both finite and positive."""
+    return abs(int(np.float64(a).view(np.int64)) - int(np.float64(b).view(np.int64)))
+
+
+def assert_the_edge_is_within_the_off_platform_budget(
+    got: float, want: float, context: str
+) -> None:
+    """Assert two support boundaries sit within :data:`OFF_PLATFORM_EDGE_ULPS`.
+
+    Split out from :func:`assert_the_support_edge_matches_the_cython` for
+    the same reason the value budget is -- on the capturing platform the
+    caller takes the exact branch, so only a direct call can show this one
+    still bites
+    (:meth:`TestOffPlatformBudgets.test_the_edge_budget_rejects_a_real_error`).
+    """
+    apart = ulps_between(got, want)
+    assert apart <= OFF_PLATFORM_EDGE_ULPS, (
+        f"{context}: the port's support boundary is {apart} ulp(s) from the "
+        f"Cython's ({got!r} vs {want!r}), past the {OFF_PLATFORM_EDGE_ULPS}-ulp "
+        f"budget. Rounding between two builds was measured at 55 ulps."
+    )
+
+
+def assert_the_support_edge_matches_the_cython(
+    got: float, want: float, context: str
+) -> None:
+    """The two implementations' window boundaries sit on the same double.
+
+    Off the capturing platform they need only sit within
+    :data:`OFF_PLATFORM_EDGE_ULPS` of each other, because the Cython
+    computes ``gamma * (e -+ beta * k)`` with whatever contraction its
+    compiler chose, and the port computes it with the contraction the
+    shipped macOS build used. A budget on the *values* cannot express
+    this: across the boundary one implementation returns a finite number
+    and the other returns zero.
+    """
+    if ON_THE_CAPTURING_PLATFORM:
+        apart = ulps_between(got, want)
+        assert apart == 0, (
+            f"{context}: the port's support boundary is {apart} ulp(s) from "
+            f"the Cython's ({got!r} vs {want!r}) on the platform the corpus "
+            f"was captured on, where the port reproduces it exactly"
+        )
+        return
+    assert_the_edge_is_within_the_off_platform_budget(got, want, context)
+
+
+# --------------------------------------------------------------------------
+# Reference implementations, parameterised by their multiply-add
+# --------------------------------------------------------------------------
+
+
 def fma(a: float, b: float, c: float) -> float:
     """``a * b + c`` with a single rounding, without ``math.fma``.
 
     ``math.fma`` arrived in Python 3.13 and this suite supports 3.10, so
     the fused product is computed exactly as a rational and rounded once
-    by ``float()``, which rounds to nearest. Used to reproduce the
-    compiler's contraction when a test needs to predict a bound.
+    by ``float()``, which rounds to nearest. Passed to the references
+    below to reproduce ``f64::mul_add``, which is correctly rounded on
+    every target Rust supports whether or not the hardware has an FMA.
     """
     return float(Fraction(a) * Fraction(b) + Fraction(c))
+
+
+def unfused(a: float, b: float, c: float) -> float:
+    """``a * b + c`` with the product rounded before the sum."""
+    return a * b + c
+
+
+#: The Cython's absolute tolerance for "this bound sits on a node"
+#: (``hazma/_utils/boost.pyx:212``), reused by
+#: :func:`integrate_reference` and wherever a test has to predict which
+#: branch fires.
+EDGE_ATOL = 1e-6
 
 
 def rust_gamma(beta: float) -> float:
     """``1 / sqrt(1 - beta**2)`` as ``rust/src/boost.rs`` computes it."""
     return 1.0 / math.sqrt(fma(-beta, beta, 1.0))
+
+
+def delta_function_reference(
+    e0: float,
+    e: float,
+    m: float,
+    beta: float,
+    *,
+    mul_add: Callable[[float, float, float], float],
+) -> float:
+    """``boost_delta_function`` with its five multiply-adds injected.
+
+    ``mul_add=fma`` is ``rust/src/boost.rs:164-170`` transcribed site for
+    site; ``mul_add=unfused`` is the same algorithm written the obvious
+    way. :class:`TestFusedArithmetic` asserts the port is the first and not
+    the second, which pins the fusion without asking what any compiler did.
+    """
+    if beta > 1.0 or beta <= 0.0 or e < m:
+        return 0.0
+    gamma = 1.0 / math.sqrt(mul_add(-beta, beta, 1.0))
+    k = math.sqrt(mul_add(e, e, -(m * m)))
+    if gamma * mul_add(-beta, k, e) < e0 < gamma * mul_add(beta, k, e):
+        return 1.0 / (2.0 * gamma * beta * math.sqrt(mul_add(e0, e0, -(m * m))))
+    return 0.0
+
+
+def integrate_reference(
+    photon_energy: float,
+    beta: float,
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    mul_add: Callable[[float, float, float], float],
+) -> float:
+    """``boost_integrate_linear_interp`` with its seven multiply-adds injected.
+
+    The counterpart of :func:`delta_function_reference` for the tabulated
+    branch; the fused sites are ``rust/src/boost.rs:257`` and ``:326-328`` /
+    ``:336-338``.
+    """
+    npts = len(x)
+    xmax, x0, y0 = float(x[-1]), float(x[0]), float(y[0])
+    gamma = 1.0 / math.sqrt(mul_add(-beta, beta, 1.0))
+    lb = photon_energy * gamma * (1.0 - beta)
+    ub = photon_energy * gamma * (1.0 + beta)
+    if lb > xmax:
+        return 0.0
+    if ub < x0:
+        return y0 * x0 / photon_energy
+
+    integral = 0.0
+    ilow = ihigh = -1
+    if ub > xmax:
+        ub, ihigh = xmax, npts - 1
+    if lb < x0:
+        rat = (1.0 - beta) * photon_energy * gamma / x0
+        integral += y0 * (1.0 - rat) / rat
+        lb, ilow = x0, 0
+    yy = y / x
+    if ilow == -1:
+        ilow = int(np.flatnonzero(lb <= x)[0])
+    if ihigh == -1:
+        ihigh = int(np.flatnonzero(ub <= x)[0])
+        if abs(float(x[ihigh]) - ub) > EDGE_ATOL:
+            ihigh -= 1
+    if ilow < ihigh:
+        integral += float(np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh]))
+    if ilow > 0 and abs(float(x[ilow]) - lb) > EDGE_ATOL:
+        x2, x1 = float(x[ilow]), float(x[ilow - 1])
+        m = (float(yy[ilow]) - float(yy[ilow - 1])) / (x2 - x1)
+        b = mul_add(-m, x1, float(yy[ilow - 1]))
+        inner = mul_add(0.5 * m, x2 + lb, b)
+        integral = mul_add(x2 - lb, inner, integral)
+    if ihigh < npts - 1 and abs(ub - float(x[ihigh])) > EDGE_ATOL:
+        x2, x1 = float(x[ihigh + 1]), float(x[ihigh])
+        m = (float(yy[ihigh + 1]) - float(yy[ihigh])) / (x2 - x1)
+        b = mul_add(-m, x1, float(yy[ihigh]))
+        inner = mul_add(0.5 * m, ub + x1, b)
+        integral = mul_add(ub - x1, inner, integral)
+    return integral / (2.0 * gamma * beta)
+
+
+# --------------------------------------------------------------------------
+# Fixtures and constants
+# --------------------------------------------------------------------------
 
 
 def photon_tables() -> dict[str, tuple[np.ndarray, np.ndarray, float]]:
@@ -186,88 +495,27 @@ def photon_tables() -> dict[str, tuple[np.ndarray, np.ndarray, float]]:
 #: just off rest, near rest, mildly boosted, strongly boosted.
 BOOST_REGIMES = (1.000_000_001, 1.05, 1.5, 2.0, 3.0, 10.0)
 
-
-def unfused_delta_function(e0: float, e: float, m: float, beta: float) -> float:
-    """``boost_delta_function`` with no contraction anywhere.
-
-    Only used to decide whether the local Cython contracts; the port's
-    own reference implementation is
-    :meth:`TestFusedArithmetic.unfused_reference`.
-    """
-    if beta > 1.0 or beta <= 0.0 or e < m:
-        return 0.0
-    gamma = 1.0 / math.sqrt(1.0 - beta * beta)
-    k = math.sqrt(e * e - m * m)
-    if gamma * (e - beta * k) < e0 < gamma * (e + beta * k):
-        return 1.0 / (2.0 * gamma * beta * math.sqrt(e0 * e0 - m * m))
-    return 0.0
-
-
-def cython_contracts() -> bool:
-    """Whether the compiled Cython fuses its multiply-adds.
-
-    Draws until the two forms are distinguishable rather than trusting a
-    single point: most arguments round the same either way.
-    """
-    cython = cython_boost("boost_delta_function")
-    rng = np.random.default_rng(0)
-    for _ in range(2048):
-        beta = float(rng.uniform(0.05, 0.95))
-        e0 = float(10.0 ** rng.uniform(0.0, 3.0))
-        e = float(e0 * 10.0 ** rng.uniform(-0.2, 0.2))
-        m = 0.510_998_928
-        if cython(e0, e, m, beta) != unfused_delta_function(e0, e, m, beta):
-            return True
-    return False
-
-
-#: True where the compiled Cython contracts, i.e. where a bit-for-bit
-#: comparison against it is a statement about this port rather than
-#: about the platform's instruction selection.
-CYTHON_CONTRACTS = cython_contracts()
-
-
-def assert_matches_cython(got: float, want: float, what: str) -> None:
-    """Assert bit-equality with the Cython, where that means anything.
-
-    Where the local Cython does not contract it computes different
-    numbers than the build this port targets, so the claim is skipped
-    rather than weakened. Called *after* a test's platform-independent
-    assertions so those still run everywhere; the skip is visible in the
-    report rather than silently passing.
-    """
-    if not CYTHON_CONTRACTS:
-        pytest.skip(
-            f"{what}: this Cython build does not contract, so a bit-for-bit "
-            "comparison against it is not a statement about the port"
-        )
-    assert got == want, what
-
-
-requires_a_contracting_cython = pytest.mark.skipif(
-    not CYTHON_CONTRACTS,
-    reason=(
-        "this Cython build does not fuse its multiply-adds, so it computes "
-        "different values than the macOS/arm64 build this port targets; the "
-        "bit-for-bit comparison is scoped to a contracting platform exactly "
-        "as the parity corpus is"
-    ),
-)
-
 #: A flat toy table with ``y / x == 1`` everywhere, so every branch's
 #: contribution is a length and can be predicted by hand.
 FLAT_X = np.arange(1.0, 9.0)
 FLAT_Y = FLAT_X.copy()
 
-#: The Cython's absolute tolerance for "this bound sits on a node"
-#: (``hazma/_utils/boost.pyx:212``), reused where a test has to predict
-#: which branch fires.
-EDGE_ATOL = 1e-6
 #: Enough bracketed window edges for the sweep to mean something.
 MIN_EDGES_CHECKED = 100
 #: The smallest miss the unfused arithmetic is recorded as producing; a
-#: smaller one means the platform stopped contracting.
+#: smaller one means :func:`integrate_reference` stopped discriminating.
 MIN_RECORDED_UNFUSED_MISS = 1e-13
+#: How far off a value has to be for the off-platform budget to reject it,
+#: as a fraction of the peak. 100x :data:`OFF_PLATFORM_BUDGET`, and ~3e6x
+#: the largest disagreement ever measured between two builds (3.4e-15).
+BUDGET_PROBE_ERROR = 1e-8
+#: The same for a support boundary, in ulps: 2**32 doubles is a relative
+#: displacement of 9.5e-7, a million times :data:`OFF_PLATFORM_EDGE_ULPS`
+#: and eight million times the 55 ulps measured between two builds --
+#: while still far too small to be a physical change. Written as an
+#: absolute figure, not as a multiple of the budget, so the guard fails if
+#: the budget itself is ever loosened past it.
+EDGE_PROBE_ERROR_ULPS = 2**32
 
 
 class TestOracle:
@@ -308,11 +556,13 @@ class TestBoostParameters:
     )
 
     @pytest.mark.parametrize(("energy", "mass"), CASES)
-    def test_gamma_matches_the_cython_bit_for_bit(
-        self, energy: float, mass: float
-    ) -> None:
+    def test_gamma_matches_the_cython(self, energy: float, mass: float) -> None:
         eng = cython_boost("boost_eng")
-        assert boost_gamma(energy, mass) == eng(energy, mass, 1.0, 0.0, 0.0)
+        assert_matches_the_cython(
+            boost_gamma(energy, mass),
+            eng(energy, mass, 1.0, 0.0, 0.0),
+            f"gamma at {energy=}, {mass=}",
+        )
 
     @pytest.mark.parametrize(("energy", "mass"), CASES)
     def test_beta_matches_the_unfused_closed_form_bit_for_bit(
@@ -326,7 +576,8 @@ class TestBoostParameters:
         of its ten inlining call sites contract it (checked by
         disassembly, Task 3.4 task note). Writing it fused would move
         every boosted spectrum, and this assertion is what fails if
-        someone does.
+        someone does. Platform-independent: both sides are Python and Rust
+        arithmetic, neither of which contracts on its own.
         """
         ratio = mass / energy
         assert boost_beta(energy, mass) == math.sqrt(1.0 - ratio * ratio)
@@ -341,7 +592,8 @@ class TestBoostParameters:
         out ``gamma`` and subtracting 1 recovers ``beta`` -- but the
         subtraction cancels, leaving an absolute error of order ``eps``
         rather than a relative one. The tolerance says exactly that: a few
-        ulp of 1, loosened by nothing else.
+        ulp of 1, loosened by nothing else. Looser than
+        :data:`OFF_PLATFORM_BUDGET` and so in force on every platform.
         """
         eng = cython_boost("boost_eng")
         gamma = eng(energy, mass, 1.0, 0.0, 0.0)
@@ -361,91 +613,108 @@ class TestBoostParameters:
 class TestBoostDeltaFunction:
     """The boosted two-body line, branch by branch."""
 
-    @requires_a_contracting_cython
     def test_matches_the_cython_over_a_random_sweep(self) -> None:
-        """40,000 draws at both live product masses, bit for bit.
+        """40,000 draws at both live product masses.
 
         ``m = 0`` is the photon and neutrino case; ``m = MASS_E`` is
         ``hazma/spectra/_positron/_pion.pyx``. The product energy is drawn
         within a factor of 2.5 of the line, which straddles both window
         edges at every boost.
+
+        The support check runs before the values and on every platform:
+        which draws are *zero* is structural, and no rounding difference
+        explains a disagreement about it. Measured at 0 disagreements over
+        these same 40,000 draws on linux/amd64.
         """
         cython = cython_boost("boost_delta_function")
         rng = np.random.default_rng(20_260_810)
         masses = [0.0, 0.510_998_928]
-        mismatched = 0
-        total = 0
-        for _ in range(40_000):
+        got = np.empty(40_000)
+        want = np.empty(40_000)
+        for i in range(40_000):
             m = float(rng.choice(masses))
             beta = float(rng.uniform(1e-6, 1.0 - 1e-9))
             e0 = float(10.0 ** rng.uniform(-1.0, 3.0))
             e = float(e0 * 10.0 ** rng.uniform(-0.4, 0.4))
-            total += 1
-            if boost_delta_function(e0, e, m, beta) != cython(e0, e, m, beta):
-                mismatched += 1
-        assert mismatched == 0, f"{mismatched} of {total} draws differ from the Cython"
+            got[i] = boost_delta_function(e0, e, m, beta)
+            want[i] = cython(e0, e, m, beta)
+        flips = int(np.count_nonzero((got == 0.0) != (want == 0.0)))
+        assert flips == 0, (
+            f"{flips} of 40,000 draws put the port and the Cython on "
+            f"opposite sides of the window, which no rounding explains"
+        )
+        assert_matches_the_cython(got, want, "40,000-draw sweep")
 
-    @requires_a_contracting_cython
-    def test_the_window_edges_agree_with_the_cython(self) -> None:
-        """Both edges, sampled just inside and just outside.
+    def test_the_window_is_where_the_cython_puts_it(self) -> None:
+        """Both edges, sampled clear of the boundary on either side.
 
-        A one-ulp difference in the bound flips the answer between a
-        finite value and zero rather than moving it slightly.
+        "Clear" is with respect to :data:`OFF_PLATFORM_EDGE_ULPS`: 1e-11
+        relative is about 45,000 ulps, so these samples stay on their own
+        side of the boundary under any displacement this module tolerates.
+        Locating the boundary itself to the last bit is
+        :meth:`test_the_window_edges_sit_where_the_cython_puts_them`'s job,
+        and it is expressed in ulps because a value tolerance cannot span a
+        finite-versus-zero disagreement.
         """
         cython = cython_boost("boost_delta_function")
         e0, m, beta = 200.0, 0.0, 0.6
         gamma = rust_gamma(beta)
         for edge in (gamma * e0 * (1.0 - beta), gamma * e0 * (1.0 + beta)):
-            for scale in (1.0 - 1e-15, 1.0, 1.0 + 1e-15, 0.99, 1.01):
+            for scale in (1.0 - 1e-11, 1.0 + 1e-11, 0.99, 1.01):
                 e = edge * scale
-                assert boost_delta_function(e0, e, m, beta) == cython(e0, e, m, beta)
+                assert_matches_the_cython(
+                    boost_delta_function(e0, e, m, beta),
+                    cython(e0, e, m, beta),
+                    f"window sample at {e=!r}",
+                )
 
     @staticmethod
-    def _window_edges(
-        cython: Callable[..., float], e0: float, m: float, beta: float
-    ) -> list[tuple[float, float]]:
-        """The adjacent doubles the Cython's support starts and ends between.
+    def _support_edge(
+        fn: Callable[..., float],
+        line: tuple[float, float, float],
+        bracket: tuple[float, float],
+    ) -> float | None:
+        """The double at which ``fn``'s support flips inside ``bracket``.
 
-        Returns one `(below, above)` pair per edge that could be
-        bracketed — at most two, and possibly none if the analytic
-        brackets do not straddle a transition for these parameters.
+        Bisects on the bit pattern, so the answer is the boundary itself
+        rather than a nearby sample. ``None`` when the bracket does not
+        straddle a transition for these parameters.
+
+        Parameters
+        ----------
+        fn : callable
+            ``fn(e0, e, m, beta)`` -- either implementation.
+        line : tuple of float
+            ``(e0, m, beta)``, the parameters held fixed while ``e`` moves.
+        bracket : tuple of float
+            ``(lo, hi)``, the product energies to bisect between.
         """
+        e0, m, beta = line
+        lo, hi = bracket
+        lo_bits = int(np.float64(lo).view(np.int64))
+        hi_bits = int(np.float64(hi).view(np.int64))
+        lo_zero = fn(e0, lo, m, beta) == 0.0
+        if lo_zero == (fn(e0, hi, m, beta) == 0.0):
+            return None
+        while hi_bits - lo_bits > 1:
+            mid_bits = (lo_bits + hi_bits) // 2
+            mid = float(np.int64(mid_bits).view(np.float64))
+            if (fn(e0, mid, m, beta) == 0.0) == lo_zero:
+                lo_bits = mid_bits
+            else:
+                hi_bits = mid_bits
+        return float(np.int64(hi_bits).view(np.float64))
 
-        def bisect(lo: float, hi: float) -> tuple[float, float]:
-            lo_bits = int(np.float64(lo).view(np.int64))
-            hi_bits = int(np.float64(hi).view(np.int64))
-            lo_zero = cython(e0, lo, m, beta) == 0.0
-            while hi_bits - lo_bits > 1:
-                mid_bits = (lo_bits + hi_bits) // 2
-                mid = float(np.int64(mid_bits).view(np.float64))
-                if (cython(e0, mid, m, beta) == 0.0) == lo_zero:
-                    lo_bits = mid_bits
-                else:
-                    hi_bits = mid_bits
-            return (
-                float(np.int64(lo_bits).view(np.float64)),
-                float(np.int64(hi_bits).view(np.float64)),
-            )
-
-        gamma = rust_gamma(beta)
-        span = 4.0 * gamma * (1.0 + beta)
-        brackets = [(max(m, e0 / span), e0), (e0, e0 * span)]
-        return [
-            bisect(lo, hi)
-            for lo, hi in brackets
-            if (cython(e0, lo, m, beta) == 0.0) != (cython(e0, hi, m, beta) == 0.0)
-        ]
-
-    @requires_a_contracting_cython
-    def test_the_window_edges_sit_on_the_same_double_as_the_cython(self) -> None:
+    def test_the_window_edges_sit_where_the_cython_puts_them(self) -> None:
         """Both edges of the support, located to the last bit, 400 times.
 
-        ``eminus`` and ``eplus`` never appear in the returned value —
+        ``eminus`` and ``eplus`` never appear in the returned value --
         they only decide whether it is ``1/(2 gamma beta k0)`` or zero.
         So a one-ulp change in how they are computed is invisible to any
         test that samples ``e`` on a grid: it moves the edge by a single
         double, and no random draw lands there. Bisecting on the bit
-        pattern does land there.
+        pattern does land there, in each implementation separately, and
+        the two boundaries are then compared as a distance.
 
         The sweep is what makes this a pin rather than an anecdote, and
         the massive product is the half that matters: with ``m = 0`` the
@@ -464,16 +733,17 @@ class TestBoostDeltaFunction:
             beta = float(rng.uniform(0.02, 0.999))
             if cython(e0, e0, m, beta) == 0.0:
                 continue
-            for below, above in self._window_edges(cython, e0, m, beta):
-                # A flip, so the assertions below compare a zero against a
-                # non-zero rather than two zeros.
-                assert (cython(e0, below, m, beta) == 0.0) != (
-                    cython(e0, above, m, beta) == 0.0
+            gamma = rust_gamma(beta)
+            span = 4.0 * gamma * (1.0 + beta)
+            line = (e0, m, beta)
+            for bracket in ((max(m, e0 / span), e0), (e0, e0 * span)):
+                want = self._support_edge(cython, line, bracket)
+                got = self._support_edge(boost_delta_function, line, bracket)
+                if want is None or got is None:
+                    continue
+                assert_the_support_edge_matches_the_cython(
+                    got, want, f"edge at {e0=!r}, {m=!r}, {beta=!r}"
                 )
-                for e in (below, above):
-                    assert boost_delta_function(e0, e, m, beta) == cython(
-                        e0, e, m, beta
-                    ), f"edge differs at e0={e0!r}, e={e!r}, m={m!r}, beta={beta!r}"
                 checked += 1
         assert (
             checked > MIN_EDGES_CHECKED
@@ -515,7 +785,7 @@ class TestBoostDeltaFunction:
 class TestBoostIntegrateLinearInterp:
     """The tabulated continuum boost, branch by branch.
 
-    Every case asserts bit-equality with the Cython *and* pins the branch
+    Every case asserts agreement with the Cython *and* pins the branch
     that fired -- either by a closed form the branch alone can produce, or
     by a sensitivity check on a table entry only that branch reads.
     """
@@ -525,7 +795,7 @@ class TestBoostIntegrateLinearInterp:
         energy, beta = 1e6, 0.5
         got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
         assert got == 0.0
-        assert_matches_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "clamp")
+        assert_matches_the_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "clamp")
 
     def test_the_whole_window_below_the_table_is_the_analytic_tail(self) -> None:
         """``y0 * x0 / E``, a closed form no other branch can produce."""
@@ -533,7 +803,7 @@ class TestBoostIntegrateLinearInterp:
         energy, beta = 1e-6, 0.5
         got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
         assert got == FLAT_Y[0] * FLAT_X[0] / energy
-        assert_matches_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "tail")
+        assert_matches_the_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "tail")
 
     def test_a_window_straddling_the_table_floor_adds_the_tail(self) -> None:
         """`lb` below the table, `ub` inside it.
@@ -549,8 +819,10 @@ class TestBoostIntegrateLinearInterp:
         bumped[0] *= 2.0
         moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
         assert moved != base
-        assert_matches_cython(base, cython(energy, beta, FLAT_X, FLAT_Y), "tail base")
-        assert_matches_cython(
+        assert_matches_the_cython(
+            base, cython(energy, beta, FLAT_X, FLAT_Y), "tail base"
+        )
+        assert_matches_the_cython(
             moved, cython(energy, beta, FLAT_X, bumped), "tail bumped"
         )
 
@@ -566,7 +838,7 @@ class TestBoostIntegrateLinearInterp:
         energy, beta = 5.0, 0.6
         got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
         assert got != 0.0
-        assert_matches_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "ceiling")
+        assert_matches_the_cython(got, cython(energy, beta, FLAT_X, FLAT_Y), "ceiling")
 
     @pytest.mark.parametrize("index", [0, 7])
     def test_both_partial_cells_are_integrated(self, index: int) -> None:
@@ -584,8 +856,10 @@ class TestBoostIntegrateLinearInterp:
         bumped[index] += 1.0
         moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
         assert moved != base
-        assert_matches_cython(base, cython(energy, beta, FLAT_X, FLAT_Y), "edge base")
-        assert_matches_cython(
+        assert_matches_the_cython(
+            base, cython(energy, beta, FLAT_X, FLAT_Y), "edge base"
+        )
+        assert_matches_the_cython(
             moved, cython(energy, beta, FLAT_X, bumped), "edge bumped"
         )
 
@@ -601,116 +875,209 @@ class TestBoostIntegrateLinearInterp:
         bumped[3] += 1.0
         moved = boost_integrate_linear_interp(energy, beta, FLAT_X, bumped)
         assert moved != base
-        assert_matches_cython(
+        assert_matches_the_cython(
             moved, cython(energy, beta, FLAT_X, bumped), "interior sum"
         )
 
-    @requires_a_contracting_cython
     @pytest.mark.parametrize("name", list(photon_tables()))
     def test_matches_the_cython_on_the_live_tables(self, name: str) -> None:
-        """The seven shipped tables, bit for bit.
+        """The seven shipped tables, six boost regimes, 400 energies each.
 
-        Six boost regimes and 400 energies each -- the sweep Phase 04's
-        swap will be graded on.
+        The sweep Phase 04's swap is graded on, and the measurement
+        :data:`OFF_PLATFORM_BUDGET` was set from. The zeros are compared
+        first and everywhere, for the same reason as in the delta-function
+        sweep: where the spectrum vanishes is structural.
         """
         cython = cython_boost("boost_integrate_linear_interp")
         x, y, mass = photon_tables()[name]
         energies = np.geomspace(1e-3, 1e4, 400)
-        mismatched = 0
-        total = 0
         for multiple in BOOST_REGIMES:
             beta = boost_beta(mass * multiple, mass)
             got = boost_integrate_linear_interp(energies, beta, x, y)
             want = np.array([cython(float(e), beta, x, y) for e in energies])
-            total += energies.size
-            mismatched += int(np.count_nonzero(got != want))
-        assert (
-            mismatched == 0
-        ), f"{name}: {mismatched} of {total} points differ from the Cython"
+            assert np.array_equal(got == 0.0, want == 0.0), (
+                f"{name} at {multiple}x rest: the port and the Cython "
+                f"disagree about where the boosted spectrum vanishes"
+            )
+            assert_matches_the_cython(got, want, f"{name} at {multiple}x rest")
 
 
-@requires_a_contracting_cython
+class TestOffPlatformBudgets:
+    """The two off-platform budgets are not vacuous.
+
+    Asserted where the budgets are *not* used: on the capturing platform
+    every comparison above takes its exact branch, so nothing else would
+    exercise either tolerance and both could rot to ``inf`` unnoticed.
+    That is the failure mode Task 4.1 recorded -- "the capturing platform
+    cannot see a bug in its own skip logic" -- one level down.
+    """
+
+    def test_the_value_budget_rejects_a_real_error(self) -> None:
+        """A perturbation of :data:`BUDGET_PROBE_ERROR` of the peak must fail.
+
+        Six orders of magnitude above the largest rounding difference
+        measured between two builds (3.4e-15 of the peak), and still far
+        too small to see in a plot.
+        """
+        x, y, mass = photon_tables()["eta"]
+        beta = boost_beta(mass * 2.0, mass)
+        energies = np.geomspace(1e-3, 1e4, 400)
+        want = boost_integrate_linear_interp(energies, beta, x, y)
+        nudged = want.copy()
+        nudged[nudged.argmax()] += BUDGET_PROBE_ERROR * want.max()
+
+        assert_within_the_off_platform_budget(want, want, "unperturbed")
+        with pytest.raises(AssertionError):
+            assert_within_the_off_platform_budget(nudged, want, "perturbed")
+
+    def test_the_edge_budget_rejects_a_real_error(self) -> None:
+        """An edge displaced past the ulp budget must fail.
+
+        Called through the budget predicate rather than through
+        :func:`assert_the_support_edge_matches_the_cython`, so it exercises
+        the tolerance on every platform -- going through the dispatcher
+        would take the exact branch here and prove nothing about
+        :data:`OFF_PLATFORM_EDGE_ULPS`, which is the whole point.
+        """
+
+        def displaced(ulps: int) -> float:
+            moved = int(np.float64(300.0).view(np.int64)) + ulps
+            return float(np.int64(moved).view(np.float64))
+
+        edge = 300.0
+        at_the_budget = displaced(OFF_PLATFORM_EDGE_ULPS)
+        a_real_error = displaced(EDGE_PROBE_ERROR_ULPS)
+
+        assert ulps_between(at_the_budget, edge) == OFF_PLATFORM_EDGE_ULPS
+        assert_the_edge_is_within_the_off_platform_budget(edge, edge, "identical")
+        # The budget's own boundary is inclusive.
+        assert_the_edge_is_within_the_off_platform_budget(
+            at_the_budget, edge, "at the budget"
+        )
+        with pytest.raises(AssertionError):
+            assert_the_edge_is_within_the_off_platform_budget(
+                a_real_error, edge, "displaced by a real error"
+            )
+
+    def test_this_platform_gets_the_mode_it_is_supposed_to(self) -> None:
+        """One ulp: rejected where the corpus was captured, tolerated off it.
+
+        The guard on the *strict* branch, and on the dispatch into it,
+        which the two above do not cover. The failure mode is silent in
+        one direction: an :data:`ON_THE_CAPTURING_PLATFORM` that had
+        rotted to ``False`` would route every comparison in this module
+        through the budget and every one of them would still pass. So the
+        expected mode is re-derived here from ``sys``/``platform`` rather
+        than read back out of the module -- reading it back would agree
+        with the dispatcher by construction and assert nothing.
+        """
+        expected_strict = (
+            sys.platform == "darwin" and platform.machine() == CAPTURE_MACHINE
+        )
+        value = 1.0
+        nudged = float(np.nextafter(value, np.inf))
+        assert_matches_the_cython(value, value, "identical")
+        if expected_strict:
+            with pytest.raises(AssertionError):
+                assert_matches_the_cython(nudged, value, "one ulp")
+        else:
+            assert_matches_the_cython(nudged, value, "one ulp")
+
+
 class TestFusedArithmetic:
     """The fused multiply-adds are load-bearing, and this is the proof.
 
-    :func:`unfused_reference` is the same algorithm written the obvious
-    way -- ``a * b + c``, as Rust would compile it without ``mul_add``.
-    It is an independent implementation as well as a discriminator: it
-    reproduces the Cython everywhere the contraction does not bite.
+    :func:`integrate_reference` and :func:`delta_function_reference` are
+    the two kernels written twice over -- once with ``fma`` at exactly the
+    sites ``rust/src/boost.rs`` spells ``mul_add``, and once the obvious
+    way. Both are pure Python and NumPy, so both are the same numbers on
+    every platform, and so is the port: ``f64::mul_add`` is correctly
+    rounded whether or not the target has an FMA instruction, and
+    ``sqrt`` is exact. That makes "the port fuses here and only here" a
+    claim this class can assert **everywhere**.
+
+    It could not before. Until 2026-08-12 the discriminator was the
+    *Cython*, which fuses only where its compiler chose to, so the class
+    was gated on a probe and skipped wherever the probe said no -- which
+    on Linux/x86-64 was always. Comparing against a reference instead
+    removes the platform from the claim entirely, and the class now
+    outlives the ``.pyx``.
     """
 
-    @staticmethod
-    def unfused_reference(
-        photon_energy: float, beta: float, x: np.ndarray, y: np.ndarray
-    ) -> float:
-        """``boost_integrate_linear_interp`` with no contraction anywhere."""
-        npts = len(x)
-        xmax, x0, y0 = float(x[-1]), float(x[0]), float(y[0])
-        gamma = 1.0 / math.sqrt(1.0 - beta * beta)
-        lb = photon_energy * gamma * (1.0 - beta)
-        ub = photon_energy * gamma * (1.0 + beta)
-        if lb > xmax:
-            return 0.0
-        if ub < x0:
-            return y0 * x0 / photon_energy
+    @pytest.mark.parametrize("name", list(photon_tables()))
+    def test_the_tabulated_port_is_the_fused_reference(self, name: str) -> None:
+        """Bit-for-bit against ``mul_add=fma``, on every platform."""
+        x, y, mass = photon_tables()[name]
+        energies = np.geomspace(1e-2, 1e3, 300)
+        for multiple in BOOST_REGIMES:
+            beta = boost_beta(mass * multiple, mass)
+            for energy in energies:
+                assert boost_integrate_linear_interp(
+                    float(energy), beta, x, y
+                ) == integrate_reference(float(energy), beta, x, y, mul_add=fma), (
+                    f"{name} at {multiple}x rest, {energy=!r}: the port is not "
+                    f"the fused reference"
+                )
 
-        integral = 0.0
-        ilow = ihigh = -1
-        if ub > xmax:
-            ub, ihigh = xmax, npts - 1
-        if lb < x0:
-            rat = (1.0 - beta) * photon_energy * gamma / x0
-            integral += y0 * (1.0 - rat) / rat
-            lb, ilow = x0, 0
-        yy = y / x
-        if ilow == -1:
-            ilow = int(np.flatnonzero(lb <= x)[0])
-        if ihigh == -1:
-            ihigh = int(np.flatnonzero(ub <= x)[0])
-            if abs(float(x[ihigh]) - ub) > EDGE_ATOL:
-                ihigh -= 1
-        if ilow < ihigh:
-            integral += float(np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh]))
-        if ilow > 0 and abs(float(x[ilow]) - lb) > EDGE_ATOL:
-            x2, x1 = float(x[ilow]), float(x[ilow - 1])
-            m = (float(yy[ilow]) - float(yy[ilow - 1])) / (x2 - x1)
-            b = float(yy[ilow - 1]) - m * x1
-            integral += (x2 - lb) * (0.5 * m * (x2 + lb) + b)
-        if ihigh < npts - 1 and abs(ub - float(x[ihigh])) > EDGE_ATOL:
-            x1 = float(x[ihigh])
-            m = (float(yy[ihigh + 1]) - float(yy[ihigh])) / (float(x[ihigh + 1]) - x1)
-            b = float(yy[ihigh]) - m * x1
-            integral += (ub - x1) * (0.5 * m * (ub + x1) + b)
-        return integral / (2.0 * gamma * beta)
+    def test_the_unfused_tabulated_form_would_be_a_different_number(self) -> None:
+        """Otherwise the test above would pass against either arithmetic.
 
-    def test_the_unfused_form_misses_the_cython_and_the_rust_does_not(self) -> None:
-        """On the eta table, over the corpus's boost regimes.
-
-        The recorded figure is the point of this test: writing the port
-        without ``mul_add`` costs up to a few parts in 1e12, which the
-        1e-12 ``TABULATED`` budget does not cover. If a future platform
-        stops contracting, ``differ`` goes empty and the assertion says so
-        rather than passing silently.
+        The recorded figure is the point: writing the port without
+        ``mul_add`` costs up to a few parts in 1e12, which the 1e-12
+        ``TABULATED`` budget in ``test/parity/tolerances.py`` does not
+        cover. It is also, to the digit, the disagreement measured against
+        the *Linux* Cython (module docstring) -- which is what a compiler
+        with no hardware FMA to contract into produces.
         """
         x, y, mass = photon_tables()["eta"]
         energies = np.geomspace(1e-2, 1e3, 300)
-        cython = cython_boost("boost_integrate_linear_interp")
 
         worst = 0.0
         differ = 0
         for multiple in BOOST_REGIMES:
             beta = boost_beta(mass * multiple, mass)
             for energy in energies:
-                want = cython(float(energy), beta, x, y)
-                assert boost_integrate_linear_interp(float(energy), beta, x, y) == want
-                unfused = self.unfused_reference(float(energy), beta, x, y)
-                if want not in (unfused, 0.0):
+                want = integrate_reference(float(energy), beta, x, y, mul_add=fma)
+                unfused_value = integrate_reference(
+                    float(energy), beta, x, y, mul_add=unfused
+                )
+                if want not in (unfused_value, 0.0):
                     differ += 1
-                    worst = max(worst, abs(unfused - want) / abs(want))
+                    worst = max(worst, abs(unfused_value - want) / abs(want))
+        assert differ > 0, "the two arithmetics agreed everywhere on the eta table"
+        assert (
+            worst > MIN_RECORDED_UNFUSED_MISS
+        ), f"unfused worst miss {worst:.3e} is smaller than recorded"
+
+    def test_the_delta_function_port_is_the_fused_reference(self) -> None:
+        """The same statement for the two-body line, over 40,000 draws.
+
+        The recorded worst miss is what the module docstring's
+        delta-function row compares against: the unfused form costs up to
+        1.87e-13 relative here, and 1.8683e-13 is what the *Linux* Cython
+        was measured to cost against the port over these same draws. The
+        two agreeing is the direct evidence that a compiler with no
+        hardware FMA to contract into simply computes this reference.
+        """
+        rng = np.random.default_rng(20_260_810)
+        masses = [0.0, 0.510_998_928]
+        differ = 0
+        worst = 0.0
+        for _ in range(40_000):
+            m = float(rng.choice(masses))
+            beta = float(rng.uniform(1e-6, 1.0 - 1e-9))
+            e0 = float(10.0 ** rng.uniform(-1.0, 3.0))
+            e = float(e0 * 10.0 ** rng.uniform(-0.4, 0.4))
+            got = boost_delta_function(e0, e, m, beta)
+            assert got == delta_function_reference(e0, e, m, beta, mul_add=fma)
+            unfused_value = delta_function_reference(e0, e, m, beta, mul_add=unfused)
+            if got != unfused_value:
+                differ += 1
+                if got:
+                    worst = max(worst, abs(unfused_value - got) / abs(got))
         assert differ > 0, (
-            "the unfused form matched the Cython everywhere; the class "
-            "guard says this platform contracts, so that is a contradiction "
-            "rather than a platform difference"
+            "the fused and unfused forms agreed on all 40,000 draws, so this "
+            "test cannot distinguish them"
         )
         assert (
             worst > MIN_RECORDED_UNFUSED_MISS
@@ -737,13 +1104,14 @@ class TestDroppedInteriorCell:
         The Cython covers ``[1.1, 2]`` (lower partial cell) and ``[2, 3]``
         (the interior sum) for ``1.9 / (2 gamma beta)``. Covering
         ``[1.1, 4]`` as intended would give ``2.9`` -- a 53% difference,
-        far too large to be roundoff.
+        far too large to be roundoff, and the scale
+        :data:`OFF_PLATFORM_BUDGET` is set nine orders of magnitude below.
         """
         cython = cython_boost("boost_integrate_linear_interp")
         got = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
         assert got == pytest.approx(1.9 / 1.5, rel=1e-15)
         assert got != pytest.approx(2.9 / 1.5, rel=1e-3)
-        assert_matches_cython(got, cython(2.2, 0.6, self.X, self.Y), "dropped cell")
+        assert_matches_the_cython(got, cython(2.2, 0.6, self.X, self.Y), "dropped cell")
 
     def test_a_clamped_window_never_reads_the_tables_last_row(self) -> None:
         """The sharpest form of the drop.


### PR DESCRIPTION
## Summary

- **`test/test_core_boost.py`'s cross-implementation gate was vacuous off macOS, and this replaces the mechanism that made it so.** It scoped its bit-equality claims against the Cython twin with `cython_contracts()` — a probe comparing the compiled kernel against an unfused Python transcription. cython-to-rust Task 4.1 showed that mechanism unsound in `test/test_core_positron_muon.py` ([PR #63](https://github.com/LoganAMorrison/Hazma/pull/63), runs 31562223329 and 31564747071): it tests one contraction mechanism and is blind to the others, so it claims bit-equality where none holds *and* voids the comparison where its own mechanism is absent. **This module was resolving the second way** — on Linux/x86-64 the probe returned `False` and all 19 of its cross-implementation claims skipped, on every CI entry but macOS since [PR #61](https://github.com/LoganAMorrison/Hazma/pull/61). Replaced with the two declared modes Task 4.1 established: `ON_THE_CAPTURING_PLATFORM`, read from `test/parity/data/manifest.json` so this module's scope cannot drift from the corpus's, bit-equality there, and a measured budget elsewhere. **Nothing in the module skips on any platform now.**
- **Both budgets were measured, not guessed.** This worktree was built for linux/amd64 (Debian, gcc, glibc, CPython 3.12.13, NumPy 2.5.1) and the two implementations compared directly over 40,000 delta-function draws and 16,800 tabulated points. `OFF_PLATFORM_BUDGET = 1e-10` is scaled to the **peak** of the compared array rather than applied pointwise, and `OFF_PLATFORM_EDGE_ULPS = 4096` bounds the support boundaries in ulps — a value tolerance cannot express those, since across the boundary one implementation returns a finite number and the other zero. Figures and headroom in the table below.
- **`TestFusedArithmetic` stopped needing a platform scope at all.** It now discriminates against a *fused* Python reference — `fma` at exactly the twelve sites `rust/src/boost.rs` spells `mul_add` — instead of against the Cython. Both references are pure Python/NumPy and `f64::mul_add` is correctly rounded on every target Rust supports, so "the port fuses here and only here" is a claim that holds everywhere, and the class now outlives the `.pyx` rather than dying with it in Phase 06 Task 6.4.
- **No public value changes.** `git diff origin/master -- hazma` is empty; this diff touches only `test/`, `docs/`, and `projects/`.
- **Docs:** `docs/agents/lessons.md`'s `[platform-scoped-oracle-asserted-globally]` and the two project docs that still prescribed "probe at import and skip" now prescribe the declared scope — that guidance would otherwise have reproduced the bug in the next task. `test/test_core_interp.py` carries the identical retired mechanism and still skips 9 claims off macOS; filed as `docs/followups/todo/interp-oracle-scoped-by-an-unsound-probe.md` rather than fixed here.

### How the vacuous gate was established

Two independent ways, because the capturing platform cannot see this failure — there the probe answers correctly by accident.

1. Directly: build this worktree for linux/amd64, run the module with `-rs`. The probe returns `False`; 19 claims skip (11 carrying `requires_a_contracting_cython`, 8 reaching a mid-test `assert_matches_cython`).
2. From CI: master run 31619425557 reports `767 passed, 41 skipped` on Linux against `1424 passed, 14 skipped` on macOS. Once the corpus's own skip drops out with `--ignore=test/parity`, that is a 28-skip excess — exactly this module's 19 plus `test_core_interp.py`'s 9.

### The measurement the budgets come from

| comparison | max relative | max \|Δ\|/peak |
| --- | --- | --- |
| `boost_delta_function` (40,000 draws) | 1.9e-13 | 7.3e-17 |
| `…_interp`, eta | 9.9e-13 | 1.2e-15 |
| `…_interp`, eta_prime | 6.3e-13 | 7.2e-16 |
| `…_interp`, charged_kaon | 3.6e-13 | 3.2e-15 |
| `…_interp`, long_kaon | 1.3e-13 | 3.1e-15 |
| `…_interp`, short_kaon | 1.2e-13 | 3.4e-15 |
| `…_interp`, omega | 2.6e-13 | 3.3e-15 |
| `…_interp`, phi | 9.1e-14 | 5.9e-16 |

No sign flip, no NaN, and no disagreement anywhere about which energies are zero — the zeros are compared first and on every platform, since where a spectrum vanishes is structural and no rounding excuses it.

`OFF_PLATFORM_BUDGET = 1e-10` is 100× the worst relative reading and 2.9e4× the worst peak-relative one. **The peak scaling is the load-bearing choice, and the two columns are why:** they differ by three orders of magnitude, because the worst relative gaps land where the integrand cancels. On the eta table the two maxima together bound the value carrying the worst relative gap at 1.2e-3 of the peak, so a pointwise `rtol` wide enough to admit it would be a thousand times wider than the spectrum is — the shape Task 3.4 rejected a tolerance over. A wrong branch or dropped term still lands at O(1) against the peak; `TestDroppedInteriorCell` measures the one defect this module knows the size of at 53%.

Support edges: measured at **55 ulps worst** over 800 bracketed edges (547 on the identical double). 4096 leaves 74× headroom and is a relative displacement of 9.1e-13 — eleven orders below anything a wrong edge formula would produce.

### Why there are three guards

On the capturing platform every comparison takes its exact branch, so neither budget nor the mode dispatch is exercised by anything else and all three could rot unnoticed. Each was verified to fail under a mutation of the constant it protects — and the first two drafts of these guards *survived* their mutations, because they derived their perturbations from the constants they were testing. Both now use fixed absolute figures (`BUDGET_PROBE_ERROR`, `EDGE_PROBE_ERROR_ULPS`), and the mode guard re-derives the expected mode from `sys`/`platform` rather than reading `ON_THE_CAPTURING_PLATFORM` back out — reading it back would agree with the dispatcher by construction and assert nothing.

## Project

`projects/cython-to-rust/` — follow-up to Phase 03 Task 3.4 and Phase 04 Task 4.1, not a numbered task of its own.

`projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md` carries a dated superseding note in §Findings (the diagnosis holds; the remedy does not) plus the skip arithmetic above. `projects/cython-to-rust/task-notes/phase-04/task-4.1-positron-muon.md` §Findings is the reasoning this copies.

## Review round 1 (`fd6090b`)

Reviewer found durable verification counts contradicting the PR head. **Documentation only — no file under `hazma/` or `test/` changed, so nothing in the Summary above moves.**

The root cause was sectioning, not arithmetic: footnoting a single row of `task-3.4-interp-boost.md`'s `## Verification` table as "left as taken" implicitly upgraded every unlabeled measurement beside it into a claim about the current tree, including the mutation campaign's `102 passed` baseline sixty lines below. Fixed at the section level with a dated banner. The genuine miss was that same footnote's `81 passed` — measured correctly, then invalidated by my own later self-review edits (two tautological tests dropped, one mode guard added) and never re-derived; the head is `80`, now shown as a derivation from diffed collected test ids (`+12 −1 = +11`) rather than a bare number.

Two apparent hits were deliberately left, because a stale-*looking* number can be right for what it claims: `phase-03/README.md:572`'s `cargo test … (69 units)` describes the **foundation's** units, so "fixing" it to the current 80 would fold in Task 4.1's kernel and make a true sentence false. The rule applied throughout — a measurement in a dated block is a record and stays as taken; a measurement in the present tense must match the PR head.

Lessons ledger: this PR cited on `[measurement-taken-before-the-task-ended]` as its third shape, plus a new `[partial-historical-labeling]` entry.

## Test plan

- [x] `scripts/agents/preflight.sh --paths test/test_core_boost.py --md "<the six changed docs>"` → **RESULT: PASS**, every gate green:

  ```text
  PASS   black --check           test/test_core_boost.py
  PASS   isort --check-only      test/test_core_boost.py
  PASS   ruff check              test/test_core_boost.py
  PASS   cargo fmt --check       rust/
  PASS   cargo clippy            rust/
  PASS   cargo test              rust/
  PASS   pytest                  1435 passed, 14 skipped, 5 warnings in 538.01s (0:08:58)
  PASS   import hazma            version 2.1.0
  PASS   markdownlint            <the six changed docs>
  PASS   forbidden tokens        none added
  ```

  `1435 passed, 14 skipped` against `1424 passed, 14 skipped` at Task 4.1. The arithmetic closes: **+11 passes, all of them this module** (69 tests → 80), and the skip count is unchanged because this module never skipped on macOS — the whole point is that it skipped everywhere else.

- [x] **macOS/arm64, the capturing platform:** `pytest test/test_core_boost.py -q -rs` → `80 passed`, nothing skipped.
- [x] **linux/amd64, built from clean in a container:** `pytest test/test_core_boost.py -q -rs` → `80 passed`, nothing skipped — the budgets hold against a genuinely different compiled Cython, which is the thing that could not be checked before. Same run confirms `test_core_interp.py` at `24 passed, 9 skipped`, the follow-up's evidence.
- [x] **Both modes on one machine:** the suite re-run with `platform.machine` forced to `x86_64` → `80 passed`, so the budget branch is exercised on the capturing platform too.
- [x] **Guard mutations, each run from a green baseline:** `OFF_PLATFORM_BUDGET → inf` fails `test_the_value_budget_rejects_a_real_error`; `OFF_PLATFORM_EDGE_ULPS → 2**60` fails `test_the_edge_budget_rejects_a_real_error`; `ON_THE_CAPTURING_PLATFORM → False` fails `test_this_platform_gets_the_mode_it_is_supposed_to`. Baseline green again after.
- [x] **The fused reference reproduces the port bit-for-bit** on both platforms (0 misses in 1,800 tabulated points and 40,000 delta draws), while the unfused form misses 980 and 5,025 respectively. Its worst delta-function miss is 1.868e-13 — the same number, to four digits, as the Linux Cython's measured 1.8683e-13, which is the direct evidence that a compiler with no hardware FMA simply computes the unfused reference.
- [x] `scripts/agents/check_doc_citations.py` over the six changed docs → `out-of-range or ambiguous: NONE`.
- [x] **Full CI matrix green** (run 31638401939), and the Linux skip counts are the direct evidence the gate is no longer vacuous:

  | | before (master run 31619425557) | this PR |
  | --- | --- | --- |
  | Linux ×5 (py3.10–3.14) | `767 passed, 41 skipped` | `797 passed, 22 skipped` |
  | macOS py3.14 | `1424 passed, 14 skipped` | `1435 passed, 14 skipped` |

  `+30 / −19` on Linux is exactly what the change predicts: the 19 previously-skipped claims now run (+19 passed, −19 skipped) plus the module's +11 net new tests. The 22 remaining Linux skips are 13 pre-existing plus `test_core_interp.py`'s 9 — the population `docs/followups/todo/interp-oracle-scoped-by-an-unsound-probe.md` tracks.
- [x] Round-1 fixes re-gated: `scripts/agents/preflight.sh` → **RESULT: PASS** (`1435 passed, 14 skipped in 570.32s`). Every count now asserted as current re-derived on the head — `test_core_{constants,special,quad,interp,dispatch}.py` at 25/65/58/33/118 unchanged, `boost` 80, `cargo test` 80, the Task 3.4 module pair 113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
