### PR TITLE
docs(followups): invert the Task 6.4 blocker premise

### DIFF
--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -103,7 +103,17 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   was wrong, so nothing downstream disagreed and a reviewer had to add
   14+1+1 to find it. Derive the *breakdown* from the command
   (`… | sort | uniq -c`), not the total alone, and the arithmetic checks
-  itself.
+  itself. The cheapest shape to miss is the one where **no number was
+  written at all**: a quantifier word stands in for the count, and
+  nothing can contradict it. PR #72 had a plan's exit criteria say "both
+  mediator photon cases" and "both mediator positron cases" against
+  populations of three and four, because the reference they quoted
+  brace-elided its lists (`mediator_spectra.vector.photon.{dnde_decay_v,
+  dnde_decay_v_pt}`) and "both" read naturally as "scalar and vector"
+  — while the same PR's own coverage arithmetic had 3 and 4 in it and
+  agreed with itself. Write a list a downstream gate will quote out in
+  full, give it an explicit count, and never let "both", "each", or "the
+  two" carry a population you have not enumerated.
 - [partial-historical-labeling] Annotating **one** measurement in a dated
   section as historical silently upgrades every unlabeled measurement
   beside it into a claim about the current tree. Label the *section*, not
@@ -592,3 +602,27 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   prose edit is frozen, and treat "I remember fixing that" as a claim to
   re-check rather than as evidence (PR #71: `pyproject.toml`'s `addopts`
   comment was spotted, left, and then reported as swept).
+- [sign-copied-from-a-defect-description] A displacement, ratio, or
+  offset quoted out of a bug report describes the **defect's** direction;
+  a plan or changelog describing the **repair** needs the opposite sign,
+  and the magnitude is identical either way, so nothing looks wrong. The
+  tell is a sentence that carries both the signed delta and the endpoint
+  values and disagrees with itself (PR #72: a plan said the φ photon
+  lines "move by +294.4 MeV and +899.8 MeV" — the follow-up's wording for
+  where the shipped lines sit above the correct ones — one clause before
+  saying the `η′γ` line "moves from 959.65 MeV to 59.82 MeV", which is
+  −899.8). Restate the endpoints rather than the delta when you copy a
+  magnitude across the fix boundary, or say "magnitude" explicitly.
+- [deadline-bound-to-the-wrong-artifact] When a deadline exists because a
+  *resource* is about to disappear, it binds on **capturing** that
+  resource, not on completing the work that consumes it — and writing it
+  the second way invents an urgency the schedule cannot satisfy, then
+  buries the step that actually has to happen first. Name the artifact
+  and the wave that strands it (PR #72: seven follow-ups were corrected
+  from "blocked until after Task 6.4" to "fix BEFORE Task 6.4", when what
+  Task 6.4 destroys is the *oracle* — the Cython twin a corrected value
+  is captured from. The repair itself is a declared delta, legal at any
+  time; the capture is not. Review caught that the two had been
+  collapsed). Pairs with [settling-a-deferral-has-two-sweeps]: correcting
+  a sequencing claim is only half done while the corrected version still
+  names the wrong unit of work.

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -39,6 +39,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [the charged-pion photon spectrum returns zero in the forward cone](todo/charged-pion-photon-spectrum-misses-the-forward-cone.md) | 2026-08-17 | cython-to-rust Task 4.4 | cross-cutting |
 | [both rho photon spectra return the boost integrand at rest](todo/rho-rest-frame-branch-returns-the-integrand.md) | 2026-08-18 | cython-to-rust Task 4.5 | cross-cutting |
 | [four scalar elastic cross sections cancel away every significant bit](todo/scalar-elastic-cross-sections-cancel-in-atan-difference.md) | 2026-08-18 | closing the parity-corpus follow-up | cross-cutting |
+| [the review-lessons ledger is past its working-set cap](todo/lessons-ledger-over-its-working-set-cap.md) | 2026-08-19 | PR #72 review round 1 | cross-cutting |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/boost-integral-drops-last-interior-cell.md
+++ b/docs/followups/todo/boost-integral-drops-last-interior-cell.md
@@ -4,24 +4,28 @@
 - **Source:** cython-to-rust Task 3.4 (the interp + boost port)
 - **Scope:** cross-cutting
 - **Status:** open
-- **Triggers / blockers:** **fix BEFORE Phase 06 Task 6.4** — the
-  constraint is a deadline, not a wait. The parity corpus does pin the
-  current values, so the repair needs corrected reference values before it
-  can pass the gate, and `projects/cython-to-rust/rules.md` rule 2 does
-  forbid regenerating them from a tree with ported kernels. But Task 6.4
-  is where `hazma/_utils/boost.pyx` is **deleted**, and that twin is the
-  only independent implementation a corrected corpus case can be re-pinned
-  from: fix the `.pyx`, drive it through the `__pyx_capi__` capsules
-  `test/test_core_boost.py` already uses as an oracle, and the corrected
-  values come from a compiler and a source tree that both predate the
-  Rust port. After Task 6.4 the only remaining source of corrected values
-  is the fixed Rust itself, which pins the port against its own answer —
-  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
-  exists to prevent. The window is open today and closes at Task 6.4.
-  Sequenced in
-  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
-  where a later section of this file still reads "after Task 6.4", that
-  wording is superseded and the plan is authoritative.
+- **Triggers / blockers:** **capture the corrected values BEFORE the
+  deletion wave that strands them** — the deadline is on the oracle, not
+  on the fix. The parity corpus does pin the current values, and
+  `projects/cython-to-rust/rules.md` rule 2 does forbid regenerating them
+  from a tree with ported kernels, so the repair needs corrected
+  reference values from somewhere else. `hazma/_utils/boost.pyx` is that
+  somewhere: fix the `.pyx` in a scratch build, drive it through the
+  `__pyx_capi__` capsules `test/test_core_boost.py` already uses as an
+  oracle, and the corrected values come from a compiler and a source tree
+  that both predate the Rust port. Phase 06 Task 6.4 deletes that twin,
+  and after it the only remaining source is the fixed Rust itself, which
+  pins the port against its own answer — the vacuous gate rule 2 exists
+  to prevent.
+  The repair itself has no deadline. Under the plan's mechanism it lands
+  as a *declared delta* against the committed corpus arrays rather than
+  as a regeneration, so it is legal on a tree with ported kernels and can
+  follow the capture by any interval. What cannot follow the deletion is
+  the capture. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md)
+  — Task 2 (capture) and
+  Task 4 (repair); where a later section of this file still reads "after
+  Task 6.4", that wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/boost-integral-drops-last-interior-cell.md
+++ b/docs/followups/todo/boost-integral-drops-last-interior-cell.md
@@ -4,12 +4,24 @@
 - **Source:** cython-to-rust Task 3.4 (the interp + boost port)
 - **Scope:** cross-cutting
 - **Status:** open
-- **Triggers / blockers:** must land **after** Phase 06 Task 6.4 (the
-  last Cython deletion). Repairing it before then would put the Rust and
-  the Cython on different answers while both are alive, and the parity
-  corpus — which pins the *current* values — would have to be regenerated
-  in the same change, which `projects/cython-to-rust/rules.md` rule 2
-  forbids for a tree with ported kernels.
+- **Triggers / blockers:** **fix BEFORE Phase 06 Task 6.4** — the
+  constraint is a deadline, not a wait. The parity corpus does pin the
+  current values, so the repair needs corrected reference values before it
+  can pass the gate, and `projects/cython-to-rust/rules.md` rule 2 does
+  forbid regenerating them from a tree with ported kernels. But Task 6.4
+  is where `hazma/_utils/boost.pyx` is **deleted**, and that twin is the
+  only independent implementation a corrected corpus case can be re-pinned
+  from: fix the `.pyx`, drive it through the `__pyx_capi__` capsules
+  `test/test_core_boost.py` already uses as an oracle, and the corrected
+  values come from a compiler and a source tree that both predate the
+  Rust port. After Task 6.4 the only remaining source of corrected values
+  is the fixed Rust itself, which pins the port against its own answer —
+  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
+  exists to prevent. The window is open today and closes at Task 6.4.
+  Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md
+++ b/docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md
@@ -4,16 +4,24 @@
 - **Source:** `projects/cython-to-rust/task-notes/phase-04/task-4.4-photon-pion.md`
 - **Scope:** cross-cutting (public spectrum values)
 - **Status:** open
-- **Triggers / blockers:** **Blocked until after cython-to-rust Phase 06
-  Task 6.4.** The parity corpus pins the zeros by construction, so any
-  repair fails the gate that governs the remaining kernel swaps. Fixing it
-  needs a declared corpus regeneration, which is the same prerequisite the
-  five other blocked defects share
-  (`docs/followups/todo/boost-integral-drops-last-interior-cell.md`,
-  `positron-muon-spectrum-normalization-inverted.md`,
-  `eta-prime-two-photon-line-missing-factor-two.md`,
-  `phi-photon-lines-use-the-daughter-meson-energy.md`,
-  `photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md`).
+- **Triggers / blockers:** **fix BEFORE cython-to-rust Phase 06
+  Task 6.4** — the constraint is a deadline, not a wait. The parity
+  corpus does pin the zeros by construction, so the repair needs
+  corrected reference values before it can pass the gate that governs the
+  remaining kernel swaps. But Task 6.4 is where
+  `hazma/spectra/_photon/_pion.pyx` is **deleted**, and that twin is the
+  only independent implementation a corrected corpus case can be re-pinned
+  from: fix the `.pyx`, drive it through its `__pyx_capi__` capsules, and
+  the corrected
+  values come from a compiler and a source tree that both predate the
+  Rust port. After Task 6.4 the only remaining source of corrected values
+  is the fixed Rust itself, which pins the port against its own answer —
+  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
+  exists to prevent. The window is open today and closes at Task 6.4.
+  Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md
+++ b/docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md
@@ -4,24 +4,28 @@
 - **Source:** `projects/cython-to-rust/task-notes/phase-04/task-4.4-photon-pion.md`
 - **Scope:** cross-cutting (public spectrum values)
 - **Status:** open
-- **Triggers / blockers:** **fix BEFORE cython-to-rust Phase 06
-  Task 6.4** — the constraint is a deadline, not a wait. The parity
-  corpus does pin the zeros by construction, so the repair needs
-  corrected reference values before it can pass the gate that governs the
-  remaining kernel swaps. But Task 6.4 is where
-  `hazma/spectra/_photon/_pion.pyx` is **deleted**, and that twin is the
-  only independent implementation a corrected corpus case can be re-pinned
-  from: fix the `.pyx`, drive it through its `__pyx_capi__` capsules, and
-  the corrected
-  values come from a compiler and a source tree that both predate the
-  Rust port. After Task 6.4 the only remaining source of corrected values
-  is the fixed Rust itself, which pins the port against its own answer —
-  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
-  exists to prevent. The window is open today and closes at Task 6.4.
-  Sequenced in
-  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
-  where a later section of this file still reads "after Task 6.4", that
-  wording is superseded and the plan is authoritative.
+- **Triggers / blockers:** **capture the corrected values BEFORE the
+  deletion wave that strands them** — the deadline is on the oracle, not
+  on the fix. The parity corpus does pin the zeros, and
+  `projects/cython-to-rust/rules.md` rule 2 does forbid regenerating them
+  from a tree with ported kernels, so the repair needs corrected
+  reference values from somewhere else. `hazma/spectra/_photon/_pion.pyx`
+  is that somewhere: fix the `.pyx` in a scratch build, drive it through
+  its `__pyx_capi__` capsules, and the corrected values come from a
+  compiler and a source tree that both predate the Rust port. The
+  mediator-spectra composition of this kernel is stranded earlier still,
+  at Tasks 6.2/6.3; Task 6.4 then deletes the twin, and after it the only
+  remaining source is the fixed Rust itself, which pins the port against
+  its own answer.
+  The repair itself has no deadline. Under the plan's mechanism it lands
+  as a *declared delta* against the committed corpus arrays rather than
+  as a regeneration, so it is legal on a tree with ported kernels and can
+  follow the capture by any interval. What cannot follow the deletion is
+  the capture. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md)
+  — Task 2 (capture) and
+  Task 8 (repair); where a later section of this file still reads "after
+  Task 6.4", that wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
+++ b/docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
@@ -9,18 +9,22 @@
 - **Scope:** cross-cutting (a published number is wrong; the repair is
   gated by the `cython-to-rust` corpus)
 - **Status:** open
-- **Triggers / blockers:** **blocked until after `cython-to-rust` Phase 06
-  Task 6.4**, for the same reason as
-  [`positron-muon-spectrum-normalization-inverted.md`](positron-muon-spectrum-normalization-inverted.md)
-  and
-  [`boost-integral-drops-last-interior-cell.md`](boost-integral-drops-last-interior-cell.md):
-  the parity corpus pins the shipped value by construction
-  (`projects/cython-to-rust/rules.md` rule 2 forbids regenerating it from
-  a tree where any kernel runs on Rust), so a repair landed during the
-  port would fail the gate that governs every remaining swap. Cheapest to
-  fix in one declared regeneration together with its two siblings and
-  with
-  [`phi-photon-lines-use-the-daughter-meson-energy.md`](phi-photon-lines-use-the-daughter-meson-energy.md).
+- **Triggers / blockers:** **corpus re-pinning only** — no ordering
+  constraint against `cython-to-rust` Phase 06 Task 6.4. Task 6.4 deletes
+  the four surviving `.pyx`; this defect's twin,
+  `hazma/spectra/_photon/_eta_prime.pyx`, is already gone, deleted in
+  Task 4.2 in the same PR as the swap, so 6.4 takes away nothing this
+  repair could have used. What the corpus pins is still wrong and still
+  has to move, but the corrected values need no Cython oracle: the fix
+  adds a second copy of a line term the stored spectrum already carries
+  once, so the expected per-position delta is
+  `BR_ETAP_TO_A_A · boost_delta_function(M_η′/2, …)` — computable from a
+  constant and from `hazma/_utils/boost.pyx`, which is still live.
+  So this repair is schedulable now, independently of the port's
+  remaining phases. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/lessons-ledger-over-its-working-set-cap.md
+++ b/docs/followups/todo/lessons-ledger-over-its-working-set-cap.md
@@ -1,0 +1,90 @@
+# The review-lessons ledger is past its working-set cap
+
+- **Added:** 2026-08-19
+- **Source:** PR #72 review round 1 — appending two class-shaped entries
+  took the ledger from 36 to 38 against its own "under ~30" contract
+- **Scope:** cross-cutting (`docs/agents/lessons.md` is read before every
+  task and by every reviewer)
+- **Status:** open
+- **Triggers / blockers:** none. Independent of any project; the only
+  cost of waiting is that every agent and every reviewer keeps paying the
+  read.
+
+## Why
+
+[`docs/agents/lessons.md`](../../agents/lessons.md) opens with its own contract:
+*"Keep this file under ~30 entries — it is a working set, not an
+archive"*, with a **Promote and prune** clause — when an entry
+stabilizes, fold it into a `docs/agents/` checklist, `AGENTS.md`, or a
+lint rule, then delete it from the ledger.
+
+The file is at **38 entries** and 42,746 bytes — `grep -c '^- \['` and
+`wc -c` over `docs/agents/lessons.md`. It has been appended to
+on most recent PRs and pruned on none of them, which is the expected
+failure mode: appending is a required step of `review-respond`, pruning
+is nobody's step. The cost is not cosmetic. The ledger is on the
+mandatory reading list for `execute-single-task` before writing code and
+for every reviewer under the review-lenses baseline duties, so each entry
+past the useful set is a tax on every task in the repo, and a long
+ledger is read less carefully than a short one — which is exactly the
+failure the entries exist to prevent.
+
+Several entries look ripe. `[unpinned-formatter-version]` describes a
+divergence that was fixed by deleting the duplicate pin, and the
+invariant now lives in `pyproject.toml`'s `[dependency-groups]` — a
+sentence in `AGENTS.md` would carry it. `[wheel-tag-vs-extension-abi]`
+is a packaging fact that belongs beside the packaging gate.
+`[elided-doc-paths]` is enforceable by
+`scripts/agents/check_doc_citations.py`, which already resolves
+ambiguous basenames — the lesson could become the checker's error text.
+Those are candidates to assess, not a decided list.
+
+## What
+
+A promote-and-prune pass over `docs/agents/lessons.md`:
+
+1. Triage each of the 38 entries into *still a live working-set class*,
+   *stabilized — promote and delete*, or *superseded by a gate that now
+   catches it*.
+2. For each promotion, write the rule into its destination
+   (`docs/agents/preflight.md`, `doc-consistency.md`,
+   `review-lenses.md`, `AGENTS.md`, or a checker's message) and delete
+   the ledger entry — the contract says promoted lessons live in their
+   destination, not in both places.
+3. Land back under ~30.
+
+Two constraints the pass has to respect. An entry's PR citations are the
+evidence that the class is real, so a promotion carries them to the
+destination rather than dropping them. And a few entries have grown into
+multi-shape essays (`[measurement-taken-before-the-task-ended]` and
+`[sibling-copies-of-a-fixed-claim]` are each several hundred words with
+four or five distinct sub-shapes) — those are candidates for splitting
+into a `docs/agents/` reference of their own rather than for deletion,
+since the sub-shapes are individually load-bearing.
+
+Worth considering alongside: make the append step in
+`.claude/skills/review-respond/SKILL.md` and its `.codex/` twin state the
+cap, so the next agent that appends past it is the one that notices.
+
+## Entry points
+
+- `docs/agents/lessons.md` — the ledger; its `## Contract` section is
+  the authority on the cap and the promote-and-prune clause
+- `docs/agents/preflight.md`, `docs/agents/doc-consistency.md`,
+  `docs/agents/review-lenses.md`, `AGENTS.md` — the promotion
+  destinations the contract names
+- `scripts/agents/check_doc_citations.py` — where `[elided-doc-paths]`
+  would land if it becomes a checker message rather than a lesson
+- `.claude/skills/review-respond/SKILL.md`, `.codex/skills/review-respond/SKILL.md`
+  — the skills that mandate the append and do not mention the cap
+
+## Risks / open questions
+
+- Pruning is lossy in a way appending is not: an entry deleted without a
+  faithful promotion silently removes a class every future reviewer was
+  checking against. Prefer moving text to deleting it, and land the pass
+  as one reviewable diff rather than trickling deletions into unrelated
+  PRs.
+- The cap is "~30", not 30. The goal is a set an agent will actually
+  read, so the pass should be judged on whether the survivors are the
+  classes that still recur — not on hitting a number.

--- a/docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
+++ b/docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
@@ -9,14 +9,21 @@
 - **Scope:** cross-cutting (a published spectrum has a feature in the
   wrong place; the repair is gated by the `cython-to-rust` corpus)
 - **Status:** open
-- **Triggers / blockers:** **blocked until after `cython-to-rust` Phase 06
-  Task 6.4**, for the same reason as
-  [`eta-prime-two-photon-line-missing-factor-two.md`](eta-prime-two-photon-line-missing-factor-two.md):
-  the parity corpus pins the shipped values by construction
-  (`projects/cython-to-rust/rules.md` rule 2), so a repair landed during
-  the port would fail the gate that governs every remaining swap.
-  Cheapest to fix in one declared regeneration together with its
-  siblings.
+- **Triggers / blockers:** **corpus re-pinning only** — no ordering
+  constraint against `cython-to-rust` Phase 06 Task 6.4. Task 6.4 deletes
+  the four surviving `.pyx`; this defect's twin,
+  `hazma/spectra/_photon/_phi.pyx`, is already gone, deleted in Task 4.2
+  in the same PR as the swap, so 6.4 takes away nothing this repair could
+  have used. What the corpus pins is still wrong and still has to move,
+  but the corrected values need no Cython oracle: both line energies are
+  closed forms, `(M_φ² − m²)/(2 M_φ)`, so the expected delta is the two
+  boosted line terms recomputed there minus the two the corpus stored,
+  and `hazma/_utils/boost.pyx` still supplies `boost_delta_function`.
+  So this repair is schedulable now, independently of the port's
+  remaining phases. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md
+++ b/docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md
@@ -8,24 +8,28 @@
   `the_in_flight_form_is_the_boost_integral_of_the_rest_frame_form`)
 - **Scope:** commit (one guard in one `.pyx`, plus the corpus block it pins)
 - **Status:** open
-- **Triggers / blockers:** **fix BEFORE cython-to-rust Phase 06
-  Task 6.4** — the constraint is a deadline, not a wait. The parity
-  corpus does pin the truncated values, so the repair needs corrected
-  reference values before it can pass the gate that governs the remaining
-  kernel swaps (`projects/cython-to-rust/rules.md` rules 1–2). But
-  Task 6.4 is where `hazma/spectra/_photon/_muon.pyx` is **deleted**, and
-  that twin is the only independent implementation a corrected corpus case
-  can be re-pinned from: fix the `.pyx`, drive it through its
-  `__pyx_capi__` capsules, and the corrected
-  values come from a compiler and a source tree that both predate the
-  Rust port. After Task 6.4 the only remaining source of corrected values
-  is the fixed Rust itself, which pins the port against its own answer —
-  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
-  exists to prevent. The window is open today and closes at Task 6.4.
-  Sequenced in
-  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
-  where a later section of this file still reads "after Task 6.4", that
-  wording is superseded and the plan is authoritative.
+- **Triggers / blockers:** **capture the corrected values BEFORE the
+  deletion wave that strands them** — the deadline is on the oracle, not
+  on the fix. The parity corpus does pin the truncated values, and
+  `projects/cython-to-rust/rules.md` rules 1–2 do forbid regenerating
+  them from a tree with ported kernels, so the repair needs corrected
+  reference values from somewhere else. `hazma/spectra/_photon/_muon.pyx`
+  is that somewhere: fix the `.pyx` in a scratch build, drive it through
+  its `__pyx_capi__` capsules, and the corrected values come from a
+  compiler and a source tree that both predate the Rust port. The
+  mediator-spectra composition of this kernel is stranded earlier still,
+  at Tasks 6.2/6.3; Task 6.4 then deletes the twin, and after it the only
+  remaining source is the fixed Rust itself, which pins the port against
+  its own answer.
+  The repair itself has no deadline. Under the plan's mechanism it lands
+  as a *declared delta* against the committed corpus arrays rather than
+  as a regeneration, so it is legal on a tree with ported kernels and can
+  follow the capture by any interval. What cannot follow the deletion is
+  the capture. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md)
+  — Task 2 (capture) and
+  Task 7 (repair); where a later section of this file still reads "after
+  Task 6.4", that wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md
+++ b/docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md
@@ -8,11 +8,24 @@
   `the_in_flight_form_is_the_boost_integral_of_the_rest_frame_form`)
 - **Scope:** commit (one guard in one `.pyx`, plus the corpus block it pins)
 - **Status:** open
-- **Triggers / blockers:** **blocked behind cython-to-rust Phase 06
-  Task 6.4.** The parity corpus pins the truncated values, so repairing
-  the guard now fails the gate that governs the remaining kernel swaps
-  (`projects/cython-to-rust/rules.md` rules 1–2). This is the fifth defect
-  waiting on the same eventual corpus regeneration — see "Risks" below.
+- **Triggers / blockers:** **fix BEFORE cython-to-rust Phase 06
+  Task 6.4** — the constraint is a deadline, not a wait. The parity
+  corpus does pin the truncated values, so the repair needs corrected
+  reference values before it can pass the gate that governs the remaining
+  kernel swaps (`projects/cython-to-rust/rules.md` rules 1–2). But
+  Task 6.4 is where `hazma/spectra/_photon/_muon.pyx` is **deleted**, and
+  that twin is the only independent implementation a corrected corpus case
+  can be re-pinned from: fix the `.pyx`, drive it through its
+  `__pyx_capi__` capsules, and the corrected
+  values come from a compiler and a source tree that both predate the
+  Rust port. After Task 6.4 the only remaining source of corrected values
+  is the fixed Rust itself, which pins the port against its own answer —
+  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
+  exists to prevent. The window is open today and closes at Task 6.4.
+  Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/positron-muon-spectrum-normalization-inverted.md
+++ b/docs/followups/todo/positron-muon-spectrum-normalization-inverted.md
@@ -8,15 +8,25 @@
 - **Scope:** cross-cutting (a published number is wrong; the repair is
   gated by the `cython-to-rust` corpus)
 - **Status:** open
-- **Triggers / blockers:** **blocked until after `cython-to-rust` Phase 06
-  Task 6.4**, for the same reason as
-  [`boost-integral-drops-last-interior-cell.md`](boost-integral-drops-last-interior-cell.md):
-  the parity corpus pins the wrong values by construction
-  (`projects/cython-to-rust/rules.md` rule 2 forbids regenerating it from
-  a tree where any kernel runs on Rust), so a repair landed during the
-  port would fail the gate that governs every remaining swap. Worth
-  telling the maintainer *now*, separately from that schedule — it
-  affects published numbers today.
+- **Triggers / blockers:** **fix BEFORE `cython-to-rust` Phase 06
+  Task 6.4** — the constraint is a deadline, not a wait, and this one
+  also affects published numbers today. The parity corpus does pin the
+  wrong values by construction, so the repair needs corrected reference
+  values before it can pass the gate that governs every remaining swap.
+  But Task 6.4 is where `hazma/spectra/_positron/_muon.pyx` is
+  **deleted**, and that twin is the only independent implementation a
+  corrected corpus case can be re-pinned from: fix the `.pyx`, drive it
+  through the `__pyx_capi__` capsules this file's "Entry points" section
+  already names, and the corrected
+  values come from a compiler and a source tree that both predate the
+  Rust port. After Task 6.4 the only remaining source of corrected values
+  is the fixed Rust itself, which pins the port against its own answer —
+  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
+  exists to prevent. The window is open today and closes at Task 6.4.
+  Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/positron-muon-spectrum-normalization-inverted.md
+++ b/docs/followups/todo/positron-muon-spectrum-normalization-inverted.md
@@ -8,25 +8,29 @@
 - **Scope:** cross-cutting (a published number is wrong; the repair is
   gated by the `cython-to-rust` corpus)
 - **Status:** open
-- **Triggers / blockers:** **fix BEFORE `cython-to-rust` Phase 06
-  Task 6.4** — the constraint is a deadline, not a wait, and this one
-  also affects published numbers today. The parity corpus does pin the
-  wrong values by construction, so the repair needs corrected reference
-  values before it can pass the gate that governs every remaining swap.
-  But Task 6.4 is where `hazma/spectra/_positron/_muon.pyx` is
-  **deleted**, and that twin is the only independent implementation a
-  corrected corpus case can be re-pinned from: fix the `.pyx`, drive it
-  through the `__pyx_capi__` capsules this file's "Entry points" section
-  already names, and the corrected
-  values come from a compiler and a source tree that both predate the
-  Rust port. After Task 6.4 the only remaining source of corrected values
-  is the fixed Rust itself, which pins the port against its own answer —
-  exactly the vacuous gate `projects/cython-to-rust/rules.md` rule 2
-  exists to prevent. The window is open today and closes at Task 6.4.
-  Sequenced in
-  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
-  where a later section of this file still reads "after Task 6.4", that
-  wording is superseded and the plan is authoritative.
+- **Triggers / blockers:** **capture the corrected values BEFORE the
+  deletion wave that strands them** — the deadline is on the oracle, not
+  on the fix, and this defect also affects published numbers today. The
+  parity corpus does pin the wrong values, and
+  `projects/cython-to-rust/rules.md` rule 2 does forbid regenerating them
+  from a tree with ported kernels, so the repair needs corrected
+  reference values from somewhere else.
+  `hazma/spectra/_positron/_muon.pyx` is that somewhere: fix the `.pyx`
+  in a scratch build, drive it through the `__pyx_capi__` capsules this
+  file's "Entry points" section already names, and the corrected values
+  come from a compiler and a source tree that both predate the Rust port.
+  **This one has the nearest deadline of the four**: the
+  `spectra.positron.charged_pion` composition dies at Task 4.6, the only
+  Phase 04 task still open. Task 6.4 then deletes the twin itself.
+  The repair itself has no deadline. Under the plan's mechanism it lands
+  as a *declared delta* against the committed corpus arrays rather than
+  as a regeneration, so it is legal on a tree with ported kernels and can
+  follow the capture by any interval. What cannot follow the deletion is
+  the capture. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md)
+  — Task 2 (capture) and
+  Task 10 (repair); where a later section of this file still reads "after
+  Task 6.4", that wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md
+++ b/docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md
@@ -4,17 +4,21 @@
 - **Source:** `projects/cython-to-rust/task-notes/phase-04/task-4.5-photon-rho.md`
 - **Scope:** cross-cutting (public spectrum values)
 - **Status:** open
-- **Triggers / blockers:** **Blocked until after cython-to-rust Phase 06
-  Task 6.4.** The parity corpus pins the wrong values by construction —
-  both rho cases carry a `rest` block — so a repair fails the gate that
-  governs the remaining kernel swaps. Fixing it needs a declared corpus
-  regeneration, the same prerequisite the six other blocked defects share
-  (`charged-pion-photon-spectrum-misses-the-forward-cone.md`,
-  `boost-integral-drops-last-interior-cell.md`,
-  `positron-muon-spectrum-normalization-inverted.md`,
-  `eta-prime-two-photon-line-missing-factor-two.md`,
-  `phi-photon-lines-use-the-daughter-meson-energy.md`,
-  `photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md`).
+- **Triggers / blockers:** **corpus re-pinning only** — no ordering
+  constraint against cython-to-rust Phase 06 Task 6.4. Task 6.4 deletes
+  the four surviving `.pyx`; this defect's twin,
+  `hazma/spectra/_photon/_rho.pyx`, is already gone, deleted in Task 4.5
+  in the same PR as the swap, so 6.4 takes away nothing this repair could
+  have used. What the corpus pins is still wrong — both rho cases carry a
+  `rest` block — but the corrected values need no Cython oracle at all:
+  the corrected `rest` value is the stored value times `E_γ` exactly, as
+  the ratio table below measures, so the expected delta is a closed-form
+  transform of the committed array.
+  So this repair is schedulable now, independently of the port's
+  remaining phases. Sequenced in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);
+  where a later section of this file still reads "after Task 6.4", that
+  wording is superseded and the plan is authoritative.
 
 ## Why
 

--- a/projects/README.md
+++ b/projects/README.md
@@ -41,6 +41,7 @@ for why `_template.md` files stay in place after scaffolding.
 | Slug | Deliverable | Phased | Started | Status |
 | --- | --- | --- | --- | --- |
 | [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | In Progress |
+| [`parity-pinned-defect-repair`](parity-pinned-defect-repair/PLAN.md) | The seven parity-pinned numerical defects repaired, each with a declared per-array delta asserted against the corpus arrays that pinned it — which stay committed | No | 2026-08-19 | In Progress |
 
 ## Completed Projects
 

--- a/projects/parity-pinned-defect-repair/PLAN.md
+++ b/projects/parity-pinned-defect-repair/PLAN.md
@@ -1,0 +1,498 @@
+---
+status: In Progress
+phased: false
+version_bump: minor
+deliverable: The seven parity-pinned numerical defects repaired, each with a declared per-array delta asserted against the corpus arrays that pinned the defect — which stay committed
+created: 2026-08-19
+---
+
+# Project: Repair the parity-pinned numerical defects
+
+**Structure:** Flat task list.
+
+## Goal
+
+Repair the seven live numerical defects the `cython-to-rust` port
+surfaced, and do it under a corpus mechanism that keeps the arrays which
+pinned each defect rather than overwriting them. Every repair ships with
+a **declared delta**: a named statement of which corpus positions move,
+by how much, and why — asserted as a gate, so a fix that leaks past its
+intended blast radius fails rather than being absorbed.
+
+The project exists because the seven follow-ups' original sequencing was
+backwards, and the correction is time-critical. See "The premise this
+project corrects" below.
+
+## The premise this project corrects
+
+All seven follow-ups under [`docs/followups/todo/`](../../docs/followups/todo/)
+carried some form of *"blocked until after `cython-to-rust` Phase 06
+Task 6.4"*. The stated reason is right: the parity corpus pins the
+shipped-but-wrong values by construction, `projects/cython-to-rust/rules.md`
+rule 2 forbids regenerating it from a tree with ported kernels, and
+`test/parity/generate.py` enforces that by refusing to run once
+`hazma._core` serves a kernel.
+
+The timing conclusion drawn from it is backwards. Task 6.4 is the task
+that **deletes** the last Cython twins
+(`projects/cython-to-rust/phases/phase-06-mediator-spectra.md`, Task 6.4
+exit criteria: the `.pyx` and `.pxd` of
+`hazma/spectra/_photon/_muon`, `hazma/spectra/_photon/_pion`,
+`hazma/spectra/_positron/_muon` and `hazma/spectra/_positron/_pion`,
+plus `hazma/_utils/boost.{pyx,pxd}` and the `_utils` headers).
+Those twins are the only independent implementation a corrected corpus
+case can be re-pinned from. After 6.4 the only source of corrected
+reference values is the fixed Rust — which pins the port against its own
+answer. Waiting for 6.4 destroys the very thing the wait was for.
+
+Every step of that is verified against this tree at `3e01590`, with the
+command beside each claim, in
+[`references/the-premise.md`](references/the-premise.md) — including the
+one that surprises: a whole-corpus regeneration has not been possible
+since Phase 04 Task 4.1, so "one declared regeneration after Task 6.4"
+was never an available move rather than a mistimed one.
+
+**The deadline is earlier than Task 6.4 for two of the four.** The twins
+die in three waves, and a corrected value has to be reachable through the
+*whole* Cython composition chain, not just through the one defective
+function:
+
+| Wave | Task | Deletes | Closes the window for |
+| --- | --- | --- | --- |
+| 1 | 4.6 (the only Phase 04 task left) | `hazma/spectra/_positron/_pion.pyx`, the neutrino pair | `spectra.positron.charged_pion` re-derivation for the positron-muon defect |
+| 2 | 6.2 / 6.3 | the four mediator spectrum `.pyx` | every `mediator_spectra.*` case for the muon and charged-pion defects |
+| 3 | 6.4 | the four capi survivors + `hazma/_utils/boost.{pyx,pxd}` | everything else |
+
+Task 2 below is what buys the deadline out: it captures the corrected
+oracle arrays once, commits them, and from that point the repairs are no
+longer racing the port.
+
+## Scope
+
+**In scope:**
+
+- The seven defects listed in "The defects" below, each repaired in the
+  Rust kernel that now serves it.
+- A delta-declaration layer under `test/parity/` that pins each repair's
+  blast radius while leaving `test/parity/data/*.npz` untouched.
+- A committed, provenance-stamped oracle capture from the four live
+  Cython twins (Task 2), taken before the port deletes them.
+- One `CHANGELOG.md` entry per moved published spectrum, with the
+  magnitude, per `projects/cython-to-rust/rules.md` rule 3 and
+  [`docs/versioning.md`](../../docs/versioning.md).
+
+**Out of scope:**
+
+- Any change to the `cython-to-rust` port's own task sequence. This
+  project runs beside it and consumes its artifacts; it does not
+  reorder its phases. Task 11 reconciles the superseded prose, and
+  anything canonical there needs that project's change control.
+- Regenerating `test/parity/data/*.npz`. The committed arrays are the
+  historical record of what 2.1.0 shipped and are never rewritten by
+  this project — that is the point of the delta layer.
+- The other open follow-ups under `docs/followups/todo/` that are not
+  corpus-pinned (`kallen-under-sqrt-remaining-call-sites.md`,
+  `scalar-elastic-cross-sections-cancel-in-atan-difference.md`,
+  `model-spectra-reject-scalar-energies.md`, and the infrastructure
+  items).
+- Widening any existing tolerance in `test/parity/tolerances.py`. A
+  repair declares a delta; it does not loosen a budget.
+
+## Numerical impact
+
+**This project moves published numbers, deliberately, seven times.** That
+is the whole deliverable, and it is what sets `version_bump: minor` —
+no public name, signature, return shape or documented unit changes, but
+users' plots move. Known magnitudes, from the follow-ups' own
+measurements:
+
+- η′ photon yield rises 0.63%, all of it in a line at `M_η′/2 = 478.89`
+  MeV.
+- φ: 0.60% of the photon yield relocates by +294.4 MeV and +899.8 MeV
+  in the φ rest frame.
+- Charged-pion photon spectrum: a hard zero over roughly the top quarter
+  of its support disappears; integrated, 0.0054% at `E_π = 1` GeV,
+  0.041% at 1396 MeV, 2.96% at 5 GeV. A shape defect, not a yield
+  defect, at hazma's scales.
+- Muon photon spectrum: the rest-frame branch regains the last 0.25 MeV
+  to the endpoint.
+- Positron muon spectrum: normalization moves by `R_FACTOR²`.
+- Boost integral: the seven tabulated photon spectra rise by the dropped
+  cell; systematic and one-signed (they are currently always slightly
+  low).
+- Both rho spectra at `E_ρ = m_ρ` exactly: divided by `E_γ`, i.e. the
+  value changes by a factor of `E_γ` at a single parent energy.
+
+Task 12 aggregates the measured figures; the per-defect numbers above are
+the pre-repair estimates the follow-ups recorded, not this project's own
+measurements, and are re-derived by each repair task.
+
+## Tasks
+
+The live task table, status, and dependency diagram are tracked in
+[`task-notes/README.md`](task-notes/README.md). This `PLAN.md` describes
+the canonical *shape* of each task below.
+
+## Orientation
+
+| Reference | Nature |
+| --- | --- |
+| [`references/the-premise.md`](references/the-premise.md) | Grounded facts — the corrected sequencing premise, claim by claim, with the command that produced each. Read once; Task 11 re-derives it. |
+| [`references/corpus-repinning.md`](references/corpus-repinning.md) | Spec — the delta-declaration mechanism, the oracle capture protocol, and the per-defect proof obligations. Tasks 1–3 and every repair task. |
+| [`references/defect-blast-radius.md`](references/defect-blast-radius.md) | Grounded facts — which corpus case and block each defect reaches, derived from the cimport graph and the committed manifest. Every repair task. |
+| [`rules.md`](rules.md) | This project's cross-cutting rules. All tasks. |
+
+## The defects
+
+Group A still has a live Cython twin and is on the clock. Group B does
+not, and is unblocked.
+
+| # | Defect | Follow-up | Twin | Serving kernel |
+| --- | --- | --- | --- | --- |
+| A1 | Boost integral mis-covers its window at both ends | [`boost-integral-drops-last-interior-cell.md`](../../docs/followups/todo/boost-integral-drops-last-interior-cell.md) | `hazma/_utils/boost.pyx` (live) | `rust/src/boost.rs` |
+| A2 | Muon photon rest-frame branch stops short of the endpoint | [`photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md`](../../docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md) | `hazma/spectra/_photon/_muon.pyx` (live) | `rust/src/kernels/photon_muon.rs` |
+| A3 | Charged-pion photon spectrum returns zero in the forward cone | [`charged-pion-photon-spectrum-misses-the-forward-cone.md`](../../docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md) | `hazma/spectra/_photon/_pion.pyx` (live) | `rust/src/kernels/photon_pion.rs` |
+| A4 | Muon positron spectrum divides by its normalization | [`positron-muon-spectrum-normalization-inverted.md`](../../docs/followups/todo/positron-muon-spectrum-normalization-inverted.md) | `hazma/spectra/_positron/_muon.pyx` (live) | `rust/src/kernels/positron_muon.rs` |
+| B1 | η′ two-photon line missing its factor of two | [`eta-prime-two-photon-line-missing-factor-two.md`](../../docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
+| B2 | φ photon lines use the daughter meson's energy | [`phi-photon-lines-use-the-daughter-meson-energy.md`](../../docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
+| B3 | Both rho spectra return the boost integrand at rest | [`rho-rest-frame-branch-returns-the-integrand.md`](../../docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md) | deleted, Task 4.5 | `rust/src/kernels/photon_rho.rs` |
+
+## Task Details
+
+### Task 1: The delta-declaration layer
+
+**Objective:** Give the parity suite a way to say "this array moved,
+here, by this much, because of this repair" without rewriting the array.
+
+**Scope / implementation notes:** A new `test/parity/deltas.py`, keyed on
+the same `(case_name, block_label, array_suffix)` tuple
+`test/parity/stability.py` already uses for `PORTABILITY_ZEROS`. Each
+declaration names the repair, the affected positions, the expected
+relation between stored and repaired value, and the measurement that
+justifies it. `test/parity/test_parity.py` consults it *after* the
+existing budget selection: a declared position is compared against the
+declared relation, an undeclared position against the original stored
+array under its existing `test/parity/tolerances.py` budget. See
+[`references/corpus-repinning.md`](references/corpus-repinning.md) for
+the declaration schema and why it is an allowlist rather than a rule
+over positions of the same shape.
+
+**Deliverable / gate:** `pytest test/parity` green with an empty
+declaration set and a collected count that matches today's, proving the
+layer is inert before any repair lands. A shape test that fails if a
+declaration names a case, block, array or position the corpus does not
+contain. `git diff --stat -- test/parity/data` empty.
+
+### Task 2: Capture the corrected-value oracles from the four live twins
+
+**Objective:** Take the one measurement that stops being possible when
+the port deletes the Cython, and commit it. **This task is the deadline;
+everything else in the project is schedulable afterwards.**
+
+**Scope / implementation notes:** For each Group A defect, apply the
+repair to the `.pyx` in a scratch build, drive the patched `cdef` through
+its `__pyx_capi__` capsules the way `test/test_core_boost.py` already
+drives `hazma._utils.boost`, and capture the corrected values on the
+corpus's own capturing platform (read it from
+`test/parity/data/manifest.json`, per `docs/agents/lessons.md`
+`[platform-scoped-oracle-asserted-globally]` — do not probe for it).
+Commit the arrays under `test/parity/oracles/` with a manifest carrying
+the patched-source digest, the platform, and the `hazma` package path
+actually imported (`[measured-tree-vs-imported-module]`). **No library
+behavior ships in this task** — the `.pyx` patch exists only inside the
+capture and is reverted, verified by `git diff -- hazma` being empty on
+the final tree.
+
+Capture the composition chain too, not only the defective function: for
+A2 and A3 that means the `mediator_spectra.*` cases, which lose their
+Cython at Tasks 6.2/6.3; for A4 it means `spectra.positron.charged_pion`,
+which loses its Cython at Task 4.6. See
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+for the per-defect case list and
+[`references/corpus-repinning.md`](references/corpus-repinning.md) for
+the capture protocol.
+
+**Deliverable / gate:** `test/parity/oracles/` committed and
+self-checking (a `--check` mode that verifies the arrays against their
+manifest hashes without a build, mirroring
+`python test/parity/generate.py --check`). A test that the oracle
+manifest's platform matches the corpus manifest's. A recorded diff, per
+defect, between the oracle and the corresponding stored corpus array —
+the first measurement of each repair's size, taken from Cython rather
+than from Rust.
+
+### Task 3: Closed-form delta models for the three twin-less defects
+
+**Objective:** Establish, for B1–B3, a non-circular statement of the
+expected delta that needs no Cython twin.
+
+**Scope / implementation notes:** Each of the three has a closed form:
+
+- **B3 (rho):** the corrected `rest` value is the stored value times
+  `E_γ` exactly. The follow-up's own ratio table measures the ratio as
+  `13.000000`, `50.000000`, `200.000000`, `300.000000` at those photon
+  energies. The delta is a transform of the committed array and needs
+  no kernel.
+- **B1 (η′):** the fix adds a second copy of a line term the stored
+  spectrum already carries once, so the delta is
+  `BR_ETAP_TO_A_A · boost_delta_function(M_η′/2, …)` — a constant times
+  a function of `hazma/_utils/boost.pyx`, which is still live and which
+  Task 2 is already capturing.
+- **B2 (φ):** both line energies are closed forms,
+  `(M_φ² − m²)/(2 M_φ)`; the delta is the two boosted line terms
+  recomputed there minus the two the corpus stored.
+
+Where the closed form is analytic, add an `mpmath` reference in the
+shape of `test/parity/reference.py` rather than trusting either
+implementation — that file is the precedent, and
+`projects/cython-to-rust/task-notes/README.md` records the pattern
+settling a comparable question in an afternoon with no build.
+
+**Deliverable / gate:** For each of B1–B3, a declaration in
+`test/parity/deltas.py` and a test that the declared model reproduces
+the **shipped** value from the corrected form plus the named defect —
+which is falsifiable without either the repaired Rust or a Cython twin,
+and is what makes the model non-circular. Recovering the deleted sources
+for review is `git show 665aed5:<path>` (B1, B2) and
+`git show b5f7f90^:hazma/spectra/_photon/_rho.pyx` (B3).
+
+### Task 4: Repair A1 — the boost integral window
+
+**Objective:** Cover `[x[ihigh-1], x[ihigh]]`, and stop dropping the
+table's final row when the boosted window reaches past the table.
+
+**Scope / implementation notes:** `rust/src/boost.rs`,
+`boost_integrate_linear_interp`. The consumer set is narrow and entirely
+Rust: `rust/src/kernels/photon_tables.rs` is the only kernel that reaches
+it, per that module's own call-site table. Sequenced first because those
+seven tabulated photon cases are also where B1 and B2 land, and doing the
+primitive first means their deltas are measured once.
+
+**Deliverable / gate:** Declared deltas for the seven tabulated photon
+cases; the repaired value reproduces Task 2's Cython oracle within the
+function's existing budget; the sign is one-signed and upward at every
+declared position, which is the follow-up's own characterization and is
+asserted rather than asserted-about. Every other corpus case unchanged
+against its original stored array.
+
+### Task 5: Repair B1 — the η′ two-photon line weight
+
+**Objective:** `2 · BR(η′ → γγ)`, matching its four `X → γγ` siblings.
+
+**Scope / implementation notes:** `rust/src/kernels/photon_tables.rs`,
+`ETAP_TO_A_A_WEIGHT`. Depends on Task 4: the same
+`spectra.photon.eta_prime` arrays carry the boost-window delta.
+The port's existing tests already state the correct physics alongside the
+shipped defect, so the repair largely flips which is asserted —
+`the_eta_prime_line_is_missing_its_factor_of_two` and
+`TestPhysics::test_the_eta_prime_line_carries_half_the_photons_it_should`
+must be renamed as well as re-pointed, per `docs/agents/lessons.md`
+`[test-name-claims-an-unmade-assertion]`.
+
+**Deliverable / gate:** Declared delta on `spectra.photon.eta_prime`
+only. The line-term integral measures `2 · BR = 0.04614` photons per
+decay against the `0.02306998 ± 1.3e-08` the follow-up measured
+pre-repair; the continuum is unchanged. `spectra.photon.eta`,
+`spectra.photon.long_kaon` and `spectra.photon.short_kaon` — the three
+siblings that were already right — do not move.
+
+### Task 6: Repair B2 — the φ photon line energies
+
+**Objective:** Place both φ lines at `(M_φ² − m²)/(2 M_φ)`.
+
+**Scope / implementation notes:** `rust/src/kernels/photon_tables.rs`.
+Depends on Task 4, same reason as Task 5. The two lines move by
++294.4 MeV and +899.8 MeV in the φ rest frame; the `η′γ` line moves from
+959.65 MeV to 59.82 MeV, a factor of 16. Nothing raises and no kinematic
+guard fires either before or after, so the gate has to be a *position*
+assertion, not a "does it still return finite" one.
+
+**Deliverable / gate:** Declared delta on `spectra.photon.phi` only, and
+the declaration names the two energies rather than a magnitude — the
+total yield is unchanged (0.013092 photons per decay, relocated), so a
+yield-only check would pass on an unrepaired kernel. `spectra.photon.omega`,
+whose lines were already right, does not move.
+
+### Task 7: Repair A2 — the muon photon rest-frame endpoint
+
+**Objective:** Guard on `y ≥ 1 − r` with `r = (m_e/m_μ)²`, not
+`1 − √r`.
+
+**Scope / implementation notes:** `rust/src/kernels/photon_muon.rs`.
+This kernel is composed by three others (charged pion, both rhos, and
+both mediator decay spectra), so it comes before Tasks 8 and 9. The Rust
+`fn` is in the PyO3-free kernel layer and Phase 06 calls it natively, so
+the repair reaches the mediator spectra whether or not Phase 06 has
+landed.
+
+**Deliverable / gate:** Declared deltas on `spectra.photon.muon`,
+`spectra.photon.charged_pion`, both rho cases and both mediator photon
+cases; the repaired value reproduces Task 2's oracle. The endpoint
+invariant that Task 4.3 wrote —
+`the_in_flight_form_is_the_boost_integral_of_the_rest_frame_form` —
+must still hold, and now holds over the extra 0.25 MeV.
+
+### Task 8: Repair A3 — the charged-pion forward cone
+
+**Objective:** Stop `qagp` from terminating successfully at `0.0` because
+every abscissa fell outside the integrand's support.
+
+**Scope / implementation notes:** `rust/src/kernels/photon_pion.rs`,
+`CHARGED_PION_QUAD`. The integrand is nonzero only where the
+pion-rest-frame photon energy stays under `ENG_GAM_MAX_PIRG = 69.783`
+MeV; the fix is to integrate over that window rather than over all of
+`cos θ` and hope the adaptive rule finds it. Depends on Task 7 (this
+kernel boosts the muon spectrum). Partition the verification grid by
+scipy's own convergence verdict rather than picking one tolerance —
+`projects/cython-to-rust/task-notes/README.md` records that lesson from
+this exact kernel, and PR #68's two CI rounds are why.
+
+**Deliverable / gate:** Declared deltas on `spectra.photon.charged_pion`,
+both rho cases and both mediator photon cases. The specific figure the
+follow-up pins: `dnde_photon_charged_pion(900, 1396)` moves from `0.0` to
+`3.586e-07` MeV⁻¹. A test that no stored zero in that case survives
+repair *except* the ones outside the kinematic support — the difference
+between the two is the whole defect, and a declaration that covers both
+would hide it.
+
+### Task 9: Repair B3 — the rho rest-frame branch
+
+**Objective:** Return the rest-frame spectrum, not the boost integrand.
+
+**Scope / implementation notes:** `rust/src/kernels/photon_rho.rs`,
+`boosted`. One line, plus the two Rust unit tests and the Python test
+that currently pin the defect — all three named in the follow-up's
+"Entry points", all three needing a rename as well as a re-point. Last
+of the rho-touching tasks because Tasks 7 and 8 also move those arrays;
+the branch fires only at `E_ρ == m_ρ` exactly, so its declared positions
+are disjoint from theirs and the two deltas must be shown not to overlap.
+
+**Deliverable / gate:** Declared delta on the `rest` block of
+`spectra.photon.charged_rho` and `spectra.photon.neutral_rho`, and
+nowhere else — the guard `E_ρ − m_ρ < DBL_EPSILON` is absolute and one
+ulp at 775.26 MeV is 1.14e-13, about 500× `DBL_EPSILON`, so no other
+double reaches it and a delta declared on any other block is a bug in the
+declaration. The ratio to the stored value is `E_γ` at every declared
+position, exactly.
+
+### Task 10: Repair A4 — the muon positron normalization
+
+**Objective:** Multiply by the normalization instead of dividing.
+
+**Scope / implementation notes:** `rust/src/kernels/positron_muon.rs`.
+Independent of Tasks 4–9 — a separate branch of the composition graph —
+so it may run in parallel with them. Blast radius is
+`spectra.positron.muon`, `spectra.positron.charged_pion` and both
+mediator positron cases.
+
+**Deliverable / gate:** Declared deltas on those four cases; the repaired
+value reproduces Task 2's oracle. The analytic normalization test that
+found the defect (Task 4.1's) now passes against the corrected constant
+rather than recording the inversion, and the Michel spectrum integrates
+to 1 over its support to a stated tolerance.
+
+### Task 11: Reconcile the superseded sequencing prose
+
+**Objective:** Leave no live document still telling a reader to wait for
+Task 6.4.
+
+**Scope / implementation notes:** The corrected premise is stated in the
+seven follow-ups' "Triggers / blockers" bullets and here. Copies survive
+elsewhere, and they split by file role, per `docs/agents/lessons.md`
+`[sweep-excluded-the-canonical-directory]`: task notes and learnings are
+dated history and stay as written; a phase file and a `references/` file
+that declares itself spec are live and do not.
+
+Known live copy, found by
+`grep -rn "Task 6\.4" --include="*.md" .` at plan time:
+`projects/cython-to-rust/phases/phase-03-numerics-foundation.md` states
+the boost repair is "blocked until after Phase 06 Task 6.4 because it
+needs a declared corpus regeneration". That is a canonical statement in
+another project's phase file, so changing it goes through that project's
+change control (`projects/cython-to-rust/rules.md`, Process; an ADR if
+the correction is canonical rather than clerical). Re-derive the full
+population at execution time rather than trusting this paragraph, and
+sweep the behavior words as well as the task id
+(`[settling-a-deferral-has-two-sweeps]`).
+
+Also in scope: the "Risks" sections of the seven follow-ups, which still
+propose "one declared regeneration after Phase 06 Task 6.4". Those were
+deliberately left standing when the blocker bullets were rewritten, so
+the correction and its evidence would land in one reviewable place
+first; each blocker bullet says so and points here.
+
+**Deliverable / gate:** `scripts/agents/check_doc_citations.py` over
+every touched doc — it is not in `preflight.sh`, per
+`[gate-green-is-not-citations-green]` — plus a paste of the sweep
+commands and their output, written after the last prose edit
+(`[sweep-block-written-from-intent]`).
+
+### Task 12: Close — aggregate the drift and ship the bump
+
+**Objective:** One `CHANGELOG.md` entry naming this slug, carrying every
+measured shift, and the `minor` bump.
+
+**Scope / implementation notes:** The per-repair figures accumulate in
+`task-notes/README.md`'s "Numerical impact so far" as each task lands;
+this task aggregates rather than reconstructs. Re-check the level against
+the aggregate before bumping — seven deliberate corrections to published
+spectra with no API change is `minor`, and nothing in Tasks 4–10 should
+have raised it, but the check is the point.
+
+**Deliverable / gate:** `scripts/agents/preflight.sh --closing` green;
+`PLAN.md` `status: Complete`; the seven follow-ups moved to
+`docs/followups/done/` with their inbound links repointed and the
+revision pinned, per
+[`docs/workflow.md`](../../docs/workflow.md)'s follow-up lifecycle and
+`[touched-doc-inherits-its-citations]`.
+
+## Dependencies
+
+- Requires: nothing complete. Tasks 1–3 run against the tree as it
+  stands.
+- **Constrains:** `cython-to-rust` Task 4.6, then Tasks 6.2/6.3, then
+  6.4. Task 2 must land before Task 4.6 for the
+  `spectra.positron.charged_pion` capture, and before 6.2/6.3 for the
+  mediator-spectra captures. If the port reaches those first, the
+  corresponding oracles are unrecoverable from any source but the Rust
+  itself and the affected repairs lose their independent check — say so
+  in the task note rather than proceeding as if nothing was lost.
+
+## Related
+
+- Background: the seven follow-ups listed under "The defects", and
+  `projects/cython-to-rust/task-notes/README.md`'s "Numerical impact so
+  far", which is where each defect was first measured.
+- `projects/cython-to-rust/rules.md` rules 1–3 (parity discipline) are
+  the constraint this project is designed around; nothing here relaxes
+  them.
+
+## Change control
+
+See [`../../docs/workflow.md#adr-placement`](../../docs/workflow.md#adr-placement)
+for when to write an ADR and where it lives (repo-wide vs project-scoped).
+Patch the affected `PLAN.md` / `rules.md` when canonical behavior
+changes.
+
+## Closing this project
+
+The PR that flips this `PLAN.md` `status:` to `Complete` must also bump
+`VERSION` in `hazma/__init__.py` per the `version_bump:` frontmatter and
+add a `CHANGELOG.md` entry naming this project slug. Re-check the level
+against the **Numerical impact** section above before bumping. Verify
+with `scripts/agents/preflight.sh --closing`. See
+[`../../docs/versioning.md`](../../docs/versioning.md) for the full
+policy.
+
+### Anticipated ADRs
+
+- **The delta-declaration layer as the standing re-pinning mechanism**
+  (project-scoped, Task 1). It changes what the parity corpus asserts,
+  which is `cython-to-rust`'s gate as much as this project's, so if the
+  layer outlives this project it is a candidate for promotion to
+  `docs/adrs/`.
+- **Whether the corrected oracles stay committed after `cython-to-rust`
+  closes** (project-scoped, Task 2). They are the last evidence that a
+  repaired value was ever checked against a non-Rust implementation;
+  the alternative is that the port's own tests become self-referential
+  the moment the Cython goes.

--- a/projects/parity-pinned-defect-repair/PLAN.md
+++ b/projects/parity-pinned-defect-repair/PLAN.md
@@ -71,8 +71,9 @@ longer racing the port.
 
 **In scope:**
 
-- The seven defects listed in "The defects" below, each repaired in the
-  Rust kernel that now serves it.
+- The seven defects rostered in
+  [`references/defect-blast-radius.md`](references/defect-blast-radius.md),
+  each repaired in the Rust kernel that now serves it.
 - A delta-declaration layer under `test/parity/` that pins each repair's
   blast radius while leaving `test/parity/data/*.npz` untouched.
 - A committed, provenance-stamped oracle capture from the four live
@@ -108,8 +109,12 @@ measurements:
 
 - η′ photon yield rises 0.63%, all of it in a line at `M_η′/2 = 478.89`
   MeV.
-- φ: 0.60% of the photon yield relocates by +294.4 MeV and +899.8 MeV
-  in the φ rest frame.
+- φ: 0.60% of the photon yield relocates **down** by 294.4 MeV and
+  899.8 MeV in the φ rest frame — the repair moves each line from where
+  it ships to where it belongs (656.942 → 362.519 MeV for `φ → ηγ`,
+  959.646 → 59.815 MeV for `φ → η′γ`). The follow-up states the same two
+  magnitudes with a `+` sign because it describes the *defect's*
+  displacement, which runs the other way.
 - Charged-pion photon spectrum: a hard zero over roughly the top quarter
   of its support disappears; integrated, 0.0054% at `E_π = 1` GeV,
   0.041% at 1396 MeV, 2.96% at 5 GeV. A shape defect, not a yield
@@ -144,18 +149,13 @@ the canonical *shape* of each task below.
 
 ## The defects
 
-Group A still has a live Cython twin and is on the clock. Group B does
-not, and is unblocked.
-
-| # | Defect | Follow-up | Twin | Serving kernel |
-| --- | --- | --- | --- | --- |
-| A1 | Boost integral mis-covers its window at both ends | [`boost-integral-drops-last-interior-cell.md`](../../docs/followups/todo/boost-integral-drops-last-interior-cell.md) | `hazma/_utils/boost.pyx` (live) | `rust/src/boost.rs` |
-| A2 | Muon photon rest-frame branch stops short of the endpoint | [`photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md`](../../docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md) | `hazma/spectra/_photon/_muon.pyx` (live) | `rust/src/kernels/photon_muon.rs` |
-| A3 | Charged-pion photon spectrum returns zero in the forward cone | [`charged-pion-photon-spectrum-misses-the-forward-cone.md`](../../docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md) | `hazma/spectra/_photon/_pion.pyx` (live) | `rust/src/kernels/photon_pion.rs` |
-| A4 | Muon positron spectrum divides by its normalization | [`positron-muon-spectrum-normalization-inverted.md`](../../docs/followups/todo/positron-muon-spectrum-normalization-inverted.md) | `hazma/spectra/_positron/_muon.pyx` (live) | `rust/src/kernels/positron_muon.rs` |
-| B1 | η′ two-photon line missing its factor of two | [`eta-prime-two-photon-line-missing-factor-two.md`](../../docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
-| B2 | φ photon lines use the daughter meson's energy | [`phi-photon-lines-use-the-daughter-meson-energy.md`](../../docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
-| B3 | Both rho spectra return the boost integrand at rest | [`rho-rest-frame-branch-returns-the-integrand.md`](../../docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md) | deleted, Task 4.5 | `rust/src/kernels/photon_rho.rs` |
+Seven, labelled **A1–A4** (a live Cython twin, so an oracle capture is on
+the clock) and **B1–B3** (no twin, and no ordering constraint at all).
+The roster — each defect's follow-up, its twin's fate, the Rust kernel
+that serves it now, and the corpus cases it reaches — is one table, in
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md).
+It lives there rather than here so the labels, the case lists and the
+counts have exactly one home; the task gates below quote it by row.
 
 ## Task Details
 
@@ -268,9 +268,14 @@ it, per that module's own call-site table. Sequenced first because those
 seven tabulated photon cases are also where B1 and B2 land, and doing the
 primitive first means their deltas are measured once.
 
-**Deliverable / gate:** Declared deltas for the seven tabulated photon
-cases; the repaired value reproduces Task 2's Cython oracle within the
-function's existing budget; the sign is one-signed and upward at every
+**Deliverable / gate:** Declared deltas on all **7** cases the A1 row of
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+names — `spectra.photon.eta`, `spectra.photon.eta_prime`,
+`spectra.photon.omega`, `spectra.photon.phi`,
+`spectra.photon.charged_kaon`, `spectra.photon.long_kaon`,
+`spectra.photon.short_kaon` — and on nothing else; the repaired value
+reproduces Task 2's Cython oracle within the function's existing
+budget; the sign is one-signed and upward at every
 declared position, which is the follow-up's own characterization and is
 asserted rather than asserted-about. Every other corpus case unchanged
 against its original stored array.
@@ -301,9 +306,9 @@ siblings that were already right — do not move.
 **Objective:** Place both φ lines at `(M_φ² − m²)/(2 M_φ)`.
 
 **Scope / implementation notes:** `rust/src/kernels/photon_tables.rs`.
-Depends on Task 4, same reason as Task 5. The two lines move by
-+294.4 MeV and +899.8 MeV in the φ rest frame; the `η′γ` line moves from
-959.65 MeV to 59.82 MeV, a factor of 16. Nothing raises and no kinematic
+Depends on Task 4, same reason as Task 5. The repair moves both lines
+**down**: `φ → ηγ` from 656.942 to 362.519 MeV (−294.4), and `φ → η′γ`
+from 959.646 to 59.815 MeV (−899.8), a factor of 16. Nothing raises and no kinematic
 guard fires either before or after, so the gate has to be a *position*
 assertion, not a "does it still return finite" one.
 
@@ -325,9 +330,16 @@ both mediator decay spectra), so it comes before Tasks 8 and 9. The Rust
 the repair reaches the mediator spectra whether or not Phase 06 has
 landed.
 
-**Deliverable / gate:** Declared deltas on `spectra.photon.muon`,
-`spectra.photon.charged_pion`, both rho cases and both mediator photon
-cases; the repaired value reproduces Task 2's oracle. The endpoint
+**Deliverable / gate:** Declared deltas on all **7** cases the A2 row of
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+names — `spectra.photon.muon`, `spectra.photon.charged_pion`,
+`spectra.photon.charged_rho`, `spectra.photon.neutral_rho`,
+`mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum`,
+`mediator_spectra.vector.photon.dnde_decay_v`, and
+`mediator_spectra.vector.photon.dnde_decay_v_pt`. The `_pt` variants are
+separate corpus cases and are exactly what a "both mediators"
+enumeration drops; the count is the check. The repaired value reproduces
+Task 2's oracle. The endpoint
 invariant that Task 4.3 wrote —
 `the_in_flight_form_is_the_boost_integral_of_the_rest_frame_form` —
 must still hold, and now holds over the extra 0.25 MeV.
@@ -347,8 +359,14 @@ scipy's own convergence verdict rather than picking one tolerance —
 `projects/cython-to-rust/task-notes/README.md` records that lesson from
 this exact kernel, and PR #68's two CI rounds are why.
 
-**Deliverable / gate:** Declared deltas on `spectra.photon.charged_pion`,
-both rho cases and both mediator photon cases. The specific figure the
+**Deliverable / gate:** Declared deltas on all **6** cases the A3 row of
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+names — `spectra.photon.charged_pion`, `spectra.photon.charged_rho`,
+`spectra.photon.neutral_rho`, and the same three mediator photon cases
+Task 7 lists. A3 is a strict subset of A2, so every case here is one
+Task 7 has already opened, and `rules.md` rule 7's no-overlap
+requirement binds on *positions* rather than on cases. The specific
+figure the
 follow-up pins: `dnde_photon_charged_pion(900, 1396)` moves from `0.0` to
 `3.586e-07` MeV⁻¹. A test that no stored zero in that case survives
 repair *except* the ones outside the kinematic support — the difference
@@ -367,13 +385,14 @@ of the rho-touching tasks because Tasks 7 and 8 also move those arrays;
 the branch fires only at `E_ρ == m_ρ` exactly, so its declared positions
 are disjoint from theirs and the two deltas must be shown not to overlap.
 
-**Deliverable / gate:** Declared delta on the `rest` block of
-`spectra.photon.charged_rho` and `spectra.photon.neutral_rho`, and
-nowhere else — the guard `E_ρ − m_ρ < DBL_EPSILON` is absolute and one
-ulp at 775.26 MeV is 1.14e-13, about 500× `DBL_EPSILON`, so no other
-double reaches it and a delta declared on any other block is a bug in the
-declaration. The ratio to the stored value is `E_γ` at every declared
-position, exactly.
+**Deliverable / gate:** Declared delta on the **2** cases the B3 row of
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+names — the `rest` block of `spectra.photon.charged_rho` and of
+`spectra.photon.neutral_rho` — and nowhere else. The guard
+`E_ρ − m_ρ < DBL_EPSILON` is absolute and one ulp at 775.26 MeV is
+1.14e-13, about 500× `DBL_EPSILON`, so no other double reaches it, and a
+delta declared on any other block is a bug in the declaration. The ratio
+to the stored value is `E_γ` at every declared position, exactly.
 
 ### Task 10: Repair A4 — the muon positron normalization
 
@@ -381,12 +400,19 @@ position, exactly.
 
 **Scope / implementation notes:** `rust/src/kernels/positron_muon.rs`.
 Independent of Tasks 4–9 — a separate branch of the composition graph —
-so it may run in parallel with them. Blast radius is
-`spectra.positron.muon`, `spectra.positron.charged_pion` and both
-mediator positron cases.
+so it may run in parallel with them — A4's radius is disjoint from every
+other defect's, which is what makes that safe.
 
-**Deliverable / gate:** Declared deltas on those four cases; the repaired
-value reproduces Task 2's oracle. The analytic normalization test that
+**Deliverable / gate:** Declared deltas on all **6** cases the A4 row of
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+names — `spectra.positron.muon`, `spectra.positron.charged_pion`,
+`mediator_spectra.scalar.positron.dnde_decay_s`,
+`mediator_spectra.scalar.positron.dnde_decay_s_pt`,
+`mediator_spectra.vector.positron.dnde_decay_v`, and
+`mediator_spectra.vector.positron.dnde_decay_v_pt`. Four mediator cases,
+not two: each mediator ships both a `dnde_decay_*` and a
+`dnde_decay_*_pt` entry point. The repaired value reproduces Task 2's
+oracle. The analytic normalization test that
 found the defect (Task 4.1's) now passes against the corrected constant
 rather than recording the inversion, and the Michel spectrum integrates
 to 1 over its support to a stated tolerance.

--- a/projects/parity-pinned-defect-repair/adrs/_template.md
+++ b/projects/parity-pinned-defect-repair/adrs/_template.md
@@ -1,0 +1,32 @@
+# ADR XXXX: <Short, imperative title>
+
+**Date:** <YYYY-MM-DD>
+**Status:** <Proposed | Accepted | Superseded by ADR-YYYY>
+**Scope:** Project-scoped (applies only within `projects/<this-slug>/`).
+
+<!--
+If this decision turns out to apply repo-wide, re-file it under
+`docs/adrs/` with a new repo-wide number, and replace this file's body
+with a one-line pointer to the new ADR.
+-->
+
+## Context
+
+<Describe the technical situation objectively. What was the original
+plan or assumption within this project? What constraint, edge case, or
+system limitation was discovered that makes the original approach
+unworkable or newly necessary?>
+
+## Decision
+
+<State the specific architectural or contractual change being made to
+resolve the issue described in the Context.>
+
+## Consequences
+
+<List the downstream effects of this decision, scoped to this project.>
+
+- **Positive:** <What benefits or safety guarantees does this provide?>
+- **Negative:** <What are the tradeoffs, performance hits, or new
+  limitations?>
+- **Mitigation:** <How will we handle the negative consequences?>

--- a/projects/parity-pinned-defect-repair/learnings/_template.md
+++ b/projects/parity-pinned-defect-repair/learnings/_template.md
@@ -1,0 +1,55 @@
+# <Phase X | Project> Learnings: <Name>
+
+<!--
+For phased projects, create one learnings file per phase when the phase
+closes: `phase-XX-<slug>.md`.
+
+For flat projects, create one retrospective when the project wraps up:
+`project-retrospective.md` (or similar).
+
+Learnings are durable memory for future work that touches the same
+area — not a status log. Synthesize from task notes; don't just copy
+them.
+-->
+
+## 1. Implementation Reality Check
+
+<Summarize how execution matched or diverged from the plan. Link to any
+ADRs generated during this phase or project.>
+
+## 2. Critical Context for Future Work
+
+<List types, variable names, invariants, or internal API boundaries
+established here that future tasks should respect.>
+
+- <Rule or contract 1>
+
+## 3. Quirk Log & Edge Cases
+
+<Document language-level fights, dependency quirks, or specification
+ambiguities resolved here, so future work doesn't repeat the same
+mistakes.>
+
+- <Quirk 1>
+
+## 4. Test Infrastructure State
+
+<Note new test harnesses, fixtures, mocks, or specific commands
+established here that should be reused.>
+
+- <Testing tool or standard 1>
+
+## 5. Follow-on seeds
+
+<List substantive deferred items the project surfaced — work that's
+out of scope here but worth picking up later. Each seed gets one or
+two paragraphs explaining what it is, what triggers it, and which
+files / facets / ADRs are involved.
+
+For every seed, also drop a stub in `../../../docs/followups/` (one
+file per seed; from `projects/<slug>/learnings/` that resolves to
+the repo's `docs/followups/`). The retrospective entry is the
+historical record; the followup file is the live actionable form.
+See `../../../docs/workflow.md#follow-ups` for the lifecycle.>
+
+- <Seed 1>

--- a/projects/parity-pinned-defect-repair/references/_template.md
+++ b/projects/parity-pinned-defect-repair/references/_template.md
@@ -1,0 +1,29 @@
+# Reference: <topic>
+
+**Audience:** <which tasks should load this — e.g. "Tasks 4, 5, 6"
+or "any task that touches the boost integrals">.
+**Nature:** <one of: Spec | Checklist | How-to | Grounded facts>.
+
+<!--
+This is an OPTIONAL per-project artifact. Use it when:
+
+- `PLAN.md`'s Task Details blocks would otherwise balloon with
+  mapping tables, code-path inventories, or checklists that several
+  tasks share.
+- You want to move grounded-facts content (line numbers, call graphs,
+  file paths) out of `PLAN.md` so the plan stays scan-friendly.
+
+Guidelines:
+
+- Keep the PLAN canonical. A reference enriches but never replaces
+  a Task Details block.
+- Name the file by topic, not by task number. Tasks cite the topic.
+- Start each reference with the Audience + Nature header above so
+  an agent can skim the top and decide whether to load it.
+
+See `docs/workflow.md#references-references` for the full pattern.
+-->
+
+## <Section>
+
+<Content.>

--- a/projects/parity-pinned-defect-repair/references/corpus-repinning.md
+++ b/projects/parity-pinned-defect-repair/references/corpus-repinning.md
@@ -1,0 +1,177 @@
+# Corpus re-pinning without losing the evidence
+
+**Audience:** Tasks 1, 2, 3, and every repair task (4–10).
+**Nature:** Spec — the delta-declaration mechanism, the oracle capture
+protocol, and the proof obligations each repair inherits.
+
+## The problem in one paragraph
+
+`test/parity/data/*.npz` holds 179,695 values captured from pre-port
+Cython at kernel digest `f5e6e269be47`. Seven of the numbers in there are
+wrong, and the corpus is the gate that keeps the Rust port faithful to
+them. The obvious move — regenerate — is barred three ways: by
+`projects/cython-to-rust/rules.md` rule 2, by
+`test/parity/cases.py`'s `assert_no_rust_core` (which already refuses,
+since Phase 04 serves the photon family), and by arithmetic — after
+Phase 06 Task 6.4 there is no non-Rust implementation left to generate
+from. The less obvious move — re-pin the affected arrays in place — is
+worse: it destroys the record of what 2.1.0 shipped, which is the only
+thing that lets anyone later ask "did this repair move what it claimed?"
+
+## The mechanism
+
+**The committed arrays are never rewritten.** A repair is expressed as a
+*declaration* that named positions of named arrays now differ from what
+is stored, in a named way.
+
+### Declaration schema
+
+`test/parity/deltas.py`, keyed the same way
+`test/parity/stability.py`'s `PORTABILITY_ZEROS` is keyed — by
+`(case_name, block_label, array_suffix)`, so the key needs no mapping to
+be usable by the runner:
+
+```python
+DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
+    ("spectra.photon.charged_rho", "rest", "values"): Delta(
+        repair="B3",                       # which task moved it
+        positions=ALL,                     # explicit tuple, or ALL
+        relation=Ratio(...),               # see "Relations" below
+        measured="ratio is E_gamma exactly at all 100 positions",
+        evidence="projects/.../task-9-rho-rest-frame.md",
+    ),
+}
+```
+
+Every field is load-bearing. `repair` is what makes an aggregate
+possible at close time without re-reading seven task notes; `measured`
+and `evidence` are what stop the table from becoming a list of
+assertions nobody re-derived.
+
+### Relations
+
+A declaration says how the repaired value relates to the stored one, not
+merely that it differs. In descending order of strength — prefer the
+strongest the physics supports:
+
+| Relation | Use when | Example |
+| --- | --- | --- |
+| `Exact(f)` | the delta is a closed-form transform of the stored array | rho `rest`: repaired == stored × `E_γ` |
+| `Oracle(path)` | a Task 2 capture holds the corrected value | all four Group A repairs |
+| `Additive(term)` | the delta is a computable additive term | η′: `+ BR · boost_delta_function(M/2, …)` |
+| `Bounded(lo, hi, sign)` | only a magnitude and a sign are known | fallback; requires a written justification |
+
+`Bounded` is the escape hatch and should be rare. A repair that can only
+say "it got bigger" has not been characterized, and
+`docs/agents/lessons.md` `[exemption-wider-than-its-mechanism]` is about
+exactly this: a carve-out written wider than the mechanism that earned it
+only ever loosens, so nothing turns red when it is wrong.
+
+### How the runner uses it
+
+`test/parity/test_parity.py`, after it has selected a budget and applied
+the `stability.py` masks:
+
+1. Position is **not** declared → compare against the original stored
+   value under the existing `test/parity/tolerances.py` budget.
+   Unchanged behavior, and this is the bulk of the corpus.
+2. Position **is** declared → compare against the declared relation.
+3. A declared position whose repaired value equals the stored value →
+   **fail**. A declaration that no longer describes a real change is
+   stale, and a stale declaration is a hole in the gate.
+
+Rule 3 is what makes the layer self-cleaning. Without it, a reverted
+repair passes.
+
+### Shape tests (Task 1)
+
+The declaration table is data, so it needs its own gate:
+
+- Every key resolves to a case, block and array the corpus contains.
+- Every position index is in range for that array.
+- No two declarations claim the same position (two repairs touching one
+  array declare disjoint position sets, or one composite declaration —
+  never two overlapping ones; see the rho case in `PLAN.md` Task 9).
+- `repair` values are drawn from the closed set of task ids.
+
+## The oracle capture protocol (Task 2)
+
+The four Group A twins are `cdef`-only — no top-level `def` — so they are
+reachable from Python solely through `__pyx_capi__` capsules.
+`test/test_core_boost.py` already drives `hazma._utils.boost` that way
+against the Rust port; reuse that harness rather than inventing a second
+one.
+
+The protocol, per defect:
+
+1. **Snapshot outside the tree.** `git checkout --` cannot revert a file
+   git has never seen, and a mutation harness that does not verify its
+   own restore accumulates edits while reporting independent
+   measurements — `[mutation-harness-poisons-its-own-baseline]`, hit
+   twice in `cython-to-rust`. Snapshot, `cmp` before each step, verify
+   the restore.
+2. **Patch the `.pyx`, rebuild with `pip install -e .`.** `cargo build`
+   is not a rebuild for anything Python imports, and neither is an
+   un-rebuilt Cython edit — `AGENTS.md` says both. Confirm with
+   `python -c "import hazma; print(hazma.__file__)"` landing inside the
+   worktree.
+3. **Capture on the corpus's capturing platform.** Read it from
+   `test/parity/data/manifest.json`; do not probe for it
+   (`[platform-scoped-oracle-asserted-globally]`). A capture taken
+   somewhere else is a measurement of a different libm.
+4. **Capture the whole composition chain**, not just the defective
+   function — see `defect-blast-radius.md`. The chain is what dies at
+   Tasks 4.6 and 6.2/6.3, earlier than the twin itself.
+5. **Record provenance the way the corpus does**: a digest over the
+   *patched* sources, the platform, the resolved `hazma` package path,
+   and the numpy/scipy/cython versions. Recording the resolved path is
+   what keeps a past capture auditable rather than only a future one
+   guarded (`[measured-tree-vs-imported-module]`).
+6. **Revert, rebuild, verify `git diff -- hazma` is empty** on the final
+   tree. Task 2 ships no library behavior.
+
+### Why this is not circular
+
+The corrected value comes from a source tree and a compiler that predate
+the Rust port, driven through an FFI boundary the port does not use. It
+is the same class of evidence the corpus itself is: an independent
+implementation, pinned. What it is *not* is a proof that the physics is
+right — that is what the analytic checks in each repair task's gate are
+for. Two independent wrong implementations agreeing would still be
+wrong, which is why every repair task's gate names a physics invariant
+(a yield, a unit, an endpoint, a normalization) alongside the oracle
+comparison.
+
+## Proof obligations every repair inherits
+
+A repair task is not done until all five hold.
+
+1. **The declared delta is exhaustive.** Every position that moved is
+   declared; every undeclared position still matches the original stored
+   array under its existing budget. This is the "moved only what it
+   intended" proof, and it is a property of the gate rather than of a
+   claim in a task note.
+2. **The declaration is minimal.** Reverting the repair fails the
+   declared-delta assertion (schema rule 3 above). Widening the
+   declaration by one position fails a shape test. Run both as
+   mutations; do not argue them.
+3. **An independent oracle agrees.** Group A: the Task 2 Cython capture.
+   Group B: the closed form, and where it is analytic an `mpmath`
+   reference in the shape of `test/parity/reference.py`.
+4. **A physics invariant holds.** Named per defect in `PLAN.md`'s task
+   gates — a yield in photons per decay, a unit, an endpoint, a
+   normalization integral. This is what a corpus comparison cannot give
+   you.
+5. **The second gate stays green.** `test/test_theory_aggregation.py`
+   pins the pure-Python aggregation as identities (`total` is the channel
+   sum, a spectrum is `bf × kernel`). A repair that moves a kernel must
+   not move an identity.
+
+## Whole-corpus accounting
+
+At close, one number: how many of the corpus's 179,695 pinned values are
+under a declaration. Derive it with a command and paste the command
+(`[derived-count-not-rederived]`), broken out per repair so the parts
+sum (`[measurement-taken-before-the-task-ended]`). If the total is
+larger than the sum of the seven per-repair figures, two declarations
+overlap and the shape test missed it.

--- a/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
+++ b/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
@@ -61,22 +61,111 @@ Two facts the graph makes easy to get wrong:
 
 ## Per-defect blast radius
 
-Case names are `test/parity/data/manifest.json` keys.
+Case names are `test/parity/data/manifest.json` keys, written out in
+full rather than brace-elided. **This is the canonical enumeration** —
+`PLAN.md`'s per-task gates quote it, and any disagreement between the
+two is resolved here, then swept into the plan. The brace shorthand this
+table used to carry is what let `PLAN.md` say "both mediator photon
+cases" against a population of three (PR #72 review).
 
-| Defect | Corpus cases predicted to move | Blocks |
-| --- | --- | --- |
-| A1 boost window | `spectra.photon.{eta, eta_prime, omega, phi, charged_kaon, long_kaon, short_kaon}` | all boosted blocks; whether `rest` moves depends on whether the integral runs at β = 0 — **measure it** |
-| A2 photon-muon endpoint | `spectra.photon.{muon, charged_pion, charged_rho, neutral_rho}`, `mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum`, `mediator_spectra.vector.photon.{dnde_decay_v, dnde_decay_v_pt}` | all; the moved region is the last 0.25 MeV below the endpoint in the muon rest frame, smeared by each boost |
-| A3 charged-pion forward cone | `spectra.photon.{charged_pion, charged_rho, neutral_rho}`, the same three `mediator_spectra.*.photon` cases | all; concentrated in the boosted blocks, where the window narrows past QUADPACK's largest first-rule abscissa |
-| A4 positron-muon normalization | `spectra.positron.{muon, charged_pion}`, `mediator_spectra.scalar.positron.{dnde_decay_s, dnde_decay_s_pt}`, `mediator_spectra.vector.positron.{dnde_decay_v, dnde_decay_v_pt}` | all blocks, every non-zero position — it is an overall factor |
-| B1 η′ line weight | `spectra.photon.eta_prime` | all blocks, at the line's image only |
-| B2 φ line energies | `spectra.photon.phi` | all blocks, at both lines' images only |
-| B3 rho rest-frame branch | `spectra.photon.{charged_rho, neutral_rho}` | `rest` **only** — the guard `E_ρ − m_ρ < DBL_EPSILON` is absolute and one ulp at 775.26 MeV is 1.14e-13, ~500× `DBL_EPSILON` |
+Counts are derived, not typed:
+
+```sh
+python3 -c "import json; m=json.load(open('test/parity/data/manifest.json')); \
+  print(sum(1 for n in m['cases'] if n.startswith('mediator_spectra') and '.photon.' in n))"
+```
+
+### A1 — boost integral window (7 cases)
+
+`spectra.photon.eta`, `spectra.photon.eta_prime`,
+`spectra.photon.omega`, `spectra.photon.phi`,
+`spectra.photon.charged_kaon`, `spectra.photon.long_kaon`,
+`spectra.photon.short_kaon`.
+
+Blocks: all boosted blocks. Whether `rest` moves depends on whether the
+integral runs at β = 0 — **measure it**, do not assume.
+
+### A2 — muon photon rest-frame endpoint (7 cases)
+
+`spectra.photon.muon`, `spectra.photon.charged_pion`,
+`spectra.photon.charged_rho`, `spectra.photon.neutral_rho`,
+`mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum`,
+`mediator_spectra.vector.photon.dnde_decay_v`,
+`mediator_spectra.vector.photon.dnde_decay_v_pt`.
+
+Blocks: all. The moved region is the last 0.25 MeV below the endpoint in
+the muon rest frame, smeared by each boost.
+
+### A3 — charged-pion forward cone (6 cases)
+
+`spectra.photon.charged_pion`, `spectra.photon.charged_rho`,
+`spectra.photon.neutral_rho`, and the same three mediator photon cases
+A2 names —
+`mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum`,
+`mediator_spectra.vector.photon.dnde_decay_v`,
+`mediator_spectra.vector.photon.dnde_decay_v_pt`.
+
+Blocks: all, concentrated in the boosted ones, where the window narrows
+past QUADPACK's largest first-rule abscissa.
+
+### A4 — positron-muon normalization (6 cases)
+
+`spectra.positron.muon`, `spectra.positron.charged_pion`,
+`mediator_spectra.scalar.positron.dnde_decay_s`,
+`mediator_spectra.scalar.positron.dnde_decay_s_pt`,
+`mediator_spectra.vector.positron.dnde_decay_v`,
+`mediator_spectra.vector.positron.dnde_decay_v_pt`.
+
+Blocks: all, every non-zero position — it is an overall factor.
+
+### B1 — η′ line weight (1 case)
+
+`spectra.photon.eta_prime`. All blocks, at the line's image only.
+
+### B2 — φ line energies (1 case)
+
+`spectra.photon.phi`. All blocks, at both lines' images only.
+
+### B3 — rho rest-frame branch (2 cases)
+
+`spectra.photon.charged_rho`, `spectra.photon.neutral_rho` — the `rest`
+block **only**. The guard `E_ρ − m_ρ < DBL_EPSILON` is absolute and one
+ulp at 775.26 MeV is 1.14e-13, ~500× `DBL_EPSILON`, so no other double
+reaches it.
+
+### The defects, and which group each is in
+
+Group A still has a live Cython twin and is on the clock for its oracle
+capture; Group B does not, and has no ordering constraint at all.
+
+| # | Defect | Follow-up | Twin | Serving kernel |
+| --- | --- | --- | --- | --- |
+| A1 | Boost integral mis-covers its window at both ends | [`boost-integral-drops-last-interior-cell.md`](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md) | `hazma/_utils/boost.pyx` (live) | `rust/src/boost.rs` |
+| A2 | Muon photon rest-frame branch stops short of the endpoint | [`photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md`](../../../docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md) | `hazma/spectra/_photon/_muon.pyx` (live) | `rust/src/kernels/photon_muon.rs` |
+| A3 | Charged-pion photon spectrum returns zero in the forward cone | [`charged-pion-photon-spectrum-misses-the-forward-cone.md`](../../../docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md) | `hazma/spectra/_photon/_pion.pyx` (live) | `rust/src/kernels/photon_pion.rs` |
+| A4 | Muon positron spectrum divides by its normalization | [`positron-muon-spectrum-normalization-inverted.md`](../../../docs/followups/todo/positron-muon-spectrum-normalization-inverted.md) | `hazma/spectra/_positron/_muon.pyx` (live) | `rust/src/kernels/positron_muon.rs` |
+| B1 | η′ two-photon line missing its factor of two | [`eta-prime-two-photon-line-missing-factor-two.md`](../../../docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
+| B2 | φ photon lines use the daughter meson's energy | [`phi-photon-lines-use-the-daughter-meson-energy.md`](../../../docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
+| B3 | Both rho spectra return the boost integrand at rest | [`rho-rest-frame-branch-returns-the-integrand.md`](../../../docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md) | deleted, Task 4.5 | `rust/src/kernels/photon_rho.rs` |
 
 ## Coverage arithmetic
 
-The corpus has 41 cases. Union of the rows above: **20**. Predicted
-untouched: **21** — the 18 `cross_sections.*`, the 2 `spectra.neutrino.*`
+The corpus has 41 cases. The rows above name 7 + 7 + 6 + 6 + 1 + 1 + 2
+= **30 case slots** across seven defects, but four of the seven sets are
+wholly contained in another — derived, not eyeballed:
+
+```text
+A3 ⊆ A2   B3 ⊆ A2   B1 ⊆ A1   B2 ⊆ A1     and A1, A2, A4 are pairwise disjoint
+```
+
+So the union is exactly `|A1| + |A2| + |A4|` = 7 + 7 + 6 = **20**.
+Two consequences worth carrying into the tasks. Every case A3 touches,
+A2 touches first — so Task 8 declares nothing on a case Task 7 has not
+already opened, and `rules.md` rule 7's no-overlap requirement binds on
+*positions* there rather than on cases. And A4 is disjoint from
+everything else, which is what makes Task 10 safe to run in parallel.
+
+Predicted untouched: **21** — the 18 `cross_sections.*`, the 2 `spectra.neutrino.*`
 (no defect on their path; they use `boost_delta_function`, not the
 interpolating integral), and `spectra.photon.neutral_pion` (the π⁰ → γγ
 box reaches neither the muon kernel nor the boost integral). 20 + 21 = 41.

--- a/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
+++ b/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
@@ -1,0 +1,102 @@
+# Which corpus cases each defect reaches
+
+**Audience:** Task 2 (what to capture) and Tasks 4–10 (what to declare).
+**Nature:** Grounded facts, derived 2026-08-19 at `3e01590`.
+
+**This table is a prediction, not a measurement.** It is derived from the
+composition graph below plus the committed manifest, and it exists so a
+repair task knows what to *look* at — not so it can skip looking. Every
+repair task re-derives its own row by running the repaired kernel over
+the whole corpus and seeing what moved. A case this table omits that
+turns out to move is a finding about the graph, not a tolerance to widen.
+
+## The composition graph
+
+Cython, from `grep -rn cimport hazma/` on this tree:
+
+```text
+hazma/_utils/boost.pyx
+  ├── hazma/spectra/_photon/_pion.pyx        (boost_beta, boost_gamma)
+  ├── hazma/spectra/_positron/_muon.pyx      (boost_beta, boost_gamma)
+  ├── hazma/spectra/_positron/_pion.pyx      (+ boost_delta_function)
+  └── hazma/spectra/_neutrino/_pion.pyx      (+ boost_delta_function)
+
+hazma/spectra/_photon/_muon.pyx
+  ├── hazma/spectra/_photon/_pion.pyx
+  ├── hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx
+  └── hazma/vector_mediator/vector_mediator_decay_spectrum.pyx
+
+hazma/spectra/_photon/_pion.pyx
+  ├── hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx
+  └── hazma/vector_mediator/vector_mediator_decay_spectrum.pyx
+
+hazma/spectra/_positron/_muon.pyx
+  ├── hazma/spectra/_positron/_pion.pyx
+  ├── hazma/scalar_mediator/scalar_mediator_positron_spec.pyx
+  └── hazma/vector_mediator/vector_mediator_positron_spec.pyx
+```
+
+Rust, from each kernel module's own call-site table:
+
+```text
+rust/src/boost.rs::boost_integrate_linear_interp
+  └── rust/src/kernels/photon_tables.rs   (the only consumer)
+
+rust/src/kernels/photon_muon.rs
+  └── rust/src/kernels/photon_pion.rs
+        └── rust/src/kernels/photon_rho.rs   (nested quadrature)
+```
+
+Two facts the graph makes easy to get wrong:
+
+- `boost_integrate_linear_interp` is reached **only** by the seven
+  tabulated photon spectra. It is not on the muon, pion, rho, positron
+  or neutrino paths — those use `boost_beta` / `boost_gamma` /
+  `boost_delta_function`, which this project does not touch. So the
+  boost-window repair does *not* move the mediator spectra.
+- The rho spectra reach the muon kernel *through* the charged pion, so
+  A2 and A3 both move both rho cases. Their declared positions will
+  overlap and must be handled as one composite declaration or as two
+  provably disjoint ones.
+
+## Per-defect blast radius
+
+Case names are `test/parity/data/manifest.json` keys.
+
+| Defect | Corpus cases predicted to move | Blocks |
+| --- | --- | --- |
+| A1 boost window | `spectra.photon.{eta, eta_prime, omega, phi, charged_kaon, long_kaon, short_kaon}` | all boosted blocks; whether `rest` moves depends on whether the integral runs at β = 0 — **measure it** |
+| A2 photon-muon endpoint | `spectra.photon.{muon, charged_pion, charged_rho, neutral_rho}`, `mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum`, `mediator_spectra.vector.photon.{dnde_decay_v, dnde_decay_v_pt}` | all; the moved region is the last 0.25 MeV below the endpoint in the muon rest frame, smeared by each boost |
+| A3 charged-pion forward cone | `spectra.photon.{charged_pion, charged_rho, neutral_rho}`, the same three `mediator_spectra.*.photon` cases | all; concentrated in the boosted blocks, where the window narrows past QUADPACK's largest first-rule abscissa |
+| A4 positron-muon normalization | `spectra.positron.{muon, charged_pion}`, `mediator_spectra.scalar.positron.{dnde_decay_s, dnde_decay_s_pt}`, `mediator_spectra.vector.positron.{dnde_decay_v, dnde_decay_v_pt}` | all blocks, every non-zero position — it is an overall factor |
+| B1 η′ line weight | `spectra.photon.eta_prime` | all blocks, at the line's image only |
+| B2 φ line energies | `spectra.photon.phi` | all blocks, at both lines' images only |
+| B3 rho rest-frame branch | `spectra.photon.{charged_rho, neutral_rho}` | `rest` **only** — the guard `E_ρ − m_ρ < DBL_EPSILON` is absolute and one ulp at 775.26 MeV is 1.14e-13, ~500× `DBL_EPSILON` |
+
+## Coverage arithmetic
+
+The corpus has 41 cases. Union of the rows above: **20**. Predicted
+untouched: **21** — the 18 `cross_sections.*`, the 2 `spectra.neutrino.*`
+(no defect on their path; they use `boost_delta_function`, not the
+interpolating integral), and `spectra.photon.neutral_pion` (the π⁰ → γγ
+box reaches neither the muon kernel nor the boost integral). 20 + 21 = 41.
+
+That arithmetic is the cheapest check on this file: if a repair task's
+measured radius changes any row, redo the sum and make it come out to 41
+again rather than patching one cell.
+
+## The deletion schedule this radius has to beat
+
+From `projects/cython-to-rust/phases/phase-04-spectra-kernels.md` Task
+4.6 and `phase-06-mediator-spectra.md` Tasks 6.2–6.4:
+
+| Task | Deletes | Group A capture it strands |
+| --- | --- | --- |
+| 4.6 | `hazma/spectra/_positron/_pion.pyx`, the neutrino pair | A4's `spectra.positron.charged_pion` |
+| 6.2 | the two mediator decay spectrum `.pyx` | A2's and A3's three `mediator_spectra.*.photon` cases |
+| 6.3 | the two mediator positron spectrum `.pyx` | A4's four `mediator_spectra.*.positron` cases |
+| 6.4 | `hazma/spectra/_photon/{_muon,_pion}.pyx`, `hazma/spectra/_positron/_muon.pyx`, `hazma/_utils/boost.{pyx,pxd}` | everything remaining in A1–A4 |
+
+Task 4.6 is the only task left in Phase 04, so the first of these
+windows is the one closing soonest. Nothing in Group B appears in this
+table — that is what "corpus re-pinning only" means for B1–B3.

--- a/projects/parity-pinned-defect-repair/references/the-premise.md
+++ b/projects/parity-pinned-defect-repair/references/the-premise.md
@@ -1,0 +1,124 @@
+# The sequencing premise, verified
+
+**Audience:** anyone reading `PLAN.md`'s "The premise this project
+corrects", and Task 11 (which sweeps the superseded copies).
+**Nature:** Grounded facts. Every claim carries the command that
+produced it, run on this tree at `3e01590` on 2026-08-19.
+
+## What the seven follow-ups said
+
+Each carried some form of *"blocked until after `cython-to-rust`
+Phase 06 Task 6.4"*, on the reasoning that the parity corpus pins the
+shipped-but-wrong values by construction, so a repair fails the gate
+that governs the remaining kernel swaps, and the fix therefore needs a
+declared corpus regeneration that `projects/cython-to-rust/rules.md`
+rule 2 forbids until the port is done.
+
+The premise is right. The conclusion inverts the causality: Task 6.4 is
+not the task that *unblocks* re-pinning, it is the task that *destroys
+the ability to re-pin*.
+
+## Claim by claim
+
+### 1. Four of the seven defects still have a live Cython twin
+
+```sh
+find hazma -name "*.pyx" -o -name "*.pxd" | sort
+```
+
+Present, among others: `hazma/spectra/_photon/_pion.pyx`,
+`hazma/spectra/_photon/_muon.pyx`, `hazma/spectra/_positron/_muon.pyx`,
+`hazma/_utils/boost.pyx` — the twins of the charged-pion forward cone,
+the muon photon endpoint, the positron-muon normalization and the boost
+integral window respectively.
+
+### 2. Three do not
+
+```sh
+git log --diff-filter=D --name-only --oneline --all \
+    -- 'hazma/spectra/_photon/*.pyx' 'hazma/spectra/_positron/*.pyx'
+```
+
+`hazma/spectra/_photon/_eta_prime.pyx` and
+`hazma/spectra/_photon/_phi.pyx` were deleted in `0954e5a`
+("feat(spectra): port the tabulated photon spectra to rust", Task 4.2);
+`hazma/spectra/_photon/_rho.pyx` in `b5f7f90` ("feat(spectra): port the
+rho photon spectra to rust", Task 4.5). Each went in the same PR as its
+swap, per `projects/cython-to-rust/rules.md` rule 1's no-drift-window
+requirement.
+
+The sources are still recoverable for review —
+`git show 665aed5:hazma/spectra/_photon/_eta_prime.pyx` and
+`git show b5f7f90^:hazma/spectra/_photon/_rho.pyx` both resolve — but a
+historical blob is not a *runnable* oracle without reconstructing the
+build it was compiled by, which is a different and much larger job than
+calling a twin that is still in the tree.
+
+### 3. Task 6.4 deletes exactly the four live twins
+
+`projects/cython-to-rust/phases/phase-06-mediator-spectra.md`, Task 6.4
+exit criteria, verbatim in substance: delete the four capi-survivor
+extensions (`_photon/_muon`, `_photon/_pion`, `_positron/_muon`,
+`_positron/_pion` `.pyx` + `.pxd`), `hazma/_utils/boost.{pyx,pxd}`,
+`constants.pxd`, `kinematics.pxd`, `legacy_parameters.pxd`, and the
+`spectra/_neutrino/_neutrino` struct module — after which
+`find hazma -name "*.pyx" -o -name "*.pxd"` returns nothing.
+
+### 4. A whole-corpus regeneration is *already* impossible
+
+`test/parity/generate.py`'s `generate()` calls
+`corpus.assert_no_rust_core()` before it evaluates anything, and
+`test/parity/cases.py`'s implementation raises as soon as
+`rust_core_kernels()` is non-empty — that is, as soon as `hazma._core`
+*serves* a kernel, which it has since Phase 04 Task 4.1 (2026-08-11)
+swapped `dnde_positron_muon` — the project's own walking skeleton, and
+the first repointed wrapper of the port.
+
+This is the load-bearing correction. Five of the seven follow-ups
+proposed "one declared regeneration after Phase 06 Task 6.4, not four"
+as the cheap path. That path has not existed since 2026-08-11, and after
+Task 6.4 it could only be reopened by relaxing the very guard rule 2
+asks for. The mechanism this project builds instead — declare the delta,
+keep the array — is not a workaround for a scheduling problem; it is the
+only shape a repair can take.
+
+### 5. The twins are `cdef`-only, so the oracle route is `__pyx_capi__`
+
+```sh
+grep -n "^def \|^cdef .*(" hazma/spectra/_photon/_pion.pyx \
+    hazma/spectra/_photon/_muon.pyx hazma/spectra/_positron/_muon.pyx \
+    hazma/_utils/boost.pyx
+```
+
+Zero top-level `def`s across all four; every entry is `cdef`. They
+survive to Task 6.4 solely because the mediator spectrum `.pyx` still
+`cimport` their `__pyx_capi__` symbols. `test/test_core_boost.py`
+already drives `hazma._utils.boost` through those capsules as an oracle
+for the Rust port, which is the existing precedent Task 2 reuses.
+
+### 6. The deadline is three dates, not one
+
+A corrected corpus value has to be reachable through the *whole* Cython
+composition chain, and the chain dies before the twin does. From
+`projects/cython-to-rust/phases/phase-04-spectra-kernels.md` Task 4.6
+and `phase-06-mediator-spectra.md` Tasks 6.2–6.4 — see
+[`defect-blast-radius.md`](defect-blast-radius.md) for the per-defect
+mapping. Task 4.6 is the only Phase 04 task still open
+(`projects/cython-to-rust/task-notes/README.md` Phases table), so the
+first window is the one closing soonest.
+
+## What this does *not* claim
+
+- It does not claim the Cython twins are *correct*. They are the
+  implementation the defects were found in. What they provide is an
+  **independent** implementation, which is a different property, and
+  it is why `rules.md` rule 4 requires a physics invariant alongside
+  every oracle comparison.
+- It does not claim the three twin-less defects are harder. They are
+  easier: each has a closed-form delta (`PLAN.md` Task 3), which is why
+  their corrected follow-up wording is "corpus re-pinning only" rather
+  than a deadline.
+- It does not claim `cython-to-rust` erred. The port preserved these
+  defects deliberately, under its own rule 1, and filed every one of
+  them. The error is in the follow-ups' sequencing conclusion, drawn
+  once and then copied across seven files.

--- a/projects/parity-pinned-defect-repair/rules.md
+++ b/projects/parity-pinned-defect-repair/rules.md
@@ -1,0 +1,77 @@
+# parity-pinned-defect-repair — Cross-Cutting Rules
+
+Rules every task in this project must follow. Repo-wide invariants
+(the preflight gate, PR conventions, versioning) are not restated here —
+see `AGENTS.md` and `docs/agents/`. The `cython-to-rust` project's own
+rules (`projects/cython-to-rust/rules.md`) still bind everything this
+project touches; nothing below relaxes them.
+
+## Rules
+
+One flat scheme, cited as "rule N" from `PLAN.md`, the references
+and the task notes. There is no per-section numbering to reconcile.
+
+1. **The committed corpus arrays are never rewritten.**
+   `test/parity/data/*.npz` and `test/parity/data/manifest.json` are the
+   record of what 2.1.0 shipped. A repair declares a delta against them
+   (see `references/corpus-repinning.md`); it does not regenerate,
+   re-pin, or edit them. `git diff --stat -- test/parity/data` is empty
+   in every PR this project ships.
+
+2. **No tolerance is widened.** If a repaired value does not match its
+   declared relation, the declaration is wrong or the repair is — not
+   the budget. `projects/cython-to-rust/task-notes/README.md` records
+   two rounds of a `cython-to-rust` PR learning this the expensive way:
+   widening a budget until it passes is how a gate becomes vacuous.
+
+3. **Every repair carries an independent oracle.** Group A: the Task 2
+   Cython capture. Group B: the closed form, with an `mpmath` reference
+   in the shape of `test/parity/reference.py` where the form is
+   analytic. A repair verified only against the implementation being
+   repaired is not verified.
+
+4. **Every repair carries a physics invariant too.** A yield in photons
+   per decay, a unit, an endpoint, a normalization integral — something
+   a corpus comparison cannot give you. Two independent implementations
+   agreeing on a wrong number is the failure mode this rule exists for.
+
+5. **A declaration is an allowlist, not a rule over a shape.** Name the
+   positions the mechanism actually reaches, with the measurement beside
+   the row. A carve-out written wider than its mechanism only ever
+   loosens, so nothing turns red when it is wrong —
+   `docs/agents/lessons.md` `[exemption-wider-than-its-mechanism]`.
+
+6. **A declaration that describes no change fails.** Reverting a repair
+   must turn the gate red. A stale declaration is a hole in the gate,
+   not a harmless leftover.
+
+7. **Declarations do not overlap.** Where two repairs move the same
+   array (A2 and A3 on both rho cases; A1 and B1/B2 on `eta_prime` and
+   `phi`), either the position sets are provably disjoint or the two
+   collapse into one composite declaration. A shape test enforces this.
+
+8. **Task 2 before the port's next deletion.** The oracle capture is the
+   only step with a hard external deadline —
+   `references/defect-blast-radius.md` has the schedule. If a window
+   closes before the capture, say which oracle was lost and what the
+   affected repair is now verified against instead. Do not proceed as
+   if nothing changed.
+
+9. **Primitives before their consumers.** A1 before B1/B2 (they share
+   the tabulated photon arrays); A2 before A3 before B3 (the rho quads
+   over the pion, which quads over the muon). A4 is a separate branch
+   and may run in parallel. Repairing a consumer first means measuring
+   its delta twice and reconciling two numbers that were both correct
+   when taken.
+
+10. **Every repair updates "Numerical impact so far" in
+    `task-notes/README.md` in its own PR**, with the function, the grid,
+    and the max shift — `projects/cython-to-rust/rules.md` rule 3, and
+    the same reason: Task 12 aggregates that section rather than
+    reconstructing it from memory at close time.
+
+11. **Re-derive every count after the last edit, and quote the command
+    next to the number.** Position counts, case counts, test counts. A
+    count measured correctly still goes stale if the task's own later
+    output changes what the command measures —
+    `[measurement-taken-before-the-task-ended]`.

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -138,6 +138,23 @@ the `CHANGELOG.md` entry — it does not reconstruct it.
   the correction and the plan that justifies it would land in one
   reviewable place first. Each corrected bullet says so and points here.
   Task 11 sweeps them.
+- **The Group A deadline binds on the oracle capture, not on the
+  repair** (PR #72 review round 1). The first draft of the four Group A
+  blocker bullets said "fix BEFORE Task 6.4", which reads as an
+  instruction to land the Cython fix, the Rust fix and the corpus change
+  together before the deletion — the thing this plan deliberately
+  decomposes. Under the delta mechanism the repair is legal on a tree
+  with ported kernels at any time; what cannot follow the deletion wave
+  is capturing the corrected values from the twin. The bullets now say
+  that, and point at Task 2 (capture) and the specific repair task
+  separately.
+- **`references/defect-blast-radius.md` is the canonical case
+  enumeration; `PLAN.md` quotes it by row** (same review). The reference
+  originally brace-elided its case lists, and the plan's gates then said
+  "both mediator photon cases" against a population of three and "both
+  mediator positron cases" against four — each mediator ships a
+  `dnde_decay_*` and a `dnde_decay_*_pt` entry point. Every list is now
+  written out with a count, and each repair gate names every case.
 
 ## Files Changed
 

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -1,0 +1,236 @@
+# Working Memory: Repair the parity-pinned numerical defects
+
+**Date:** 2026-08-19 (created)
+**Project:** parity-pinned-defect-repair
+**Status:** In Progress
+**Plan References:** `../PLAN.md` (all sections)
+**Related ADRs:** none yet — two anticipated, see `../PLAN.md`
+**Depends On:** none. **Constrains** `cython-to-rust` Tasks 4.6, 6.2,
+6.3 and 6.4 — see Open Questions.
+
+## Objective
+
+Track cumulative context and live task status across all twelve tasks so
+any agent picking up work mid-project has the facts, decisions and open
+questions needed to start without re-discovering them.
+
+## Tasks
+
+Canonical task *shape* lives in `../PLAN.md` under "Task Details". This
+section tracks live *status*.
+
+| # | Task | Depends on | Status | Task Note |
+|---|------|------------|--------|-----------|
+| 1 | Delta-declaration layer | — | Not started | `task-1-delta-declarations.md` |
+| 2 | Capture the corrected-value oracles | — | Not started | `task-2-cython-oracles.md` |
+| 3 | Closed-form delta models (B1–B3) | 1 | Not started | `task-3-closed-form-deltas.md` |
+| 4 | Repair A1 — boost integral window | 1, 2 | Not started | `task-4-boost-window.md` |
+| 5 | Repair B1 — η′ line weight | 3, 4 | Not started | `task-5-eta-prime-line.md` |
+| 6 | Repair B2 — φ line energies | 3, 4 | Not started | `task-6-phi-lines.md` |
+| 7 | Repair A2 — muon photon endpoint | 1, 2 | Not started | `task-7-photon-muon-endpoint.md` |
+| 8 | Repair A3 — charged-pion forward cone | 7 | Not started | `task-8-charged-pion-cone.md` |
+| 9 | Repair B3 — rho rest-frame branch | 3, 8 | Not started | `task-9-rho-rest-frame.md` |
+| 10 | Repair A4 — positron-muon normalization | 1, 2 | Not started | `task-10-positron-muon-norm.md` |
+| 11 | Reconcile the superseded sequencing prose | 4–10 | Not started | `task-11-prose-reconciliation.md` |
+| 12 | Close — aggregate the drift, bump | 11 | Not started | `task-12-close.md` |
+
+```text
+1 ──┬──► 3 ──┬──────────► 5 ──┐
+    │        │                │
+    ├──► 4 ──┴────────────────┼──► 11 ──► 12
+    │        └──► 6 ──────────┤
+2 ──┼──► 7 ──► 8 ──► 9 ───────┤
+    └──► 10 ──────────────────┘
+```
+
+Task 2 has no upstream dependency and a hard external deadline. Start
+there if only one task can run.
+
+## Exit Criteria
+
+- All twelve tasks complete; all seven follow-ups moved to
+  `docs/followups/done/` with inbound links repointed and the revision
+  pinned.
+- No live document still sequences any of the seven repairs "after
+  Phase 06 Task 6.4".
+- `git diff --stat -- test/parity/data` empty across the whole project.
+- Closing PR bumps `VERSION` in `hazma/__init__.py` per `PLAN.md`'s
+  `version_bump: minor` and adds a `CHANGELOG.md` entry naming this
+  project slug, carrying the aggregated per-defect shifts. See
+  [`../../../docs/versioning.md`](../../../docs/versioning.md).
+
+## Inputs Reviewed
+
+- `../PLAN.md`, `../rules.md`, all three `../references/*.md`.
+- The seven follow-ups under `docs/followups/todo/` — the defects, their
+  measured magnitudes, and their entry points.
+- `projects/cython-to-rust/rules.md` rules 1–3 (parity discipline),
+  `projects/cython-to-rust/task-notes/README.md` ("Numerical impact so
+  far" and Findings), `projects/cython-to-rust/phases/phase-04-spectra-kernels.md`
+  and `phase-06-mediator-spectra.md` (the deletion schedule).
+- `test/parity/README.md` — the corpus's own account of what it pins,
+  what it compares, and when not to regenerate.
+- `docs/agents/lessons.md` — the classes this project is most exposed to
+  are listed under Findings.
+
+## Findings
+
+- **The corpus cannot be regenerated wholesale, and has not been able to
+  since Phase 04 Task 4.1 (2026-08-11), the first wrapper swap.**
+  `test/parity/generate.py` calls
+  `cases.assert_no_rust_core()` first, which raises once `hazma._core`
+  *serves* any kernel. So "one declared regeneration after Task 6.4",
+  which five of the seven follow-ups proposed, was never an available
+  move — not merely a mistimed one.
+- **The four Group A twins are `cdef`-only.** None of
+  `hazma/spectra/_photon/_pion.pyx`, `hazma/spectra/_photon/_muon.pyx`,
+  `hazma/spectra/_positron/_muon.pyx` or `hazma/_utils/boost.pyx`
+  defines a top-level `def`, so they are reachable from Python solely
+  through `__pyx_capi__`. `test/test_core_boost.py` already drives
+  `hazma._utils.boost` that way — that harness is the model for Task 2,
+  not something to reinvent.
+- **The deadline is not one date, it is three.** Task 4.6 (the only
+  Phase 04 task left) strands A4's `spectra.positron.charged_pion`
+  capture; Tasks 6.2/6.3 strand the mediator-spectra captures; only the
+  remainder waits for 6.4. `../references/defect-blast-radius.md` has
+  the table.
+- **`boost_integrate_linear_interp` reaches only the seven tabulated
+  photon spectra.** Its former Cython call sites were
+  `_photon/{_eta,_eta_prime,_kaon,_omega,_phi}.pyx`, all deleted in Task
+  4.2; `rust/src/kernels/photon_tables.rs` is now the sole consumer. The
+  boost-window repair therefore does not touch the muon, pion, rho,
+  positron, neutrino or mediator paths, which is narrower than the
+  follow-up's "cross-cutting" scope line suggests.
+- **Two repair pairs land on the same arrays.** A2 and A3 both move both
+  rho cases (the rho quads over the pion, which quads over the muon);
+  A1 shares `spectra.photon.eta_prime` with B1 and `spectra.photon.phi`
+  with B2. `../rules.md` rule 7 is the constraint that falls out of it.
+- **Lesson classes this project is most exposed to**, from
+  `docs/agents/lessons.md`: `[exemption-wider-than-its-mechanism]` (a
+  declaration written wider than the mechanism that earned it),
+  `[platform-scoped-oracle-asserted-globally]` (the Task 2 capture is a
+  locally compiled oracle — declare the scope from the corpus manifest's
+  platform, never probe for it), `[mutation-harness-poisons-its-own-baseline]`
+  (Task 2 patches and reverts `.pyx` files repeatedly),
+  `[measured-tree-vs-imported-module]` (what the capture imports and what
+  it hashes must be proven the same tree), and
+  `[test-name-claims-an-unmade-assertion]` (several existing tests are
+  named for the defect they pin and need renaming, not just
+  re-pointing).
+
+## Numerical impact so far
+
+_No public code paths touched yet._ Tasks 1–3 are expected to stay at
+"no public value changes"; Tasks 4–10 each move a published spectrum by
+design, and each records the function, the grid and the max shift here in
+its own PR (`../rules.md` rule 10). Task 12 aggregates this section into
+the `CHANGELOG.md` entry — it does not reconstruct it.
+
+## Decisions and Implementation Notes
+
+- **The corpus is extended, not regenerated.** The committed arrays stay
+  as the record of what 2.1.0 shipped; each repair adds a declared delta
+  against them. Rationale and schema in
+  `../references/corpus-repinning.md`; candidate for a project-scoped
+  ADR at Task 1 (`../PLAN.md`, Anticipated ADRs).
+- **The seven follow-ups' "Risks" sections were deliberately left
+  standing** when their "Triggers / blockers" bullets were corrected, so
+  the correction and the plan that justifies it would land in one
+  reviewable place first. Each corrected bullet says so and points here.
+  Task 11 sweeps them.
+
+## Files Changed
+
+_None yet — no task started._ The change that created this project
+touched only `docs/followups/todo/*.md` (seven blocker bullets, one hunk
+per file), `projects/README.md` (the Active Projects row) and
+`projects/parity-pinned-defect-repair/` itself. No library file, test or
+build input is in that diff.
+
+## Verification
+
+**The scaffolding change itself** (the seven corrected blocker bullets +
+this project tree; no task of this project has run yet) was gated with:
+
+```sh
+scripts/agents/preflight.sh \
+    --paths "test/parity/generate.py test/parity/cases.py test/parity/stability.py" \
+    --md "$(git show --name-only --format= HEAD | grep '\.md$' | tr '\n' ' ')"
+```
+
+`RESULT: PASS` — every row green, `pytest` at `1810 passed, 15 skipped`
+on a tree cleaned of stale `.c`/`.so` and rebuilt with
+`uv pip install -e .`. Two notes for whoever repeats it. `--paths` names
+Python the diff does not contain, because the diff contains none and
+omitting the flag selects the `hazma test` directory form that is red on
+the trunk for reasons unrelated to any branch. And the gate does not run
+`scripts/agents/check_doc_citations.py` — that was run separately over
+all 18 changed docs (15 in-repo citations, none out of range), together
+with a script confirming all 52 relative markdown links in those docs
+resolve.
+
+- Tasks 1–3: `pytest test/parity` (collected count unchanged),
+  `python test/parity/generate.py --check`, the new oracle `--check`.
+- Tasks 4–10: `pytest test/parity` plus `pytest test/test_theory_aggregation.py`,
+  the per-task mutation pair (revert → red, widen → red), and
+  `cargo test --manifest-path rust/Cargo.toml --no-default-features`.
+- Task 11: `scripts/agents/check_doc_citations.py` over every touched
+  doc, with paths passed explicitly while fixes are uncommitted.
+- Task 12: `scripts/agents/preflight.sh --closing`.
+
+Every one of these needs a built tree (`uv pip install -e .`); a
+non-editable install leaves no extension where the corpus insists on
+measuring one.
+
+## Open Questions
+
+- **Does the boost integral run at β = 0?** If the tabulated kernels
+  short-circuit at rest, A1's declaration excludes every `rest` block
+  and the case count in `../references/defect-blast-radius.md` shifts.
+  Measured in Task 4, not assumed.
+- **Do A2's and A3's declared positions on the two rho cases actually
+  overlap, or only appear to?** They are different mechanisms (an
+  endpoint guard and a lost quadrature support) reaching the same arrays
+  through the same nesting. `../rules.md` rule 7 forces the question to
+  be answered rather than absorbed.
+- **What happens if `cython-to-rust` reaches Task 4.6 before Task 2
+  lands?** The A4 `spectra.positron.charged_pion` oracle becomes
+  unrecoverable from anything but the repaired Rust. The fallback is a
+  closed-form model (the defect is an overall factor, so the delta may
+  be expressible as one) — but that has to be established, not assumed,
+  and the loss recorded rather than papered over.
+- **Should the Task 2 oracles stay committed after `cython-to-rust`
+  closes?** They are the last evidence that a repaired value was ever
+  checked against a non-Rust implementation. Anticipated ADR.
+
+## Plan Impact
+
+**Impact Level:** None (this file is metadata, not a canonical change).
+
+## Handoff to Next Task
+
+**For the next agent starting any task in this project:**
+
+1. Read `../PLAN.md` end-to-end once — especially "The premise this
+   project corrects" — then this file, then `../rules.md`.
+2. Read the task's detail block in `../PLAN.md` and the references its
+   detail names.
+3. Check "Open Questions" above.
+4. Build first: nothing is prebuilt on a fresh worktree, and stale
+   generated `.c`/`.cpp` must be cleaned before the build
+   (`docs/agents/environment.md`).
+
+**Currently safe to assume:**
+
+- The four Group A `.pyx` twins are present and buildable on this tree,
+  verified at `3e01590`.
+- `test/parity/data/` is intact — `python test/parity/generate.py --check`
+  verifies it in under a second with no build.
+- Nothing in this project has changed a library value yet.
+
+**Currently risky / unknown:**
+
+- The blast-radius table is derived from the composition graph, not
+  measured. Treat it as where to look, never as what you will find.
+- Every deadline in this plan depends on `cython-to-rust`'s pace, which
+  this project does not control and must not assume.

--- a/projects/parity-pinned-defect-repair/task-notes/_template.md
+++ b/projects/parity-pinned-defect-repair/task-notes/_template.md
@@ -1,0 +1,71 @@
+# Task <N>: <Short Title>
+
+**Date:** <YYYY-MM-DD>
+**Project:** <project slug>
+**Status:** <In Progress | Complete | Blocked | Superseded>
+**Plan References:** <sections of `../PLAN.md`, a phase file, or `../rules.md`>
+**Related ADRs:** <none | ADR-XXXX (project-scoped) | ADR-XXXX (`docs/adrs/`)>
+**Depends On:** <none | Task N-1 | ADR-XXXX>
+
+## Objective
+
+<One or two sentences stating what this task accomplishes.>
+
+## Exit Criteria
+
+<Concrete, testable outcomes that define when this task is done. Fill this
+in at task start, before implementation — it's the gate you're working
+toward. "Verification" below captures retrospectively what you actually did
+to check these.>
+
+- <criterion 1>
+- <criterion 2>
+
+## Inputs Reviewed
+
+- <`../PLAN.md` sections consulted>
+- <Phase file, if phased project>
+- <`../rules.md` sections, if any>
+- <Existing code, docs, specs, external references>
+- <Prior task notes or ADRs consulted>
+
+## Findings
+
+- <Key fact or constraint discovered>
+- <Edge case, limitation, or interoperability note>
+
+## Decisions and Implementation Notes
+
+- <Decision made while implementing>
+- <Why that decision was taken over the obvious alternative>
+
+## Files Changed
+
+- <Path> — <purpose>
+
+## Verification
+
+- <Tests run, with command — e.g., `pytest test/spectra -q`>
+- <Manual checks or fixture validation>
+- <Anything intentionally deferred>
+
+## Open Questions
+
+- <Unresolved question, or `None`>
+
+## Plan Impact
+
+**Impact Level:** <None | Follow-up in learnings | Update phase file or
+`../rules.md` | ADR required | Both ADR and phase/rules update>
+
+<Describe whether this task changed canonical behavior, future task
+ordering, acceptance criteria, or internal contracts. If impact is
+"None", say so explicitly. For canonical changes, patch the affected
+`PLAN.md` / phase file / `rules.md`; promote to a repo-wide ADR under
+`docs/adrs/` if the decision has implications outside this project.>
+
+## Handoff to Next Task
+
+- <What the next agent should read first>
+- <What assumptions are now safe to make>
+- <What remains risky or incomplete>


### PR DESCRIPTION
## Summary

- **Inverts a sequencing premise that seven follow-ups agreed on.** Each
  of the seven corpus-pinned defects under `docs/followups/todo/` said it
  was *"blocked until after `cython-to-rust` Phase 06 Task 6.4"*. The
  reasoning is right — the parity corpus pins the shipped-but-wrong values
  by construction, so a repair fails the gate — but the timing conclusion
  is backwards. **Task 6.4 is where the last Cython twins are deleted**,
  and those twins are the only independent implementation a corrected
  corpus case can be re-pinned from. After 6.4 the only source of
  corrected values is the fixed Rust, which pins the port against its own
  answer. Verified at `3e01590`: four defects still have a live twin
  (`hazma/spectra/_photon/_pion.pyx`, `hazma/spectra/_photon/_muon.pyx`,
  `hazma/spectra/_positron/_muon.pyx`, `hazma/_utils/boost.pyx`); three do
  not — theirs went in Tasks 4.2 (`0954e5a`) and 4.5 (`b5f7f90`).
- **Two findings that sharpen it.** First, *"one declared regeneration
  after Task 6.4"* — the cheap path five of the seven proposed — has not
  been available since **Task 4.1 (2026-08-11)**, when the first wrapper
  swap made `cases.assert_no_rust_core()` raise. It was never an option,
  rather than a mistimed one. Second, **the deadline is three dates, not
  one**: a corrected value must be reachable through the whole Cython
  composition chain, and the chain dies before the twins do — Task 4.6
  (the only Phase 04 task still open) takes
  `hazma/spectra/_positron/_pion.pyx`, Tasks 6.2/6.3 take the mediator
  spectra, and only the remainder waits for 6.4.
- **Rewrites only the `Triggers / blockers` bullet of each of the seven.**
  The four with live twins bind the deadline to **capturing the corrected
  values from the twin**, not to landing the repair — under the plan's
  mechanism the repair is a *declared delta* rather than a regeneration,
  so it is legal on a tree with ported kernels at any time; what cannot
  follow the deletion wave is the capture. The three without twins become
  *"corpus re-pinning only"*, each citing the closed-form delta that makes
  a Cython oracle unnecessary (the rho's corrected `rest` value is the
  stored value times `E_γ` exactly, per that file's own ratio table). The
  `Risks` sections still proposing the after-6.4 regeneration were left
  standing deliberately so the correction lands in one reviewable place;
  each corrected bullet says so and points at the plan, and plan Task 11
  sweeps them.
- **Adds `projects/parity-pinned-defect-repair/`** — a flat twelve-task
  plan sequencing both groups. Its shape: the committed corpus arrays are
  never rewritten; each repair declares a per-array delta against them and
  the gate gets a rule that a declaration describing *no* change fails, so
  a reverted or leaking fix goes red instead of being absorbed. Task 2
  captures the corrected oracles from the four live twins and commits
  them, which buys the deadline out. Repairs sequence primitives-first
  because the blast radii overlap; the derived radius is 20 of 41 corpus
  cases moving and 21 not (18 cross-sections, 2 neutrino, neutral pion),
  and 20 + 21 = 41 is the reference's own cheapest self-check.

### Review round 1 (three blocking, one non-blocking — all addressed)

- **Deadline bound to the wrong artifact.** "Fix BEFORE Task 6.4" read as
  an instruction to land the Cython fix, the Rust fix and the corpus
  change together before the deletion. Rewritten as above; the Summary
  bullet reflects the corrected framing.
- **Under-enumerated mediator cases.** The gates said "both mediator
  photon cases" against a population of **three** and "both mediator
  positron cases" against **four** — each mediator ships a `dnde_decay_*`
  *and* a `dnde_decay_*_pt` entry point — and "those four cases" for a
  radius of six. `references/defect-blast-radius.md` is now the canonical
  enumeration with every list written out and counted, and each repair
  gate names every case and cites the row. The plan's defect roster moved
  there so the labels and lists have one home.
- **φ line shifts carried the defect's sign, not the repair's.** The
  repair moves both lines **down**: 656.942 → 362.519 MeV (−294.4) and
  959.646 → 59.815 MeV (−899.8). The follow-up's `+294.4/+899.8` describes
  the *defect's* displacement and is correct as written; the plan copied
  it across the fix boundary, one clause before contradicting itself with
  the endpoints. This PR body never carried the figures
  (`gh pr view 72 --json body | grep 294.4` → no match), so only the plan
  needed the fix.
- **Non-blocking, `PLAN.md` size.** Moved the defect roster into the
  reference — the breakout material the ~15 KB guideline actually names.
  The enumeration fix pushes the other way, so `PLAN.md` is **26,795**
  bytes against 26,286 before. What remains is twelve Task Details
  blocks, which `docs/workflow.md` requires live in `PLAN.md`.

Also derived rather than eyeballed while fixing the second: A3 and B3 are
strict subsets of A2, and B1/B2 of A1, so the 30 case slots collapse to a
union of 20 = `|A1| + |A2| + |A4|` over three pairwise-disjoint sets. The
first draft's overlap breakdown was typed, and wrong.

Two lessons appended to `docs/agents/lessons.md` and one extended, all
citing this PR: `[sign-copied-from-a-defect-description]`,
`[deadline-bound-to-the-wrong-artifact]`, and a new shape under
`[derived-count-not-rederived]` for a quantifier word standing in for a
count. That takes the ledger to 38 against its own "under ~30" contract,
filed as `docs/followups/todo/lessons-ledger-over-its-working-set-cap.md`
rather than pruned here.

**No returned value moves in this PR.** No defect is fixed here — the
deliverable is the corrected premise and the plan. The diff contains no
library module, kernel, test, or build input: `git diff --stat
origin/master...HEAD` is 18 files, all markdown, under
`docs/followups/todo/`, `projects/README.md`, and the new project tree.

## Project

`projects/parity-pinned-defect-repair/` — the project this PR scaffolds.
No task of it has run yet; every row in
`projects/parity-pinned-defect-repair/task-notes/README.md` is
`Not started`, and its `## Verification` section records the gate for
this scaffolding change itself.

## Test plan

- [x] `scripts/agents/preflight.sh --paths "test/parity/generate.py test/parity/cases.py test/parity/stability.py" --md "<the 18 changed docs>"`

  ```text
  PASS   black --check           test/parity/generate.py test/parity/cases.py test/parity/stability.py
  PASS   isort --check-only      test/parity/generate.py test/parity/cases.py test/parity/stability.py
  PASS   ruff check              test/parity/generate.py test/parity/cases.py test/parity/stability.py
  PASS   cargo fmt --check       rust/
  PASS   cargo clippy            rust/
  PASS   cargo test              rust/
  PASS   pytest                  1810 passed, 15 skipped, 6 warnings in 139.51s (0:02:19)
  PASS   import hazma            version 2.1.0
  PASS   markdownlint            <18 files>
  SKIP   version bump            not a closing PR (pass --closing)
  PASS   forbidden tokens        none added
  -------------------------------------------------------------------
  RESULT: PASS
  ```

  Re-run on `eee4b61` after the round-1 fixes, on a tree cleaned of stale `.c`/`.so` and
  rebuilt with `uv pip install -e .` (`hazma.__file__` and
  `hazma._core.__file__` both confirmed inside the worktree). `--paths`
  names Python the diff does not contain, because the diff contains none
  and omitting the flag selects the `hazma test` directory form that is
  red on the trunk for reasons unrelated to any branch.

- [x] `scripts/agents/check_doc_citations.py` over the round-1 fix set —
  the preflight gate does not run it.

  ```text
  docs scanned: 10
  in-repo citations checked: 14
    resolved by exact: 14
  out-of-range or ambiguous: NONE
  ```

- [x] Relative-link resolution over the same 10 docs (nothing checks this
  otherwise): `relative links checked: 75`, `broken: NONE` — one broken
  link caught and fixed by this check, a `lessons.md` written relative to
  `docs/agents/` from a file in `docs/followups/todo/`.

- [x] Blast-radius arithmetic re-derived against
  `test/parity/data/manifest.json`:
  `total cases: 41 | touched: 20 | untouched: 21`, with the 21 splitting
  as 18 `cross_sections.*` + `spectra.neutrino.{muon,charged_pion}` +
  `spectra.photon.neutral_pion`; and the per-defect sizes re-derived as
  `A1 7, A2 7, A3 6, A4 6, B1 1, B2 1, B3 2` (sum 30) with
  `A3 ⊆ A2, B3 ⊆ A2, B1 ⊆ A1, B2 ⊆ A1` and `A1, A2, A4` pairwise
  disjoint, so `union = 7 + 7 + 6 = 20`.

- [x] Diff shape: `git diff -U0` shows exactly **one hunk per follow-up
  file**, each confined to the `Triggers / blockers` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

