### PR TITLE
test(suite): parallelize with xdist and reuse the GeV width fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -v .
-          python -m pip install pytest
+          python -m pip install pytest pytest-xdist
       - name: Import smoke test
         # The test suite only touches part of the public API; importing the
         # main entry points catches missing dependencies, missing package
@@ -141,7 +141,10 @@ jobs:
         # docs/followups/todo/parity-corpus-pins-ill-conditioned-points.md.
         #
         # `--ignore` rather than a marker: it skips collection outright,
-        # so the Linux entries also stop paying the corpus's ~9 minutes.
+        # so the Linux entries also stop paying the corpus's ~5 minutes
+        # of single-core quadrature (spread across the runner's cores by
+        # the pytest-xdist `addopts` in pyproject.toml, hence the
+        # pytest-xdist install above).
         #
         # The condition is inverted on purpose. Actions' `&&`/`||` return
         # values and the empty string is falsy, so the natural spelling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,9 @@ A leading underscore on a package (`_utils`, `spectra/_photon`) means
 
 ```sh
 pip install -e .          # build the Cython + Rust extensions in place
-pip install --group dev   # black, isort, ruff, pytest at their pinned versions
-pytest                    # full suite (hazma + test; minutes, not seconds)
+pip install --group dev   # black, isort, ruff, pytest, pytest-xdist pins
+pytest                    # full suite (hazma + test), parallel via xdist
+pytest -n 0               # same suite in-process (--pdb needs this)
 pytest test/spectra -q    # one area
 black hazma test          # format
 isort hazma test          # import order

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -160,11 +160,13 @@ alone, so a bare run collected the in-package `*_test.py` modules
 CI, `preflight.sh`, and a contributor typing `pytest` each ran a
 different subset. They now run the same one. The cost is the golden
 parity corpus and its nested adaptive quadrature under `test/parity/`.
-Budget minutes, not seconds — 8m58s measured for the bare run on
-macOS/arm64 under concurrent load, 4m38s for `pytest test/parity` alone
-measured idle (cython-to-rust Tasks 1.3 and 1.2). Narrow with an
-explicit target while iterating, but cite the command you ran — "the
-full suite" is only true of the bare form.
+The work is minutes of CPU — 598s serial for the bare run, measured
+idle on macOS/arm64 (2026-08-17) — but the pytest-xdist `addopts` in
+`pyproject.toml` spread it across cores: 45s wall at `-n 12` on the
+same machine, identical collection and outcomes. `pytest -n 0` restores
+the in-process run that `--pdb` and clean sequential output need.
+Narrow with an explicit target while iterating, but cite the command
+you ran — "the full suite" is only true of the bare form.
 
 **Running the parity suite needs an editable install, not just any
 install.** `test/parity/cases.py` refuses a `hazma` that resolves

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -112,7 +112,10 @@ group. Anything else risks a formatter that disagrees with CI:
 uv pip install --group lint     # or: pip install --group lint
 ```
 
-`--group dev` adds `pytest` on top, for the full preflight toolchain.
+`--group dev` adds `pytest` and `pytest-xdist` on top, for the full
+preflight toolchain. The plugin is not optional: `pyproject.toml`'s
+`addopts` passes `--numprocesses` to every run, and a pytest without
+xdist rejects that flag outright.
 Note these are PEP 735 groups, **not** extras — the old
 `pip install -e '.[dev]'` no longer resolves, and `--group` needs
 pip >= 25.1.

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -533,3 +533,14 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   complete while the roster still claims the check. Sibling of
   [gate-disabled-stays-green]: there the gate silently stopped running,
   here it silently never started.
+- [stale-group-membership-claim] Adding a package to a
+  `[dependency-groups]` group silently falsifies every prose enumeration
+  of what that group installs — those live in `docs/agents/` and
+  `AGENTS.md`, not next to the group, so nothing fails when they rot,
+  and here the omission was load-bearing: `pytest-xdist` joined `dev`
+  because `addopts` passes `--numprocesses` to every run, so a reader
+  who installed "pytest" per the stale prose got a pytest that rejects
+  the repo's own default flags. After editing a group, `rg` the group's
+  name and member list out of `docs/agents/` and `AGENTS.md` and
+  re-derive each claim (PR #69). Sibling of [stale-ci-capability-claim]:
+  same rot, config group instead of workflow.

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -203,8 +203,10 @@ a blocked commit — fix and re-run; do not commit around a red gate.
 
 A `WARN` row means a tool is not installed and its gate did **not** run —
 it is a hole in your coverage, not a pass. Install the toolchain
-(`pip install --group dev`, which pulls black, isort, ruff, and pytest at
-the versions CI uses; `cargo` is not in any Python group — get it from
+(`pip install --group dev`, which pulls black, isort, ruff, pytest, and
+pytest-xdist at the versions CI uses — the xdist plugin is required,
+since `pyproject.toml`'s `addopts` passes `--numprocesses` to every
+run; `cargo` is not in any Python group — get it from
 rustup, and note you need it to build hazma from source at all) rather
 than shipping on an unchecked gate. Do not
 `pip install black` on its own: this script runs whatever is on `PATH`,

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -48,10 +48,12 @@ before you stage anything.
    only reproduces on the platform that captured it, so a green gate here
    predicts a green CI but not the reverse. Narrowing to a target
    (`pytest test/spectra`) is
-   for iterating; run it bare before you commit. Budget minutes, not
-   seconds — nearly all of it the parity corpus's nested adaptive
-   quadrature (8m58s measured for the bare run on macOS/arm64 under
-   concurrent load, cython-to-rust Task 1.3).
+   for iterating; run it bare before you commit. The work is minutes of
+   CPU — nearly all of it the parity corpus's nested adaptive quadrature
+   (598s serial for the bare run, measured idle on macOS/arm64,
+   2026-08-17) — but the pytest-xdist `addopts` in `pyproject.toml`
+   spread it across cores, so a bare run's wall-clock is that divided by
+   the machine (45s at `-n 12` on the same hardware).
 
    **Read the summary line.** `pytest` exits **5** when it collects zero
    tests, and a wrapper that only checks "non-zero exit" will happily

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,12 @@ Documentation = "http://hazma.readthedocs.io"
 # reformats the whole repo, so it should land as a deliberate PR rather
 # than arrive silently in a CI run. `ruff` is capped the same way even
 # though CI only runs its `--isolated --select E9,F63,F7,F82` subset.
+#
+# `pytest-xdist>=3.2` is the floor that ships `--dist=worksteal`, which
+# [tool.pytest.ini_options]'s `addopts` passes on every run.
 [dependency-groups]
 lint = ["black>=23.3,<27.0", "isort>=5.12,<9.0", "ruff>=0.1,<1.0"]
-dev = [{ include-group = "lint" }, "pytest>=7.0"]
+dev = [{ include-group = "lint" }, "pytest>=7.0", "pytest-xdist>=3.2"]
 
 [build-system]
 build-backend = "setuptools.build_meta"
@@ -100,11 +103,17 @@ version = { attr = "hazma.VERSION" }
 # collects one root is not the suite, and the divergence is invisible
 # because both halves are green on their own.
 #
-# `test/parity/` dominates the runtime with nested adaptive
-# quadrature: 8m58s for the whole bare run measured on the corpus's
-# capturing machine under load, 4m38s for `pytest test/parity` alone
-# measured idle. That is the price of the gate, paid on every matrix
-# entry deliberately — see test/parity/README.md.
+# `test/parity/` dominates a serial run with nested adaptive
+# quadrature — 295s of a 598s bare run, measured idle on the corpus's
+# capturing machine (2026-08-17, 1697 tests). That work is the price of
+# the gate (see test/parity/README.md; in CI only the macOS entry pays
+# it, ci.yml ignoring the corpus elsewhere), so `addopts` spreads it
+# over every core instead of narrowing what is collected: same
+# collection, same assertions, 45s wall at `-n 12` on the same machine.
+# `worksteal` rebalances the corpus's heavy tail of mediator-spectrum
+# blocks. Debugging escape hatch: `pytest -n 0` runs in-process again
+# (`--pdb` needs it, and it serializes output).
+addopts = "--numprocesses=auto --dist=worksteal"
 testpaths = ["hazma", "test"]
 markers = [
   "broken: mark a test as known to be broken",

--- a/test/parity/README.md
+++ b/test/parity/README.md
@@ -18,16 +18,21 @@ function's budget.
 ## Commands
 
 Run the gate. One test per corpus block (623 of them) plus three guards;
-takes around five minutes, nearly all of it the nested adaptive
-quadrature in the rho and mediator-spectrum kernels:
+around five minutes of single-core work, nearly all of it the nested
+adaptive quadrature in the rho and mediator-spectrum kernels. The
+pytest-xdist `addopts` in `pyproject.toml` spread it across cores, so
+the wall-clock is that cost divided by the machine:
 
 ```bash
 pytest test/parity
 ```
 
-A bare `pytest` runs it too, and so does CI on every matrix entry —
-`pyproject.toml`'s `testpaths` is `["hazma", "test"]` (cython-to-rust
-Task 1.3). That runtime is the standing price of the gate. Note that
+A bare `pytest` runs it too — `pyproject.toml`'s `testpaths` is
+`["hazma", "test"]` (cython-to-rust Task 1.3) — and in CI the macOS
+entry pays it while the Linux entries pass `--ignore=test/parity`, the
+corpus being pinned to the capturing platform's libm (see the comment in
+`.github/workflows/ci.yml`). That work is the standing price of the
+gate. Note that
 the suite needs the extensions built **inside the repository**:
 `cases.assert_module_is_repo_tree` refuses a `hazma` resolving anywhere
 else, so `pip install -e .`, not `pip install .`.

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -50,9 +50,11 @@ reports.
 
 Runtime
 -------
-Around five minutes, nearly all of it nested adaptive quadrature in the
-rho and mediator-spectrum kernels. That is the cost of the gate, not
-overhead — it is the same work `generate.py` does.
+Around five minutes of single-core work, nearly all of it nested
+adaptive quadrature in the rho and mediator-spectrum kernels. That is
+the cost of the gate, not overhead — it is the same work `generate.py`
+does. The pytest-xdist `addopts` in `pyproject.toml` spread it across
+workers, so the wall-clock is that cost divided by the machine.
 """
 
 from __future__ import annotations

--- a/test/vector_mediator/test_form_factors.py
+++ b/test/vector_mediator/test_form_factors.py
@@ -34,7 +34,14 @@ class ModuleFunction(NamedTuple):
         return func(val, *self.extra_args)
 
 
-@pytest.fixture
+# Module-scoped: `synchronize_herwig` calls `width_v()` on every model in
+# every test, and the first evaluation fills the model's `_width_cache`
+# with every partial width — among them two 4-body RAMBO integrations and
+# three 3-body ones at npts=50_000, ~2.7s per model. Function scope threw
+# those caches away between tests, which cost ~250s of this file's ~257s
+# (measured 2026-08-17). Sharing is safe: no test mutates the models, and
+# the cache invalidates itself on any parameter change.
+@pytest.fixture(scope="module")
 def models() -> List[VectorModel]:
     model1 = VectorMediatorGeV(
         mx=5e3,


### PR DESCRIPTION
## Summary

- **Run the suite in parallel by default.** `addopts = "--numprocesses=auto --dist=worksteal"` in `[tool.pytest.ini_options]`, `pytest-xdist>=3.2` in the `dev` dependency group, and `pytest-xdist` added to CI's test-job install — so the bare `pytest` that CI, `scripts/agents/preflight.sh`, and contributors all run parallelizes identically everywhere. Collection and assertions are untouched (xdist changes execution only); `pytest -n 0` restores the in-process run `--pdb` needs.
- **Module-scope the `models` fixture in `test/vector_mediator/test_form_factors.py`.** Every test calls `synchronize_herwig` → `model.width_v()`, whose first evaluation fills the model's `_width_cache` with every partial width — among them two 4-body RAMBO integrations and three 3-body ones at `npts=50_000`, ~2.7s per model. Function scope threw those caches away between tests, costing ~250s of the file's 257s. Sharing is safe: no test mutates the models, and the cache self-invalidates on any parameter change.
- **Update the runtime prose these changes invalidate** (`pyproject.toml`, `test/parity/README.md`, the `test_parity.py` docstring, `docs/agents/{environment,preflight}.md`, `AGENTS.md`, `ci.yml`) — including the stale claim that parity is "paid on every matrix entry": `ci.yml` has run the corpus macOS-only since 2026-08-08.

Measured on the corpus's capturing machine (16-core M-series, idle, 2026-08-17, at `1005e56`), outcomes identical throughout (`1682 passed, 15 skipped`):

| configuration | wall clock |
| --- | --- |
| bare `pytest`, serial (before) | 598s |
| `-n 12 --dist worksteal` only | 65s |
| + module-scoped fixture (= this PR, `-n 12`) | 45s |
| this PR at `-n 4` (CI-runner-shaped core count) | 96s |

Serial attribution behind those numbers: `test/parity` 295s (213.8s of it the `mediator_spectra.vector.photon.dnde_decay_v_pt` family alone — the pinned `*_pt` entry points rebuild two 500-point interpolation tables per scalar call, which is the library behavior the corpus pins, not harness overhead), `test_form_factors.py` 257s, everything else ~38s.

**No returned value moves** — the diff is test scaffolding, dependency/CI wiring, and docs. The parity corpus itself is untouched (its grids cannot change mid-port; `projects/cython-to-rust/rules.md` rule 2).

**Pre-existing ruff debt, unchanged:** preflight's strict-config ruff row is red on the two touched test files with **119 errors — byte-identical to the same files at trunk `bbba825`** (same ruff 0.16.3, side-by-side), i.e. this diff adds zero. CI's lint gate (`--isolated --select E9,F63,F7,F82`) is unaffected.

## Test plan

- [x] Preflight on the fast-forwarded tip (`bbba825` base): every gate green except the pre-existing ruff debt above — pytest row: `1755 passed, 15 skipped, 8 warnings in 48.04s` (bare `pytest`, now parallel, full collection including the parity corpus)
- [x] Same collection before/after: `pytest --collect-only -q` → `1697 tests collected` at `1005e56` both with and without the `addopts` change (now 1770 after PR #68's new tests)
- [x] Outcome parity vs serial baseline at `1005e56`: serial `1682 passed, 15 skipped` == `-n 12` run == `-n 4` run
- [x] Escape hatch: `pytest -n 0 test/test_parameters.py -q` → `12 passed in 0.28s`
- [x] `scripts/agents/check_pr_title.py "test(suite): parallelize with xdist and reuse the GeV width fixture"` → OK
- [x] `cargo fmt --check` / `clippy -D warnings` / `cargo test --no-default-features`: PASS (untouched crate, gate rows green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
