### PR TITLE
feat(models): add the mediator spectrum table foundation

### DIFF
--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -791,3 +791,48 @@ location: paste the `rg` and its hit count into the note, so the
 provenance sentence is falsifiable by re-running one line. Sibling of
 [sibling-copies-of-a-fixed-claim] — there the sweep ran and missed a
 copy; here the record of the sweep is what misleads.
+
+### phase-handoff-outlives-its-question
+
+A phase working-memory README carries a `## Handoff to Next Task` block
+written when the *phase* was scaffolded, long before any of its tasks
+ran. It is a list of things the scaffolder thought would be risky, and
+the phase's first task typically answers two or three of them outright —
+which makes that block the highest-density source of stale claims in the
+project tree, and the one least likely to be swept, because the task
+that invalidates it is editing its *own* note and the phase file rather
+than the README's tail.
+
+PR #79 (cython-to-rust Task 6.1) is the worked case. The Phase 06 README
+had shipped since 2026-08-03 saying: "**Currently risky / unknown:**
+memoization keying (mediator mass + partial widths) must match how model
+classes mutate parameters — verify against
+`hazma/scalar_mediator/__init__.py` setter behavior before trusting the
+cache." Task 6.1 discharged that premise twice over — the key is the
+mediator mass alone, because `__set_spectra` reads no partial width; and
+no setter can strand the cache at all, because the wrappers read
+`self.ms` / `self.mv` fresh on every call and pass the mass as an
+argument (`_scalar_mediator_spectra.py:72,81`), so a mutated mass
+re-keys by construction. The task amended the *canonical* criterion in
+the phase file, recorded the finding in its own note, and rewrote the
+project-level handoff. It did not touch the phase README's handoff, so
+the one file whose entire job is telling Task 6.2 what to worry about
+was the one still telling it to worry about the wrong thing. Review
+caught it as the round's only blocking finding.
+
+The reason a claim-keyed sweep misses this is that the stale text shares
+no distinctive string with the fix: the task's own prose says "keyed on
+the mediator mass", the stale copy says "memoization keying (mediator
+mass + partial widths) must match how model classes mutate parameters".
+An `rg` for the *new* wording finds nothing; an `rg` for the old wording
+only works if you already remember the block exists. The cheap habit is
+positional rather than lexical — before finishing the first task in any
+phase, open `task-notes/phase-XX/README.md` and read its handoff block
+top to bottom against what you shipped, treating every "currently risky
+/ unknown" bullet as a question you must either close with evidence or
+restate. Closing one is worth a strikethrough plus the evidence rather
+than a deletion, so the next reader can see the question was answered
+and not merely dropped. Sibling of
+[settling-a-deferral-has-two-sweeps]: there the two populations are
+pointers and behavior statements within the swept files; here the second
+population is a whole file the sweep never opened.

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -212,3 +212,8 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   claim lived is itself a claim; naming one location for a claim a repo-wide
   `rg` returns several times silently caps the next sweep. Paste the sweep and
   its hit count into the note instead of a location (PR #76).
+- [phase-handoff-outlives-its-question] A phase README's `## Handoff to Next
+  Task` is written *before* the phase starts, as a list of open worries; the
+  phase's first task answers several of them and closing one in the task note
+  does not close it in the README. Re-read that block against what you shipped
+  before calling the sweep done (PR #79).

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -44,6 +44,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [two vector cross sections raise `TypeError` at `e_cm = 2 m_x`](todo/vector-cross-sections-raise-at-the-two-mx-threshold.md) | 2026-08-20 | cython-to-rust Task 5.1 | cross-cutting |
 | [`thermal_cross_section` returns its integrator's initial estimate](todo/thermal-cross-section-quadrature-never-converges.md) | 2026-08-20 | cython-to-rust Task 5.1 | cross-cutting |
 | [`pip install -e .` builds `hazma._core` unoptimized](todo/editable-installs-build-the-rust-extension-in-debug.md) | 2026-08-20 | cython-to-rust Task 5.1 | cross-cutting |
+| [mediator spectra return 0.0 for an unrecognised mode string](todo/mediator-spectra-accept-unknown-mode-strings.md) | 2026-08-23 | cython-to-rust Task 6.1 | cross-cutting |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md
+++ b/docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md
@@ -1,0 +1,79 @@
+# Mediator spectra return 0.0 for an unrecognised mode string
+
+- **Added:** 2026-08-23
+- **Source:** `projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md`
+- **Scope:** cross-cutting (four public entry points, both mediator models)
+- **Status:** open
+- **Triggers / blockers:** none technically, but the repair is a
+  behaviour change on a public API, so it wants the same
+  major-version window as the cython-to-rust port itself. Reproduced
+  under `projects/cython-to-rust/rules.md` rule 1 by Phase 06.
+
+## Why
+
+All four mediator-spectrum entry points take a mode selector — a `str`
+for six of the seven and a `list[str]` for the seventh — and none of
+them validates it. A caller who writes `"pi0g"` for `"pi0 g"`, or
+`"e e g"` where the positron modules accept only `"e e"`, gets `0.0`
+back rather than an exception. A spectrum that is identically zero is
+easy to mistake for a closed channel, so the failure is silent at the
+call site *and* plausible downstream.
+
+The mechanism is uniform. Every integrand is a `cdef double` ending in
+a chain of `if mode == ...: return ...` with no `else`
+(`hazma/vector_mediator/vector_mediator_decay_spectrum.pyx:166-178`,
+`hazma/scalar_mediator/scalar_mediator_positron_spec.pyx:150-161`, and
+the two clones). A C function that falls off its end returns zero, so
+an unknown mode integrates a zero integrand, and the enclosing
+`__dnde_decay_*` adds a line term only for modes it recognises — so
+`0.0` comes all the way back out. The list-valued entry point reaches
+the same place by a different route: `scalar_mediator_decay_spectrum`
+folds its list with `if "pi pi" in modes: bitflag += BITFLAG_PP` and an
+unrecognised name simply sets no bit
+(`hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx:253-266`).
+
+## What
+
+Raise `ValueError` naming the offending selector and listing the
+accepted ones, at each entry point, once per call. The parsing already
+happens in one place after cython-to-rust Task 6.1 —
+`rust/src/kernels/mediator_tables.rs`'s `PhotonMode::parse`,
+`PositronMode::parse` and `ScalarPhotonModes::from_names` all return
+`Option`/skip precisely so the current `0.0` is reproducible — so the
+change is at their call sites in `rust/src/{scalar,vector}_mediator.rs`
+plus the accompanying tests, not in the parsers.
+
+Two decisions the repair has to make explicitly:
+
+- **the empty list.** `scalar_mediator_decay_spectrum(..., modes=[])`
+  is a legitimate way to ask for nothing and today returns `0.0`. It
+  should probably keep doing so, which means the list-valued entry
+  point rejects *unrecognised names*, not an empty result.
+- **whether the two positron modules and the two photon modules share
+  one vocabulary.** They do not today: `"e e g"` is a photon mode and
+  `"e e"` a positron one, and each set rejects the other's spelling. A
+  single error message listing the wrong vocabulary would be worse
+  than none.
+
+## Entry points
+
+- `hazma/scalar_mediator/scalar_mediator_decay_spectrum.pyx:253-266`
+- `hazma/vector_mediator/vector_mediator_decay_spectrum.pyx:166-178`
+- `hazma/scalar_mediator/scalar_mediator_positron_spec.pyx:150-161`
+- `hazma/vector_mediator/vector_mediator_positron_spec.pyx:151-162`
+- `rust/src/kernels/mediator_tables.rs` — the parsers, and the module
+  docs' "Modes are parsed once" section
+- `test/test_core_mediator_tables.py` —
+  `test_the_rejected_set_is_what_the_cython_answers_with_zero` pins the
+  current behaviour against the live Cython twins in two classes, and
+  is what a repair has to rewrite
+- Related project: `projects/cython-to-rust/`
+
+## Risks / open questions
+
+The parity corpus samples only valid modes
+(`test/parity/cases.py:1147-1219`), so it neither pins the `0.0` nor
+gates a change to it — but the two Cython twins that could serve as an
+oracle are deleted by Phase 06 Tasks 6.2–6.4, so the pins in
+`test/test_core_mediator_tables.py` become the only record of the
+pre-repair behaviour. Do not delete them without replacing them.

--- a/projects/cython-to-rust/phases/phase-06-mediator-spectra.md
+++ b/projects/cython-to-rust/phases/phase-06-mediator-spectra.md
@@ -1,7 +1,7 @@
 ---
 phase: 06
 title: Mediator spectra
-status: Not started
+status: In Progress
 ---
 
 # Phase 06: Mediator spectra
@@ -34,11 +34,27 @@ symbols) — none of which survives contact with Rust.
 - A Rust struct owning the precomputed 500-point log-spaced rest-frame
   tables (built once per parameter set by calling the Phase 04 kernel
   `fn`s natively — no Python round trips), with genuine memoization
-  keyed on the mediator mass + partial widths (fixing the dead-cache
-  bug; same numbers, declared as performance-only per rules.md 3, 12).
+  keyed on the mediator mass (fixing the dead-cache bug; same numbers,
+  declared as performance-only per rules.md 3, 12).
+
+  **Amended by Task 6.1 (2026-08-23):** this bullet read "keyed on the
+  mediator mass + partial widths", copying the key the Cython's dead
+  predicate *declares*. `__set_spectra` takes only the mass and reads no
+  width, so the tables are a pure function of the mass; keying on the
+  widths too would be equally correct and strictly slower, rebuilding
+  both tables whenever a caller varies a coupling at fixed mass — the
+  sweep the cache exists to make cheap.
 - Mode dispatch (`"total"`, `"e e g"`, `"pi pi g"`, …) becomes an enum
   at the PyO3 boundary; string parsing happens once per call, not per
-  quadrature node. Accepted strings and error text byte-match today's.
+  quadrature node. Accepted strings byte-match today's.
+
+  **Amended by Task 6.1 (2026-08-23):** this bullet read "Accepted
+  strings and error text byte-match today's". There is no error text to
+  match: an unrecognised mode raises nothing today, it returns `0.0` —
+  every `cdef double` integrand ends in an `if`-chain with no `else` and
+  a C function that falls off its end returns zero. Reproduced under
+  rule 1 and filed as
+  [`../../../docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md`](../../../docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md).
 - Design reviewed against both decay + both positron modules before
   implementation (they are two clone-pairs — one parameterized
   implementation each).

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -269,6 +269,16 @@ raising, so the parsers return `Option` and the entry points owe that
 never reads, so the port keys on the mediator mass alone — the phase
 file's Task 6.1 bullet is amended to say so.
 
+**A fourth result, and the one that cost a red CI round:** the Rust
+grid is bit-equal to `numpy.logspace` on macOS/arm64 and **one ulp off
+it at ~5% of points on Linux/x86-64** — NumPy's vectorised `power` loop
+and `f64::powf` are not the same code. Every measured disagreement was
+exactly one ulp. Nothing downstream changes (the corpus already runs in
+budget mode off its capturing platform), but **"bit-equal to the
+Cython" is a macOS/arm64 statement for anything that reads these
+tables**, and any 6.2/6.3 comparison against a NumPy oracle must be
+scoped with `ON_THE_CAPTURING_PLATFORM` rather than left open.
+
 **A sixth `_CORE_TEST_ONLY_MODULES` probe exists**,
 `hazma._core.mediator_tables`, because every oracle for the foundation
 lives in Python. Its `test/test_core_mediator_tables.py` also holds the

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -27,7 +27,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | 03 | Numerics foundation | [phase-03-numerics-foundation.md](../phases/phase-03-numerics-foundation.md) | [phase-03/README.md](phase-03/README.md) | **Complete (2026-08-11)** — all five tasks done; [learnings](../learnings/phase-03-numerics-foundation.md) |
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | **Complete (2026-08-20)** — all six tasks done; 16 entry points on Rust and `hazma/spectra/` holds no Cython `def`; [learnings](../learnings/phase-04-spectra-kernels.md) |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | **Complete (2026-08-21)** — all three tasks done; [learnings](../learnings/phase-05-mediator-cross-sections.md) |
-| 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | Not started |
+| 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | **In Progress** — Task 6.1 complete (2026-08-23); 6.2–6.4 open |
 | 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | Not started |
 
 ```text
@@ -249,11 +249,31 @@ than quoting them: the current state is in the open phase's
 ## Handoff to Next Task
 
 **Phases 00–05 are closed** (2026-08-06, 08-08, 08-09, 08-11, 08-20,
-08-21). Phase 05 shipped all 18 consumed cross-section defs, dropped the
-2 unconsumed `sigma_xx_to_all` exports, deleted both `_c_*` `.pyx`, and
-closed with Task 5.3's relic-density end-to-end pin and benchmark.
-**Next is Phase 06** (mediator spectra), then **Phase 07** (cutover +
-close). 06 depends on 04's kernels and on 05 only for ordering.
+08-21) and **Phase 06 is open**: Task 6.1 landed the shared
+table/cache/mode foundation on 2026-08-23, so **the next task is 6.2**
+(the decay spectrum pair), then 6.3, 6.4 and Phase 07.
+
+**Three Task 6.1 results a 6.2/6.3 agent should not re-derive.** (1) The
+`grep -c SoftComplexToDouble` the Phase 05 learnings demanded has been
+run: **6 / 0 / 6 / 0** for scalar-decay / scalar-positron /
+vector-decay / vector-positron, one live site each in the photon pair
+(the `** 1.5` FSR coefficient at
+`scalar_mediator_decay_spectrum.pyx:113` and
+`vector_mediator_decay_spectrum.pyx:73`), both covered by the existing
+`crate::kernels::soft_complex` pair — **neither positron module needs
+it**. (2) An unrecognised mode string returns `0.0` today rather than
+raising, so the parsers return `Option` and the entry points owe that
+`0.0`; the tightening is
+[filed](../../../docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md).
+(3) The Cython's cache key names partial widths that `__set_spectra`
+never reads, so the port keys on the mediator mass alone — the phase
+file's Task 6.1 bullet is amended to say so.
+
+**A sixth `_CORE_TEST_ONLY_MODULES` probe exists**,
+`hazma._core.mediator_tables`, because every oracle for the foundation
+lives in Python. Its `test/test_core_mediator_tables.py` also holds the
+only record of the pre-repair unknown-mode behaviour once Tasks 6.2–6.4
+delete the twins.
 
 **Read [`../learnings/phase-05-mediator-cross-sections.md`](../learnings/phase-05-mediator-cross-sections.md)
 before starting Phase 06.** It replaces the three Phase 05 notes. Its

--- a/projects/cython-to-rust/task-notes/phase-06/README.md
+++ b/projects/cython-to-rust/task-notes/phase-06/README.md
@@ -62,6 +62,13 @@ Phase-scoped, from Task 6.1; the full evidence is in its note.
 - **`__set_spectra` reads only the mass**, so the tables are a pure
   function of it and the Cython's declared width-bearing key is wider
   than its inputs.
+- **`numpy.logspace` and `f64::powf` are not the same code.** The grid
+  is bit-equal to NumPy's on macOS/arm64 and one ulp off it at ~5% of
+  points on Linux/x86-64 (CI run 32681245809; every measured
+  disagreement exactly one ulp, worst relative 2.16e-16). So
+  "bit-equal to the Cython" is a **capturing-platform statement** for
+  anything reading these tables. No gate changes — the corpus already
+  runs in budget mode off macOS.
 
 ## Decisions and Implementation Notes
 
@@ -73,8 +80,12 @@ Phase-scoped, from Task 6.1; the full evidence is in its note.
   probe, because every oracle (`numpy.logspace`, `numpy.interp`, the
   Phase 04 entry points, the four live twins) is in Python.
 - **`cargo` gates the grid algorithm, Python gates its agreement with
-  NumPy** — captured NumPy bits in a cargo test would turn a Linux CI
-  job red for a libm difference (Phase 04 learnings §4).
+  NumPy, scoped by platform** — captured NumPy bits in a cargo test
+  would turn a Linux CI job red for a libm difference (Phase 04
+  learnings §4), and the first CI round proved the same is true of an
+  unscoped Python comparison. The mode is declared from
+  `ON_THE_CAPTURING_PLATFORM`, never probed, and the two off-platform
+  comparators are separate functions so they are exercised everywhere.
 
 ## Files Changed
 
@@ -91,7 +102,7 @@ Phase-scoped, from Task 6.1; the full evidence is in its note.
 - Corpus (quad budgets); benchmark vs pre-swap Cython (dead-cache fix
   is the expected headline); import smoke after 6.4.
 - **After Task 6.1:** `cargo test --no-default-features` → `222 passed`
-  (201 at Phase 05's close); `pytest -q` → `2158 passed, 15 skipped, 12
+  (201 at Phase 05's close); `pytest -q` → `2163 passed, 15 skipped, 12
   subtests passed`; `pytest test/parity -q` → `658 passed, 1 skipped`;
   `pytest test/test_theory_aggregation.py -q` → `69 passed`. No public
   value moved — nothing appended to `../numerical-impact.md`.

--- a/projects/cython-to-rust/task-notes/phase-06/README.md
+++ b/projects/cython-to-rust/task-notes/phase-06/README.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 06
-**Status:** Not started
+**Status:** In Progress
 **Plan References:** `../../phases/phase-06-mediator-spectra.md`
 **Related ADRs:** ADR-0001, ADR-0002
 **Depends On:** Phases 04 and 05 complete
@@ -17,7 +17,7 @@ spectrum redesign — the last Cython.
 
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
-| 6.1 | Spectrum-table struct design | — | Not started | [task-6.1-table-struct.md](task-6.1-table-struct.md) |
+| 6.1 | Spectrum-table struct design | — | **Complete (2026-08-23)** | [task-6.1-table-struct.md](task-6.1-table-struct.md) |
 | 6.2 | Decay spectrum pair | 6.1 | Not started | [task-6.2-decay-spectra.md](task-6.2-decay-spectra.md) |
 | 6.3 | Positron spectrum pair | 6.1 | Not started | [task-6.3-positron-spectra.md](task-6.3-positron-spectra.md) |
 | 6.4 | Retire capi survivors + `_utils` headers | 6.2, 6.3 | Not started | [task-6.4-retire-survivors.md](task-6.4-retire-survivors.md) |
@@ -36,24 +36,74 @@ spectrum redesign — the last Cython.
 
 ## Findings
 
-_None yet._
+Phase-scoped, from Task 6.1; the full evidence is in its note.
+
+- **The four `.pyx` differ in exactly four ways and all four are data:**
+  grid start (`10⁻¹` MeV vs legacy `m_e`), below-grid policy (`1/E` tail
+  vs `np.interp`'s clamp), which tables are built, and the selector type
+  (`list[str]` → bitflag for the scalar decay module, one `str` for the
+  other six entry points). One parameterised implementation each, as the
+  phase file predicted.
+- **`grep -c SoftComplexToDouble` on the generated C: 6 / 0 / 6 / 0** for
+  scalar-decay / scalar-positron / vector-decay / vector-positron — the
+  check the Phase 05 learnings record as unrun for this phase. Five of
+  each six are proto/definition lines; the one live site each is the
+  `** 1.5` in an FSR coefficient
+  (`scalar_mediator_decay_spectrum.pyx:113`,
+  `vector_mediator_decay_spectrum.pyx:73`), both already covered by
+  `crate::kernels::soft_complex`. **Neither positron module needs it.**
+- **An unrecognised mode string returns `0.0`, not an error** — verified
+  against the shipped extensions, reproduced under rule 1, filed as
+  [`../../../../docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md`](../../../../docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md).
+- **The dead cache is two different bugs.** The decay modules have no
+  cache; the positron modules have the predicate and never assign to
+  what it reads. Both rebuild a 500-point quadrature-backed table per
+  call.
+- **`__set_spectra` reads only the mass**, so the tables are a pure
+  function of it and the Cython's declared width-bearing key is wider
+  than its inputs.
 
 ## Decisions and Implementation Notes
 
-_None yet._
+- **Task 6.1 amended two of its own exit criteria in the phase file**
+  (cache key, and "error text"). See its `## Plan Impact`. No ADR.
+- **`crate::kernels::mediator_tables`** is the shared foundation, a
+  documented naming exception beside `soft_complex`;
+  **`hazma._core.mediator_tables`** is a sixth `_CORE_TEST_ONLY_MODULES`
+  probe, because every oracle (`numpy.logspace`, `numpy.interp`, the
+  Phase 04 entry points, the four live twins) is in Python.
+- **`cargo` gates the grid algorithm, Python gates its agreement with
+  NumPy** — captured NumPy bits in a cargo test would turn a Linux CI
+  job red for a libm difference (Phase 04 learnings §4).
 
 ## Files Changed
 
-_None yet — phase not started._
+### Task 6.1
+
+`rust/src/kernels/mediator_tables.rs` (new), `rust/src/mediator_tables_probe.rs`
+(new), `rust/src/kernels.rs`, `rust/src/lib.rs`,
+`test/test_core_mediator_tables.py` (new), `test/parity/cases.py`,
+`../../phases/phase-06-mediator-spectra.md`,
+`docs/followups/{todo/mediator-spectra-accept-unknown-mode-strings.md,README.md}`.
 
 ## Verification
 
 - Corpus (quad budgets); benchmark vs pre-swap Cython (dead-cache fix
   is the expected headline); import smoke after 6.4.
+- **After Task 6.1:** `cargo test --no-default-features` → `222 passed`
+  (201 at Phase 05's close); `pytest -q` → `2158 passed, 15 skipped, 12
+  subtests passed`; `pytest test/parity -q` → `658 passed, 1 skipped`;
+  `pytest test/test_theory_aggregation.py -q` → `69 passed`. No public
+  value moved — nothing appended to `../numerical-impact.md`.
 
 ## Open Questions
 
-_None yet._
+- **Does the charged pion's forward-cone defect reach the mediator
+  spectra?** Still open — carried in from Phase 04 and owed by Task 6.2,
+  which builds the boost integral over exactly the affected kernel.
+- **Is one cache slot enough, and should the shared photon table set stop
+  building the muon table the scalar module ignores?** Both are
+  performance questions Task 6.2's benchmark answers.
 
 ## Plan Impact
 

--- a/projects/cython-to-rust/task-notes/phase-06/README.md
+++ b/projects/cython-to-rust/task-notes/phase-06/README.md
@@ -122,15 +122,48 @@ Phase-scoped, from Task 6.1; the full evidence is in its note.
 
 ## Handoff to Next Task
 
-**For the next agent working in Phase 06:** read `../../PLAN.md`,
-`../README.md`, this file, then the phase file. This is a redesign —
-review Task 6.1's design against all four modules before writing
-kernel code.
+**For the next agent working in Phase 06 (Task 6.2 is next):** read
+`../../PLAN.md`, `../README.md`, this file, then the phase file, then
+[`task-6.1-table-struct.md`](task-6.1-table-struct.md) — its `## Findings`
+and `## Handoff` carry the four measurements 6.2/6.3 would otherwise
+re-derive at the cost of a build.
 
-**Currently safe to assume:** the Phase 04 kernel `fn`s are natively
-callable from Rust (rules.md rule 8 kept them PyO3-free).
+**Now safe to assume** (Task 6.1 delivered all of it):
 
-**Currently risky / unknown:** memoization keying (mediator mass +
-partial widths) must match how model classes mutate parameters —
-verify against `hazma/scalar_mediator/__init__.py` setter behavior
-before trusting the cache.
+- The Phase 04 kernel `fn`s are natively callable from Rust (rules.md
+  rule 8 kept them PyO3-free), and `crate::kernels::mediator_tables`
+  already calls them: `photon_tables(mass)` / `positron_tables(mass)`
+  return memoized `Arc`s whose columns are those kernels on a
+  `numpy.logspace`-identical grid, and `RestFrameTable::lookup` carries
+  each clone-pair's below-grid policy.
+- **The cache keys on the mediator mass alone**, and the phase file's
+  Task 6.1 criterion is amended to say so. `__set_spectra` reads no
+  partial width, so the tables are a pure function of the mass.
+- ~~Memoization keying must match how model classes mutate parameters —
+  verify against `hazma/scalar_mediator/__init__.py` setter behavior
+  before trusting the cache.~~ **Closed by Task 6.1, and the premise was
+  wrong twice over.** The key is the mass, not mass + widths; and no
+  setter can strand the cache, because the wrappers read `self.ms` /
+  `self.mv` fresh on every call and pass the mass as an argument
+  (`hazma/scalar_mediator/_scalar_mediator_spectra.py:72,81`,
+  `hazma/vector_mediator/_vector_mediator_spectra.py:84`), so a mutated
+  mass re-keys on the next call by construction.
+- The mode selectors are enums parsed once per call, and an
+  **unrecognised mode owes `0.0`, not a raise** — see Findings.
+
+**Still risky / unknown for Task 6.2:**
+
+- **Whether the charged pion's forward-cone defect reaches the mediator
+  spectra**, carried in unanswered from Phase 04. The charged-pion photon
+  table Task 6.1 builds *is* the affected kernel, so the measurement is
+  one lookup away and 6.2 owns it.
+- **The FMA reading is not discharged.** `grep -c SoftComplexToDouble`
+  answered the complex-`pow` question only; the disassembly still has to
+  be read per kernel before transliterating (Phase 04 learnings §2,
+  step 1).
+- **Take the benchmark before deleting the twins.** While all four
+  `.pyx` are alive, 6.2 can time both implementations in one
+  interpreter; afterwards a baseline costs a build from a git commit.
+- **Any comparison against a NumPy oracle must be platform-scoped** with
+  `ON_THE_CAPTURING_PLATFORM`, not left open — see Findings for what an
+  unscoped one cost Task 6.1.

--- a/projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md
+++ b/projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md
@@ -1,0 +1,380 @@
+# Task 6.1: Spectrum-table struct design
+
+**Date:** 2026-08-23
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-06-mediator-spectra.md` (Task
+6.1), `../../PLAN.md` §Numerical impact, `../../rules.md` rules 1–4,
+6–9, 12
+**Related ADRs:** ADR-0001, ADR-0002
+**Depends On:** Phases 04 and 05 complete
+
+## Objective
+
+Give Phase 06 the shared Rust foundation its four mediator-spectrum
+`.pyx` need: one struct owning the 500-point log-spaced rest-frame
+interpolation tables, a real memo cache to replace the Cython's dead
+one, and the mode selectors as enums parsed once per call rather than
+per quadrature node. No entry point is swapped here — Tasks 6.2 and 6.3
+consume this.
+
+## Exit Criteria
+
+Copied from the phase file's Task 6.1 block, with the two amendments
+this task made to it (see `## Plan Impact`):
+
+- A Rust struct owning the precomputed 500-point log-spaced rest-frame
+  tables, built once per parameter set by calling the Phase 04 kernel
+  `fn`s natively (no Python round trips), with genuine memoization
+  keyed on the mediator mass (fixing the dead-cache bug; same numbers,
+  declared as performance-only per rules.md 3, 12). — **met**
+- Mode dispatch (`"total"`, `"e e g"`, `"pi pi g"`, …) becomes an enum
+  at the PyO3 boundary; string parsing happens once per call, not per
+  quadrature node. Accepted strings byte-match today's. — **met**
+- Design reviewed against both decay + both positron modules before
+  implementation (they are two clone-pairs — one parameterized
+  implementation each). — **met**; all four `.pyx` were read in full
+  first and the differences between them are the module's parameters
+  ([`Findings`](#findings) rows 1–3).
+
+## Inputs Reviewed
+
+- `../../PLAN.md` (all sections); `../README.md`; `README.md` (phase);
+  `../../rules.md`.
+- `../../phases/phase-06-mediator-spectra.md` — Tasks 6.1–6.4.
+- `../../learnings/phase-04-spectra-kernels.md`,
+  `../../learnings/phase-05-mediator-cross-sections.md`.
+- The four `.pyx` in full:
+  `hazma/{scalar,vector}_mediator/*_{decay_spectrum,positron_spec}.pyx`.
+- `rust/src/kernels.rs`, `rust/src/lib.rs`,
+  `rust/src/kernels/photon_tables.rs` (the house style for a
+  table-owning kernel struct), `rust/src/kernels/soft_complex.rs`,
+  `rust/src/interp.rs`, `rust/src/constants.rs`.
+- `test/parity/cases.py` (mediator-spectrum blocks),
+  `test/parity/tolerances.py` (the seven `NESTED_RTOL` budgets).
+
+## Findings
+
+**The four modules differ in exactly four ways**, and every one is data:
+
+| | photon (`*_decay_spectrum.pyx`) | positron (`*_positron_spec.pyx`) |
+| --- | --- | --- |
+| grid start | `10⁻¹` MeV (literal exponent `-1.0`) | `m_e` (legacy, 0.510998928) |
+| below grid | `dnde[0]·e[0]/E` tail below `10**-1` | `np.interp`'s clamp, no guard |
+| tables | scalar: charged pion only; vector: + muon | both: charged pion + muon |
+| selector | scalar: `list[str]` → bitflag; vector: one `str` | one `str` |
+
+- **The dead cache is deader than the phase file's "broken memo-cache"
+  suggests, and in two different ways.** The two *decay* modules have no
+  cache at all — `__set_spectra` runs unconditionally at the top of every
+  entry point. The two *positron* modules have the predicate
+  (`__recompute_rf_spectra`) but **no line anywhere assigns to `cache_ms`
+  / `cache_mv` or `cache_pws`**, so the `-1.0` sentinels never change and
+  it always returns 1. Both spellings rebuild a 500-point,
+  quadrature-backed table on every single call.
+- **The Cython's declared cache key is wider than the tables' actual
+  inputs.** `__set_spectra` takes the mediator mass and reads no partial
+  width; the tables are a pure function of `m/2`. Keying the port on the
+  widths as well would be slower for no correctness gain, so the cache
+  keys on the mass. This amends the phase file (see `## Plan Impact`).
+- **An unrecognised mode string raises nothing today — it returns
+  `0.0`.** Every `cdef double` integrand ends in `if mode == …: return …`
+  with no `else`, and a C function that falls off its end returns zero,
+  so a typo'd mode integrates a zero integrand; the enclosing
+  `__dnde_decay_*` adds a line term only for modes it *does* recognise.
+  Verified against the shipped extensions, not inferred:
+  `dnde_decay_v_pt(30, 600, 550, pws, "pi0g")` and
+  `dnde_decay_s_pt(30, 600, 550, pws, "e e g")` both return exactly
+  `0.0`. Reproduced under rule 1 and filed.
+- **Both photon modules carry one live complex-`pow` site; neither
+  positron module carries any.** `grep -c SoftComplexToDouble` on the
+  generated C — the check the Phase 05 learnings say must be run and
+  records as unrun for Phase 06 — returns **6 / 0 / 6 / 0** for
+  scalar-decay / scalar-positron / vector-decay / vector-positron, and
+  five of each six are the proto and definition lines. The one call site
+  each is the `** 1.5` in an FSR coefficient:
+  `scalar_mediator_decay_spectrum.pyx:113`
+  (`qe**2 / (16.·(1 − 4 mul²)**1.5·π²)`, in `dnde_fsr_l_srf`) and
+  `vector_mediator_decay_spectrum.pyx:73`
+  (`qe**2 / (4.·(1 − 4 mupi²)**1.5·π²)`, in `__dnde_fsr_cp_vrf`). Both
+  are the shape `crate::kernels::soft_complex` already covers —
+  `soft_complex_pow_1_5` plus `complex_quotient_real_denominator` — so
+  Task 6.2 inherits the pair rather than deriving new ones. The sibling
+  FSR functions in each file spell the same factor `sqrt(1 − 4μ²)` and
+  stay real.
+- **`np.log10` and libc `log10` agree here.** The scalar decay module
+  takes its upper grid endpoint from `np.log10` and the other three from
+  `libc.math.log10`. Measured equal at every mass tried on the capturing
+  platform, so the port takes one `log10`.
+- **`numpy.logspace`'s final-point substitution is not cosmetic.** NumPy
+  overwrites the last exponent with `stop` rather than continuing the
+  step arithmetic; the two differ by one ulp at **732 of 8,008**
+  (mass, start) pairs over `np.linspace(1, 2000, 4001)` MeV × the two
+  grid starts — and at **none** of the corpus's three masses, so a
+  three-mass check would have missed it.
+
+## Decisions and Implementation Notes
+
+- **One shared module, not one per clone-pair.**
+  `rust/src/kernels/mediator_tables.rs` is a documented exception to
+  `kernels.rs`'s one-submodule-per-`.pyx` rule, alongside
+  `soft_complex` — it is the part all four repeat, and the four
+  differences above are its parameters (`BelowGrid`, the grid start, the
+  table set, the selector type).
+- **The cache is one slot per table set, keyed on the mass's bit
+  pattern.** One slot because the Cython had one set of module globals
+  and consumers sweep a whole grid at one mass. Bits rather than `==`
+  so a `NaN` mass is a hit rather than an unbounded rebuild loop; the
+  one place that is *stricter* than `==` is `0.0` vs `-0.0`, asserted
+  deliberately rather than discovered later. The value is an `Arc` so a
+  caller drops the lock before integrating.
+- **The parsers return `Option`, and `None` means the Cython's `0.0`.**
+  Tightening it into a raise would be a behaviour change the corpus
+  cannot gate (it samples valid modes only) — filed instead.
+- **`cargo` gates the grid *algorithm*; Python gates its agreement with
+  NumPy.** Hard-coding the capturing platform's NumPy bits into a cargo
+  test would turn a Linux CI job red for a libm difference rather than a
+  defect — the failure Phase 04 learnings §4 records twice. So
+  `cargo test` asserts the unfused step, the substituted endpoint and
+  monotonicity, and `test/test_core_mediator_tables.py` compares against
+  live `numpy.logspace` on whatever platform runs.
+- **A sixth probe submodule, `hazma._core.mediator_tables`.** Added to
+  `_CORE_TEST_ONLY_MODULES` with the rest, and for the same reason the
+  five before it were: the oracles (`numpy.logspace`, `numpy.interp`,
+  the Phase 04 entry points, and the four *live* Cython twins) are all
+  in Python. No module under `hazma/` imports it, which
+  `test_test_only_core_submodules_have_no_importer` asserts.
+- **`ScalarPhotonModes::contains` was written and then removed.** It had
+  no non-test caller, so `clippy -D warnings` rejected it; Task 6.2 adds
+  it back with the integrand that branches on it rather than carrying a
+  `dead_code` allowance through the phase.
+- **The shared photon table set builds the muon table the scalar decay
+  module will not read.** One 500-point evaluation per *distinct mass*
+  against the two-per-*call* the dead cache costs today; Task 6.2
+  measures it either way.
+
+## Files Changed
+
+- `rust/src/kernels/mediator_tables.rs` — **new.** `logspace`,
+  `RestFrameTable` + `BelowGrid`, `TableCache`, `PhotonTables` /
+  `PositronTables` and their memoized constructors, `PhotonMode` /
+  `PositronMode` / `ScalarPhotonModes`. 22 unit tests.
+- `rust/src/mediator_tables_probe.rs` — **new.** `hazma._core.mediator_tables`:
+  `logspace`, `photon_tables`, `positron_tables`, `lookup`,
+  `photon_mode`, `positron_mode`, `scalar_photon_mode_bits`.
+- `rust/src/kernels.rs` — register the module; document why it is the
+  fifth naming exception.
+- `rust/src/lib.rs` — register the probe; extend the probe paragraph.
+- `test/test_core_mediator_tables.py` — **new.** 65 tests over six
+  classes.
+- `test/parity/cases.py` — `hazma._core.mediator_tables` added to
+  `_CORE_TEST_ONLY_MODULES`, with its rationale in the existing comment.
+- `projects/cython-to-rust/phases/phase-06-mediator-spectra.md` — Task
+  6.1's first two exit criteria amended (see `## Plan Impact`);
+  frontmatter `status: In Progress`, as Task 5.1 did for Phase 05.
+- `docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md`
+  and `docs/followups/README.md` — **new** follow-up and its index row.
+- `projects/cython-to-rust/task-notes/phase-06/README.md`,
+  `projects/cython-to-rust/task-notes/README.md` — status, findings,
+  handoff.
+
+## Verification
+
+- `cargo fmt --manifest-path rust/Cargo.toml --check` — clean.
+- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
+  — clean.
+- `cargo test --manifest-path rust/Cargo.toml --no-default-features` —
+  `222 passed; 0 failed`, from 201 at Phase 05's close. The 22 new tests
+  cover: the `logspace` algorithm (the unfused step *and* that `logspace`
+  is the unfused one, the substituted endpoint, endpoints, monotonicity);
+  `RestFrameTable` (values are the kernel at the nodes, exact node hits,
+  the `1/E` tail's continuity at the threshold, that the tail opens at
+  the threshold and **not above it**, the clamp, the upper clamp under
+  both policies, `NaN`); `TableCache` (build-once, re-key, one slot,
+  `NaN` hit, `±0.0` miss); the two table sets (memoized, endpoints,
+  columns are the Phase 04 kernels, legacy `m_e`); and all three
+  selectors (accepted set, rejected set, line-carrying modes, bit values,
+  the default list, repeated/unknown names).
+- `pytest test/test_core_mediator_tables.py -q -n 0` — `65 passed`.
+  Covers: `logspace` vs `numpy.logspace` at the corpus masses and over a
+  4,001-mass sweep, the last point, the `num < 2` raise; both table sets'
+  grids and columns against the public Rust entry points; the legacy vs
+  PDG electron mass; `lookup` vs `np.interp` and vs the `.pyx` tail
+  branch over 6,000+ probes, both clamps, `NaN`, both error paths; and
+  every selector's accepted and rejected sets — the rejected sets
+  **against the live Cython twins**, which return `0.0` for them.
+- `pytest test/parity -q` — `658 passed, 1 skipped`; all 41 entry points
+  unchanged.
+- `pytest test/test_theory_aggregation.py -q` — `69 passed` (the
+  model-layer gate the corpus cannot be).
+- `pytest -q` (full suite) — `2158 passed, 15 skipped, 12 subtests
+  passed`. `git diff origin/master --name-only -- test/` names only
+  `test/parity/cases.py` (a comment and one `frozenset` entry) and the
+  new module, so the 65 new tests are the whole delta.
+- `scripts/agents/preflight.sh --paths "…"` — see the sweep block.
+- **Mutation campaign, 8/8 killed** — the Phase 04 discipline, run
+  against `cargo test` because that is the gate a future edit meets
+  first:
+
+  | # | Mutation | Result |
+  | --- | --- | --- |
+  | M1 | `i * step + start` → `mul_add(step, start)` | killed |
+  | M2 | drop `grid[num - 1] = stop` | killed (2 tests) |
+  | M3 | cache computes the key and never stores it (the Cython's bug) | killed (3 tests) |
+  | M4 | tail threshold `0.1` → `0.2` | **survived**, then killed |
+  | M5 | tables built at `mass` rather than `mass / 2` | killed |
+  | M6 | `has_line` also true for `"pi pi"` | killed |
+  | M7 | positron grid starts at `pdg::MASS_E` | killed |
+  | M8 | the `1/E` tail branch never taken | killed |
+
+  M1 and M4 are the two the campaign paid for. M1 survived the first
+  version of `logspace_does_not_fuse_the_step_arithmetic`, which asserted
+  only that the fused and unfused exponents *differ* somewhere and never
+  that `logspace` used the unfused one — a test that would have passed
+  against either spelling. M4 survived because every tail probe sat far
+  from the threshold; a new test now pins that at and above `10**-1` the
+  table interpolates, so moving the constant up cannot silently convert
+  the grid's first decade into extrapolation. Both were caught by
+  `test/test_core_mediator_tables.py` (M1: 13 failures) — the campaign's
+  value was making `cargo` catch them too.
+- **Test validity.** Most new assertions pin behaviour this task
+  created, so there is no production change to stash; the mutation
+  campaign above is the substitute, and it is stronger — every mutation
+  was applied to the real source, built, and run.
+- **Deferred:** no benchmark. `rules.md` rule 12 wants one for a
+  performance claim, and this task makes none — the cache has no caller
+  until Task 6.2, which the phase file already charges with the
+  measurement ("benchmark vs pre-swap Cython recorded").
+
+## Numerical impact
+
+**No public value changes.** No file under `hazma/` is touched
+(`git diff origin/master --name-only -- hazma/` is empty), no existing
+Rust function is modified, and the whole diff outside `projects/` and
+`docs/` is two new Rust modules, one new test module, two registration
+lines and a `frozenset` entry in a test helper. Verified rather than
+argued: `pytest test/parity -q` → `658 passed, 1 skipped` evaluates all
+41 pinned entry points against the stored corpus, and
+`pytest test/test_theory_aggregation.py -q` → `69 passed` is the
+model-layer gate. Nothing is appended to
+[`../numerical-impact.md`](../numerical-impact.md).
+
+## Open Questions
+
+- **Does the charged pion's forward-cone defect reach the mediator
+  spectra?** Carried forward from Phase 04 unanswered — the project
+  README asks it of Phase 06 specifically, and it is a question about
+  the boost integral, not about the tables. Task 6.2 owns it: the
+  charged-pion photon table this task builds is exactly the kernel the
+  defect lives in, so the measurement is one table lookup away.
+- **Is one cache slot enough?** The Cython had one and consumers sweep a
+  whole grid per mass, but nothing measured a real caller's access
+  pattern. If Task 6.2's benchmark shows thrashing on a mass scan, the
+  fix is a small LRU and nothing else changes.
+- **Should the shared photon table set stop building the muon table the
+  scalar module ignores?** Only worth answering with Task 6.2's numbers.
+
+## Plan Impact
+
+**Impact Level:** Update phase file.
+
+Two of Task 6.1's three exit criteria were factually wrong about the
+code they described, and both are patched in
+[`../../phases/phase-06-mediator-spectra.md`](../../phases/phase-06-mediator-spectra.md)
+with a dated amendment rather than deferred:
+
+1. "keyed on the mediator mass + partial widths" → "keyed on the
+   mediator mass". `__set_spectra` reads no partial width; the wider key
+   was the Cython's *declared* one, and honouring it would rebuild both
+   tables on every coupling change at fixed mass.
+2. "Accepted strings and error text byte-match today's" → "Accepted
+   strings byte-match today's". There is no error text: an unrecognised
+   mode returns `0.0` today.
+
+No ADR. Neither amendment changes an architecture, an interface or a
+public number — the first is a performance decision inside one struct
+and the second is a correction of a factual claim about the source. The
+behaviour the second one preserves is filed as a follow-up so the
+project does not lose it.
+
+`rules.md` is unchanged: rule 9 ("Cython `assert`s become unconditional
+error returns") does not reach the silent-`0.0` fall-through, because
+there is no `assert` involved.
+
+## Stale-state sweep
+
+Every command below was run on this branch
+(`claude/cython-to-rust/task-6.1-spectrum-table-struct-design`) against
+an editable install in this worktree — `hazma.__file__` and
+`hazma._core.__file__` both resolve inside it.
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Task 6.1 status, all copies | `rg -n "6\.1" projects/cython-to-rust/task-notes/{README.md,phase-06/README.md}` | phase README cell `**Complete (2026-08-23)**`; project README phase row `**In Progress** — Task 6.1 complete (2026-08-23)`; note header `**Status:** Complete`. Agree. |
+| Phase 06 frontmatter | `head -5 projects/cython-to-rust/phases/phase-06-mediator-spectra.md` | `status: In Progress` — flipped by this task, as Task 5.1 did for Phase 05. `PLAN.md`'s Phases row carries a Delivers cell, not a status, and is unchanged. |
+| Every `.pyx:NNN` citation added | `grep -rhoE '\.pyx:[0-9]+(-[0-9]+)?'` over the six touched files, then `sed -n` on each line | 20 distinct citations, **all re-derived from the live sources**. Ten were wrong on the first pass — both `__set_spectra` call sites, both cache predicates, both tail branches, both mode chains, the line-term line and the grid line — and are corrected. |
+| Other citations | `sed -n '1218,1222p' test/parity/cases.py` | the mediator-spectrum registrations run 1147–1219, ending before `by_name = {…}` at 1221; the follow-up cites that range. |
+| Corpus mode / served kernels | `python -c "import cases; print(len(cases.rust_core_kernels()))"` | **34**, unchanged — the probe sits in `_CORE_TEST_ONLY_MODULES`, now six entries. |
+| No `hazma/` source touched | `git diff origin/master --name-only -- hazma/` | no occurrences. |
+| Forbidden tokens in new files | `rg -n "TODO\|FIXME\|breakpoint()\|import pdb\|print("` over the three new source files | no occurrences; preflight's own gate reports `none added`. |
+| Follow-up not a duplicate | `rg` over `docs/followups/{todo,done}/`; `gh pr list --state open` | no existing entry, no open PRs. New stub plus index row. |
+| The two prose lists of probe submodules | `rg -n "_CORE_TEST_ONLY_MODULES" test/parity/cases.py`; `rust/src/lib.rs` module docs | both name all six submodules and their oracles, and agree with the `frozenset`. |
+| Numerical-impact statement | `pytest test/parity -q`; `pytest test/test_theory_aggregation.py -q` | `658 passed, 1 skipped` and `69 passed`. **No public value changes**; nothing appended to `../numerical-impact.md`. |
+| Preflight | `env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh --paths … --md …` | `RESULT: PASS` — eleven rows, one `SKIP` (version bump, not a closing PR). |
+
+## Handoff to Next Task
+
+**Read this note's `## Findings` before writing any Task 6.2 kernel
+code.** Three of its rows are answers to questions the phase and project
+handoffs were still asking, and re-deriving them costs a build:
+
+1. **`grep -c SoftComplexToDouble` has been run** — 6 / 0 / 6 / 0 for
+   scalar-decay / scalar-positron / vector-decay / vector-positron, one
+   live site each in the photon pair and **none** in either positron
+   module. Both live sites are the `** 1.5` in an FSR coefficient and
+   both are the shape `crate::kernels::soft_complex` already covers, so
+   Task 6.2 inherits `soft_complex_pow_1_5` and
+   `complex_quotient_real_denominator` rather than deriving new shims.
+   This does **not** discharge the FMA reading: `grep -c` on the
+   generated C answers the complex-`pow` question only, and the
+   disassembly still has to be read per kernel (Phase 04 learnings §2,
+   step 1).
+2. **An unrecognised mode returns `0.0`**, so `PhotonMode::parse` /
+   `PositronMode::parse` return `Option` and the entry points owe that
+   `0.0` on `None` — do not turn it into a raise; the tightening is
+   [filed](../../../../docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md).
+3. **The cache keys on the mediator mass alone**, and the phase file's
+   exit criterion is amended to say so.
+
+**Safe to assume:**
+
+- `crate::kernels::mediator_tables` gives Task 6.2 the whole rest-frame
+  half: `photon_tables(mass)` / `positron_tables(mass)` return memoized
+  `Arc`s whose columns are the Phase 04 kernels evaluated natively on a
+  `numpy.logspace`-identical grid, and `RestFrameTable::lookup` carries
+  each clone-pair's below-grid policy. What is left for 6.2/6.3 is the
+  FSR functions, the boost integrand, the `qagp` call, the line terms
+  and the PyO3 boundary.
+- `hazma._core.mediator_tables` is a test surface only, already in
+  `_CORE_TEST_ONLY_MODULES`, so it does not move the corpus's mode.
+  `cases.rust_core_kernels()` is still **34**.
+- `ScalarPhotonModes::contains` does **not** exist — it was written,
+  found to have no non-test caller, and removed rather than carrying a
+  `dead_code` allowance. Add it back with the integrand that branches
+  on it.
+
+**Still risky / unknown:**
+
+- **Whether the charged pion's forward-cone defect reaches the mediator
+  spectra is still open**, and Task 6.2 is where it gets measured — the
+  charged-pion photon table this task builds *is* the affected kernel,
+  so the measurement is one lookup away.
+- **No benchmark exists yet.** The cache has no caller until 6.2, which
+  the phase file already charges with the comparison against pre-swap
+  Cython. Establishing that baseline costs a build from a git commit
+  only *after* the twins are deleted — while they are alive, 6.2 can
+  measure both in one interpreter, which is much cheaper. **Take the
+  benchmark before the deletion, not after.**
+- **One cache slot, and the shared photon set builds a muon table the
+  scalar decay module ignores.** Both are deliberate and both are
+  cheap to change; 6.2's numbers decide.

--- a/projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md
+++ b/projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md
@@ -112,6 +112,23 @@ this task made to it (see `## Plan Impact`):
   (mass, start) pairs over `np.linspace(1, 2000, 4001)` MeV × the two
   grid starts — and at **none** of the corpus's three masses, so a
   three-mass check would have missed it.
+- **The Rust grid is bit-equal to `numpy.logspace` on macOS/arm64 and
+  one ulp off it on Linux/x86-64** — found by CI, not locally (run
+  32681245809: green on macOS, red on all five Linux jobs, in exactly
+  the 15 tests that compare against NumPy and none of the 50 that do
+  not). `numpy.logspace` evaluates `10 ** y` through NumPy's own
+  vectorised `power` loop; `logspace` calls `f64::powf` and reaches the
+  platform libm. **They are not the same code.** About 5% of the 500
+  points differ per grid — 19 to 31 — and every measured disagreement
+  was exactly one ulp, worst relative 2.16e-16, which is the most two
+  correctly-rounded implementations of `10 ** y` can differ.
+
+  Consequence for 6.2/6.3: a table built on Linux sits within one ulp of
+  the one the Cython built there. That is inside every budget the corpus
+  applies off its capturing platform, and the corpus already runs in
+  budget mode off macOS — so it changes no gate, but it does mean
+  "bit-equal to the Cython" is a **macOS/arm64 statement** for anything
+  that reads these tables.
 
 ## Decisions and Implementation Notes
 
@@ -132,12 +149,30 @@ this task made to it (see `## Plan Impact`):
   Tightening it into a raise would be a behaviour change the corpus
   cannot gate (it samples valid modes only) — filed instead.
 - **`cargo` gates the grid *algorithm*; Python gates its agreement with
-  NumPy.** Hard-coding the capturing platform's NumPy bits into a cargo
-  test would turn a Linux CI job red for a libm difference rather than a
-  defect — the failure Phase 04 learnings §4 records twice. So
+  NumPy, scoped by platform.** Hard-coding the capturing platform's
+  NumPy bits into a cargo test would turn a Linux CI job red for a libm
+  difference rather than a defect — the failure Phase 04 learnings §4
+  records twice, and this task then reproduced it in the Python half.
   `cargo test` asserts the unfused step, the substituted endpoint and
-  monotonicity, and `test/test_core_mediator_tables.py` compares against
-  live `numpy.logspace` on whatever platform runs.
+  monotonicity; `test/test_core_mediator_tables.py` compares against live
+  `numpy.logspace` and demands bit-equality **on the capturing platform
+  only**, one ulp elsewhere, declaring the mode from
+  `ON_THE_CAPTURING_PLATFORM` the way `test/test_core_interp.py` does
+  rather than from a probe (Phase 04 learnings §4 records that probe
+  mechanism as unsound twice).
+- **The two off-platform comparators are separate functions, tested
+  directly.** `assert_within_one_ulp` and `assert_within_peak_budget` are
+  split out of the scoped callers so `TestTheOffPlatformBudgets` can
+  exercise them on **every** platform, including the one whose callers
+  never reach them. The first draft tested them through the scoped
+  entry points, which on macOS took the exact branch and asserted
+  nothing about the budgets — the same way `test_core_interp.py`'s probe
+  silently voided nine claims before its rewrite.
+- **The `lookup`-vs-`np.interp` budget is `test_core_interp.py`'s**
+  (`OFF_PLATFORM_BUDGET = 1e-12` of the compared array's peak), cited
+  rather than re-derived: same port, same question about a contracted
+  multiply-add, and the grid is shared by both sides, so a second
+  derivation would measure the same thing.
 - **A sixth probe submodule, `hazma._core.mediator_tables`.** Added to
   `_CORE_TEST_ONLY_MODULES` with the rest, and for the same reason the
   five before it were: the oracles (`numpy.logspace`, `numpy.interp`,
@@ -165,8 +200,8 @@ this task made to it (see `## Plan Impact`):
 - `rust/src/kernels.rs` — register the module; document why it is the
   fifth naming exception.
 - `rust/src/lib.rs` — register the probe; extend the probe paragraph.
-- `test/test_core_mediator_tables.py` — **new.** 65 tests over six
-  classes.
+- `test/test_core_mediator_tables.py` — **new.** 70 tests over seven
+  classes, two of the comparisons scoped to the capturing platform.
 - `test/parity/cases.py` — `hazma._core.mediator_tables` added to
   `_CORE_TEST_ONLY_MODULES`, with its rationale in the existing comment.
 - `projects/cython-to-rust/phases/phase-06-mediator-spectra.md` — Task
@@ -195,22 +230,24 @@ this task made to it (see `## Plan Impact`):
   columns are the Phase 04 kernels, legacy `m_e`); and all three
   selectors (accepted set, rejected set, line-carrying modes, bit values,
   the default list, repeated/unknown names).
-- `pytest test/test_core_mediator_tables.py -q -n 0` — `65 passed`.
+- `pytest test/test_core_mediator_tables.py -q -n 0` — `70 passed`.
   Covers: `logspace` vs `numpy.logspace` at the corpus masses and over a
   4,001-mass sweep, the last point, the `num < 2` raise; both table sets'
   grids and columns against the public Rust entry points; the legacy vs
   PDG electron mass; `lookup` vs `np.interp` and vs the `.pyx` tail
   branch over 6,000+ probes, both clamps, `NaN`, both error paths; and
   every selector's accepted and rejected sets — the rejected sets
-  **against the live Cython twins**, which return `0.0` for them.
+  **against the live Cython twins**, which return `0.0` for them; and
+  `TestTheOffPlatformBudgets`, which runs both off-platform comparators
+  on every machine.
 - `pytest test/parity -q` — `658 passed, 1 skipped`; all 41 entry points
   unchanged.
 - `pytest test/test_theory_aggregation.py -q` — `69 passed` (the
   model-layer gate the corpus cannot be).
-- `pytest -q` (full suite) — `2158 passed, 15 skipped, 12 subtests
+- `pytest -q` (full suite) — `2163 passed, 15 skipped, 12 subtests
   passed`. `git diff origin/master --name-only -- test/` names only
   `test/parity/cases.py` (a comment and one `frozenset` entry) and the
-  new module, so the 65 new tests are the whole delta.
+  new module, so the 70 new tests are the whole delta.
 - `scripts/agents/preflight.sh --paths "…"` — see the sweep block.
 - **Mutation campaign, 8/8 killed** — the Phase 04 discipline, run
   against `cargo test` because that is the gate a future edit meets
@@ -237,10 +274,21 @@ this task made to it (see `## Plan Impact`):
   the grid's first decade into extrapolation. Both were caught by
   `test/test_core_mediator_tables.py` (M1: 13 failures) — the campaign's
   value was making `cargo` catch them too.
+- **CI found what the local machine could not.** The first round
+  (run 32681245809) was green on macOS/arm64 and red on all five Linux
+  jobs, in exactly the 15 tests that compare against NumPy and in none of
+  the 50 that do not — so the port was never in question, the
+  cross-implementation claim's *scope* was. See `## Findings` for the
+  measurement and `## Decisions` for the fix. Phase 04 learnings §4 says
+  to read a Linux-only failure in a bit-equality assertion as "the scope
+  is wrong" before "the port is wrong"; that is what this was.
 - **Test validity.** Most new assertions pin behaviour this task
   created, so there is no production change to stash; the mutation
   campaign above is the substitute, and it is stronger — every mutation
-  was applied to the real source, built, and run.
+  was applied to the real source, built, and run. The two off-platform
+  budgets carry their own inversions:
+  `test_the_grid_budget_rejects_two_ulp` and
+  `test_the_interp_budget_rejects_a_visible_error`.
 - **Deferred:** no benchmark. `rules.md` rule 12 wants one for a
   performance claim, and this task makes none — the cache has no caller
   until Task 6.2, which the phase file already charges with the
@@ -319,7 +367,7 @@ an editable install in this worktree — `hazma.__file__` and
 | Forbidden tokens in new files | `rg -n "TODO\|FIXME\|breakpoint()\|import pdb\|print("` over the three new source files | no occurrences; preflight's own gate reports `none added`. |
 | Follow-up not a duplicate | `rg` over `docs/followups/{todo,done}/`; `gh pr list --state open` | no existing entry, no open PRs. New stub plus index row. |
 | The two prose lists of probe submodules | `rg -n "_CORE_TEST_ONLY_MODULES" test/parity/cases.py`; `rust/src/lib.rs` module docs | both name all six submodules and their oracles, and agree with the `frozenset`. |
-| Numerical-impact statement | `pytest test/parity -q`; `pytest test/test_theory_aggregation.py -q` | `658 passed, 1 skipped` and `69 passed`. **No public value changes**; nothing appended to `../numerical-impact.md`. |
+| Numerical-impact statement | `pytest test/parity -q`; `pytest test/test_theory_aggregation.py -q` | `658 passed, 1 skipped` and `69 passed`, on both CI platforms. **No public value changes**; nothing appended to `../numerical-impact.md`. |
 | Preflight | `env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh --paths … --md …` | `RESULT: PASS` — eleven rows, one `SKIP` (version bump, not a closing PR). |
 
 ## Handoff to Next Task

--- a/projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md
+++ b/projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md
@@ -183,6 +183,20 @@ this task made to it (see `## Plan Impact`):
   no non-test caller, so `clippy -D warnings` rejected it; Task 6.2 adds
   it back with the integrand that branches on it rather than carrying a
   `dead_code` allowance through the phase.
+- **Review round 1 (blocking, 1 finding): the phase README's handoff was
+  never refreshed.** It still told Task 6.2 that "memoization keying
+  (mediator mass + partial widths) must match how model classes mutate
+  parameters — verify against `hazma/scalar_mediator/__init__.py` setter
+  behavior before trusting the cache", contradicting the amended
+  criterion, this note, and the shipped `TableCache`. Rewritten, and the
+  premise closed on evidence rather than deleted: the key is the mass
+  alone, **and** no setter can strand the cache, because the wrappers
+  read `self.ms` / `self.mv` fresh per call and pass the mass as an
+  argument (`_scalar_mediator_spectra.py:72,81`,
+  `_vector_mediator_spectra.py:84`), so a mutated mass re-keys by
+  construction. The whole block was refreshed, not the cited line —
+  "currently safe to assume" was equally stale. Filed as
+  `[phase-handoff-outlives-its-question]` in the lessons ledger.
 - **The shared photon table set builds the muon table the scalar decay
   module will not read.** One 500-point evaluation per *distinct mass*
   against the two-per-*call* the dead cache costs today; Task 6.2
@@ -211,7 +225,10 @@ this task made to it (see `## Plan Impact`):
   and `docs/followups/README.md` — **new** follow-up and its index row.
 - `projects/cython-to-rust/task-notes/phase-06/README.md`,
   `projects/cython-to-rust/task-notes/README.md` — status, findings,
-  handoff.
+  handoff. The phase README's `## Handoff to Next Task` was rewritten in
+  review round 1; it was still the pre-phase block from 2026-08-03.
+- `docs/agents/lessons.md`, `docs/agents/lessons-examples.md` —
+  `[phase-handoff-outlives-its-question]` (PR #79).
 
 ## Verification
 
@@ -368,6 +385,7 @@ an editable install in this worktree — `hazma.__file__` and
 | Follow-up not a duplicate | `rg` over `docs/followups/{todo,done}/`; `gh pr list --state open` | no existing entry, no open PRs. New stub plus index row. |
 | The two prose lists of probe submodules | `rg -n "_CORE_TEST_ONLY_MODULES" test/parity/cases.py`; `rust/src/lib.rs` module docs | both name all six submodules and their oracles, and agree with the `frozenset`. |
 | Numerical-impact statement | `pytest test/parity -q`; `pytest test/test_theory_aggregation.py -q` | `658 passed, 1 skipped` and `69 passed`, on both CI platforms. **No public value changes**; nothing appended to `../numerical-impact.md`. |
+| Phase README handoff vs what shipped (review round 1) | `rg -n "mass \+ partial widths\|before trusting the cache" projects/ docs/ hazma/ test/` | 3 hits, **all** amendment records or strikethroughs that quote the old wording deliberately; zero live claims. Before the fix the phase README's handoff carried a live one. |
 | Preflight | `env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh --paths … --md …` | `RESULT: PASS` — eleven rows, one `SKIP` (version bump, not a closing PR). |
 
 ## Handoff to Next Task

--- a/rust/src/kernels.rs
+++ b/rust/src/kernels.rs
@@ -25,6 +25,12 @@
 //! `c_scalar_mediator_cross_sections` and whose `<model>_mediator` halves
 //! are already the PyO3 submodules' names.
 //!
+//! [`mediator_tables`] is a fifth, and the only one that is shared
+//! *foundation* rather than a port: the four mediator-spectrum `.pyx`
+//! repeat one rest-frame-table construction, one memo cache and one set
+//! of mode selectors between them, so cython-to-rust Task 6.1 factored
+//! those out before Tasks 6.2 and 6.3 built the entry points on top.
+//!
 //! [`soft_complex`] is the one submodule that is not a `.pyx` at all. It
 //! holds the two pieces of C complex arithmetic Cython's `**` operator
 //! drags in, which both cross-section modules need and neither owns;
@@ -33,6 +39,7 @@
 //! below stay at this level for the opposite reason — they belong to no
 //! `.pyx` and to no domain.
 
+pub mod mediator_tables;
 pub mod neutrino_flavors;
 pub mod neutrino_muon;
 pub mod neutrino_pion;

--- a/rust/src/kernels/mediator_tables.rs
+++ b/rust/src/kernels/mediator_tables.rs
@@ -1,0 +1,989 @@
+//! The shared foundation of the four mediator-spectrum `.pyx`:
+//! rest-frame interpolation tables, their memo cache, and the mode
+//! selectors.
+//!
+//! PyO3-free (`projects/cython-to-rust/rules.md`, Rust conventions
+//! rule 3). Nothing here is a hazma entry point; Tasks 6.2 and 6.3 build
+//! `scalar_mediator_decay_spectrum`, `dnde_decay_v`/`dnde_decay_v_pt`
+//! and `dnde_decay_s`/`dnde_decay_s_pt` on top of it.
+//!
+//! # Which `.pyx` this serves
+//!
+//! Like [`crate::kernels::soft_complex`] and unlike the rest of
+//! [`crate::kernels`], this module is not the port of one `.pyx`. It is
+//! the part all four mediator-spectrum modules repeat verbatim:
+//!
+//! | `.pyx` | Tables | Grid start | Below-grid |
+//! | --- | --- | --- | --- |
+//! | `scalar_mediator/scalar_mediator_decay_spectrum.pyx` | charged pion photon | `10⁻¹` MeV | `1/E` tail |
+//! | `vector_mediator/vector_mediator_decay_spectrum.pyx` | charged pion photon, muon photon | `10⁻¹` MeV | `1/E` tail |
+//! | `scalar_mediator/scalar_mediator_positron_spec.pyx` | charged pion positron, muon positron | `m_e` | clamp |
+//! | `vector_mediator/vector_mediator_positron_spec.pyx` | charged pion positron, muon positron | `m_e` | clamp |
+//!
+//! The two decay modules are one clone-pair and the two positron
+//! modules another, so there are two table *sets* here, each
+//! parameterised by the mediator mass: [`PhotonTables`] and
+//! [`PositronTables`].
+//!
+//! # The grid is `numpy.logspace`, bit for bit
+//!
+//! All four `.pyx` build their abscissae with
+//! `np.logspace(start, log10(m/2), num=500)`, and the values a
+//! bit-equality-class comparison sees depend on reproducing that
+//! exactly rather than on any equivalent spelling. [`logspace`] is
+//! NumPy's own arithmetic: `step = (stop - start) / (num - 1)`, then
+//! `10**(i * step + start)` with the multiply and the add rounded
+//! separately — **not** fused — and the final point taken as `10**stop`
+//! rather than as `10**(499 * step + start)`. That last substitution is
+//! worth one ulp at about 9% of mediator masses — 732 of 8,008
+//! (mass, start) pairs over `numpy.linspace(1, 2000, 4001)` MeV crossed
+//! with the two grid starts — and none of the corpus's three masses is
+//! among them, so it is a correctness detail rather than something a
+//! Phase 06 measurement would have caught.
+//!
+//! Note also that the grid's last point is not `m/2` exactly: at
+//! `m = 550` MeV, `10**log10(275)` is `275.0000000000001`.
+//!
+//! `cargo` gates the *algorithm* only — the tests below assert the
+//! unfused step, the substituted endpoint and the endpoints themselves.
+//! Agreement with NumPy is a claim about libm, which
+//! `test/test_core_mediator_tables.py` re-derives live through
+//! [`crate::mediator_tables_probe`] on whatever platform the suite runs;
+//! hard-coding one platform's bits here would turn a Linux CI job red
+//! for a libm difference rather than a defect
+//! (`projects/cython-to-rust/learnings/phase-04-spectra-kernels.md` §4).
+//!
+//! One spelling difference between the four sources is *not* a
+//! numerical one: `scalar_mediator_decay_spectrum.pyx:45` takes its
+//! upper endpoint from `np.log10`, the other three from libc `log10`.
+//! Measured on the capturing platform, the two agree bit-for-bit at
+//! every mass the corpus samples, so this module takes one `log10`.
+//!
+//! # Why the cache is real here and dead in the Cython
+//!
+//! Neither decay module caches at all — `__set_spectra` is called
+//! unconditionally at the top of every entry point
+//! (`scalar_mediator_decay_spectrum.pyx:245`,
+//! `vector_mediator_decay_spectrum.pyx:250` and `:274`), so every call rebuilds a
+//! 500-point quadrature-backed table. Both positron modules *look*
+//! cached and are not: `__recompute_rf_spectra` compares against
+//! `cache_ms` / `cache_pws` and **no line anywhere assigns to either**,
+//! so the sentinel `-1.0` they are initialised with never changes and
+//! the predicate is always true
+//! (`scalar_mediator_positron_spec.pyx:49-55`, and the identical
+//! `vector_mediator_positron_spec.pyx:50-56`).
+//!
+//! [`TableCache`] is the fix, and it is a performance change only
+//! (`rules.md` rules 3 and 12): a cache hit returns the table a miss
+//! would have rebuilt from the same inputs, so no value moves.
+//!
+//! The key is the mediator mass alone. The Cython's dead predicate also
+//! named three partial widths, but `__set_spectra` takes only the mass
+//! and reads no width — the tables are a pure function of `m/2`, the
+//! daughter energy the Phase 04 kernels are evaluated at. Keying on the
+//! widths as well would be equally correct and strictly slower: it
+//! would rebuild both tables whenever a caller varies a coupling at
+//! fixed mass, which is the sweep the cache exists to make cheap.
+//!
+//! # Modes are parsed once, and an unknown mode is not an error
+//!
+//! The Cython re-dispatches on `str` **inside the integrand**, so a
+//! mode string is compared once per quadrature node
+//! (`vector_mediator_decay_spectrum.pyx:166-178`,
+//! `scalar_mediator_positron_spec.pyx:150-161`). [`PhotonMode`],
+//! [`PositronMode`] and [`ScalarPhotonModes`] move that to the call
+//! boundary.
+//!
+//! An unrecognised selector raises nothing today. Every `cdef double`
+//! integrand ends in a chain of `if mode == ...: return ...` with no
+//! `else`, and a C function that falls off its end returns zero — so a
+//! typo'd mode integrates a zero integrand and the entry point returns
+//! `0.0`. The parsers below therefore return [`Option`] and leave that
+//! `0.0` to their caller rather than tightening it into a raise; the
+//! behaviour is reproduced under `rules.md` rule 1 and filed as
+//! `docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md`.
+//! Rule 9's "Cython `assert`s become raises" does not reach it: there
+//! is no `assert` here, only a fall-through.
+
+use std::sync::{LazyLock, Mutex};
+
+use std::sync::Arc;
+
+use crate::constants::legacy;
+use crate::interp;
+use crate::kernels::{photon_muon, photon_pion, positron_muon, positron_pion};
+
+// ===========================================================================
+// ---- The grid -------------------------------------------------------------
+// ===========================================================================
+
+/// Points in every mediator-spectrum interpolation table.
+///
+/// `n_interp_pts` in all four `.pyx`.
+pub const N_INTERP_PTS: usize = 500;
+
+/// The decay modules' lower grid endpoint, `10⁻¹` MeV.
+///
+/// Written as the literal exponent `-1.0` in both
+/// (`scalar_mediator_decay_spectrum.pyx:45`,
+/// `vector_mediator_decay_spectrum.pyx:33`), and reused as the
+/// threshold of the `1/E` tail below the grid — the same number in both
+/// roles, which is why it is one constant.
+pub const PHOTON_GRID_LOG10_START: f64 = -1.0;
+
+/// `numpy.logspace(start, stop, num)`, reproduced exactly.
+///
+/// NumPy evaluates `10 ** linspace(start, stop, num)`, and its
+/// `linspace` computes `step = (stop - start) / (num - 1)` once, forms
+/// `i * step` and adds `start` as two separately rounded operations, then
+/// **overwrites the last element with `stop`**. That last assignment is
+/// not cosmetic: `10**stop` and `10**(499 * step + start)` differ by one
+/// ulp at about 9% of mediator masses (see this module's docs), and
+/// `m = 2` MeV is one of them.
+///
+/// `i * step + start` is deliberately *not* written `mul_add`. NumPy's
+/// loop is two IEEE operations and a fused one would round differently.
+///
+/// # Panics
+///
+/// Panics if `num < 2`. Every call site passes [`N_INTERP_PTS`]; NumPy
+/// defines `num == 1` as `[10**start]` and `num == 0` as empty, and
+/// reproducing either would be dead code.
+#[must_use]
+pub fn logspace(start: f64, stop: f64, num: usize) -> Vec<f64> {
+    assert!(num >= 2, "logspace: num must be at least 2");
+    let step = (stop - start) / ((num - 1) as f64);
+    let mut grid: Vec<f64> = (0..num).map(|i| (i as f64) * step + start).collect();
+    grid[num - 1] = stop;
+    for exponent in &mut grid {
+        *exponent = 10.0_f64.powf(*exponent);
+    }
+    grid
+}
+
+// ===========================================================================
+// ---- The table ------------------------------------------------------------
+// ===========================================================================
+
+/// What a table returns below its first abscissa.
+///
+/// The two clone-pairs disagree, and both behaviours are shipped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BelowGrid {
+    /// `dnde[0] * energies[0] / energy` — the decay modules' `1/E` tail
+    /// (`scalar_mediator_decay_spectrum.pyx:55-56`,
+    /// `vector_mediator_decay_spectrum.pyx:49-56`), anchored so it meets
+    /// the first tabulated value at the threshold.
+    ///
+    /// The threshold is the grid's own lower endpoint written a second
+    /// time as `10**-1`; the Cython compares against that literal rather
+    /// than against `e_gams[0]`, and the two are the same double.
+    InverseEnergy,
+    /// `numpy.interp`'s own clamp to `dnde[0]` — the positron modules,
+    /// which interpolate with no guard at all
+    /// (`scalar_mediator_positron_spec.pyx:96-101`).
+    Clamp,
+}
+
+/// A rest-frame spectrum tabulated on a log-spaced energy grid.
+///
+/// `dnde[i]` is the Phase 04 kernel evaluated at `energies[i]` — called
+/// natively, with no Python round trip, where the Cython went through
+/// `dnde_*_array` and a NumPy allocation.
+pub struct RestFrameTable {
+    /// Rest-frame product energies, MeV, ascending.
+    energies: Vec<f64>,
+    /// `dN/dE` in MeV⁻¹ at each energy.
+    dnde: Vec<f64>,
+    below: BelowGrid,
+}
+
+impl RestFrameTable {
+    /// Tabulate `kernel` on `logspace(log10_start, log10_stop, num)`.
+    ///
+    /// `log10_start` and `log10_stop` are base-10 logarithms of energies
+    /// in MeV; `kernel` maps an energy in MeV to `dN/dE` in MeV⁻¹.
+    #[must_use]
+    pub fn build<F>(log10_start: f64, log10_stop: f64, below: BelowGrid, kernel: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        let energies = logspace(log10_start, log10_stop, N_INTERP_PTS);
+        let dnde = energies.iter().map(|&energy| kernel(energy)).collect();
+        Self {
+            energies,
+            dnde,
+            below,
+        }
+    }
+
+    /// Wrap columns that were tabulated elsewhere.
+    ///
+    /// Only [`crate::mediator_tables_probe`] calls this: it is how a
+    /// Python test puts abscissae through [`Self::lookup`] without
+    /// rebuilding a quadrature-backed table first. Every table hazma
+    /// itself evaluates comes from [`Self::build`].
+    ///
+    /// # Errors
+    ///
+    /// A message naming the violation if the columns are empty or of
+    /// different lengths — the two cases [`interp::interp`] would
+    /// otherwise panic on.
+    pub fn from_columns(
+        energies: Vec<f64>,
+        dnde: Vec<f64>,
+        below: BelowGrid,
+    ) -> Result<Self, String> {
+        if energies.is_empty() {
+            return Err("array of sample points is empty".to_owned());
+        }
+        if energies.len() != dnde.len() {
+            return Err("fp and xp are not of the same length.".to_owned());
+        }
+        Ok(Self {
+            energies,
+            dnde,
+            below,
+        })
+    }
+
+    /// The tabulated `dN/dE` in MeV⁻¹ at `energy` MeV.
+    ///
+    /// Inside the grid this is `numpy.interp`; below it, whichever of
+    /// [`BelowGrid`]'s two behaviours the source `.pyx` had. Above the
+    /// grid both clone-pairs take NumPy's clamp to the last value, which
+    /// is what [`interp::interp`] already does — neither `.pyx` guards
+    /// that side.
+    ///
+    /// A `NaN` energy fails the `<` comparison, so it reaches
+    /// [`interp::interp`] and propagates, exactly as the Cython's
+    /// `np.interp` did.
+    #[must_use]
+    pub fn lookup(&self, energy: f64) -> f64 {
+        if self.below == BelowGrid::InverseEnergy && energy < PHOTON_GRID_LOG10_TAIL_THRESHOLD {
+            return self.dnde[0] * self.energies[0] / energy;
+        }
+        interp::interp(energy, &self.energies, &self.dnde)
+    }
+
+    /// The grid's abscissae, MeV — for tests and for
+    /// [`crate::kernels`]'s own assertions.
+    #[must_use]
+    pub fn energies(&self) -> &[f64] {
+        &self.energies
+    }
+
+    /// The tabulated values, MeV⁻¹, aligned with [`Self::energies`].
+    #[must_use]
+    pub fn values(&self) -> &[f64] {
+        &self.dnde
+    }
+}
+
+/// The `10**-1` the decay modules compare against before extrapolating.
+///
+/// Named separately from [`PHOTON_GRID_LOG10_START`] because it is an
+/// *energy* in MeV where that is a base-10 exponent, even though the
+/// Cython spells both `-1` and the tail therefore begins exactly at the
+/// grid's first point.
+const PHOTON_GRID_LOG10_TAIL_THRESHOLD: f64 = 0.1;
+
+// ===========================================================================
+// ---- The cache ------------------------------------------------------------
+// ===========================================================================
+
+/// A one-slot memo keyed on the mediator mass.
+///
+/// One slot, because the Cython had one set of module globals and
+/// because every consumer sweeps a whole energy grid at one mass before
+/// moving to the next. The key is compared on the mass's **bit
+/// pattern**, so it is reflexive at every value a caller can pass —
+/// including `NaN`, which `==` would make a permanent miss and an
+/// unbounded rebuild loop.
+///
+/// The stored value is an [`Arc`] so a caller can drop the lock before
+/// integrating: a quadrature over 500-point tables must not hold a mutex
+/// across thousands of integrand evaluations.
+pub struct TableCache<T> {
+    slot: Mutex<Option<(u64, Arc<T>)>>,
+}
+
+impl<T> Default for TableCache<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> TableCache<T> {
+    /// An empty cache.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            slot: Mutex::new(None),
+        }
+    }
+
+    /// The tables for `mass` MeV, building them with `build` on a miss.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex was poisoned by a previous panic inside
+    /// `build`. `build` calls kernel `fn`s that return `NaN` rather than
+    /// panicking on bad input, so this is a crate bug rather than a
+    /// reachable path.
+    pub fn get_or_build<F>(&self, mass: f64, build: F) -> Arc<T>
+    where
+        F: FnOnce(f64) -> T,
+    {
+        let key = mass.to_bits();
+        let mut slot = self.slot.lock().expect("mediator table cache poisoned");
+        if let Some((cached_key, tables)) = slot.as_ref()
+            && *cached_key == key
+        {
+            return Arc::clone(tables);
+        }
+        let tables = Arc::new(build(mass));
+        *slot = Some((key, Arc::clone(&tables)));
+        tables
+    }
+}
+
+// ===========================================================================
+// ---- The two table sets ---------------------------------------------------
+// ===========================================================================
+
+/// The rest-frame photon tables both decay modules interpolate.
+///
+/// Built at the daughter energy `m/2`, which is what a two-body decay of
+/// a mediator at rest gives each daughter.
+pub struct PhotonTables {
+    /// `π± → …γ` at `E_π = m/2`.
+    pub charged_pion: RestFrameTable,
+    /// `μ± → e ν ν γ` at `E_μ = m/2`.
+    ///
+    /// Only `vector_mediator_decay_spectrum.pyx` builds this one; the
+    /// scalar module calls `dnde_photon_muon_point` per node instead of
+    /// tabulating it. Both table sets are built together anyway — see
+    /// the note on [`photon_tables_for`].
+    pub muon: RestFrameTable,
+}
+
+/// The rest-frame positron tables both positron modules interpolate.
+pub struct PositronTables {
+    /// `π± → μ ν → e ν ν ν` at `E_π = m/2`.
+    pub charged_pion: RestFrameTable,
+    /// `μ± → e ν ν` at `E_μ = m/2`.
+    pub muon: RestFrameTable,
+}
+
+/// Photon tables for a mediator of mass `mass` MeV.
+///
+/// The scalar decay module tabulates only the charged pion and the
+/// vector module tabulates both, so a shared set builds one table the
+/// scalar half will not read. That is deliberate: the alternative is two
+/// caches whose only difference is a field, and the wasted table is one
+/// 500-point evaluation per *distinct mass*, where the dead cache it
+/// replaces cost two per *call*. Task 6.2 measures the result either
+/// way.
+fn photon_tables_for(mass: f64) -> PhotonTables {
+    let daughter_energy = mass / 2.0;
+    let log10_stop = daughter_energy.log10();
+    PhotonTables {
+        charged_pion: RestFrameTable::build(
+            PHOTON_GRID_LOG10_START,
+            log10_stop,
+            BelowGrid::InverseEnergy,
+            |energy| photon_pion::dnde_photon_charged_pion(energy, daughter_energy),
+        ),
+        muon: RestFrameTable::build(
+            PHOTON_GRID_LOG10_START,
+            log10_stop,
+            BelowGrid::InverseEnergy,
+            |energy| photon_muon::dnde_photon_muon(energy, daughter_energy),
+        ),
+    }
+}
+
+/// Positron tables for a mediator of mass `mass` MeV.
+///
+/// The grid starts at the **legacy** electron mass — all four `.pyx`
+/// `include "../_utils/legacy_parameters.pxd"`, so `me` here is
+/// `0.510998928` and not [`crate::constants::pdg::MASS_E`]
+/// (`rules.md` rule 4).
+fn positron_tables_for(mass: f64) -> PositronTables {
+    let daughter_energy = mass / 2.0;
+    let log10_start = legacy::MASS_E.log10();
+    let log10_stop = daughter_energy.log10();
+    PositronTables {
+        charged_pion: RestFrameTable::build(log10_start, log10_stop, BelowGrid::Clamp, |energy| {
+            positron_pion::dnde_positron_charged_pion(energy, daughter_energy)
+        }),
+        muon: RestFrameTable::build(log10_start, log10_stop, BelowGrid::Clamp, |energy| {
+            positron_muon::dnde_positron_muon(energy, daughter_energy)
+        }),
+    }
+}
+
+/// The process-wide photon-table cache.
+static PHOTON_TABLES: LazyLock<TableCache<PhotonTables>> = LazyLock::new(TableCache::new);
+
+/// The process-wide positron-table cache.
+static POSITRON_TABLES: LazyLock<TableCache<PositronTables>> = LazyLock::new(TableCache::new);
+
+/// Memoized [`PhotonTables`] for a mediator of mass `mass` MeV.
+#[must_use]
+pub fn photon_tables(mass: f64) -> Arc<PhotonTables> {
+    PHOTON_TABLES.get_or_build(mass, photon_tables_for)
+}
+
+/// Memoized [`PositronTables`] for a mediator of mass `mass` MeV.
+#[must_use]
+pub fn positron_tables(mass: f64) -> Arc<PositronTables> {
+    POSITRON_TABLES.get_or_build(mass, positron_tables_for)
+}
+
+// ===========================================================================
+// ---- Mode selectors -------------------------------------------------------
+// ===========================================================================
+
+/// The vector decay module's `mode` argument.
+///
+/// The seven strings `vector_mediator_decay_spectrum.pyx:166-178`
+/// compares against, in that order. Parsed once per call by
+/// [`PhotonMode::parse`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PhotonMode {
+    /// `"total"` — every channel, plus the `π⁰γ` line.
+    Total,
+    /// `"e e g"` — FSR off the electron pair.
+    ElectronFsr,
+    /// `"pi pi g"` — FSR off the charged pions.
+    ChargedPionFsr,
+    /// `"pi pi"` — the charged pions' decay continuum.
+    ChargedPionDecay,
+    /// `"pi0 g"` — the `π⁰` continuum plus the monochromatic line.
+    NeutralPionLine,
+    /// `"mu mu g"` — FSR off the muon pair.
+    MuonFsr,
+    /// `"mu mu"` — the muons' decay continuum.
+    MuonDecay,
+}
+
+impl PhotonMode {
+    /// The mode `mode` names, or `None` if it names nothing.
+    ///
+    /// `None` is not an error: see this module's docs — the Cython
+    /// returns `0.0` for an unrecognised mode and the caller reproduces
+    /// that.
+    #[must_use]
+    pub fn parse(mode: &str) -> Option<Self> {
+        match mode {
+            "total" => Some(Self::Total),
+            "e e g" => Some(Self::ElectronFsr),
+            "pi pi g" => Some(Self::ChargedPionFsr),
+            "pi pi" => Some(Self::ChargedPionDecay),
+            "pi0 g" => Some(Self::NeutralPionLine),
+            "mu mu g" => Some(Self::MuonFsr),
+            "mu mu" => Some(Self::MuonDecay),
+            _ => None,
+        }
+    }
+
+    /// Whether this mode carries the `π⁰ → γ` line term.
+    ///
+    /// `vector_mediator_decay_spectrum.pyx:223` adds it for `"pi0 g"`
+    /// and `"total"` only.
+    #[must_use]
+    pub fn has_line(self) -> bool {
+        matches!(self, Self::Total | Self::NeutralPionLine)
+    }
+}
+
+/// The positron modules' `fs` argument.
+///
+/// Both `scalar_mediator_positron_spec.pyx:150-161` and its vector clone
+/// compare against these four strings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PositronMode {
+    /// `"total"` — the charged-pion and muon continua, plus the `e⁺e⁻`
+    /// line.
+    Total,
+    /// `"e e"` — the `e⁺e⁻` line alone; no integral is performed.
+    ElectronLine,
+    /// `"mu mu"` — the muon continuum, plus the line.
+    MuonDecay,
+    /// `"pi pi"` — the charged-pion continuum, plus the line.
+    ChargedPionDecay,
+}
+
+impl PositronMode {
+    /// The final state `fs` names, or `None` if it names nothing.
+    #[must_use]
+    pub fn parse(fs: &str) -> Option<Self> {
+        match fs {
+            "total" => Some(Self::Total),
+            "e e" => Some(Self::ElectronLine),
+            "mu mu" => Some(Self::MuonDecay),
+            "pi pi" => Some(Self::ChargedPionDecay),
+            _ => None,
+        }
+    }
+}
+
+/// The scalar decay module's `modes` argument, reduced to a bit set.
+///
+/// Alone among the four, this entry point takes a *list* of modes and
+/// folds it into an `int` bitflag
+/// (`scalar_mediator_decay_spectrum.pyx:253-266`). The bit values are
+/// that file's, so a set built here and one built there compare equal.
+///
+/// Two properties of the Cython's fold are reproduced deliberately: an
+/// unrecognised entry sets no bit and raises nothing, and a repeated
+/// entry sets its bit once — the `.pyx` writes `bitflag += BITFLAG_PP`
+/// under `if "pi pi" in modes`, and `in` is tested once per mode name
+/// rather than once per list element, so a duplicate cannot double a
+/// flag into its neighbour's bit.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ScalarPhotonModes(u32);
+
+impl ScalarPhotonModes {
+    /// `"pi pi"` — the charged pions' decay continuum.
+    pub const CHARGED_PION_DECAY: u32 = 1;
+    /// `"mu mu"` — the muons' decay continuum.
+    pub const MUON_DECAY: u32 = 2;
+    /// `"pi0 pi0"` — the neutral pions' decay continuum.
+    pub const NEUTRAL_PION_DECAY: u32 = 4;
+    /// `"g g"` — the monochromatic two-photon line.
+    pub const TWO_PHOTON_LINE: u32 = 8;
+    /// `"e e g"` — FSR off the electron pair.
+    pub const ELECTRON_FSR: u32 = 16;
+    /// `"pi pi g"` — FSR off the charged pions.
+    pub const CHARGED_PION_FSR: u32 = 32;
+    /// `"mu mu g"` — FSR off the muon pair.
+    pub const MUON_FSR: u32 = 64;
+
+    /// The bit a mode name sets, or `None` if it names nothing.
+    #[must_use]
+    pub fn bit_for(mode: &str) -> Option<u32> {
+        match mode {
+            "pi pi" => Some(Self::CHARGED_PION_DECAY),
+            "mu mu" => Some(Self::MUON_DECAY),
+            "pi0 pi0" => Some(Self::NEUTRAL_PION_DECAY),
+            "g g" => Some(Self::TWO_PHOTON_LINE),
+            "e e g" => Some(Self::ELECTRON_FSR),
+            "pi pi g" => Some(Self::CHARGED_PION_FSR),
+            "mu mu g" => Some(Self::MUON_FSR),
+            _ => None,
+        }
+    }
+
+    /// Fold an iterator of mode names into a bit set.
+    #[must_use]
+    pub fn from_names<I, S>(modes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut bits = 0;
+        for mode in modes {
+            if let Some(bit) = Self::bit_for(mode.as_ref()) {
+                bits |= bit;
+            }
+        }
+        Self(bits)
+    }
+
+    /// The raw bitflag, for comparison against the Cython's `int`.
+    ///
+    /// The only reader the bit set needs today. A `contains(bit)`
+    /// helper belongs with the integrand that branches on it, so Task
+    /// 6.2 adds one when it has a caller rather than leaving a
+    /// `dead_code` allowance here.
+    #[must_use]
+    pub fn bits(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BelowGrid, N_INTERP_PTS, PHOTON_GRID_LOG10_START, PhotonMode, PositronMode, RestFrameTable,
+        ScalarPhotonModes, TableCache, logspace, photon_tables, positron_tables,
+    };
+    use crate::constants::legacy;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// The *fused* spelling of the exponent loop — the wrong one.
+    ///
+    /// The foil [`logspace`]'s unfused arithmetic is compared against.
+    /// It is written out here rather than derived from `logspace` so an
+    /// edit to the implementation cannot silently make the comparison
+    /// vacuous.
+    fn fused_exponents(start: f64, stop: f64, num: usize) -> Vec<f64> {
+        let step = (stop - start) / ((num - 1) as f64);
+        let mut exponents: Vec<f64> = (0..num).map(|i| (i as f64).mul_add(step, start)).collect();
+        exponents[num - 1] = stop;
+        exponents
+    }
+
+    #[test]
+    fn logspace_does_not_fuse_the_step_arithmetic() {
+        // `i * step + start` is two roundings in NumPy and one in a
+        // `mul_add`. `fused_exponents` above is the fused variant; this
+        // asserts both halves of the contract -- that the two really do
+        // disagree on this grid, so the comparison is not vacuous, and
+        // that `logspace` is the unfused one.
+        let (start, stop) = (PHOTON_GRID_LOG10_START, 275.0_f64.log10());
+        let grid = logspace(start, stop, N_INTERP_PTS);
+        let step = (stop - start) / ((N_INTERP_PTS - 1) as f64);
+        let fused = fused_exponents(start, stop, N_INTERP_PTS);
+
+        // The last position is excluded: it is substituted from `stop`
+        // and belongs to the test below, not to the step arithmetic.
+        let mut differing = 0;
+        for (index, &fused_exponent) in fused.iter().enumerate().take(N_INTERP_PTS - 1) {
+            let unfused_exponent = (index as f64) * step + start;
+            if unfused_exponent.to_bits() != fused_exponent.to_bits() {
+                differing += 1;
+            }
+            assert_eq!(
+                grid[index].to_bits(),
+                10.0_f64.powf(unfused_exponent).to_bits(),
+                "grid position {index} is not the unfused exponent"
+            );
+        }
+        assert!(
+            differing > 0,
+            "fused and unfused step arithmetic agree everywhere on this \
+             grid; the test no longer gates the spelling"
+        );
+    }
+
+    #[test]
+    fn logspace_takes_its_last_point_from_stop_not_from_the_step() {
+        // The property the final assignment exists for, stated without
+        // the captured constants: the last point is `10**stop` exactly,
+        // and it is *not* what continuing the step arithmetic gives.
+        //
+        // `m = 2` MeV rather than one of the corpus's three masses,
+        // because at 250/550/900 MeV the two spellings happen to agree —
+        // they part company at about 9% of masses and a test built on one
+        // of the other 91% would assert nothing.
+        let (start, stop) = (PHOTON_GRID_LOG10_START, 1.0_f64.log10());
+        let grid = logspace(start, stop, N_INTERP_PTS);
+        let step = (stop - start) / ((N_INTERP_PTS - 1) as f64);
+        let stepped = 10.0_f64.powf(((N_INTERP_PTS - 1) as f64) * step + start);
+        assert_eq!(
+            grid[N_INTERP_PTS - 1].to_bits(),
+            10.0_f64.powf(stop).to_bits()
+        );
+        assert_ne!(grid[N_INTERP_PTS - 1].to_bits(), stepped.to_bits());
+    }
+
+    #[test]
+    fn logspace_is_ascending_and_spans_its_endpoints() {
+        let grid = logspace(-1.0, 3.0, N_INTERP_PTS);
+        assert!(grid.windows(2).all(|pair| pair[0] < pair[1]));
+        assert_eq!(grid[0].to_bits(), 0.1_f64.to_bits());
+        assert_eq!(grid[N_INTERP_PTS - 1].to_bits(), 1000.0_f64.to_bits());
+    }
+
+    /// A table over `dN/dE = 1/E`, which makes every regime checkable in
+    /// closed form.
+    fn reciprocal_table(below: BelowGrid) -> RestFrameTable {
+        RestFrameTable::build(-1.0, 3.0, below, |energy| 1.0 / energy)
+    }
+
+    #[test]
+    fn table_values_are_the_kernel_at_the_grid_points() {
+        let table = reciprocal_table(BelowGrid::Clamp);
+        assert_eq!(table.energies().len(), N_INTERP_PTS);
+        assert_eq!(table.values().len(), N_INTERP_PTS);
+        for (&energy, &value) in table.energies().iter().zip(table.values()) {
+            assert_eq!(value.to_bits(), (1.0 / energy).to_bits());
+        }
+    }
+
+    #[test]
+    fn table_lookup_hits_a_node_exactly() {
+        let table = reciprocal_table(BelowGrid::Clamp);
+        let energy = table.energies()[123];
+        assert_eq!(
+            table.lookup(energy).to_bits(),
+            table.values()[123].to_bits()
+        );
+    }
+
+    #[test]
+    fn inverse_energy_tail_is_continuous_at_the_threshold() {
+        // The tail's whole point: `dnde[0] * e[0] / e` meets `dnde[0]` at
+        // `e = e[0]`, so the branch introduces no jump.
+        let table = reciprocal_table(BelowGrid::InverseEnergy);
+        let first = table.energies()[0];
+        assert_eq!(first.to_bits(), 0.1_f64.to_bits());
+        let just_below = f64::from_bits(first.to_bits() - 1);
+        let ratio = table.lookup(just_below) / table.values()[0];
+        assert!((ratio - 1.0).abs() < 1e-15, "tail jumps by {ratio}");
+        // Below the threshold it really is a `1/E` tail, not a clamp.
+        assert_eq!(
+            table.lookup(0.01).to_bits(),
+            (table.values()[0] * first / 0.01).to_bits()
+        );
+    }
+
+    #[test]
+    fn the_tail_branch_opens_exactly_at_the_threshold_and_not_above_it() {
+        // The threshold is a boundary, not a region: at and above `10**-1`
+        // the table interpolates. Without this, moving the constant up
+        // silently converts the first decade of the grid into
+        // extrapolation and every other test still passes.
+        let table = reciprocal_table(BelowGrid::InverseEnergy);
+        for energy in [0.1, 0.11, 0.15, 0.2, 0.5, 1.0] {
+            assert_eq!(
+                table.lookup(energy).to_bits(),
+                crate::interp::interp(energy, table.energies(), table.values()).to_bits(),
+                "lookup at {energy} extrapolated where it should interpolate"
+            );
+        }
+    }
+
+    #[test]
+    fn clamp_below_grid_returns_the_first_value() {
+        let table = reciprocal_table(BelowGrid::Clamp);
+        assert_eq!(table.lookup(1e-6).to_bits(), table.values()[0].to_bits());
+        assert_eq!(table.lookup(-5.0).to_bits(), table.values()[0].to_bits());
+    }
+
+    #[test]
+    fn both_policies_clamp_above_the_grid() {
+        // Neither `.pyx` guards the upper side, so both inherit
+        // `numpy.interp`'s clamp.
+        let last = N_INTERP_PTS - 1;
+        for below in [BelowGrid::Clamp, BelowGrid::InverseEnergy] {
+            let table = reciprocal_table(below);
+            assert_eq!(table.lookup(1e6).to_bits(), table.values()[last].to_bits());
+        }
+    }
+
+    #[test]
+    fn nan_propagates_through_both_policies() {
+        for below in [BelowGrid::Clamp, BelowGrid::InverseEnergy] {
+            assert!(reciprocal_table(below).lookup(f64::NAN).is_nan());
+        }
+    }
+
+    #[test]
+    fn cache_builds_once_per_mass_and_rebuilds_when_it_changes() {
+        let cache: TableCache<f64> = TableCache::new();
+        let builds = AtomicUsize::new(0);
+        let mut build = |mass: f64| {
+            builds.fetch_add(1, Ordering::SeqCst);
+            mass * 2.0
+        };
+
+        assert_eq!(*cache.get_or_build(550.0, &mut build), 1100.0);
+        assert_eq!(*cache.get_or_build(550.0, &mut build), 1100.0);
+        assert_eq!(builds.load(Ordering::SeqCst), 1, "a hit rebuilt the tables");
+
+        assert_eq!(*cache.get_or_build(900.0, &mut build), 1800.0);
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+        // The slot holds one entry, so returning to the first mass is a
+        // miss — the Cython's single set of module globals, made real.
+        assert_eq!(*cache.get_or_build(550.0, &mut build), 1100.0);
+        assert_eq!(builds.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn cache_hits_on_a_nan_mass() {
+        // Keyed on bits rather than on `==`, so `NaN` is a hit and not an
+        // unbounded rebuild. The tables it caches are all-`NaN`, which is
+        // what the Cython produced too.
+        let cache: TableCache<f64> = TableCache::new();
+        let builds = AtomicUsize::new(0);
+        let mut build = |_mass: f64| {
+            builds.fetch_add(1, Ordering::SeqCst);
+            0.0
+        };
+        cache.get_or_build(f64::NAN, &mut build);
+        cache.get_or_build(f64::NAN, &mut build);
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn cache_distinguishes_the_two_zeros() {
+        // `0.0 == -0.0` but their bits differ, so this is the one place
+        // bit-keying is *stricter* than `==`. It costs one extra build at
+        // a mass that is unphysical anyway; asserted so the choice is
+        // deliberate rather than discovered later.
+        let cache: TableCache<f64> = TableCache::new();
+        let builds = AtomicUsize::new(0);
+        let mut build = |_mass: f64| {
+            builds.fetch_add(1, Ordering::SeqCst);
+            0.0
+        };
+        cache.get_or_build(0.0, &mut build);
+        cache.get_or_build(-0.0, &mut build);
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn photon_tables_are_memoized_and_hold_the_phase_04_kernels() {
+        let tables = photon_tables(550.0);
+        let again = photon_tables(550.0);
+        assert!(
+            std::sync::Arc::ptr_eq(&tables, &again),
+            "a second call rebuilt the photon tables"
+        );
+
+        // Grid endpoints: `10**-1` MeV to the daughter energy `m/2`.
+        assert_eq!(
+            tables.charged_pion.energies()[0].to_bits(),
+            0.1_f64.to_bits()
+        );
+        assert_eq!(
+            tables.charged_pion.energies()[N_INTERP_PTS - 1].to_bits(),
+            10.0_f64.powf(275.0_f64.log10()).to_bits()
+        );
+
+        // The tabulated values are the native kernels, not a re-derivation.
+        for index in [0, 137, N_INTERP_PTS - 1] {
+            let energy = tables.charged_pion.energies()[index];
+            assert_eq!(
+                tables.charged_pion.values()[index].to_bits(),
+                crate::kernels::photon_pion::dnde_photon_charged_pion(energy, 275.0).to_bits()
+            );
+            let energy = tables.muon.energies()[index];
+            assert_eq!(
+                tables.muon.values()[index].to_bits(),
+                crate::kernels::photon_muon::dnde_photon_muon(energy, 275.0).to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn positron_tables_start_at_the_legacy_electron_mass() {
+        let tables = positron_tables(550.0);
+        // `rules.md` rule 4: the mediator `.pyx` include the legacy
+        // header, so this is 0.510998928 and not the PDG value.
+        assert_eq!(
+            tables.charged_pion.energies()[0].to_bits(),
+            legacy::MASS_E.to_bits()
+        );
+        assert_ne!(legacy::MASS_E, crate::constants::pdg::MASS_E);
+
+        for index in [0, 137, N_INTERP_PTS - 1] {
+            let energy = tables.muon.energies()[index];
+            assert_eq!(
+                tables.muon.values()[index].to_bits(),
+                crate::kernels::positron_muon::dnde_positron_muon(energy, 275.0).to_bits()
+            );
+            let energy = tables.charged_pion.energies()[index];
+            assert_eq!(
+                tables.charged_pion.values()[index].to_bits(),
+                crate::kernels::positron_pion::dnde_positron_charged_pion(energy, 275.0).to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn photon_mode_accepts_exactly_the_cython_strings() {
+        let accepted = [
+            ("total", PhotonMode::Total),
+            ("e e g", PhotonMode::ElectronFsr),
+            ("pi pi g", PhotonMode::ChargedPionFsr),
+            ("pi pi", PhotonMode::ChargedPionDecay),
+            ("pi0 g", PhotonMode::NeutralPionLine),
+            ("mu mu g", PhotonMode::MuonFsr),
+            ("mu mu", PhotonMode::MuonDecay),
+        ];
+        for (name, mode) in accepted {
+            assert_eq!(PhotonMode::parse(name), Some(mode));
+        }
+        // Near-misses a caller will actually make, all of which the
+        // Cython answers with 0.0 rather than an exception.
+        for rejected in ["", "Total", "total ", "pi0g", "e e", "pi0 pi0", "g g"] {
+            assert_eq!(PhotonMode::parse(rejected), None, "{rejected:?}");
+        }
+    }
+
+    #[test]
+    fn only_the_two_line_carrying_photon_modes_have_a_line() {
+        assert!(PhotonMode::Total.has_line());
+        assert!(PhotonMode::NeutralPionLine.has_line());
+        for mode in [
+            PhotonMode::ElectronFsr,
+            PhotonMode::ChargedPionFsr,
+            PhotonMode::ChargedPionDecay,
+            PhotonMode::MuonFsr,
+            PhotonMode::MuonDecay,
+        ] {
+            assert!(!mode.has_line(), "{mode:?} claims a line term");
+        }
+    }
+
+    #[test]
+    fn positron_mode_accepts_exactly_the_cython_strings() {
+        assert_eq!(PositronMode::parse("total"), Some(PositronMode::Total));
+        assert_eq!(PositronMode::parse("e e"), Some(PositronMode::ElectronLine));
+        assert_eq!(PositronMode::parse("mu mu"), Some(PositronMode::MuonDecay));
+        assert_eq!(
+            PositronMode::parse("pi pi"),
+            Some(PositronMode::ChargedPionDecay)
+        );
+        // "e e g" is a *photon* mode; the positron modules never accept it.
+        for rejected in ["", "e e g", "pi0 g", "ee", "TOTAL"] {
+            assert_eq!(PositronMode::parse(rejected), None, "{rejected:?}");
+        }
+    }
+
+    #[test]
+    fn scalar_photon_bits_match_the_cython_bitflags() {
+        // The literal values at
+        // `scalar_mediator_decay_spectrum.pyx:16-22`.
+        assert_eq!(ScalarPhotonModes::CHARGED_PION_DECAY, 1);
+        assert_eq!(ScalarPhotonModes::MUON_DECAY, 2);
+        assert_eq!(ScalarPhotonModes::NEUTRAL_PION_DECAY, 4);
+        assert_eq!(ScalarPhotonModes::TWO_PHOTON_LINE, 8);
+        assert_eq!(ScalarPhotonModes::ELECTRON_FSR, 16);
+        assert_eq!(ScalarPhotonModes::CHARGED_PION_FSR, 32);
+        assert_eq!(ScalarPhotonModes::MUON_FSR, 64);
+    }
+
+    #[test]
+    fn scalar_photon_default_mode_list_sets_every_bit() {
+        // The list `_scalar_mediator_spectra.py` passes when the caller
+        // gives none.
+        let default = [
+            "pi pi", "mu mu", "pi0 pi0", "g g", "e e g", "pi pi g", "mu mu g",
+        ];
+        let modes = ScalarPhotonModes::from_names(default);
+        assert_eq!(modes.bits(), 127);
+        for bit in [
+            ScalarPhotonModes::CHARGED_PION_DECAY,
+            ScalarPhotonModes::MUON_DECAY,
+            ScalarPhotonModes::NEUTRAL_PION_DECAY,
+            ScalarPhotonModes::TWO_PHOTON_LINE,
+            ScalarPhotonModes::ELECTRON_FSR,
+            ScalarPhotonModes::CHARGED_PION_FSR,
+            ScalarPhotonModes::MUON_FSR,
+        ] {
+            assert!(modes.bits() & bit != 0);
+        }
+    }
+
+    #[test]
+    fn scalar_photon_modes_ignore_unknown_and_repeated_names() {
+        // Both are the Cython's `if "x" in modes: bitflag += BIT`
+        // reduction: a repeat cannot carry into the next bit, and an
+        // unknown name contributes nothing and raises nothing.
+        let modes = ScalarPhotonModes::from_names(["mu mu", "mu mu", "not a mode", ""]);
+        assert_eq!(modes.bits(), ScalarPhotonModes::MUON_DECAY);
+        assert_eq!(modes.bits() & ScalarPhotonModes::NEUTRAL_PION_DECAY, 0);
+        assert_eq!(
+            ScalarPhotonModes::from_names::<[&str; 0], &str>([]).bits(),
+            0
+        );
+        assert_eq!(ScalarPhotonModes::default().bits(), 0);
+    }
+}

--- a/rust/src/kernels/mediator_tables.rs
+++ b/rust/src/kernels/mediator_tables.rs
@@ -25,12 +25,12 @@
 //! parameterised by the mediator mass: [`PhotonTables`] and
 //! [`PositronTables`].
 //!
-//! # The grid is `numpy.logspace`, bit for bit
+//! # The grid is `numpy.logspace`
 //!
 //! All four `.pyx` build their abscissae with
 //! `np.logspace(start, log10(m/2), num=500)`, and the values a
 //! bit-equality-class comparison sees depend on reproducing that
-//! exactly rather than on any equivalent spelling. [`logspace`] is
+//! algorithm exactly rather than on any equivalent spelling. [`logspace`] is
 //! NumPy's own arithmetic: `step = (stop - start) / (num - 1)`, then
 //! `10**(i * step + start)` with the multiply and the add rounded
 //! separately — **not** fused — and the final point taken as `10**stop`
@@ -46,11 +46,23 @@
 //!
 //! `cargo` gates the *algorithm* only — the tests below assert the
 //! unfused step, the substituted endpoint and the endpoints themselves.
-//! Agreement with NumPy is a claim about libm, which
-//! `test/test_core_mediator_tables.py` re-derives live through
-//! [`crate::mediator_tables_probe`] on whatever platform the suite runs;
-//! hard-coding one platform's bits here would turn a Linux CI job red
-//! for a libm difference rather than a defect
+//! Agreement with NumPy is a separate claim, and a platform-dependent
+//! one: `numpy.logspace` evaluates `10 ** y` through NumPy's own
+//! `power` loop, which is vectorised on x86-64, while [`logspace`] calls
+//! `f64::powf` and reaches the platform libm. **They are not the same
+//! code, and they do not always agree.** Measured on CI run
+//! 32681245809: bit-for-bit at every abscissa on macOS/arm64 (the
+//! platform the parity corpus was captured on), and on Linux/x86-64
+//! about 5% of the 500 points differ — 19 to 31 per grid, **every one of
+//! them by exactly one ulp**, worst relative 2.16e-16.
+//!
+//! So a Phase 06 table built on Linux sits within one ulp of the one the
+//! Cython built there, not on top of it. That is inside every budget the
+//! corpus applies off its capturing platform, and it is why the NumPy
+//! comparison lives in `test/test_core_mediator_tables.py` — scoped by
+//! platform, the way `test/test_core_interp.py` scopes the same kind of
+//! claim — rather than as captured bits in a `cargo` test, which would
+//! turn a Linux CI job red for a libm difference rather than a defect
 //! (`projects/cython-to-rust/learnings/phase-04-spectra-kernels.md` §4).
 //!
 //! One spelling difference between the four sources is *not* a
@@ -64,8 +76,8 @@
 //! Neither decay module caches at all — `__set_spectra` is called
 //! unconditionally at the top of every entry point
 //! (`scalar_mediator_decay_spectrum.pyx:245`,
-//! `vector_mediator_decay_spectrum.pyx:250` and `:274`), so every call rebuilds a
-//! 500-point quadrature-backed table. Both positron modules *look*
+//! `vector_mediator_decay_spectrum.pyx:250` and `:274`), so every call
+//! rebuilds a 500-point quadrature-backed table. Both positron modules *look*
 //! cached and are not: `__recompute_rf_spectra` compares against
 //! `cache_ms` / `cache_pws` and **no line anywhere assigns to either**,
 //! so the sentinel `-1.0` they are initialised with never changes and

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -23,15 +23,18 @@
 //! interpolation/boost foundation are the crate's most reusable surface,
 //! and Phases 03–06 consume them from every kernel module.
 //!
-//! [`special_probe`], [`quad_probe`], [`interp_probe`], [`boost_probe`]
-//! and [`dispatch_probe`] are the exception to "registration only means
-//! per-domain": they register `special`, `quad`, `interp`, `boost` and
-//! `dispatch` submodules that expose the foundation modules to Python
-//! purely so `test/test_core_special.py`, `test/test_core_quad.py`,
-//! `test/test_core_interp.py`, `test/test_core_boost.py` and
-//! `test/test_core_dispatch.py` can compare them against their oracles —
-//! scipy, NumPy, the Cython twin itself through `__pyx_capi__`, and the
-//! `.pyx` sources' own error strings. No hazma module imports any of them.
+//! [`special_probe`], [`quad_probe`], [`interp_probe`], [`boost_probe`],
+//! [`dispatch_probe`] and [`mediator_tables_probe`] are the exception to
+//! "registration only means per-domain": they register `special`,
+//! `quad`, `interp`, `boost`, `dispatch` and `mediator_tables`
+//! submodules that expose the foundation modules to Python purely so
+//! `test/test_core_special.py`, `test/test_core_quad.py`,
+//! `test/test_core_interp.py`, `test/test_core_boost.py`,
+//! `test/test_core_dispatch.py` and `test/test_core_mediator_tables.py`
+//! can compare them against their oracles — scipy, NumPy, the Cython
+//! twin itself through `__pyx_capi__`, the `.pyx` sources' own error
+//! strings, and the Phase 04 kernels' own entry points. No hazma module
+//! imports any of them.
 
 pub mod boost;
 mod boost_probe;
@@ -41,6 +44,7 @@ mod dispatch_probe;
 pub mod interp;
 mod interp_probe;
 mod kernels;
+mod mediator_tables_probe;
 mod neutrino;
 mod photon;
 mod positron;
@@ -118,6 +122,7 @@ fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     add_submodule(module, "interp", interp_probe::register)?;
     add_submodule(module, "boost", boost_probe::register)?;
     add_submodule(module, "dispatch", dispatch_probe::register)?;
+    add_submodule(module, "mediator_tables", mediator_tables_probe::register)?;
 
     Ok(())
 }

--- a/rust/src/mediator_tables_probe.rs
+++ b/rust/src/mediator_tables_probe.rs
@@ -1,0 +1,197 @@
+//! `hazma._core.mediator_tables` — the Python-visible half of
+//! [`crate::kernels::mediator_tables`].
+//!
+//! Registration only, and a **test surface, not physics**: Tasks 6.2 and
+//! 6.3 call [`crate::kernels::mediator_tables`] directly in Rust and
+//! nothing under `hazma/` imports this module. It joins
+//! `test/parity/cases.py`'s `_CORE_TEST_ONLY_MODULES` beside
+//! `special` / `quad` / `interp` / `boost` / `dispatch`.
+//!
+//! It exists for the same reason [`crate::interp_probe`] does — the
+//! oracle lives in Python. Two claims Task 6.1 makes cannot be checked
+//! from `cargo test` alone:
+//!
+//! * the grid is `numpy.logspace(start, log10(m/2), 500)`. `cargo` can
+//!   pin the *algorithm* — unfused `i * step + start`, the last point
+//!   substituted from `stop` — but not the agreement with NumPy, because
+//!   that rests on Rust's `log10`/`powf` and NumPy's `power` loop
+//!   reaching the same libm. They do on the capturing platform;
+//!   hard-coding its bits into a `cargo` test would turn a Linux CI job
+//!   red for a platform difference rather than a defect
+//!   (`projects/cython-to-rust/learnings/phase-04-spectra-kernels.md`
+//!   §4). Comparing live against `numpy.logspace` re-derives the claim
+//!   wherever the suite runs.
+//! * the tables hold the Phase 04 kernels themselves. Exposing the
+//!   built columns lets `test/test_core_mediator_tables.py` assert them
+//!   against `hazma._core.photon` / `hazma._core.positron` — the same
+//!   kernels through the public entry points — rather than against a
+//!   re-derivation.
+
+use numpy::{PyArray1, ToPyArray};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::dispatch::map_unary;
+use crate::kernels::mediator_tables::{
+    self, BelowGrid, PhotonMode, PositronMode, RestFrameTable, ScalarPhotonModes,
+};
+
+/// One table set as Python sees it: `(energies, charged_pion, muon)`.
+type TableColumns<'py> = (
+    Bound<'py, PyArray1<f64>>,
+    Bound<'py, PyArray1<f64>>,
+    Bound<'py, PyArray1<f64>>,
+);
+
+/// `numpy.logspace(start, stop, num)`, from Rust.
+///
+/// `start` and `stop` are base-10 exponents; the result is a fresh 1-D
+/// `float64` array of `num` points.
+///
+/// # Errors
+///
+/// `ValueError` if `num < 2`. NumPy accepts 0 and 1; the kernel does not,
+/// because every hazma call site passes 500 and reproducing NumPy's
+/// degenerate cases would be untested code.
+#[pyfunction]
+#[pyo3(name = "logspace")]
+#[pyo3(text_signature = "(start, stop, num)")]
+fn logspace_py<'py>(
+    py: Python<'py>,
+    start: f64,
+    stop: f64,
+    num: usize,
+) -> PyResult<Bound<'py, PyArray1<f64>>> {
+    if num < 2 {
+        return Err(PyValueError::new_err("num must be at least 2"));
+    }
+    Ok(mediator_tables::logspace(start, stop, num).to_pyarray(py))
+}
+
+/// The decay modules' photon tables for a mediator of mass `mass` MeV.
+///
+/// Returns `(energies, charged_pion, muon)` — the shared abscissae in
+/// MeV and the two `dN/dE` columns in MeV⁻¹.
+#[pyfunction]
+#[pyo3(name = "photon_tables")]
+#[pyo3(text_signature = "(mass)")]
+fn photon_tables_py(py: Python<'_>, mass: f64) -> TableColumns<'_> {
+    let tables = mediator_tables::photon_tables(mass);
+    (
+        tables.charged_pion.energies().to_pyarray(py),
+        tables.charged_pion.values().to_pyarray(py),
+        tables.muon.values().to_pyarray(py),
+    )
+}
+
+/// The positron modules' tables for a mediator of mass `mass` MeV.
+///
+/// Returns `(energies, charged_pion, muon)`, units as for
+/// [`photon_tables_py`].
+#[pyfunction]
+#[pyo3(name = "positron_tables")]
+#[pyo3(text_signature = "(mass)")]
+fn positron_tables_py(py: Python<'_>, mass: f64) -> TableColumns<'_> {
+    let tables = mediator_tables::positron_tables(mass);
+    (
+        tables.charged_pion.energies().to_pyarray(py),
+        tables.charged_pion.values().to_pyarray(py),
+        tables.muon.values().to_pyarray(py),
+    )
+}
+
+/// The `1/E`-tail lookup the decay modules use, over a table built from
+/// `kernel_values` on `energies`.
+///
+/// Exposed so `test/test_core_mediator_tables.py` can put the same
+/// abscissae through this and through `numpy.interp` plus the Cython's
+/// `if eng_gam < 10**-1` guard, rather than inferring the branch from a
+/// spectrum. `energies` and `values` are the columns
+/// [`photon_tables_py`] returns.
+///
+/// # Errors
+///
+/// Whatever the dispatch contract raises for `x`.
+#[pyfunction]
+#[pyo3(name = "lookup")]
+#[pyo3(text_signature = "(x, energies, values, inverse_energy_tail)")]
+fn lookup_py(
+    x: &Bound<'_, PyAny>,
+    energies: numpy::PyReadonlyArray1<'_, f64>,
+    values: numpy::PyReadonlyArray1<'_, f64>,
+    inverse_energy_tail: bool,
+) -> PyResult<Py<PyAny>> {
+    let below = if inverse_energy_tail {
+        BelowGrid::InverseEnergy
+    } else {
+        BelowGrid::Clamp
+    };
+    let table = RestFrameTable::from_columns(
+        energies.as_array().to_vec(),
+        values.as_array().to_vec(),
+        below,
+    )
+    .map_err(PyValueError::new_err)?;
+    map_unary(x, "Energies", |energy| table.lookup(energy))
+}
+
+/// The vector decay module's `mode` string, resolved.
+///
+/// Returns the variant's name, or `None` for a string the Cython would
+/// answer with `0.0`.
+#[pyfunction]
+#[pyo3(name = "photon_mode")]
+#[pyo3(text_signature = "(mode)")]
+fn photon_mode_py(mode: &str) -> Option<(&'static str, bool)> {
+    PhotonMode::parse(mode).map(|parsed| (photon_mode_name(parsed), parsed.has_line()))
+}
+
+/// The stable name `photon_mode` reports for a variant.
+fn photon_mode_name(mode: PhotonMode) -> &'static str {
+    match mode {
+        PhotonMode::Total => "Total",
+        PhotonMode::ElectronFsr => "ElectronFsr",
+        PhotonMode::ChargedPionFsr => "ChargedPionFsr",
+        PhotonMode::ChargedPionDecay => "ChargedPionDecay",
+        PhotonMode::NeutralPionLine => "NeutralPionLine",
+        PhotonMode::MuonFsr => "MuonFsr",
+        PhotonMode::MuonDecay => "MuonDecay",
+    }
+}
+
+/// The positron modules' `fs` string, resolved.
+#[pyfunction]
+#[pyo3(name = "positron_mode")]
+#[pyo3(text_signature = "(fs)")]
+fn positron_mode_py(fs: &str) -> Option<&'static str> {
+    PositronMode::parse(fs).map(|parsed| match parsed {
+        PositronMode::Total => "Total",
+        PositronMode::ElectronLine => "ElectronLine",
+        PositronMode::MuonDecay => "MuonDecay",
+        PositronMode::ChargedPionDecay => "ChargedPionDecay",
+    })
+}
+
+/// The scalar decay module's mode *list*, folded to its bitflag.
+///
+/// The integer this returns is the one
+/// `scalar_mediator_decay_spectrum.pyx:253-266` builds, so a test can
+/// compare the two directly.
+#[pyfunction]
+#[pyo3(name = "scalar_photon_mode_bits")]
+#[pyo3(text_signature = "(modes)")]
+fn scalar_photon_mode_bits_py(modes: Vec<String>) -> u32 {
+    ScalarPhotonModes::from_names(modes).bits()
+}
+
+/// Populate the submodule.
+pub fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(logspace_py, module)?)?;
+    module.add_function(wrap_pyfunction!(photon_tables_py, module)?)?;
+    module.add_function(wrap_pyfunction!(positron_tables_py, module)?)?;
+    module.add_function(wrap_pyfunction!(lookup_py, module)?)?;
+    module.add_function(wrap_pyfunction!(photon_mode_py, module)?)?;
+    module.add_function(wrap_pyfunction!(positron_mode_py, module)?)?;
+    module.add_function(wrap_pyfunction!(scalar_photon_mode_bits_py, module)?)?;
+    Ok(())
+}

--- a/test/parity/cases.py
+++ b/test/parity/cases.py
@@ -1308,7 +1308,13 @@ _CORE_SCAFFOLD_NAMES = frozenset({"roundtrip"})
 #: ``hazma._core.dispatch`` is Task 3.5's argument-and-error layer,
 #: exposed so ``test/test_core_dispatch.py`` can render every error
 #: message with a caller-chosen quantity and compare it byte for byte
-#: against the strings extracted from the ``.pyx`` sources. In every case the
+#: against the strings extracted from the ``.pyx`` sources; and
+#: ``hazma._core.mediator_tables`` is Phase 06 Task 6.1's rest-frame
+#: table, cache and mode selectors, exposed so
+#: ``test/test_core_mediator_tables.py`` can compare its grid against
+#: ``numpy.logspace``, its columns against the Phase 04 kernels' own
+#: entry points, and its mode parsers against the four mediator
+#: ``.pyx`` that are still alive. In every case the
 #: kernels that will use them call the Rust side directly, in Rust, and
 #: never through Python. What makes the exemption safe rather than
 #: convenient is that no module under `hazma/` may import these — asserted
@@ -1323,6 +1329,7 @@ _CORE_TEST_ONLY_MODULES = frozenset(
         "hazma._core.interp",
         "hazma._core.boost",
         "hazma._core.dispatch",
+        "hazma._core.mediator_tables",
     }
 )
 

--- a/test/test_core_mediator_tables.py
+++ b/test/test_core_mediator_tables.py
@@ -15,22 +15,58 @@ crate, so ``cargo`` cannot state them:
 
 * **the grid is ``numpy.logspace``.** ``cargo`` pins the algorithm — the
   unfused ``i * step + start``, the last point substituted from ``stop``
-  — but agreement with NumPy rests on Rust's ``log10``/``powf`` and
-  NumPy's ``power`` loop reaching the same libm. Hard-coding one
-  platform's bits into a ``cargo`` test would turn a Linux CI job red for
-  a libm difference rather than a defect, the failure mode Phase 04
-  learnings §4 records twice. Here the comparison re-derives on whatever
-  platform the suite runs, and if a platform ever *does* disagree this
-  module is where it says so.
+  — but agreement with NumPy rests on Rust's ``powf`` and NumPy's
+  ``power`` loop, which are not the same code. Hard-coding one platform's
+  bits into a ``cargo`` test would turn a Linux CI job red for a libm
+  difference rather than a defect, the failure mode Phase 04 learnings §4
+  records twice. Here the comparison re-derives wherever the suite runs.
 * **the tables hold the Phase 04 kernels themselves**, called natively
   rather than through Python. Asserting that against
   ``hazma._core.photon`` / ``hazma._core.positron`` — the same kernels
   through their public entry points — is a real check; a re-derivation
-  inside the crate would only compare the kernel to itself.
+  inside the crate would only compare the kernel to itself. That claim is
+  Rust against Rust and holds bit-for-bit on every platform.
 
 The mode oracles are stronger still, because the Cython twins are all
 four alive until Tasks 6.2-6.4 delete them: an unrecognised mode string
 can be put through the shipped ``.pyx`` and the Rust parser side by side.
+
+Two comparisons are platform-scoped, and both were measured
+------------------------------------------------------------
+The first CI round on this module was green on macOS/arm64 and red on all
+five Linux jobs, in exactly the fifteen tests that compare against NumPy
+and in none of the fifty that do not (run 32681245809). The port is not
+what differs — ``hazma._core`` reproduces the Phase 04 kernels on both —
+so the mode is **declared from the platform**, the way
+``test/test_core_interp.py`` declares it, rather than detected by a
+probe that Phase 04 learnings §4 records as unsound twice over.
+
+**The grid.** ``numpy.logspace`` evaluates ``10 ** y`` through NumPy's
+own ``power`` loop, which is vectorised on x86-64; ``rust/src/kernels/
+mediator_tables.rs`` calls ``f64::powf``, which goes to the platform
+libm. On macOS/arm64 the two agree bit-for-bit at every abscissa. On
+Linux/x86-64 about 5% of the 500 points disagree — 19 to 31 per grid —
+and **every disagreement measured was exactly one ulp**, worst relative
+2.16e-16 across the nine pairs the failing run reported. That is the most
+two implementations of ``10 ** y`` can differ if both round correctly, so
+:func:`assert_matches_numpy_grid` allows one ulp off-platform and nothing
+on it.
+
+**The interpolation.** ``TestLookup`` compares ``hazma._core``'s
+``np.interp`` port against NumPy's on a grid both sides share, so the only
+divergence is whether ``slope * (x - xp[j]) + fp[j]`` is contracted — the
+same question ``test/test_core_interp.py`` answers at length. This module
+reuses that module's derived figure rather than inventing one:
+:data:`OFF_PLATFORM_BUDGET` is ``1e-12`` of the compared array's **peak**,
+4.6e3x the worst peak-relative disagreement measured on linux/amd64.
+Peak-scaled and not pointwise, because the pointwise relative reading
+reaches 4e-2 at cancellation points; see that module's docstring for the
+measurement table.
+
+What neither budget may absorb is a *support* change — an abscissa moving
+to a different cell, or a value that was exactly zero becoming nonzero.
+The tail-branch test asserts the branch structure separately from the
+values for that reason.
 
 The tables are the *legacy* constants
 -------------------------------------
@@ -41,7 +77,11 @@ way; :class:`TestPositronTables` asserts the difference rather than
 letting a later cleanup pass silently unify them.
 """
 
+import json
 import math
+import platform
+import sys
+from pathlib import Path
 from typing import ClassVar
 
 import numpy as np
@@ -79,19 +119,126 @@ REFERENCE_DAUGHTER_ENERGY = REFERENCE_MASS / 2.0
 ALL_SCALAR_PHOTON_BITS = 127
 
 
+#: The machine the parity corpus was captured on, read from its own
+#: manifest so the two cannot drift apart -- the same source
+#: ``test/test_core_interp.py`` reads.
+CAPTURE_MACHINE = json.loads(
+    (
+        Path(__file__).resolve().parents[1]
+        / "test"
+        / "parity"
+        / "data"
+        / "manifest.json"
+    ).read_text()
+)["environment"]["machine"]
+
+ON_THE_CAPTURING_PLATFORM = (
+    sys.platform == "darwin" and platform.machine() == CAPTURE_MACHINE
+)
+
+#: What ``lookup`` may differ from ``numpy.interp`` by off the capturing
+#: platform, as a fraction of the compared array's peak. Taken verbatim
+#: from ``test/test_core_interp.py``, which derived it from a linux/amd64
+#: build over 1.15 million abscissae; the mechanism here is identical (the
+#: same port, the same question about a contracted multiply-add) and the
+#: grid is shared by both sides, so a second derivation would measure the
+#: same thing.
+OFF_PLATFORM_BUDGET = 1e-12
+
+
 def bits(array: np.ndarray) -> np.ndarray:
     """Reinterpret a ``float64`` array as its bit patterns."""
     return np.asarray(array, dtype=np.float64).view(np.int64)
 
 
+def ulp_distance(actual: np.ndarray, expected: np.ndarray) -> np.ndarray:
+    """How many representable doubles separate each pair.
+
+    Valid for the same-sign, finite values these grids hold; a sign
+    change or a NaN is not something a one-ulp budget should absorb, and
+    the callers below never produce one.
+    """
+    return np.abs(bits(actual).astype(np.int64) - bits(expected).astype(np.int64))
+
+
 def assert_bit_equal(actual: np.ndarray, expected: np.ndarray, what: str) -> None:
-    """Assert two ``float64`` arrays agree in every bit."""
+    """Assert two ``float64`` arrays agree in every bit, on any platform.
+
+    For Rust-against-Rust claims, which carry no libm question.
+    """
     differing = np.flatnonzero(bits(actual) != bits(expected))
     assert differing.size == 0, (
         f"{what}: {differing.size} of {np.size(expected)} values differ; "
         f"first at index {differing[0] if differing.size else -1} "
         f"({actual[differing[0]]!r} != {expected[differing[0]]!r})"
     )
+
+
+def assert_within_one_ulp(actual: np.ndarray, expected: np.ndarray, what: str) -> None:
+    """The off-platform half of :func:`assert_matches_numpy_grid`.
+
+    A separate function so :class:`TestTheOffPlatformBudgets` can
+    exercise it on every platform, including the one where the caller
+    below never reaches it. A budget only the CI machines run is a budget
+    nobody has checked.
+    """
+    distance = ulp_distance(actual, expected)
+    worst = int(distance.max(initial=0))
+    assert worst <= 1, (
+        f"{what}: {int(np.count_nonzero(distance))} of {np.size(expected)} "
+        f"values differ from numpy.logspace by up to {worst} ulp, off the "
+        f"platform the corpus was captured on where one ulp is the most two "
+        f"correctly-rounded implementations of 10**y can differ"
+    )
+
+
+def assert_within_peak_budget(
+    actual: np.ndarray, expected: np.ndarray, what: str
+) -> None:
+    """The off-platform half of :func:`assert_matches_numpy_interp`.
+
+    Split out for the same reason as :func:`assert_within_one_ulp`.
+    """
+    peak = float(np.max(np.abs(expected), initial=0.0))
+    tolerance = OFF_PLATFORM_BUDGET * max(peak, 1.0)
+    np.testing.assert_allclose(
+        actual, expected, rtol=OFF_PLATFORM_BUDGET, atol=tolerance, err_msg=what
+    )
+
+
+def assert_matches_numpy_grid(
+    actual: np.ndarray, expected: np.ndarray, what: str
+) -> None:
+    """Assert a grid matches ``numpy.logspace``.
+
+    Bit-for-bit where the corpus was captured -- the port was written
+    against *this* build's arithmetic and reproduces it exactly, which is
+    a stronger statement than any tolerance. One ulp elsewhere, because
+    off it the comparison measures NumPy's ``power`` loop against the
+    platform libm rather than measuring the port. See the module
+    docstring for the measurement behind the figure.
+    """
+    if ON_THE_CAPTURING_PLATFORM:
+        assert_bit_equal(actual, expected, what)
+    else:
+        assert_within_one_ulp(actual, expected, what)
+
+
+def assert_matches_numpy_interp(
+    actual: np.ndarray, expected: np.ndarray, what: str
+) -> None:
+    """Assert a lookup matches ``numpy.interp``.
+
+    Bit-for-bit on the capturing platform; :data:`OFF_PLATFORM_BUDGET` of
+    the compared array's peak elsewhere, scaled to the peak rather than
+    applied pointwise for the reason ``test/test_core_interp.py``
+    documents -- the pointwise relative reading reaches 4e-2 at
+    cancellation points and cannot set an honest figure.
+    """
+    if ON_THE_CAPTURING_PLATFORM:
+        assert_bit_equal(actual, expected, what)
+    else:
+        assert_within_peak_budget(actual, expected, what)
 
 
 class TestLogspace:
@@ -105,7 +252,7 @@ class TestLogspace:
         self, mass: float, start: float
     ) -> None:
         stop = math.log10(mass / 2.0)
-        assert_bit_equal(
+        assert_matches_numpy_grid(
             tables.logspace(start, stop, N_INTERP_PTS),
             np.logspace(start, stop, num=N_INTERP_PTS),
             f"logspace({start}, {stop}, {N_INTERP_PTS})",
@@ -119,7 +266,7 @@ class TestLogspace:
         for mass in np.linspace(1.0, 2000.0, 4001):
             for start in (PHOTON_LOG10_START, math.log10(LEGACY_ELECTRON_MASS)):
                 stop = math.log10(mass / 2.0)
-                assert_bit_equal(
+                assert_matches_numpy_grid(
                     tables.logspace(start, stop, N_INTERP_PTS),
                     np.logspace(start, stop, num=N_INTERP_PTS),
                     f"logspace at m = {mass}, start = {start}",
@@ -139,13 +286,65 @@ class TestLogspace:
             tables.logspace(-1.0, 1.0, 1)
 
 
+class TestTheOffPlatformBudgets:
+    """The two off-platform comparators reject what they must reject.
+
+    They are called **directly** rather than through
+    :func:`assert_matches_numpy_grid` / :func:`assert_matches_numpy_interp`,
+    so they run on every platform including the one where the scoped
+    callers never reach them. A budget only the CI machines execute is a
+    budget nobody has checked -- which is how
+    ``test/test_core_interp.py``'s probe silently voided nine claims
+    before its 2026-08-12 rewrite.
+    """
+
+    @staticmethod
+    def _grid() -> np.ndarray:
+        return np.logspace(PHOTON_LOG10_START, math.log10(275.0), num=N_INTERP_PTS)
+
+    def test_the_grid_budget_accepts_one_ulp(self) -> None:
+        grid = self._grid()
+        nudged = np.nextafter(grid, np.inf)
+        assert np.all(ulp_distance(nudged, grid) == 1)
+        assert_within_one_ulp(nudged, grid, "one ulp")
+
+    def test_the_grid_budget_rejects_two_ulp(self) -> None:
+        grid = self._grid()
+        nudged = np.nextafter(np.nextafter(grid, np.inf), np.inf)
+        with pytest.raises(AssertionError, match="by up to 2 ulp"):
+            assert_within_one_ulp(nudged, grid, "two ulp")
+
+    def test_the_interp_budget_accepts_a_last_bit_difference(self) -> None:
+        values = self._grid()
+        assert_within_peak_budget(np.nextafter(values, np.inf), values, "one ulp")
+
+    def test_the_interp_budget_rejects_a_visible_error(self) -> None:
+        # 1e-8 of the peak: 1e4x the budget, and still far too small to
+        # see in a plot -- the probe size test_core_interp.py uses.
+        values = self._grid()
+        perturbed = values + 1e-8 * float(np.max(values))
+        with pytest.raises(AssertionError):
+            assert_within_peak_budget(perturbed, values, "visible error")
+
+    def test_the_scoped_comparator_is_exact_here_and_budgeted_elsewhere(self) -> None:
+        # Which branch this machine takes, asserted rather than assumed,
+        # so a platform that silently changed mode would say so.
+        grid = self._grid()
+        nudged = np.nextafter(grid, np.inf)
+        if ON_THE_CAPTURING_PLATFORM:
+            with pytest.raises(AssertionError, match="values differ"):
+                assert_matches_numpy_grid(nudged, grid, "one ulp")
+        else:
+            assert_matches_numpy_grid(nudged, grid, "one ulp")
+
+
 class TestPhotonTables:
     """The decay modules' tables: grid, values, and their provenance."""
 
     @pytest.mark.parametrize("mass", CORPUS_MASSES)
     def test_grid_is_the_pyx_grid(self, mass: float) -> None:
         energies, _, _ = tables.photon_tables(mass)
-        assert_bit_equal(
+        assert_matches_numpy_grid(
             energies,
             np.logspace(PHOTON_LOG10_START, math.log10(mass / 2.0), num=N_INTERP_PTS),
             f"photon grid at m = {mass}",
@@ -188,7 +387,7 @@ class TestPositronTables:
         from hazma.parameters import electron_mass  # noqa: PLC0415
 
         energies, _, _ = tables.positron_tables(mass)
-        assert_bit_equal(
+        assert_matches_numpy_grid(
             energies,
             np.logspace(
                 math.log10(LEGACY_ELECTRON_MASS),
@@ -198,8 +397,17 @@ class TestPositronTables:
             f"positron grid at m = {mass}",
         )
         # rules.md rule 4: the mediator `.pyx` include the legacy header,
-        # so this is *not* the PDG value hazma.parameters exposes.
-        assert energies[0] == LEGACY_ELECTRON_MASS
+        # so this is *not* the PDG value hazma.parameters exposes. The
+        # first abscissa is `10 ** log10(m_e)`, which round-trips exactly
+        # on the capturing platform and is allowed one ulp elsewhere for
+        # the same reason the grid is; the gap to the PDG mass is 6e-9
+        # relative, seven decades outside that, so the second assertion
+        # needs no scoping.
+        assert_matches_numpy_grid(
+            np.array([energies[0]]),
+            np.array([LEGACY_ELECTRON_MASS]),
+            "positron grid start",
+        )
         assert energies[0] != electron_mass
 
     @pytest.mark.parametrize("mass", CORPUS_MASSES)
@@ -237,7 +445,7 @@ class TestLookup:
                 energies,
             ]
         )
-        assert_bit_equal(
+        assert_matches_numpy_interp(
             tables.lookup(probes, energies, values, False),
             np.interp(probes, energies, values),
             "clamped lookup",
@@ -260,11 +468,17 @@ class TestLookup:
             values[0] * energies[0] / probes,
             np.interp(probes, energies, values),
         )
+        got = tables.lookup(probes, energies, values, True)
+        # The branch structure first, and exactly, on every platform: a
+        # tolerance may absorb a rounding difference but must never absorb
+        # a probe taking the wrong branch.
+        below = probes < PHOTON_GRID_FIRST_ENERGY
         assert_bit_equal(
-            tables.lookup(probes, energies, values, True),
-            expected,
-            "1/E-tail lookup",
+            got[below],
+            (values[0] * energies[0] / probes)[below],
+            "1/E tail below the threshold",
         )
+        assert_matches_numpy_interp(got[~below], expected[~below], "1/E-tail lookup")
 
     def test_the_tail_threshold_is_the_grids_own_first_point(self) -> None:
         # The Cython compares against the literal `10**-1` rather than

--- a/test/test_core_mediator_tables.py
+++ b/test/test_core_mediator_tables.py
@@ -1,0 +1,425 @@
+""":mod:`hazma._core.mediator_tables` against NumPy and the live Cython.
+
+The four mediator-spectrum ``.pyx`` — ``scalar_mediator_decay_spectrum``,
+``vector_mediator_decay_spectrum`` and the two ``*_positron_spec`` — each
+rebuild a 500-point log-spaced rest-frame table, interpolate it, and
+re-dispatch a mode string inside their integrand. cython-to-rust Task 6.1
+factors those three things into ``rust/src/kernels/mediator_tables.rs``;
+Tasks 6.2 and 6.3 build the entry points on it. This module is the gate
+on the factored part, before any entry point moves.
+
+Why the oracles live here rather than in ``cargo test``
+-------------------------------------------------------
+Two of Task 6.1's claims are about agreement with something outside the
+crate, so ``cargo`` cannot state them:
+
+* **the grid is ``numpy.logspace``.** ``cargo`` pins the algorithm — the
+  unfused ``i * step + start``, the last point substituted from ``stop``
+  — but agreement with NumPy rests on Rust's ``log10``/``powf`` and
+  NumPy's ``power`` loop reaching the same libm. Hard-coding one
+  platform's bits into a ``cargo`` test would turn a Linux CI job red for
+  a libm difference rather than a defect, the failure mode Phase 04
+  learnings §4 records twice. Here the comparison re-derives on whatever
+  platform the suite runs, and if a platform ever *does* disagree this
+  module is where it says so.
+* **the tables hold the Phase 04 kernels themselves**, called natively
+  rather than through Python. Asserting that against
+  ``hazma._core.photon`` / ``hazma._core.positron`` — the same kernels
+  through their public entry points — is a real check; a re-derivation
+  inside the crate would only compare the kernel to itself.
+
+The mode oracles are stronger still, because the Cython twins are all
+four alive until Tasks 6.2-6.4 delete them: an unrecognised mode string
+can be put through the shipped ``.pyx`` and the Rust parser side by side.
+
+The tables are the *legacy* constants
+-------------------------------------
+All four ``.pyx`` ``include "../_utils/legacy_parameters.pxd"``, so the
+positron grid starts at ``0.510998928`` MeV and not at
+``hazma.parameters.electron_mass``. ``rules.md`` rule 4 keeps it that
+way; :class:`TestPositronTables` asserts the difference rather than
+letting a later cleanup pass silently unify them.
+"""
+
+import math
+from typing import ClassVar
+
+import numpy as np
+import pytest
+
+from hazma._core import mediator_tables as tables
+from hazma._core import photon as core_photon
+from hazma._core import positron as core_positron
+
+#: The mediator masses ``test/parity/cases.py`` samples, in MeV.
+CORPUS_MASSES = (250.0, 550.0, 900.0)
+
+#: ``MASS_E`` in ``hazma/_utils/legacy_parameters.pxd``, MeV. The value the
+#: positron grid starts at; deliberately not ``hazma.parameters``'s.
+LEGACY_ELECTRON_MASS = 0.510998928
+
+#: Points in every mediator-spectrum table (``n_interp_pts`` in all four
+#: ``.pyx``).
+N_INTERP_PTS = 500
+
+#: The decay modules' lower grid endpoint, as the base-10 exponent both
+#: files write (``np.logspace(-1.0, ...)``).
+PHOTON_LOG10_START = -1.0
+
+#: The energy that exponent names, MeV -- the tail threshold the decay
+#: modules compare against (``if eng_gam < 10**-1``).
+PHOTON_GRID_FIRST_ENERGY = 0.1
+
+#: The mediator mass the ``lookup`` and last-point tests work at, MeV,
+#: and the daughter energy it implies.
+REFERENCE_MASS = 550.0
+REFERENCE_DAUGHTER_ENERGY = REFERENCE_MASS / 2.0
+
+#: Every bit set, i.e. the scalar decay module's default mode list.
+ALL_SCALAR_PHOTON_BITS = 127
+
+
+def bits(array: np.ndarray) -> np.ndarray:
+    """Reinterpret a ``float64`` array as its bit patterns."""
+    return np.asarray(array, dtype=np.float64).view(np.int64)
+
+
+def assert_bit_equal(actual: np.ndarray, expected: np.ndarray, what: str) -> None:
+    """Assert two ``float64`` arrays agree in every bit."""
+    differing = np.flatnonzero(bits(actual) != bits(expected))
+    assert differing.size == 0, (
+        f"{what}: {differing.size} of {np.size(expected)} values differ; "
+        f"first at index {differing[0] if differing.size else -1} "
+        f"({actual[differing[0]]!r} != {expected[differing[0]]!r})"
+    )
+
+
+class TestLogspace:
+    """``mediator_tables.logspace`` against ``numpy.logspace``."""
+
+    @pytest.mark.parametrize("mass", CORPUS_MASSES)
+    @pytest.mark.parametrize(
+        "start", [PHOTON_LOG10_START, math.log10(LEGACY_ELECTRON_MASS)]
+    )
+    def test_matches_numpy_on_the_grids_the_pyx_build(
+        self, mass: float, start: float
+    ) -> None:
+        stop = math.log10(mass / 2.0)
+        assert_bit_equal(
+            tables.logspace(start, stop, N_INTERP_PTS),
+            np.logspace(start, stop, num=N_INTERP_PTS),
+            f"logspace({start}, {stop}, {N_INTERP_PTS})",
+        )
+
+    def test_matches_numpy_across_a_wide_mass_sweep(self) -> None:
+        # 4,001 masses rather than the corpus's three: the last-point
+        # substitution NumPy performs is worth one ulp at about 9% of
+        # masses and at none of the corpus's, so a three-mass sweep would
+        # not reach it.
+        for mass in np.linspace(1.0, 2000.0, 4001):
+            for start in (PHOTON_LOG10_START, math.log10(LEGACY_ELECTRON_MASS)):
+                stop = math.log10(mass / 2.0)
+                assert_bit_equal(
+                    tables.logspace(start, stop, N_INTERP_PTS),
+                    np.logspace(start, stop, num=N_INTERP_PTS),
+                    f"logspace at m = {mass}, start = {start}",
+                )
+
+    def test_the_last_point_is_ten_to_the_stop_exponent(self) -> None:
+        # Not ``mass / 2``: ``10 ** log10(275)`` is 275.0000000000001, and
+        # a table whose last abscissa were exactly 275.0 would be a
+        # different table.
+        stop = math.log10(REFERENCE_DAUGHTER_ENERGY)
+        grid = tables.logspace(PHOTON_LOG10_START, stop, N_INTERP_PTS)
+        assert grid[-1] == 10.0**stop
+        assert grid[-1] != REFERENCE_DAUGHTER_ENERGY
+
+    def test_rejects_a_degenerate_point_count(self) -> None:
+        with pytest.raises(ValueError, match="num must be at least 2"):
+            tables.logspace(-1.0, 1.0, 1)
+
+
+class TestPhotonTables:
+    """The decay modules' tables: grid, values, and their provenance."""
+
+    @pytest.mark.parametrize("mass", CORPUS_MASSES)
+    def test_grid_is_the_pyx_grid(self, mass: float) -> None:
+        energies, _, _ = tables.photon_tables(mass)
+        assert_bit_equal(
+            energies,
+            np.logspace(PHOTON_LOG10_START, math.log10(mass / 2.0), num=N_INTERP_PTS),
+            f"photon grid at m = {mass}",
+        )
+        assert energies.size == N_INTERP_PTS
+
+    @pytest.mark.parametrize("mass", CORPUS_MASSES)
+    def test_values_are_the_phase_04_kernels(self, mass: float) -> None:
+        # The exit criterion "built by calling the Phase 04 kernel fns
+        # natively" made checkable: the tabulated columns must be exactly
+        # what the public entry points return on the same abscissae.
+        energies, charged_pion, muon = tables.photon_tables(mass)
+        daughter = mass / 2.0
+        assert_bit_equal(
+            charged_pion,
+            core_photon.dnde_photon_charged_pion(energies, daughter),
+            f"charged-pion photon column at m = {mass}",
+        )
+        assert_bit_equal(
+            muon,
+            core_photon.dnde_photon_muon(energies, daughter),
+            f"muon photon column at m = {mass}",
+        )
+
+    def test_is_memoized_and_re_keys_on_the_mass(self) -> None:
+        first, _, _ = tables.photon_tables(550.0)
+        again, _, _ = tables.photon_tables(550.0)
+        assert_bit_equal(again, first, "photon grid on a cache hit")
+        other, _, _ = tables.photon_tables(900.0)
+        assert not np.array_equal(bits(other), bits(first))
+        back, _, _ = tables.photon_tables(550.0)
+        assert_bit_equal(back, first, "photon grid after a re-key")
+
+
+class TestPositronTables:
+    """The positron modules' tables."""
+
+    @pytest.mark.parametrize("mass", CORPUS_MASSES)
+    def test_grid_starts_at_the_legacy_electron_mass(self, mass: float) -> None:
+        from hazma.parameters import electron_mass  # noqa: PLC0415
+
+        energies, _, _ = tables.positron_tables(mass)
+        assert_bit_equal(
+            energies,
+            np.logspace(
+                math.log10(LEGACY_ELECTRON_MASS),
+                math.log10(mass / 2.0),
+                num=N_INTERP_PTS,
+            ),
+            f"positron grid at m = {mass}",
+        )
+        # rules.md rule 4: the mediator `.pyx` include the legacy header,
+        # so this is *not* the PDG value hazma.parameters exposes.
+        assert energies[0] == LEGACY_ELECTRON_MASS
+        assert energies[0] != electron_mass
+
+    @pytest.mark.parametrize("mass", CORPUS_MASSES)
+    def test_values_are_the_phase_04_kernels(self, mass: float) -> None:
+        energies, charged_pion, muon = tables.positron_tables(mass)
+        daughter = mass / 2.0
+        assert_bit_equal(
+            charged_pion,
+            core_positron.dnde_positron_charged_pion(energies, daughter),
+            f"charged-pion positron column at m = {mass}",
+        )
+        assert_bit_equal(
+            muon,
+            core_positron.dnde_positron_muon(energies, daughter),
+            f"muon positron column at m = {mass}",
+        )
+
+
+class TestLookup:
+    """The two below-grid policies, against the ``.pyx`` they come from."""
+
+    @staticmethod
+    def _table() -> tuple[np.ndarray, np.ndarray]:
+        energies, charged_pion, _ = tables.photon_tables(REFERENCE_MASS)
+        return energies, charged_pion
+
+    def test_clamped_lookup_is_numpy_interp(self) -> None:
+        energies, values = self._table()
+        # Interior points, both endpoints, and both outsides -- the whole
+        # domain `numpy.interp` defines.
+        probes = np.concatenate(
+            [
+                [1e-6, 1e-3, energies[0], energies[-1], 1e3, 1e6],
+                np.geomspace(energies[0], energies[-1], 4001),
+                energies,
+            ]
+        )
+        assert_bit_equal(
+            tables.lookup(probes, energies, values, False),
+            np.interp(probes, energies, values),
+            "clamped lookup",
+        )
+
+    def test_inverse_energy_tail_is_the_pyx_branch(self) -> None:
+        # `scalar_mediator_decay_spectrum.pyx:55-56`: below 10**-1 the
+        # Cython returns `spec_cp[0] * e_gams[0] / eng_gam` and otherwise
+        # defers to np.interp.
+        energies, values = self._table()
+        probes = np.concatenate(
+            [
+                np.geomspace(1e-8, energies[0], 2001),
+                np.geomspace(energies[0], energies[-1], 2001),
+                [1e3, 1e6],
+            ]
+        )
+        expected = np.where(
+            probes < PHOTON_GRID_FIRST_ENERGY,
+            values[0] * energies[0] / probes,
+            np.interp(probes, energies, values),
+        )
+        assert_bit_equal(
+            tables.lookup(probes, energies, values, True),
+            expected,
+            "1/E-tail lookup",
+        )
+
+    def test_the_tail_threshold_is_the_grids_own_first_point(self) -> None:
+        # The Cython compares against the literal `10**-1` rather than
+        # against `e_gams[0]`; the two are the same double, so the branch
+        # opens exactly at the grid's lower endpoint and introduces no
+        # jump there.
+        energies, values = self._table()
+        assert energies[0] == PHOTON_GRID_FIRST_ENERGY
+        just_below = np.nextafter(energies[0], 0.0)
+        assert tables.lookup(just_below, energies, values, True) == pytest.approx(
+            values[0], rel=1e-15
+        )
+        assert tables.lookup(energies[0], energies, values, True) == values[0]
+
+    def test_both_policies_clamp_above_the_grid(self) -> None:
+        # Neither `.pyx` guards the upper side, so both inherit NumPy's.
+        energies, values = self._table()
+        for tail in (True, False):
+            assert tables.lookup(1e12, energies, values, tail) == values[-1]
+
+    def test_nan_propagates(self) -> None:
+        energies, values = self._table()
+        for tail in (True, False):
+            assert math.isnan(tables.lookup(float("nan"), energies, values, tail))
+
+    def test_rejects_mismatched_columns(self) -> None:
+        energies, values = self._table()
+        with pytest.raises(ValueError, match="not of the same length"):
+            tables.lookup(1.0, energies, values[:-1], False)
+        with pytest.raises(ValueError, match="empty"):
+            tables.lookup(1.0, energies[:0], values[:0], False)
+
+
+class TestPhotonMode:
+    """The vector decay module's ``mode`` argument."""
+
+    #: Every string `vector_mediator_decay_spectrum.pyx:166-178` compares
+    #: against, with whether `:223` adds the pi0 line for it.
+    ACCEPTED: ClassVar[dict[str, tuple[str, bool]]] = {
+        "total": ("Total", True),
+        "e e g": ("ElectronFsr", False),
+        "pi pi g": ("ChargedPionFsr", False),
+        "pi pi": ("ChargedPionDecay", False),
+        "pi0 g": ("NeutralPionLine", True),
+        "mu mu g": ("MuonFsr", False),
+        "mu mu": ("MuonDecay", False),
+    }
+
+    @pytest.mark.parametrize("mode", sorted(ACCEPTED))
+    def test_accepts_the_pyx_strings(self, mode: str) -> None:
+        assert tables.photon_mode(mode) == self.ACCEPTED[mode]
+
+    @pytest.mark.parametrize(
+        "mode", ["", " ", "Total", "total ", "pi0g", "e e", "pi0 pi0", "g g"]
+    )
+    def test_rejects_everything_else(self, mode: str) -> None:
+        assert tables.photon_mode(mode) is None
+
+    def test_the_rejected_set_is_what_the_cython_answers_with_zero(self) -> None:
+        # The strongest oracle available while the twin is alive: a mode
+        # the parser rejects is one the shipped `.pyx` returns 0.0 for --
+        # its integrand falls off the end of a `cdef double` -- so the
+        # port must not tighten it into a raise.
+        from hazma.vector_mediator.vector_mediator_decay_spectrum import (  # noqa: PLC0415
+            dnde_decay_v_pt,
+        )
+
+        pws = np.array([0.25, 0.25, 0.25, 0.25])
+        for mode in ["", "Total", "pi0g", "g g", "not a mode"]:
+            assert tables.photon_mode(mode) is None
+            assert dnde_decay_v_pt(30.0, 600.0, 550.0, pws, mode) == 0.0
+
+
+class TestPositronMode:
+    """The positron modules' ``fs`` argument."""
+
+    ACCEPTED: ClassVar[dict[str, str]] = {
+        "total": "Total",
+        "e e": "ElectronLine",
+        "mu mu": "MuonDecay",
+        "pi pi": "ChargedPionDecay",
+    }
+
+    @pytest.mark.parametrize("fs", sorted(ACCEPTED))
+    def test_accepts_the_pyx_strings(self, fs: str) -> None:
+        assert tables.positron_mode(fs) == self.ACCEPTED[fs]
+
+    @pytest.mark.parametrize("fs", ["", "e e g", "pi0 g", "ee", "TOTAL", "pi pi g"])
+    def test_rejects_everything_else(self, fs: str) -> None:
+        assert tables.positron_mode(fs) is None
+
+    def test_the_rejected_set_is_what_the_cython_answers_with_zero(self) -> None:
+        from hazma.scalar_mediator.scalar_mediator_positron_spec import (  # noqa: PLC0415
+            dnde_decay_s_pt,
+        )
+
+        pws = np.array([0.4, 0.3, 0.3])
+        for fs in ["", "e e g", "pi0 g", "not a mode"]:
+            assert tables.positron_mode(fs) is None
+            assert dnde_decay_s_pt(30.0, 600.0, 550.0, pws, fs) == 0.0
+
+
+class TestScalarPhotonModes:
+    """The scalar decay module's mode *list*, folded to a bitflag."""
+
+    #: `scalar_mediator_decay_spectrum.pyx:16-22`.
+    BITS: ClassVar[dict[str, int]] = {
+        "pi pi": 1,
+        "mu mu": 2,
+        "pi0 pi0": 4,
+        "g g": 8,
+        "e e g": 16,
+        "pi pi g": 32,
+        "mu mu g": 64,
+    }
+
+    #: The list `_scalar_mediator_spectra.py` passes by default.
+    DEFAULT: ClassVar[list[str]] = [
+        "pi pi",
+        "mu mu",
+        "pi0 pi0",
+        "g g",
+        "e e g",
+        "pi pi g",
+        "mu mu g",
+    ]
+
+    @pytest.mark.parametrize("mode", sorted(BITS))
+    def test_each_mode_sets_its_own_bit(self, mode: str) -> None:
+        assert tables.scalar_photon_mode_bits([mode]) == self.BITS[mode]
+
+    def test_the_default_list_sets_every_bit(self) -> None:
+        assert tables.scalar_photon_mode_bits(self.DEFAULT) == ALL_SCALAR_PHOTON_BITS
+
+    def test_unknown_and_repeated_names_are_ignored(self) -> None:
+        # The `.pyx` writes `if "mu mu" in modes: bitflag += BITFLAG_MM`,
+        # so `in` is tested once per mode name: a duplicate cannot double
+        # a flag into its neighbour's bit, and an unknown name adds
+        # nothing and raises nothing.
+        muon_decay = self.BITS["mu mu"]
+        assert (
+            tables.scalar_photon_mode_bits(["mu mu", "mu mu", "junk", ""]) == muon_decay
+        )
+        assert tables.scalar_photon_mode_bits([]) == 0
+
+    def test_a_repeated_mode_does_not_change_the_cython_result(self) -> None:
+        # The same claim against the shipped entry point, which is what
+        # actually consumes the bitflag.
+        from hazma.scalar_mediator.scalar_mediator_decay_spectrum import (  # noqa: PLC0415
+            scalar_mediator_decay_spectrum,
+        )
+
+        pws = np.array([0.2, 0.2, 0.2, 0.2, 0.2])
+        once = scalar_mediator_decay_spectrum(30.0, 600.0, 550.0, pws, ["mu mu"])
+        twice = scalar_mediator_decay_spectrum(
+            30.0, 600.0, 550.0, pws, ["mu mu", "mu mu", "junk"]
+        )
+        assert once == twice


### PR DESCRIPTION
## Summary

- **Adds `kernels::mediator_tables`**, the part all four mediator-spectrum `.pyx` repeat: a `logspace` that reproduces `numpy.logspace`'s algorithm, `RestFrameTable` + `BelowGrid` built by calling the Phase 04 kernel `fn`s natively, a `TableCache` keyed on the mediator mass, and `PhotonMode` / `PositronMode` / `ScalarPhotonModes` so a mode string is parsed once per call rather than once per quadrature node. PyO3-free, per `rules.md` rule 8.
- **Fixes a cache that is dead in two different ways** — the decay modules have no cache at all, and both positron modules have a predicate reading `cache_ms` / `cache_pws` while no line anywhere assigns to either, so all four rebuild a 500-point quadrature-backed table on every call. Performance only (`rules.md` rules 3 and 12): a hit returns the table a miss would have rebuilt from the same inputs. The key is the mass alone — `__set_spectra` reads no partial width.
- **Reproduces, rather than tightens, the silent-zero mode behaviour.** An unrecognised mode raises nothing today: every `cdef double` integrand ends in an `if` chain with no `else`, and a C function that falls off its end returns zero. Verified against the shipped extensions, kept under `rules.md` rule 1, and [filed](https://github.com/LoganAMorrison/Hazma/blob/claude/cython-to-rust/task-6.1-spectrum-table-struct-design/docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md).
- **No public value changes.** No file under `hazma/` is touched, no existing Rust function is modified, and no entry point moves — Tasks 6.2 and 6.3 do that. `git diff origin/master --name-only -- hazma/` is empty, and `test/parity` is `658 passed, 1 skipped` on every CI platform.
- Adds `hazma._core.mediator_tables` as a sixth `_CORE_TEST_ONLY_MODULES` probe. Every oracle for this layer lives in Python — `numpy.logspace`, `numpy.interp`, the Phase 04 entry points, and the four Cython twins that are still alive.
- Amends two of Task 6.1's own exit criteria in the phase file, both because the criterion was factually wrong about the code (the cache key, and an "error text" that does not exist), and flips the Phase 06 frontmatter to `In Progress` as Task 5.1 did for Phase 05.

### One number worth flagging, though nothing published moves

`numpy.logspace` evaluates `10 ** y` through NumPy's own `power` loop, which is vectorised on x86-64; `logspace` calls `f64::powf` and reaches the platform libm. **They are not the same code.** The grid is bit-equal to NumPy's on macOS/arm64 — the platform the parity corpus was captured on — and on Linux/x86-64 about 5% of the 500 abscissae differ per grid, **every measured disagreement exactly one ulp**, worst relative 2.16e-16.

This was found by CI, not locally: round 1 was green on macOS and red on all five Linux jobs, in exactly the 15 tests that compare against NumPy and none of the 50 that do not. The consequence for Tasks 6.2/6.3 is that a table built on Linux sits within one ulp of the one the Cython built there, so **"bit-equal to the Cython" is a macOS/arm64 statement** for anything reading these tables. No gate changes — the corpus already runs in budget mode off its capturing platform — and no published value moves, since no entry point reads these tables yet.

The fix declares the mode from the platform (`ON_THE_CAPTURING_PLATFORM`) the way `test/test_core_interp.py` does, rather than probing for it; Phase 04 learnings §4 records the probe mechanism as unsound twice over. It deliberately does not widen anything that could hide a support change — the `1/E` tail test asserts the branch structure bit-exactly on every platform, separately from the values.

## Project

`projects/cython-to-rust/` — Task 6.1: Spectrum-table struct design.

See `projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md` for implementation detail, decisions, the eight-mutation campaign, and verification.

One finding worth surfacing outside the note: the `grep -c SoftComplexToDouble` the Phase 05 learnings ask for and record as unrun has been run, and the answer is **6 / 0 / 6 / 0** for scalar-decay / scalar-positron / vector-decay / vector-positron. Five of each six are proto and definition lines; the one live call site each is the `** 1.5` in an FSR coefficient (`scalar_mediator_decay_spectrum.pyx:113`, `vector_mediator_decay_spectrum.pyx:73`), and both are shapes `kernels::soft_complex` already covers. Neither positron module needs it.

## Test plan

- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features`

  ```text
  test result: ok. 222 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  ```

  From 201 at Phase 05's close. The 22 new tests cover the `logspace` algorithm, `RestFrameTable`'s two below-grid policies and its `NaN` path, `TableCache` (build-once, re-key, one slot, `NaN` hit, `±0.0` miss), both table sets, and all three selectors.

- [x] `pytest test/test_core_mediator_tables.py -q -n 0`

  ```text
  70 passed, 3 warnings in 0.95s
  ```

  `logspace` against `numpy.logspace` at the corpus masses and over a 4,001-mass sweep; both table sets' grids and columns against the public Rust entry points; the legacy vs PDG electron mass; `lookup` against `np.interp` and against the `.pyx` tail branch; every selector's accepted and rejected sets — the rejected sets **against the live Cython twins**, which return `0.0` for them; and `TestTheOffPlatformBudgets`, which calls both off-platform comparators directly so they are exercised on every machine, including the one whose callers never reach them.

- [x] `pytest test/parity -q`

  ```text
  658 passed, 1 skipped in 38.30s
  ```

  All 41 pinned entry points, unchanged. `cases.rust_core_kernels()` is still 34 — the probe is exempt.

- [x] `pytest test/test_theory_aggregation.py -q` — `69 passed` (the model-layer gate the corpus cannot be).

- [x] `scripts/agents/preflight.sh --paths … --md …`

  ```text
  RESULT: PASS
  PASS   pytest                  2163 passed, 15 skipped, 10 warnings, 12 subtests passed
  ```

  Eleven rows, one `SKIP` (version bump — not a closing PR).

- [x] **Mutation campaign, 8/8 killed.** Two survived the first pass and both tests were strengthened: fusing `logspace`'s step (the original test asserted only that fused and unfused exponents *differ* somewhere, never that `logspace` used the unfused one) and moving the `1/E` tail threshold from `0.1` to `0.2` (every tail probe sat far from the threshold). Table in the task note.

- [x] **Both off-platform budgets carry their own inversions** — `test_the_grid_budget_rejects_two_ulp` and `test_the_interp_budget_rejects_a_visible_error` — so neither can go vacuous on a machine that never runs the branch it guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)