### PR TITLE
ci(actions): rebuild release.yml on maturin and cache cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
         # below, and hence a Python on PATH here.
         with:
           python-version: "3.12"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # The crate declares its own `[workspace]`, so the workspace root
+          # is `rust/` and the target directory it caches is `rust/target`.
+          workspaces: rust
       - name: Check formatting with rustfmt
         run: cargo fmt --manifest-path rust/Cargo.toml --check
       - name: Lint with clippy
@@ -94,6 +99,16 @@ jobs:
         # toolchain step), but nothing in this repo required them to keep
         # doing so, and an image refresh that dropped Rust would have taken
         # every entry down at once.
+      - uses: Swatinem/rust-cache@v2
+        # One cache per operating system, shared across the whole Python
+        # matrix. That is sound because the crate is abi3 (`abi3-py310` in
+        # rust/Cargo.toml): it links against CPython's limited API rather
+        # than against the interpreter of the moment, so the cargo artifacts
+        # the matrix entries produce are the same artifacts. pip builds
+        # in-tree, so `pip install .` and `pip install -e .` below both
+        # populate and reuse `rust/target` here rather than a temporary copy.
+        with:
+          workspaces: rust
       - name: Build and install hazma
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,15 +94,23 @@ jobs:
           wheel = wheels[0]
           print(f"wheel: {wheel.name}")
 
+          # A wheel filename's last three fields are compressed tag *sets*
+          # (PEP 425): each is dot-separated, and the wheel is tagged with
+          # their cross product. The manylinux wheel exercises this and the
+          # macOS one does not -- `manylinux_2_17_x86_64.manylinux2014_x86_64`
+          # is one filename field standing for two platform tags, which
+          # `.dist-info/WHEEL` then writes on two `Tag:` lines.
           fields = wheel.stem.split("-")
           if len(fields) != 5:
               sys.exit(f"cannot parse wheel filename into 5 fields: {wheel.stem}")
-          _, _, python_tag, abi_tag, platform_tag = fields
-          if (python_tag, abi_tag) != ("cp310", "abi3"):
+          python_tags, abi_tags, platform_tags = (
+              field.split(".") for field in fields[2:]
+          )
+          if (python_tags, abi_tags) != (["cp310"], ["abi3"]):
               sys.exit(
-                  f"filename tag is {python_tag}-{abi_tag}, expected cp310-abi3"
+                  f"filename tag is {fields[2]}-{fields[3]}, expected cp310-abi3"
               )
-          print(f"platform tag: {platform_tag}")
+          print(f"platform tags: {platform_tags}")
 
           archive = zipfile.ZipFile(wheel)
           names = archive.namelist()
@@ -114,15 +122,23 @@ jobs:
           ]
           if len(metadata) != 1:
               sys.exit(f"expected one .dist-info/WHEEL, found {metadata}")
-          declared = sorted(
+          declared = {
               line.split(":", 1)[1].strip()
               for line in archive.read(metadata[0]).decode().splitlines()
               if line.startswith("Tag:")
-          )
-          expected = [f"cp310-abi3-{platform_tag}"]
+          }
+          expected = {
+              f"{python}-{abi}-{platform}"
+              for python in python_tags
+              for abi in abi_tags
+              for platform in platform_tags
+          }
           if declared != expected:
-              sys.exit(f"WHEEL declares Tag: {declared}, expected {expected}")
-          print(f"WHEEL Tag: {declared[0]}")
+              sys.exit(
+                  f"WHEEL declares Tag: {sorted(declared)}, "
+                  f"filename expands to {sorted(expected)}"
+              )
+          print(f"WHEEL Tag: {sorted(declared)}")
 
           shared_objects = [
               name for name in names if name.endswith((".so", ".pyd", ".dylib"))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,104 +1,222 @@
-# Build wheels + sdist and publish to PyPI when a GitHub release is published.
-# Can also be run manually (workflow_dispatch) to test the build without
-# publishing.
+# Build the abi3 wheels + sdist and publish to PyPI when a GitHub release is
+# published.
+#
+# Two wheels cover every supported interpreter and platform: the crate's
+# `abi3-py310` feature (rust/Cargo.toml) makes one shared object serve every
+# CPython >= 3.10, and maturin tags the wheel `cp310-abi3` from it. Before
+# cython-to-rust Phase 07 this job was a cibuildwheel matrix of five CPython
+# versions x two platforms = ten wheels, each carrying its own copy of the
+# same limited-API extension.
 name: Release
 
 on:
   release:
     types: [published]
   workflow_dispatch:
+  # Nothing else in the repository exercises this file, so an edit to it used
+  # to be unmeasurable until a release ran -- see docs/agents/lessons.md
+  # `[unrun-workflow-cannot-close-a-criterion]`. The path filter keeps that
+  # from costing every pull request: these two files are the packaging inputs
+  # whose edits can break a release build without turning ci.yml red. Rust
+  # source is deliberately absent -- ci.yml already compiles the crate on both
+  # operating systems for every pull request.
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - pyproject.toml
 
 permissions:
   contents: read
 
 jobs:
-  build-wheels:
-    name: Build wheels (${{ matrix.os }})
+  build-wheel:
+    name: Build wheel (${{ matrix.artifact }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact: manylinux-x86_64
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            artifact: macos-arm64
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        # macOS only in effect: cibuildwheel builds the macOS wheels on
-        # the runner itself, so the host toolchain is the one that builds
-        # hazma._core. The Linux wheels are built inside a manylinux
-        # container that cannot see this one — CIBW_BEFORE_ALL_LINUX
-        # below is their toolchain.
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v4.1.1
-        env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
-          # scipy ships no musllinux wheels, so testing there would compile
-          # scipy from source; not worth the build time.
-          CIBW_SKIP: "*-musllinux*"
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_MACOS: "arm64"
-          # setuptools-rust needs cargo inside the manylinux container.
-          # This is cibuildwheel's documented recipe for Rust projects;
-          # CIBW_ENVIRONMENT_LINUX is what puts the freshly-installed
-          # toolchain on PATH for the build step that follows.
-          CIBW_BEFORE_ALL_LINUX: >-
-            curl -sSf https://sh.rustup.rs
-            | sh -s -- -y --profile minimal --default-toolchain stable
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$HOME/.cargo/bin:$PATH"'
-          # Import a compiled extension module, not just the (pure-Python)
-          # top-level package, so a mistagged or broken wheel fails the build.
-          # `hazma._core` is the only one left: cython-to-rust Task 6.4
-          # deleted the last Cython extension, which this command also named
-          # until then.
-          CIBW_TEST_COMMAND: >-
-            python -c "import hazma._core"
-      - name: Assert every wheel ships the Rust extension as abi3
-        # The wheels themselves stay CPython-tagged. The last Cython
-        # extension went in cython-to-rust Task 6.4, so that is no longer
-        # what holds them there — a wheel tag is a property of the
-        # distribution, and setting it is Phase 07 Task 7.2's job, which
-        # rebuilds this workflow on maturin. What is checkable here is
-        # still extension-level: PyO3's abi3-py310 feature
-        # makes setuptools-rust install the cdylib as `_core.abi3.so`,
-        # so that filename inside the archive *is* the limited-API
-        # assertion. A plain `_core.cpython-312-*.so` would mean the
-        # feature silently stopped applying.
+
+      - name: Build the wheel with maturin
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: ${{ matrix.target }}
+          # Linux only: the action builds inside a manylinux container that
+          # ships its own Rust toolchain and CPythons, which is why no
+          # rustup step appears in this job. `auto` takes the container's
+          # highest applicable policy rather than pinning one here; the
+          # resulting platform tag is asserted below, not assumed.
+          manylinux: auto
+          # `--locked` makes the published artifact a build of the committed
+          # rust/Cargo.lock rather than of whatever resolves on the day.
+          # No `-i`: for an abi3 crate maturin emits a single wheel however
+          # many interpreters it finds, and the "exactly one wheel" assertion
+          # below is what holds that to be true.
+          args: --release --locked --out dist
+
+      - name: Assert the wheel is a single cp310-abi3 distribution
+        # Two distinct claims, both checkable from the archive alone:
+        #
+        #   distribution level  the filename and the .dist-info/WHEEL `Tag:`
+        #                       lines both say `cp310-abi3`, so one wheel
+        #                       installs on every CPython >= 3.10;
+        #   extension level     the only shared object inside is
+        #                       `hazma/_core.abi3.so`, so the extension
+        #                       really was built against the limited API.
+        #
+        # Keeping both is the point of docs/agents/lessons.md
+        # `[wheel-tag-vs-extension-abi]`: a wheel tag is a property of the
+        # distribution and can disagree with what the distribution contains.
+        # Under setuptools-rust it did -- the wheel was tagged `cp314-cp314`
+        # while carrying a correct `_core.abi3.so` (cython-to-rust Task 7.1).
         shell: bash
         run: |
           python3 - <<'PY'
-          import pathlib, sys, zipfile
+          import pathlib
+          import sys
+          import zipfile
 
-          wheels = sorted(pathlib.Path("wheelhouse").glob("*.whl"))
-          if not wheels:
-              sys.exit("no wheels in wheelhouse/ — nothing was verified")
-          bad = []
-          for wheel in wheels:
-              names = zipfile.ZipFile(wheel).namelist()
-              ok = "hazma/_core.abi3.so" in names
-              print(f"{'ok  ' if ok else 'FAIL'} {wheel.name}")
-              if not ok:
-                  bad.append(wheel.name)
-          if bad:
-              sys.exit(f"missing hazma/_core.abi3.so in: {', '.join(bad)}")
-          print(f"{len(wheels)} wheel(s) carry hazma/_core.abi3.so")
+          wheels = sorted(pathlib.Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              sys.exit(
+                  "expected exactly one abi3 wheel in dist/, found "
+                  f"{len(wheels)}: {[w.name for w in wheels]}"
+              )
+          wheel = wheels[0]
+          print(f"wheel: {wheel.name}")
+
+          fields = wheel.stem.split("-")
+          if len(fields) != 5:
+              sys.exit(f"cannot parse wheel filename into 5 fields: {wheel.stem}")
+          _, _, python_tag, abi_tag, platform_tag = fields
+          if (python_tag, abi_tag) != ("cp310", "abi3"):
+              sys.exit(
+                  f"filename tag is {python_tag}-{abi_tag}, expected cp310-abi3"
+              )
+          print(f"platform tag: {platform_tag}")
+
+          archive = zipfile.ZipFile(wheel)
+          names = archive.namelist()
+
+          metadata = [
+              name
+              for name in names
+              if name.endswith(".dist-info/WHEEL")
+          ]
+          if len(metadata) != 1:
+              sys.exit(f"expected one .dist-info/WHEEL, found {metadata}")
+          declared = sorted(
+              line.split(":", 1)[1].strip()
+              for line in archive.read(metadata[0]).decode().splitlines()
+              if line.startswith("Tag:")
+          )
+          expected = [f"cp310-abi3-{platform_tag}"]
+          if declared != expected:
+              sys.exit(f"WHEEL declares Tag: {declared}, expected {expected}")
+          print(f"WHEEL Tag: {declared[0]}")
+
+          shared_objects = [
+              name for name in names if name.endswith((".so", ".pyd", ".dylib"))
+          ]
+          if shared_objects != ["hazma/_core.abi3.so"]:
+              sys.exit(
+                  "expected hazma/_core.abi3.so as the only compiled object, "
+                  f"found {shared_objects}"
+              )
+          print("extension: hazma/_core.abi3.so")
           PY
+
+      # The two ends of the range the `cp310-abi3` tag claims. They are the
+      # oldest and newest entries of ci.yml's test matrix and of
+      # pyproject.toml's `requires-python`; move all three together.
+      #
+      # `--no-deps` on purpose. The claim under test is that this one wheel
+      # loads on both interpreters, and installing numpy/scipy/matplotlib/
+      # scikit-image alongside it would let a third-party wheel gap on the
+      # newest CPython read as an abi3 failure. Importing `hazma._core` needs
+      # none of them: `hazma/__init__.py` imports only the standard library.
+      # The full-dependency install smoke is ci.yml's `Import smoke test`,
+      # which runs on every matrix entry.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+      - name: Import the wheel on CPython 3.10
+        # Outside the checkout, so the installed package is what gets
+        # imported rather than the source tree next to it.
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-deps "$GITHUB_WORKSPACE"/dist/*.whl
+          python -c "import hazma, hazma._core; print(hazma.VERSION, hazma._core.__file__)"
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - name: Import the wheel on CPython 3.14
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-deps "$GITHUB_WORKSPACE"/dist/*.whl
+          python -c "import hazma, hazma._core; print(hazma.VERSION, hazma._core.__file__)"
+
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}
-          path: wheelhouse/*.whl
+          name: wheel-${{ matrix.artifact }}
+          path: dist/*.whl
 
   build-sdist:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+
+      - name: Build the sdist with maturin
+        uses: PyO3/maturin-action@v1
         with:
-          python-version: "3.12"
-      - name: Build sdist
+          command: sdist
+          args: --out dist
+
+      - name: Check the sdist
+        # `twine check` reads the metadata; it cannot tell whether the
+        # archive holds enough to build from. That is what the second half
+        # asserts -- an sdist without the crate named by `[tool.maturin]
+        # manifest-path` is unbuildable, and nothing else in the pipeline
+        # would notice, since the wheel jobs build from the checkout.
         run: |
-          python -m pip install build twine
-          python -m build --sdist
-          python -m twine check dist/*
+          python -m pip install --upgrade pip twine
+          python -m twine check dist/*.tar.gz
+          python3 - <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+
+          sdists = sorted(pathlib.Path("dist").glob("*.tar.gz"))
+          if len(sdists) != 1:
+              sys.exit(f"expected one sdist, found {[s.name for s in sdists]}")
+          with tarfile.open(sdists[0]) as archive:
+              names = archive.getnames()
+          root = names[0].split("/")[0]
+          required = [
+              f"{root}/pyproject.toml",
+              f"{root}/rust/Cargo.toml",
+              f"{root}/rust/Cargo.lock",
+              f"{root}/hazma/__init__.py",
+          ]
+          missing = [path for path in required if path not in names]
+          if missing:
+              sys.exit(f"sdist {sdists[0].name} is missing {missing}")
+          print(f"{sdists[0].name}: {len(names)} members, all build inputs present")
+          PY
+
       - uses: actions/upload-artifact@v7
         with:
           name: sdist
@@ -106,9 +224,11 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    # Only publish on an actual release; manual runs just exercise the build.
+    # Only publish on an actual release. Manual runs and the packaging-path
+    # pull-request runs above just exercise the build, and this condition is
+    # the only thing that keeps them from uploading.
     if: github.event_name == 'release'
-    needs: [build-wheels, build-sdist]
+    needs: [build-wheel, build-sdist]
     runs-on: ubuntu-latest
     # Registered as the environment on PyPI's trusted publisher for hazma, so
     # only this job can mint an upload token.  Its deployment rule restricts

--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -55,6 +55,19 @@ cites a real PR.
   -q | awk -F'::' '{print $2}' | sort | uniq -c`, `grep -c '#\[test\]'` —
   so the next reader re-runs it instead of trusting it.
 
+- [derived-count-not-rederived] The count most likely to go stale is the
+  one describing **your own diff**, because it is written early and the
+  diff keeps growing. PR #84 (cython-to-rust Task 7.2) wrote "the four
+  markdown files this diff touches" into its task note, then added
+  `task-notes/README.md` to the diff two commits later. The number was by
+  then in five places — a pasted `preflight.sh` invocation and its
+  `markdownlint` row, two `## Numerical impact` sentences, and a
+  four-argument `check_doc_citations.py` command that consequently
+  scanned four of five documents. The note's own count sweep re-derived
+  eight other numbers and had no row for this one, so nothing caught it;
+  review did. `git diff origin/master --name-only | grep -c '\.md$'`
+  answers it in one command, and it now has a sweep row.
+
 ### measurement-taken-before-the-task-ended
 
 - [measurement-taken-before-the-task-ended] A number measured *correctly*,
@@ -776,6 +789,19 @@ cites a real PR.
   *claim*, not the digit — both stale sites also carried the superseded
   justification ("bounds step-selection spread") and omitted the solver
   override that made the new value portable.
+
+- [sweep-block-written-from-intent] A subtler variant: the block *was*
+  written last from real output, but the command printed beside it is not
+  the command that produced it. PR #84's forward-looking-phrase sweep
+  showed a bare repo-wide
+  `rg -n '(Task 7\.[0-9] will|…|Not started)'` above two hits and the
+  conclusion that the falsified phrases "return nothing". Run as written
+  it returns matches from all over `projects/`; run as actually executed —
+  scoped to the touched files — it returns five, three of them the note
+  quoting the very phrases it had just declared absent. Scope the command
+  in the block to what you ran (`$(git diff origin/master --name-only)`
+  makes the scope self-deriving), and classify every hit, including the
+  ones your own note reintroduces as quotations.
 
 ### sign-copied-from-a-defect-description
 

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -63,7 +63,9 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
 - [derived-count-not-rederived] Every count in a plan, note or PR body — your
   own artifacts included — is re-derived from source with a stated command at
   write time, and the command is quoted next to the number so the next reader
-  re-runs it instead of trusting it (PR #35, #59).
+  re-runs it instead of trusting it. A count describing *your own diff* goes
+  stale the moment the diff grows, so give it a row in the count sweep like any
+  other — an uncounted count is one nothing re-checks (PR #35, #59, #84).
 - [measurement-taken-before-the-task-ended] Re-run every measurement against the
   final tree after your last edit; take both halves of a before/after on the
   same tree and environment; derive breakdowns from the command so the parts
@@ -202,9 +204,11 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   outward (PR #71).
 - [sweep-block-written-from-intent] Write the stale-state sweep block last, by
   pasting command output after every prose edit is frozen; "I remember fixing
-  that" is a claim to re-check, not evidence. The same rule binds any inventory
-  of what a task is *deferring* — enumerate it from the grep, not from memory
-  (PR #71, #78, #83).
+  that" is a claim to re-check, not evidence. The command you paste must be the
+  one that produced the output beside it — a narrowed run written up under a
+  repo-wide command reads as a clean sweep and is unreproducible. The same rule
+  binds any inventory of what a task is *deferring* — enumerate it from the
+  grep, not from memory (PR #71, #78, #83, #84).
 - [sign-copied-from-a-defect-description] A delta quoted from a bug report
   carries the *defect's* sign and the repair's is the opposite with the same
   magnitude; restate the endpoints, or say "magnitude", when you copy a figure

--- a/projects/cython-to-rust/learnings/phase-02-rust-scaffold.md
+++ b/projects/cython-to-rust/learnings/phase-02-rust-scaffold.md
@@ -136,13 +136,20 @@ wrong?" before it is called done. Three of the three tasks here found a
   installs rustup in the container, `CIBW_ENVIRONMENT_LINUX` puts it on
   `PATH`). Same shape as Phase 00's `MANIFEST.in`-vs-wheel lesson: two
   artifacts, two mechanisms, and fixing one has never fixed the other.
-  **Phase 07 Task 7.1 rewrites this job for maturin and inherits it.**
+  **Settled by Phase 07 Task 7.2 (2026-08-29), not inherited:**
+  `PyO3/maturin-action@v1` builds Linux inside a manylinux container that
+  ships its own Rust toolchain, so the rustup-in-the-container recipe and
+  the host toolchain step both came out. The two-artifacts-two-mechanisms
+  shape survives one level up, between the wheel jobs and the sdist job.
 - **`release.yml` has no pull-request trigger**, so nothing about it is
   verifiable from a PR check however green the PR is. Closing one of its
   criteria takes an explicit `gh workflow run release.yml --ref <branch>`
   (safe because `publish` is gated on
   `github.event_name == 'release'` — check that gate before dispatching).
-  Measured cost ~17 min for both platforms.
+  Measured cost ~17 min for both platforms. **Task 7.2 gave it one**,
+  filtered to `release.yml` and `pyproject.toml`, so a packaging edit is
+  now measured by an ordinary PR check; a dispatch is still what covers
+  an edit anywhere else.
 - **The live Cython dispatch is not the contract the reference
   described** — four measured divergences, now written into
   `../references/numerics-replacements.md`: a 0-d array raises rather

--- a/projects/cython-to-rust/phases/phase-07-cutover.md
+++ b/projects/cython-to-rust/phases/phase-07-cutover.md
@@ -20,9 +20,14 @@ close the project (version bump + CHANGELOG per `PLAN.md`).
   layout; `setup.py` and `MANIFEST.in` are deleted; the version is
   static in `[project] version`, with `hazma.VERSION` reading it back
   from `importlib.metadata`; pytest config moved to pyproject in
-  Phase 01. **Not yet touched:** release.yml still uses cibuildwheel
-  (cp310–cp314 × {linux x86_64, macos arm64} = 10 wheels, sdist job,
-  PyPI trusted publishing), which is Task 7.2's.
+  Phase 01.
+- Release pipeline, as of Task 7.2 (2026-08-29): release.yml is built on
+  `PyO3/maturin-action@v1` and produces one `cp310-abi3` wheel per
+  platform plus the sdist, replacing the cibuildwheel matrix
+  (cp310–cp314 × {linux x86_64, macos arm64} = 10 wheels) it carried
+  until then. The trusted-publishing job is unchanged and still gated on
+  `github.event_name == 'release'`; the workflow also runs on pull
+  requests that touch `release.yml` or `pyproject.toml`.
 
 ## Tasks
 
@@ -120,6 +125,20 @@ close the project (version bump + CHANGELOG per `PLAN.md`).
   | `environment.md` | 67 | "exactly like a `.pyx`" inside the `.rs` rebuild note |
   | `environment.md` | 77–84 | "Deleting a `.pyx` does not make its module unimportable" — the stale-`.so` note; its *mechanism* is still true of `.rs`, so rewrite rather than delete |
   | `environment.md` | 106–107 | "Never hand-edit generated `.c` / `.cpp`. They are cythonize output" |
+
+  **Extended by Task 7.2 (2026-08-29):** two more sites, in the skills
+  rather than in those two files, and invisible to the grep above because
+  they name setuptools instead of Cython. Both tell a reviewer to check
+  new package data against a table `pyproject.toml` no longer has:
+
+  | File | Line | What is wrong |
+  | --- | --- | --- |
+  | `.claude/skills/review-plan/SKILL.md` | 217–219 | "New `*.dat` / `*.csv` under `hazma/` must be registered in `[tool.setuptools.package-data]`" — maturin ships the whole `hazma/` tree, so there is nothing to register |
+  | `.claude/skills/review-pr/SKILL.md` | 107–109 | the same claim, as a review finding to look for |
+  | `.codex/skills/review-pr/SKILL.md` | 30 | "package data registration" in the lens summary — the pointer to the claim above |
+
+  Derived from `rg -n 'package-data|package data' .claude/ .codex/`; the
+  `.codex/` copies carry only that one pointer, not the claim itself.
 
 - README / docs/source install instructions updated (Rust toolchain
   only needed for source builds; wheels cover normal installs);

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -28,7 +28,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | **Complete (2026-08-20)** — all six tasks done; 16 entry points on Rust and `hazma/spectra/` holds no Cython `def`; [learnings](../learnings/phase-04-spectra-kernels.md) |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | **Complete (2026-08-21)** — all three tasks done; [learnings](../learnings/phase-05-mediator-cross-sections.md) |
 | 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | **Complete (2026-08-27)** — all four tasks done; zero `.pyx`/`.pxd` remain; [learnings](../learnings/phase-06-mediator-spectra.md) |
-| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | **In progress** — Task 7.1 complete (2026-08-27); 7.2 and 7.3 unblocked |
+| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | **In progress** — Tasks 7.1–7.2 complete (7.2 on 2026-08-29); 7.3 unblocked |
 
 ```text
 00 ──► 01 ──► 02 ──► 03 ──► 04 ──► 06 ──► 07
@@ -276,13 +276,23 @@ points are on `hazma._core`, and after Task 6.4
 `find hazma -name "*.pyx" -o -name "*.pxd"` returns **nothing**.
 
 **Phase 07 is in progress: Task 7.1 landed the maturin cutover on
-2026-08-27, and Tasks 7.2 (release pipeline) and 7.3 (docs sweep) are
-both unblocked and share no files.** Read [`../PLAN.md`](../PLAN.md),
-this file, then
-[`phase-07/README.md`](phase-07/README.md)'s `## Handoff` and Task 7.1's
+2026-08-27 and Task 7.2 rebuilt the release pipeline on it on 2026-08-29,
+leaving Task 7.3 (docs sweep) the only unblocked task.** Read
+[`../PLAN.md`](../PLAN.md), this file, then
+[`phase-07/README.md`](phase-07/README.md)'s `## Handoff` and Task 7.2's
 note. The four Phase-07 risks Task 6.4 flagged are all discharged — and
 all four were real; `phase-06/README.md` is history now
 ([ADR-0002](../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md)).
+
+**The release pipeline is maturin's too, and it has been observed to
+run.** `release.yml` builds one `cp310-abi3` wheel per platform plus the
+sdist on `PyO3/maturin-action@v1`, replacing a ten-wheel cibuildwheel
+matrix, and asserts the tag, the sole-`.abi3.so` claim, imports on
+CPython 3.10 and 3.14, and the sdist's build inputs inside the workflow.
+It also now runs on pull requests touching `release.yml` or
+`pyproject.toml`, so a packaging edit is no longer unmeasurable until a
+release happens; `publish` stays gated on
+`github.event_name == 'release'`.
 
 **The build is maturin and nothing else.** `[build-system] requires` is
 `["maturin>=1.5,<2.0"]`; `setup.py` and `MANIFEST.in` are deleted;

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -187,7 +187,10 @@ cutover and project close.
 ### Task 7.2
 
 - Both dispatched `release.yml` runs, with `publish` skipped in each;
-  conclusions and the assertion output are pasted in the task note.
+  conclusions and the assertion output are pasted in the task note. PR #84
+  then ran it a third time through the new `pull_request` trigger, where
+  `Publish to PyPI` again reported `skipping` — the release gate holding
+  on a real pull-request event, not only under `workflow_dispatch`.
 - The two assertion scripts extracted verbatim from the workflow and run
   against locally built artifacts, then against eleven mutants — every
   failure branch fires and the compressed-manylinux shape passes.

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -191,6 +191,10 @@ cutover and project close.
 - The two assertion scripts extracted verbatim from the workflow and run
   against locally built artifacts, then against eleven mutants — every
   failure branch fires and the compressed-manylinux shape passes.
+- `ci.yml` dispatched on the branch (it does not run on a branch push):
+  run 33284511292, **all eight jobs success**, both cache steps observed
+  targeting `rust/target` and the five Linux matrix entries deriving one
+  shared key.
 
 ### Task 7.1
 

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 07
-**Status:** In progress (Task 7.1 complete 2026-08-27)
+**Status:** In progress (Tasks 7.1–7.2 complete; 7.2 on 2026-08-29)
 **Plan References:** `../../phases/phase-07-cutover.md`
 **Related ADRs:** ADR-0001
 **Depends On:** Phase 06 complete
@@ -18,7 +18,7 @@ cutover and project close.
 | # | Task | Depends on | Status | Task Note |
 | --- | ------ | ------------ | -------- | ----------- |
 | 7.1 | Backend switch to maturin | — | **Complete (2026-08-27)** | [task-7.1-maturin-backend.md](task-7.1-maturin-backend.md) |
-| 7.2 | Release pipeline (abi3 wheels) | 7.1 | Not started | [task-7.2-release-pipeline.md](task-7.2-release-pipeline.md) |
+| 7.2 | Release pipeline (abi3 wheels) | 7.1 | **Complete (2026-08-29)** | [task-7.2-release-pipeline.md](task-7.2-release-pipeline.md) |
 | 7.3 | Documentation sweep | 7.1 | Not started | [task-7.3-docs-sweep.md](task-7.3-docs-sweep.md) |
 | 7.4 | Close the project | 7.1–7.3 | Not started | [task-7.4-close.md](task-7.4-close.md) |
 
@@ -36,6 +36,35 @@ cutover and project close.
   impact so far" section on 2026-08-21) — input to the CHANGELOG.
 
 ## Findings
+
+### Task 7.2
+
+- **A wheel filename's last three fields are compressed tag *sets*, not
+  tags.** Each is dot-separated and the wheel carries their cross
+  product, one `Tag:` line per member. The manylinux wheel is
+  `cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64` — one platform
+  field standing for two tags — and the macOS wheel is one tag per field,
+  so an assertion comparing field against `Tag:` line as a single string
+  passes on macOS and rejects a correct Linux wheel. Both halves of a
+  two-platform matrix have to run before a format assertion is believed;
+  a locally built wheel is the macOS shape only.
+- **`twine check` cannot fail an unbuildable sdist.** It reads metadata.
+  An archive missing `rust/Cargo.toml` passes it and then fails every
+  `pip install --no-binary`, and nothing else in the pipeline notices,
+  because both wheel jobs build from the checkout rather than from the
+  sdist.
+- **The manylinux container ships its own Rust toolchain.** Phase 02's
+  `CIBW_BEFORE_ALL_LINUX` rustup install, its `CIBW_ENVIRONMENT_LINUX`
+  `PATH` edit, and the host `dtolnay/rust-toolchain` step that covered
+  macOS all came out with cibuildwheel; `maturin-action` needs none of
+  them. The phase-02 learnings entry that handed this recipe forward is
+  settled in place.
+- **`ci.yml` never had Cython caching to drop.** The Task 7.2 criterion's
+  first clause was written in the August 2026 analysis against an
+  anticipated shape. `rg -in 'cython' .github/workflows/` returns six
+  hits on `origin/master`, every one prose inside a comment; no step,
+  flag or cache key mentions Cython. The sole caching in the file is
+  `actions/setup-python`'s `cache: pip`, which is unrelated and stays.
 
 ### Task 7.1
 
@@ -69,6 +98,37 @@ cutover and project close.
 
 ## Decisions and Implementation Notes
 
+### Task 7.2
+
+- **`PyO3/maturin-action@v1` over cibuildwheel's maturin support.**
+  cibuildwheel's value here was the CPython matrix and the manylinux
+  container; `abi3-py310` removes the first and maturin-action supplies
+  the second, so keeping it would mean narrowing `CIBW_BUILD` to one
+  version to stop it rebuilding the same wheel five times.
+- **No aarch64 or Windows wheels** — the decision the criterion asks for,
+  default kept. The support surface is unchanged and neither target has a
+  user asking for it. They are a matrix row each under maturin, which is
+  why this is a deliberate no rather than an oversight; `PLAN.md`'s Scope
+  already records it as a cheap follow-up, so no stub was filed.
+- **The two import checks use `--no-deps`.** The claim is that one
+  `cp310-abi3` wheel loads on both ends of the range it advertises, and
+  `hazma/__init__.py` imports only the standard library. Installing
+  numpy/scipy/matplotlib/scikit-image would let a third-party wheel gap
+  on the newest CPython read as an abi3 failure; the full-dependency
+  install smoke stays in `ci.yml`, on every matrix entry.
+- **A path-filtered `pull_request` trigger** on `release.yml` and
+  `pyproject.toml` retires the `[unrun-workflow-cannot-close-a-criterion]`
+  workaround for packaging edits, at the cost of two rare paths rather
+  than every PR. `rust/**` is excluded: `ci.yml` already compiles the
+  crate on both operating systems for every PR. The `publish` job's
+  existing `if: github.event_name == 'release'` gate is what keeps the
+  new trigger from uploading.
+- **One cargo cache per OS across the whole Python matrix.** abi3 links
+  against the limited API, so the cargo artifacts do not vary with the
+  interpreter; `workspaces: rust` points `Swatinem/rust-cache@v2` at the
+  crate's own `[workspace]` root, and pip's in-tree build means both
+  installs in that job reuse `rust/target`.
+
 ### Task 7.1
 
 - `[project] version` is the source of truth; `hazma.VERSION` reads it
@@ -95,6 +155,14 @@ cutover and project close.
 
 ## Files Changed
 
+### Task 7.2
+
+- Workflows: `.github/workflows/release.yml` (rewritten),
+  `.github/workflows/ci.yml` (cargo cache in the `rust` and `test` jobs)
+- Project docs: `../../phases/phase-07-cutover.md` (Prerequisites; Task
+  7.3's enumeration extended), `../../learnings/phase-02-rust-scaffold.md`
+  (two forward pointers settled), this file and the task note
+
 ### Task 7.1
 
 - Build: `pyproject.toml`; `setup.py` and `MANIFEST.in` deleted;
@@ -116,6 +184,14 @@ cutover and project close.
   import check on CPython 3.10 and newest; RTD/Sphinx build;
   `scripts/agents/preflight.sh --closing`.
 
+### Task 7.2
+
+- Both dispatched `release.yml` runs, with `publish` skipped in each;
+  conclusions and the assertion output are pasted in the task note.
+- The two assertion scripts extracted verbatim from the workflow and run
+  against locally built artifacts, then against eleven mutants — every
+  failure branch fires and the compressed-manylinux shape passes.
+
 ### Task 7.1
 
 - Bare `pytest -q`: **2231 passed, 15 skipped, 12 subtests passed**.
@@ -129,8 +205,10 @@ cutover and project close.
 
 ## Open Questions
 
-- Add aarch64/Windows wheels now that they are cheap? (Task 7.2
-  records the call; default no.)
+- **Answered by Task 7.2 (2026-08-29): no aarch64 or Windows wheels.**
+  The support surface is unchanged and neither has a user asking for it;
+  `PLAN.md`'s Scope keeps them as a cheap follow-up, and each is one
+  matrix row whenever that changes.
 - Should the four tracked editor leftovers under `hazma/` be deleted from
   the repository, not just excluded from the distribution? Handed to Task
   7.3 alongside `requirements.txt` and the `Dockerfile`.
@@ -141,11 +219,12 @@ cutover and project close.
 
 ## Handoff to Next Task
 
-**Tasks 7.2 (release pipeline) and 7.3 (docs sweep) are both unblocked
-and share no files.** Read `../../PLAN.md`, `../README.md`, this file,
-then the phase file — whose Prerequisites block and whose 7.2/7.3 exit
-criteria Task 7.1 rewrote against the post-cutover tree, so they no
-longer need re-verifying by hand.
+**Task 7.3 (documentation sweep) is the only unblocked task**; 7.4 waits
+on it. Read `../../PLAN.md`, `../README.md`, this file, then the phase
+file — whose Prerequisites block carries both the Task 7.1 packaging
+facts and the Task 7.2 release-pipeline facts, and whose 7.3 exit
+criteria enumerate the remaining stale sites rather than describing them.
+Re-derive the line numbers in that enumeration before editing.
 
 **Currently safe to assume:**
 
@@ -154,33 +233,40 @@ longer need re-verifying by hand.
   `manifest-path`, `module-name`, `exclude`, `include`. No `setup.py`, no
   `MANIFEST.in`, no `setuptools`. `test/test_no_cython_remains.py` asserts
   it, and nothing else in `test/` reads a build script any more.
-- **The wheel is already `cp310-abi3` and portable across CPythons.**
-  Task 7.2 owes CI verification of the tag and the two platform wheels,
-  not the tag itself.
+- **The release pipeline is maturin's too, and it has been observed to
+  run.** `release.yml` builds one `cp310-abi3` wheel per platform plus the
+  sdist on `PyO3/maturin-action@v1`; the tag, the sole-`.abi3.so` claim,
+  the 3.10/3.14 imports and the sdist's build inputs are all asserted in
+  the workflow. Task 7.2's criteria are closed against a dispatched run,
+  not against the file.
+- **`release.yml` now has a `pull_request` trigger**, filtered to
+  `release.yml` and `pyproject.toml`. An edit to either is measured by an
+  ordinary PR check; an edit anywhere else still needs
+  `gh workflow run release.yml --ref <branch>`. `publish` stays gated on
+  `github.event_name == 'release'`, which is what makes both safe.
 - **The sdist is 264 files** — `hazma/` + `rust/` + pyproject +
   README/LICENSE/CHANGELOG — and source-installs into a fresh CPython
   3.10 venv. maturin honors `.gitignore` for both artifacts, so build
   output stays out; an untracked *unignored* file does not.
-- **The version lives in `pyproject.toml`'s `[project] version`.** Task
-  7.4's bump edits that line; `preflight.sh --closing` already reads it.
-  Its tooling tendrils were swept: `docs/versioning.md`,
-  `docs/workflow.md`, `docs/agents/{preflight,doc-consistency}.md`, and
-  the three project `PLAN.md` closing paragraphs.
+- **The version lives in `pyproject.toml`'s `[project] version`, and it
+  is on `origin/master`.** Task 7.4's bump edits that line;
+  `preflight.sh --closing` reads it and is no longer vacuous (Task 7.1
+  merged in PR #83).
 - **`pip install -e .` builds release now**, so a `rules.md` rule 12
   benchmark from an editable tree is sound again.
 
 **Currently risky / unknown:**
 
-- **`preflight.sh --closing` is vacuous on a branch cut before Task 7.1
-  merged**: `origin/master`'s `pyproject.toml` has no `[project] version`
-  to compare against, so the gate reports "bump unverifiable" — a FAIL,
-  not a false pass. It resolves once 7.1 is on master, which is before
-  7.4 runs.
 - **An exact assertion against a compiled kernel may be scoped to the
   cargo profile.** Task 7.1 found and fixed one; the suite is green, but
   a newly written bit-equality claim should be checked against both
   profiles before being trusted.
-- **`release.yml` still has no pull-request trigger**, so Task 7.2 cannot
-  measure its own rewrite without an explicit dispatch
-  (`../../../../docs/agents/lessons.md`
-  `[unrun-workflow-cannot-close-a-criterion]`).
+- **A format assertion written against one platform's artifact encodes
+  that platform's shape.** Task 7.2's wheel-tag check passed locally and
+  on macOS and rejected a correct manylinux wheel, because a filename's
+  tag fields are compressed *sets* and only the Linux wheel has more than
+  one member. Both halves of the matrix have to run.
+- **`--paths` on `preflight.sh` feeds black, isort and ruff directly**, so
+  naming a `.yml` file there makes them parse it as Python and the gate
+  goes red on a clean tree. Pass source paths (or the `hazma test`
+  default) and use `--md` for markdown.

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
@@ -161,6 +161,23 @@ narrowing.
   the `pip install -e .` in that job populate and reuse `rust/target`
   rather than a temporary copy.
 
+### Review round 1 (PR #84)
+
+- **The changed-file count was stale in five places** and the citation
+  sweep ran over four of five documents, because "four markdown files"
+  was written before `task-notes/README.md` joined the diff. Every
+  affected block is re-run rather than re-numbered, and the count now has
+  a row in the count sweep — it had none, which is why nothing caught it.
+- **The forward-looking-phrase sweep printed a repo-wide command above
+  path-scoped output.** Re-run scoped to `$(git diff origin/master
+  --name-only)`, which returns **five** hits, not two: the three extra
+  are this note quoting the phrases it falsified, now classified rather
+  than declared absent.
+- Both are class-shaped and cited on the existing
+  `[derived-count-not-rederived]` and `[sweep-block-written-from-intent]`
+  ledger entries; the second one's rule text gained the "the command must
+  be the one that produced the output" clause it did not have.
+
 ## Files Changed
 
 - `.github/workflows/release.yml` — rewritten on maturin: two wheel
@@ -177,6 +194,10 @@ narrowing.
   deleted (the rustup-in-container recipe, the missing PR trigger).
 - `projects/cython-to-rust/task-notes/phase-07/README.md` and this note —
   status, findings, handoff.
+- `projects/cython-to-rust/task-notes/README.md` — the project Phases
+  table row and the cross-phase handoff.
+- `docs/agents/{lessons,lessons-examples}.md` — review round 1: this PR
+  cited on two existing classes, with a worked example for each.
 
 ## Verification
 
@@ -284,30 +305,37 @@ the saving half is what a first run can show, and every job reached
 
 ### Local gates
 
+The `--md` list is derived, not typed, so it cannot fall behind the diff
+the way the four-file list it replaces did:
+
 ```text
 $ scripts/agents/preflight.sh --paths "hazma test" \
-    --md "<the four markdown files this diff touches>"
+    --md "$(git diff origin/master --name-only | grep '\.md$' | tr '\n' ' ')"
 PASS   black --check           hazma test
 FAIL   isort --check-only      run `isort hazma test` and re-check
 FAIL   ruff check              see output below
 PASS   cargo fmt --check       rust/
 PASS   cargo clippy            rust/
 PASS   cargo test              rust/
-PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed in 29.52s
+PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed in 30.62s
 PASS   import hazma            version 2.1.0
-PASS   markdownlint            <the four files>
+PASS   markdownlint            docs/agents/lessons-examples.md docs/agents/lessons.md
+                               projects/cython-to-rust/learnings/phase-02-rust-scaffold.md
+                               projects/cython-to-rust/phases/phase-07-cutover.md
+                               projects/cython-to-rust/task-notes/README.md
+                               projects/cython-to-rust/task-notes/phase-07/README.md
+                               projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
 SKIP   version bump            not a closing PR (pass --closing)
 PASS   forbidden tokens        none added
 ```
+
+(The `markdownlint` row is one line in the real output; wrapped here.)
 
 The two red rows are inherited, not introduced:
 `docs/followups/todo/preflight-isort-ruff-red-on-trunk.md` records both
 gates as failing on unmodified trunk code, and
 `git diff origin/master --name-only | grep -E '\.py$|\.pyx$|\.rs$'`
-returns nothing, so this diff cannot have moved either count. The
-markdownlint row was red on the first run — four `MD013` line-length
-violations in this note — and the lines were rewrapped rather than the
-rule relaxed.
+returns nothing, so this diff cannot have moved either count.
 
 - `cargo metadata --manifest-path rust/Cargo.toml --locked` succeeds, so
   `--locked` in the wheel build cannot fail on a stale lockfile.
@@ -339,8 +367,10 @@ cibuildwheel Linux job alone ran 16m 25s of its 16m 30s.
 
 ## Numerical impact
 
-None. The diff touches two GitHub Actions workflow files and four project
-documents; no `hazma/` module, no `rust/` source, no test. Verified:
+None. `git diff origin/master --name-only` returns **nine** paths: two
+GitHub Actions workflow files, five `projects/` documents, and the two
+`docs/agents/` lessons files review round 1 added. No `hazma/` module, no
+`rust/` source, no test. Verified:
 `git diff origin/master --stat` lists no path under `hazma/`, `rust/` or
 `test/`, and the bare `pytest` in the preflight table above reports the
 same **2231 passed, 15 skipped, 12 subtests passed** as Task 7.1.
@@ -417,42 +447,67 @@ criterion, the phase-02 learnings settlement).
 
 ### Line-number citation sweep
 
+Over every Markdown file this diff changes, derived rather than listed:
+
+```sh
+git diff origin/master --name-only | grep '\.md$' | tr '\n' '\0' \
+  | xargs -0 python scripts/agents/check_doc_citations.py
+```
+
 ```text
-$ python scripts/agents/check_doc_citations.py \
-    projects/cython-to-rust/phases/phase-07-cutover.md \
-    projects/cython-to-rust/learnings/phase-02-rust-scaffold.md \
-    projects/cython-to-rust/task-notes/phase-07/README.md \
-    projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
-docs scanned: 4
-in-repo citations checked: 0
-external citations skipped: 1
+docs scanned: 7
+in-repo citations checked: 1
+  resolved by suffix: 1
+external citations skipped: 2
+  hazma/_utils/constants.pxd (1)
   hazma/spectra/_neutrino/_muon.pyx (1)
 out-of-range or ambiguous: NONE
 ```
 
-The skipped `.pyx` is pre-existing in the phase-02 learnings and is the
-known `docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md`
-behavior, not something this diff introduced. The line numbers this diff
-*does* add — Task 7.3's three skill sites — are stated with their
-derivation command in the phase file, so the next reader re-derives them
-rather than trusting them.
+Both skipped citations are pre-existing — the `.pxd` in
+`task-notes/README.md`, the `.pyx` in the phase-02 learnings — and both
+are the known
+`docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md`
+behavior: the checker cannot bounds-check a citation whose file the port
+deleted. Neither was introduced here, and nothing is out of range. The
+line numbers this diff *does* add — Task 7.3's three skill sites — are
+stated in the phase file with the command that derives them, so the next
+reader re-derives rather than trusts them.
 
 ### Forward-looking phrase sweep
 
-Over the six touched files:
+Scoped to the paths this diff touches, so the command reproduces the
+output beneath it. Counted per file rather than per line: this block
+contains the pattern it greps for, so its own line numbers move whenever
+it is edited, and a pinned `file:line` listing here would be stale before
+it was committed.
 
 ```sh
-rg -n '(Task 7\.[0-9] will|will be added|still pending|Not yet touched|still has no pull-request|Not started)'
+rg -c '(Task 7\.[0-9] will|will be added|still pending|Not yet touched|still has no pull-request|Not started)' \
+  $(git diff origin/master --name-only)
 ```
 
 ```text
-task-notes/phase-07/README.md:22   KEPT  | 7.3 | ... | Not started |
-task-notes/phase-07/README.md:23   KEPT  | 7.4 | ... | Not started |
+projects/cython-to-rust/task-notes/phase-07/README.md:2
+projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md:5
+docs/agents/lessons-examples.md:1
 ```
 
-Both are live status in the Tasks table and correct. "Not yet touched"
-and "still has no pull-request trigger", the two phrases this task
-falsified, return nothing.
+Eight hits, all kept, and **none of them asserts a falsified phrase**:
+
+- The two in the phase README are live status — the `Not started` cells
+  for Tasks 7.3 and 7.4 in the Tasks table.
+- Five are in this note: §Plan Impact quoting the "Not yet touched"
+  Prerequisites text it replaced, and this block's own `rg` pattern,
+  pasted output and commentary.
+- One is the worked example this round added under
+  `[sweep-block-written-from-intent]` in `docs/agents/lessons-examples.md`,
+  which quotes the pattern to explain the finding.
+
+The claim worth making is the negative one, and the identifier sweep
+above is what carries it: no *assertion* of "Not yet touched" or "still
+has no pull-request trigger" survives in the phase file or the phase-02
+learnings, which are the two documents that made them.
 
 ### Count sweep
 
@@ -466,12 +521,23 @@ falsified, return nothing.
 | §Verification 16m 30s → 1m 18s | `gh run view <id> --json createdAt,updatedAt` | 05:53:39→06:10:09; 00:45:05→00:46:23 | OK |
 | §Verification "Linux job alone ran 16m 25s" | same, `jobs[].startedAt/completedAt` | 05:53:43→06:10:08 | OK |
 | Exit criterion "2 abi3 wheels" | the green run's job list, plus the in-workflow assertion | 2 wheel jobs, one wheel each | OK |
+| §Numerical impact "nine paths … two workflow files, five `projects/` documents, two `docs/agents/`" | `git diff origin/master --name-only`, then `grep -c` per prefix | 9 = 2 + 5 + 2 | OK |
+| §Verification "docs scanned: 7" | `git diff origin/master --name-only \| grep -c '\.md$'` | 7 | OK |
+| §Verification forward sweep "eight hits" | the `rg -c` in that block, summed | 2 + 5 + 1 = 8 | OK |
+
+The last three rows exist because this table did not have them. The
+changed-file count was written once as "four" and copied to four more
+places, and nothing in the sweep re-derived it — which is how it survived
+into review after `task-notes/README.md` joined the diff. A count that
+appears in the note but not in this table is a count nothing checks, and
+this one proved the point twice: adding the two lessons files during the
+review round moved it again, from seven to nine, and the row caught it.
 
 ### Numerical-impact statement
 
 **No public value changes (verified: `git diff origin/master --stat`
 lists no path under `hazma/`, `rust/` or `test/`).** The diff is two
-workflow files and four project documents. The bare `pytest` in the
+workflow files and seven Markdown documents. The bare `pytest` in the
 preflight table reports the same **2231 passed, 15 skipped, 12 subtests
 passed** as Task 7.1, from a `pip install -e .` tree whose
 `hazma._core.__file__` resolves inside this worktree. No entry is owed to

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
@@ -1,0 +1,506 @@
+# Task 7.2: Release pipeline
+
+**Date:** 2026-08-29
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../phases/phase-07-cutover.md` (Task 7.2);
+`../../PLAN.md` (Scope, Phases)
+**Related ADRs:** ADR-0001 (framework choice, names maturin and abi3-py310)
+**Depends On:** Task 7.1 (maturin backend)
+
+## Objective
+
+Rebuild `.github/workflows/release.yml` on maturin so a release publishes
+two abi3 wheels and an sdist instead of a ten-entry cibuildwheel matrix,
+verify the wheel tag and cross-CPython importability inside the workflow,
+and give `ci.yml` a cargo cache.
+
+## Exit Criteria
+
+Copied from the phase file's Task 7.2 block, including its Task 7.1
+narrowing.
+
+- `release.yml` rebuilt on maturin (PyO3/maturin-action or cibuildwheel's
+  maturin support — pick and record): **2 abi3 wheels** (manylinux
+  x86_64, macOS arm64) + sdist; trusted-publishing job preserved; wheel
+  abi3 tags and importability verified in the workflow
+  (`CIBW_TEST_COMMAND`-equivalent import check on the oldest supported
+  CPython, 3.10, and the newest).
+  - Narrowed by Task 7.1: the tag itself is already correct
+    (`cp310-abi3`, verified locally cross-version). What this task owes
+    is producing the *two platform* wheels in CI and verifying the tag
+    and the import **there**.
+- Decision recorded (one line in this note): whether to add
+  linux aarch64 / Windows wheels now that they are cheap — default no,
+  matching the current support surface.
+- `ci.yml`: drop per-version rebuild caching of Cython; add cargo
+  caching; matrix unchanged.
+- The workflow is *observed to run*, not merely wired
+  (`docs/agents/lessons.md` `[unrun-workflow-cannot-close-a-criterion]`):
+  a dispatch on this branch with the publish job gated, and the job
+  conclusions pasted into the Verification section below.
+
+## Inputs Reviewed
+
+- `../../PLAN.md` — Scope, Numerical impact, Phases table.
+- `../../phases/phase-07-cutover.md` — Prerequisites and the Task 7.2
+  block.
+- `../README.md` (project) and `README.md` (phase 07) — handoff, open
+  questions.
+- `../../rules.md` — rules 6–9 (Rust conventions), rule 12 (measured
+  claims).
+- `task-7.1-maturin-backend.md` — `## Handoff to Next Task` only.
+- `../../learnings/phase-02-rust-scaffold.md` — the cibuildwheel/rustup
+  recipe and the "release.yml never runs" finding.
+- `../../learnings/phase-06-mediator-spectra.md` §1–2 — zero Cython,
+  corpus is the only pin.
+- `docs/agents/lessons.md` — whole ledger;
+  `[unrun-workflow-cannot-close-a-criterion]`,
+  `[stale-ci-capability-claim]`, `[gate-disabled-stays-green]` and
+  `[wheel-tag-vs-extension-abi]` bind here.
+- `docs/agents/environment.md` — packaging section (wheel vs sdist
+  machinery under maturin).
+- `.github/workflows/{ci,release}.yml`, `pyproject.toml`,
+  `rust/Cargo.toml` — the tree being changed.
+
+## Findings
+
+- **A wheel filename's last three fields are compressed tag *sets*, not
+  tags.** Each is dot-separated and the wheel carries their cross product,
+  one `Tag:` line per member (PEP 425). The manylinux wheel is
+  `cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64` — one platform
+  field standing for two tags — while the macOS wheel is one tag per
+  field. An assertion comparing the field against the `.dist-info/WHEEL`
+  lines as a single string therefore passes locally, passes on macOS, and
+  rejects a correct Linux wheel, which is exactly what run 33283941251
+  did. The local mutation harness could not have caught it: every wheel
+  this machine builds is the macOS shape.
+- **The criterion's first ci.yml clause had nothing to drop.** "Drop
+  per-version rebuild caching of Cython" was written in the August 2026
+  analysis against an anticipated shape; no such caching was ever in the
+  file. `rg -in 'cython' .github/workflows/` returns six hits on
+  `origin/master` and every one is prose inside a comment: three are the
+  project slug `cython-to-rust` dating a design note, three say Task 6.4
+  deleted the last Cython extension. No step, flag or cache key mentions
+  Cython. The only caching `ci.yml` has is `actions/setup-python`'s
+  `cache: pip`, which caches wheel downloads keyed on `pyproject.toml`
+  and is unrelated. Recorded rather than silently satisfied.
+- **cibuildwheel had nothing left to iterate over.** Its per-version
+  matrix is its purpose, and `abi3-py310` removes the versions: the ten
+  wheels it built were five copies per platform of one shared object.
+  That is what makes this a replacement rather than a port of the same
+  job to a new driver.
+- **The manylinux container ships its own Rust toolchain.** The
+  `CIBW_BEFORE_ALL_LINUX` rustup install and the `CIBW_ENVIRONMENT_LINUX`
+  `PATH` edit that Phase 02 worked out, and the host
+  `dtolnay/rust-toolchain` step that covered macOS, all come out with
+  cibuildwheel. `maturin-action` needs neither.
+- **`twine check` cannot fail an unbuildable sdist.** It validates
+  metadata. An archive missing `rust/Cargo.toml` would pass it and then
+  fail every `pip install --no-binary` — and nothing else in the pipeline
+  would catch that, because both wheel jobs build from the checkout, not
+  from the sdist.
+
+## Decisions and Implementation Notes
+
+- **`PyO3/maturin-action@v1` over cibuildwheel's maturin support**, the
+  choice the phase file asked to record. cibuildwheel's value here was
+  the CPython matrix and the manylinux container; abi3 removes the first
+  and maturin-action supplies the second. Keeping cibuildwheel would mean
+  narrowing `CIBW_BUILD` to a single version to avoid rebuilding the same
+  wheel five times — configuring a tool to not do the thing it is for.
+- **No aarch64 or Windows wheels** (the decision the criterion asks for,
+  default kept). `PLAN.md` puts them out of scope and Task 7.2 is where
+  the call is made explicit: the support surface is unchanged, the two
+  platforms are the two CI tests on, and neither target has a user asking
+  for it. They are cheaper under maturin than they were — a matrix row
+  each — which is exactly why this stays a deliberate no rather than an
+  oversight. `docs/followups/todo/` gets no stub: `PLAN.md`'s Scope
+  already records it as a cheap follow-up.
+- **`--no-deps` for the two import checks.** The claim under test is that
+  one `cp310-abi3` wheel loads on both ends of the range it advertises.
+  `hazma/__init__.py` imports only the standard library, so
+  `import hazma._core` needs none of numpy/scipy/matplotlib/scikit-image,
+  and installing them would let a third-party wheel gap on the newest
+  CPython fail this job for a reason that is not hazma's. The
+  full-dependency install smoke already exists in `ci.yml`'s
+  `Import smoke test`, on every matrix entry.
+- **Two assertions, not one.** The old step checked only that
+  `hazma/_core.abi3.so` was inside each wheel, which is the
+  extension-level claim; `docs/agents/lessons.md`
+  `[wheel-tag-vs-extension-abi]` exists because the distribution-level
+  claim can disagree with it, and under setuptools-rust it did. The new
+  step asserts the filename tag set, the `.dist-info/WHEEL` `Tag:` lines,
+  and that the abi3 object is the *only* compiled object — a
+  `_core.cpython-312-*.so` appearing beside it would mean the feature
+  stopped applying.
+- **`--locked` on the wheel build**, so the published artifact is a build
+  of the committed `rust/Cargo.lock` rather than of whatever resolves that
+  day. Verified the lockfile is current:
+  `cargo metadata --manifest-path rust/Cargo.toml --locked` succeeds.
+- **A path-filtered `pull_request` trigger**, scoped to `release.yml` and
+  `pyproject.toml`. It resolves the class this task had to work around —
+  `docs/agents/lessons.md` `[unrun-workflow-cannot-close-a-criterion]`,
+  which Phase 02 hit on the same file — at the cost of two rare paths
+  rather than every PR. Rust source is deliberately excluded: `ci.yml`
+  already compiles the crate on both operating systems for every PR, so
+  adding `rust/**` here would buy a duplicate build. The `publish` job's
+  existing `if: github.event_name == 'release'` gate is what keeps the new
+  trigger from uploading, and it was checked before dispatching.
+- **`manylinux: auto` rather than a pinned policy.** The criterion names
+  "manylinux x86_64" without a policy; pinning one here would assert a
+  container the action may move off. The resulting platform tags are
+  printed and compared against the filename instead of assumed — they came
+  back `manylinux_2_17_x86_64` and `manylinux2014_x86_64`.
+- **One cargo cache per OS across the whole Python matrix.** abi3 links
+  against the limited API, so the cargo artifacts do not vary with the
+  interpreter and five matrix entries would otherwise fill five caches
+  with the same objects. `Swatinem/rust-cache@v2` keys on `runner.os` and
+  the toolchain already; `workspaces: rust` points it at the crate's own
+  `[workspace]` root. pip builds in-tree, so both the `pip install .` and
+  the `pip install -e .` in that job populate and reuse `rust/target`
+  rather than a temporary copy.
+
+## Files Changed
+
+- `.github/workflows/release.yml` — rewritten on maturin: two wheel
+  matrix rows, the tag/extension assertion, the two import checks, the
+  sdist build-input assertion, the new `pull_request` trigger.
+- `.github/workflows/ci.yml` — `Swatinem/rust-cache@v2` in the `rust` and
+  `test` jobs. Matrix, steps and commands otherwise unchanged.
+- `projects/cython-to-rust/phases/phase-07-cutover.md` — Prerequisites
+  gains the post-7.2 release-pipeline facts; Task 7.3's enumeration gains
+  the three `[tool.setuptools.package-data]` sites in the skills, which
+  its Cython-worded grep could not have found.
+- `projects/cython-to-rust/learnings/phase-02-rust-scaffold.md` — the two
+  forward pointers this task discharged, settled in place rather than
+  deleted (the rustup-in-container recipe, the missing PR trigger).
+- `projects/cython-to-rust/task-notes/phase-07/README.md` and this note —
+  status, findings, handoff.
+
+## Verification
+
+### The workflow, observed running
+
+`docs/agents/lessons.md` `[unrun-workflow-cannot-close-a-criterion]`:
+these criteria are closed against dispatched runs, not against the file.
+`publish`'s `if: github.event_name == 'release'` gate was read before
+each dispatch, and `publish` skipped in both.
+
+`gh workflow run release.yml --ref claude/cython-to-rust/task-7.2-release-pipeline`
+
+| Run | Wheel (manylinux) | Wheel (macOS) | sdist | publish |
+| --- | --- | --- | --- | --- |
+| [33283941251](https://github.com/LoganAMorrison/Hazma/actions/runs/33283941251) | failure | success | success | skipped |
+| [33284053186](https://github.com/LoganAMorrison/Hazma/actions/runs/33284053186) | success | success | success | skipped |
+
+The first run's failure is the compressed-tag-set finding above: the
+build was correct and the assertion was wrong. It is kept in this table
+rather than replaced by the green one, because it is the evidence that
+the assertion can fail.
+
+Assertion output from the green run (`gh run view 33284053186 --log`):
+
+```text
+Build wheel (manylinux-x86_64)  wheel: hazma-2.1.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+Build wheel (manylinux-x86_64)  platform tags: ['manylinux_2_17_x86_64', 'manylinux2014_x86_64']
+Build wheel (manylinux-x86_64)  WHEEL Tag: ['cp310-abi3-manylinux2014_x86_64', 'cp310-abi3-manylinux_2_17_x86_64']
+Build wheel (manylinux-x86_64)  extension: hazma/_core.abi3.so
+Build wheel (manylinux-x86_64)  Import 3.10  2.1.0 /opt/hostedtoolcache/Python/3.10.21/x64/lib/python3.10/site-packages/hazma/_core.abi3.so
+Build wheel (manylinux-x86_64)  Import 3.14  2.1.0 /opt/hostedtoolcache/Python/3.14.7/x64/lib/python3.14/site-packages/hazma/_core.abi3.so
+Build wheel (macos-arm64)       wheel: hazma-2.1.0-cp310-abi3-macosx_11_0_arm64.whl
+Build wheel (macos-arm64)       platform tags: ['macosx_11_0_arm64']
+Build wheel (macos-arm64)       WHEEL Tag: ['cp310-abi3-macosx_11_0_arm64']
+Build wheel (macos-arm64)       extension: hazma/_core.abi3.so
+Build wheel (macos-arm64)       Import 3.10  2.1.0 /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/hazma/_core.abi3.so
+Build wheel (macos-arm64)       Import 3.14  2.1.0 /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/hazma/_core.abi3.so
+Build sdist                     hazma-2.1.0.tar.gz: 264 members, all build inputs present
+```
+
+Two wheels, both `cp310-abi3`, both imported on 3.10 and 3.14, each
+carrying `hazma/_core.abi3.so` and no other compiled object. 264 sdist
+members matches the count Task 7.1 measured locally.
+
+### The assertions, proved able to fail
+
+A check that cannot fail is not a check. Both `python3 - <<'PY'` blocks
+were extracted **from the workflow file** by regex — not retyped — run
+against locally built artifacts, then against mutants built by rewriting
+the archives:
+
+| Mutant | Exit | Message |
+| --- | --- | --- |
+| macOS wheel, unmodified | 0 | `extension: hazma/_core.abi3.so` |
+| manylinux compressed tag set | 0 | `extension: hazma/_core.abi3.so` |
+| one `Tag:` line dropped | 1 | `WHEEL declares Tag: [...], filename expands to [...]` |
+| a `cp311-cp311` `Tag:` line added | 1 | same |
+| filename retagged `cp314-cp314` | 1 | `filename tag is cp314-cp314, expected cp310-abi3` |
+| `Tag:` rewritten to `cp314-cp314` | 1 | `WHEEL declares Tag: [...], filename expands to [...]` |
+| `_core.cpython-312-darwin.so` added | 1 | `expected hazma/_core.abi3.so as the only compiled object` |
+| two wheels in `dist/` | 1 | `expected exactly one abi3 wheel in dist/, found 2` |
+| no wheels in `dist/` | 1 | `... found 0: []` |
+| sdist, unmodified | 0 | `264 members, all build inputs present` |
+| sdist without `rust/Cargo.lock` | 1 | `missing ['hazma-2.1.0/rust/Cargo.lock']` |
+| sdist without `rust/Cargo.toml` | 1 | `missing ['hazma-2.1.0/rust/Cargo.toml']` |
+| two sdists in `dist/` | 1 | `expected one sdist, found [...]` |
+
+### Local gates
+
+```text
+$ scripts/agents/preflight.sh --paths "hazma test" \
+    --md "<the four markdown files this diff touches>"
+PASS   black --check           hazma test
+FAIL   isort --check-only      run `isort hazma test` and re-check
+FAIL   ruff check              see output below
+PASS   cargo fmt --check       rust/
+PASS   cargo clippy            rust/
+PASS   cargo test              rust/
+PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed in 29.52s
+PASS   import hazma            version 2.1.0
+PASS   markdownlint            <the four files>
+SKIP   version bump            not a closing PR (pass --closing)
+PASS   forbidden tokens        none added
+```
+
+The two red rows are inherited, not introduced:
+`docs/followups/todo/preflight-isort-ruff-red-on-trunk.md` records both
+gates as failing on unmodified trunk code, and
+`git diff origin/master --name-only | grep -E '\.py$|\.pyx$|\.rs$'`
+returns nothing, so this diff cannot have moved either count. The
+markdownlint row was red on the first run — four `MD013` line-length
+violations in this note — and the lines were rewrapped rather than the
+rule relaxed.
+
+- `cargo metadata --manifest-path rust/Cargo.toml --locked` succeeds, so
+  `--locked` in the wheel build cannot fail on a stale lockfile.
+- `uv build --wheel` / `uv build --sdist` locally:
+  `hazma-2.1.0-cp310-abi3-macosx_11_0_arm64.whl`, `hazma-2.1.0.tar.gz`.
+
+### Measured cost
+
+Wall clock for the whole workflow, `createdAt` to `updatedAt`:
+
+| Run | Driver | Wheels | Wall |
+| --- | --- | --- | --- |
+| [31297673951](https://github.com/LoganAMorrison/Hazma/actions/runs/31297673951) (2026-08-09, Task 2.2) | cibuildwheel | 10 | 16m 30s |
+| [33284053186](https://github.com/LoganAMorrison/Hazma/actions/runs/33284053186) (2026-08-30) | maturin-action | 2 | 1m 18s |
+
+Not a controlled comparison — different days, different runner images,
+and the cibuildwheel run installed each of its ten wheels with full
+dependencies while these two import-check with `--no-deps`. The
+order-of-magnitude is nevertheless the ten-to-two wheel count: the
+cibuildwheel Linux job alone ran 16m 25s of its 16m 30s.
+
+### Deferred
+
+- The sdist is asserted to *contain* its build inputs, not to build. A
+  source install compiles the crate from scratch and Task 7.1 verified it
+  locally (`uv pip install --no-binary hazma` into a fresh 3.10 venv);
+  adding it here would put minutes of `cargo build` on every packaging PR
+  to re-check something the wheel jobs already prove compiles.
+
+## Numerical impact
+
+None. The diff touches two GitHub Actions workflow files and four project
+documents; no `hazma/` module, no `rust/` source, no test. Verified:
+`git diff origin/master --stat` lists no path under `hazma/`, `rust/` or
+`test/`, and the bare `pytest` in the preflight table above reports the
+same **2231 passed, 15 skipped, 12 subtests passed** as Task 7.1.
+
+## Open Questions
+
+- None outstanding. The aarch64/Windows question the criterion posed is
+  answered in §Decisions (no, deliberately), and the phase README's Open
+  Questions entry is rewritten to state the answer rather than keep
+  posing it.
+
+## Plan Impact
+
+**Impact Level:** Phase file patched.
+
+Two patches, both because this task's own diff falsified or narrowed
+canonical text. No ADR is needed: ADR-0001 already names maturin and
+`abi3-py310`, and nothing about that changed.
+
+- **Prerequisites** carried "**Not yet touched:** release.yml still uses
+  cibuildwheel (cp310–cp314 × {linux x86_64, macos arm64} = 10 wheels
+  …)". Replaced with the post-7.2 facts, dated, in the same shape as the
+  Task 7.1 bullet beside it.
+- **Task 7.3's exit criteria** gained three sites its own derivation
+  could not have found. That enumeration came from
+  `rg -n 'Cython|\.pyx|\.pxd|cythoniz'` over `AGENTS.md` and
+  `environment.md`; the three stale `[tool.setuptools.package-data]`
+  claims live in the skills and say "setuptools", not "Cython", so
+  neither the pattern nor the file set reaches them. Extending the table
+  is cheaper than letting 7.3 miss them, and Step 7's canonical-contract
+  rule says to patch it here rather than defer.
+
+Also settled, in `../../learnings/phase-02-rust-scaffold.md`: the two
+forward pointers this task discharged — the rustup-in-the-container
+recipe it said Task 7.1 would inherit (7.2 retired it instead), and the
+missing pull-request trigger. Settled in place with a date rather than
+deleted, so the phase's record of what it learned stays intact.
+
+## Stale-state sweep
+
+Run against this branch after every prose edit was frozen.
+
+### Identifier sweep
+
+Task notes are excluded throughout — they are history (ADR-0002).
+
+```sh
+rg -n 'cibuildwheel|CIBW_' \
+  projects/cython-to-rust/{phases,learnings}/ \
+  projects/cython-to-rust/PLAN.md docs/ .github/ README.md AGENTS.md
+```
+
+```text
+learnings/phase-02-rust-scaffold.md:133,135,136   KEPT   historical; the entry now carries "Settled by Phase 07 Task 7.2"
+.github/workflows/release.yml:7                   EDITED new header naming what the job replaced
+phases/phase-07-cutover.md:26                     EDITED new Prerequisites bullet, same sentence
+phases/phase-07-cutover.md:69,73                  KEPT   Task 7.2's criterion as written; the spec, not a claim
+phases/phase-07-cutover.md:182                    KEPT   phase Exit Criteria "no cibuildwheel-version-matrix residue"
+docs/agents/lessons-examples.md:471               KEPT   worked example for [unrun-workflow-cannot-close-a-criterion]
+```
+
+`rg -n 'pypa/cibuildwheel' .github/ docs/ AGENTS.md projects/cython-to-rust/{phases,learnings}/`
+→ no occurrences. The action pin this diff removes is cited nowhere but
+closed task notes.
+
+```sh
+rg -n 'PyO3/maturin-action|Swatinem/rust-cache' \
+  .github/ projects/cython-to-rust/{phases,learnings}/ docs/
+```
+
+→ 7 hits: 4 in the two workflows (the `uses:` lines) and 3 in project
+docs this diff wrote (the phase file's Prerequisites and Task 7.2
+criterion, the phase-02 learnings settlement).
+
+### Line-number citation sweep
+
+```text
+$ python scripts/agents/check_doc_citations.py \
+    projects/cython-to-rust/phases/phase-07-cutover.md \
+    projects/cython-to-rust/learnings/phase-02-rust-scaffold.md \
+    projects/cython-to-rust/task-notes/phase-07/README.md \
+    projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
+docs scanned: 4
+in-repo citations checked: 0
+external citations skipped: 1
+  hazma/spectra/_neutrino/_muon.pyx (1)
+out-of-range or ambiguous: NONE
+```
+
+The skipped `.pyx` is pre-existing in the phase-02 learnings and is the
+known `docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md`
+behavior, not something this diff introduced. The line numbers this diff
+*does* add — Task 7.3's three skill sites — are stated with their
+derivation command in the phase file, so the next reader re-derives them
+rather than trusting them.
+
+### Forward-looking phrase sweep
+
+Over the six touched files:
+
+```sh
+rg -n '(Task 7\.[0-9] will|will be added|still pending|Not yet touched|still has no pull-request|Not started)'
+```
+
+```text
+task-notes/phase-07/README.md:22   KEPT  | 7.3 | ... | Not started |
+task-notes/phase-07/README.md:23   KEPT  | 7.4 | ... | Not started |
+```
+
+Both are live status in the Tasks table and correct. "Not yet touched"
+and "still has no pull-request trigger", the two phrases this task
+falsified, return nothing.
+
+### Count sweep
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| §Findings "six hits on `origin/master`" | `rg -in 'cython' <origin/master>/.github/workflows/` | 6 (ci.yml 2, release.yml 4) | OK |
+| §Findings "no step, flag or cache key mentions Cython" | same command, each hit read | all six begin `#` | OK |
+| §Handoff "four hits, all dated historical notes" | `rg -in 'cython\|cibuildwheel\|CIBW' .github/workflows/` | 4 | OK |
+| phase README "eleven mutants" | mutation-table rows minus the two unmodified baselines | 13 − 2 = 11 | OK |
+| §Verification "264 members" | the workflow's own output; `uv build --sdist` locally | 264 in both | OK |
+| §Verification 16m 30s → 1m 18s | `gh run view <id> --json createdAt,updatedAt` | 05:53:39→06:10:09; 00:45:05→00:46:23 | OK |
+| §Verification "Linux job alone ran 16m 25s" | same, `jobs[].startedAt/completedAt` | 05:53:43→06:10:08 | OK |
+| Exit criterion "2 abi3 wheels" | the green run's job list, plus the in-workflow assertion | 2 wheel jobs, one wheel each | OK |
+
+### Numerical-impact statement
+
+**No public value changes (verified: `git diff origin/master --stat`
+lists no path under `hazma/`, `rust/` or `test/`).** The diff is two
+workflow files and four project documents. The bare `pytest` in the
+preflight table reports the same **2231 passed, 15 skipped, 12 subtests
+passed** as Task 7.1, from a `pip install -e .` tree whose
+`hazma._core.__file__` resolves inside this worktree. No entry is owed to
+`../numerical-impact.md` and none was appended.
+
+### Exit Criteria → evidence mapping
+
+| Criterion | Evidence |
+| --- | --- |
+| release.yml rebuilt on maturin; driver picked and recorded | `PyO3/maturin-action@v1`; §Decisions bullet 1 |
+| 2 abi3 wheels (manylinux x86_64, macOS arm64) + sdist | run 33284053186: three build jobs green, tags asserted in-workflow |
+| trusted-publishing job preserved | `publish` unchanged — `environment: pypi`, `id-token: write`, `pypa/gh-action-pypi-publish@release/v1` |
+| wheel abi3 tags verified in the workflow | `Assert the wheel is a single cp310-abi3 distribution`; output pasted above |
+| importability on oldest (3.10) and newest CPython | `Import the wheel on CPython 3.10` / `3.14`, both platforms; output pasted above |
+| aarch64/Windows decision recorded | §Decisions bullet 2 — no; the phase README's Open Questions entry now answers rather than poses it |
+| ci.yml: drop per-version Cython caching | none existed; §Findings bullet 2 carries the derivation |
+| ci.yml: add cargo caching | `Swatinem/rust-cache@v2` in the `rust` and `test` jobs |
+| ci.yml: matrix unchanged | `git diff origin/master -- .github/workflows/ci.yml` adds only the two cache steps |
+| workflow observed to run, publish gated | two dispatches; `publish: skipped` in both |
+
+### Task-note self-consistency
+
+`**Status:** Complete` matches the phase README's Tasks-table cell for
+7.2. Every file named in §Files Changed appears in
+`git diff origin/master --stat`: `.github/workflows/{ci,release}.yml`,
+`phases/phase-07-cutover.md`, `learnings/phase-02-rust-scaffold.md`,
+`task-notes/phase-07/README.md`, and this note as a created file.
+
+## Handoff to Next Task
+
+**Task 7.3 (documentation sweep) is next, and is the only thing blocking
+7.4.** Read `../../PLAN.md`, `../README.md`, `README.md` (phase 07), then
+the phase file's Task 7.3 block — whose enumeration this task extended.
+Re-derive its line numbers before editing; the originals are Task 7.1's.
+
+**Currently safe to assume:**
+
+- **The release pipeline is done and has been observed running.** Two
+  `cp310-abi3` wheels plus the sdist, on `PyO3/maturin-action@v1`, with
+  the tag, the sole-`.abi3.so` claim, the 3.10/3.14 imports and the
+  sdist's build inputs all asserted inside the workflow.
+- **`release.yml` is no longer unmeasurable from a PR.** It runs on pull
+  requests touching `release.yml` or `pyproject.toml`. An edit anywhere
+  else still needs `gh workflow run release.yml --ref <branch>`, and
+  `publish` stays gated on `github.event_name == 'release'`, which is
+  what makes both safe.
+- **`ci.yml` is otherwise untouched** — same matrix, same steps, same
+  commands. Only `Swatinem/rust-cache@v2` was added, to the `rust` and
+  `test` jobs.
+- **No Cython or cibuildwheel residue remains in `.github/workflows/`**
+  beyond prose in comments: `rg -in 'cython|cibuildwheel|CIBW'
+  .github/workflows/` returns four hits, each a dated note explaining why
+  a step looks the way it does.
+
+**Currently risky / unknown:**
+
+- **A format assertion written against one platform's artifact encodes
+  that platform's shape.** This task's wheel-tag check passed locally and
+  on macOS and rejected a correct manylinux wheel, because a filename's
+  tag fields are compressed *sets* and only the Linux wheel has more than
+  one member. Both halves of the matrix have to run — the same shape as
+  `[exactness-untestable-on-one-platform]`, applied to a file format
+  rather than to arithmetic.
+- **`--paths` on `preflight.sh` feeds black, isort and ruff directly.**
+  Naming a `.yml` there makes them parse it as Python: this task's first
+  run reported `FAIL black --check` and `Found 331 errors` from ruff on
+  an otherwise clean tree. Pass source paths or the `hazma test` default,
+  and use `--md` for markdown.
+- **An exact assertion against a compiled kernel may still be scoped to
+  the cargo profile** (inherited from Task 7.1, unchanged here).

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
@@ -244,6 +244,36 @@ the archives:
 | sdist without `rust/Cargo.toml` | 1 | `missing ['hazma-2.1.0/rust/Cargo.toml']` |
 | two sdists in `dist/` | 1 | `expected one sdist, found [...]` |
 
+### ci.yml, observed running
+
+`ci.yml` runs on `push: branches: [master]` and `pull_request`, so a
+branch push does not exercise it. Dispatched instead:
+`gh workflow run ci.yml --ref claude/cython-to-rust/task-7.2-release-pipeline`
+→ [33284511292](https://github.com/LoganAMorrison/Hazma/actions/runs/33284511292),
+**all eight jobs success** (Lint; Rust; Test on ubuntu 3.10/3.11/3.12/
+3.13/3.14 and macOS 3.14).
+
+The cache steps executed and targeted the crate's own workspace:
+
+```text
+Rust (fmt, clippy, test)     /home/runner/work/Hazma/Hazma/rust/target
+                             v0-rust-rust-Linux-x64-0b9fd15e
+                             No cache found. ... Saving cache ...
+Test (ubuntu-latest, py3.10) v0-rust-test-Linux-x64-0b9fd15e
+Test (ubuntu-latest, py3.11) v0-rust-test-Linux-x64-0b9fd15e
+Test (ubuntu-latest, py3.12) v0-rust-test-Linux-x64-0b9fd15e
+Test (ubuntu-latest, py3.13) v0-rust-test-Linux-x64-0b9fd15e
+Test (ubuntu-latest, py3.14) v0-rust-test-Linux-x64-0b9fd15e
+Test (macos-latest,  py3.14) v0-rust-test-Darwin-arm64-2bc65c5a
+```
+
+That is the "one cache per operating system across the whole Python
+matrix" claim, measured: all five Linux entries derive the same key, and
+the key carries the job name and the runner architecture but nothing
+about the interpreter. `No cache found` on this first run is expected —
+the saving half is what a first run can show, and every job reached
+`... Saving cache ...`.
+
 ### Local gates
 
 ```text
@@ -450,8 +480,8 @@ passed** as Task 7.1, from a `pip install -e .` tree whose
 | importability on oldest (3.10) and newest CPython | `Import the wheel on CPython 3.10` / `3.14`, both platforms; output pasted above |
 | aarch64/Windows decision recorded | §Decisions bullet 2 — no; the phase README's Open Questions entry now answers rather than poses it |
 | ci.yml: drop per-version Cython caching | none existed; §Findings bullet 2 carries the derivation |
-| ci.yml: add cargo caching | `Swatinem/rust-cache@v2` in the `rust` and `test` jobs |
-| ci.yml: matrix unchanged | `git diff origin/master -- .github/workflows/ci.yml` adds only the two cache steps |
+| ci.yml: add cargo caching | `Swatinem/rust-cache@v2` in the `rust` and `test` jobs; run 33284511292 shows both executing against `rust/target` |
+| ci.yml: matrix unchanged | `git diff origin/master -- .github/workflows/ci.yml` adds only the two cache steps; run 33284511292 has the same eight jobs, all green |
 | workflow observed to run, publish gated | two dispatches; `publish: skipped` in both |
 
 ### Task-note self-consistency

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md
@@ -199,6 +199,14 @@ build was correct and the assertion was wrong. It is kept in this table
 rather than replaced by the green one, because it is the evidence that
 the assertion can fail.
 
+The new `pull_request` trigger is exercised by the PR that ships it
+([#84](https://github.com/LoganAMorrison/Hazma/pull/84), run
+33288783161): the three build jobs appear as PR checks and pass, and
+`Publish to PyPI` reports **skipping**. That is the
+`github.event_name == 'release'` gate holding on a real `pull_request`
+event rather than only under `workflow_dispatch`, which is the property
+the trigger's safety rests on.
+
 Assertion output from the green run (`gh run view 33284053186 --log`):
 
 ```text


### PR DESCRIPTION
## Summary

- **`release.yml` is rebuilt on `PyO3/maturin-action@v1`.** It built ten
  wheels — five CPython versions on each of two platforms — and every one
  of them carried the same limited-API `hazma/_core.abi3.so`, because the
  crate's `abi3-py310` feature makes one shared object serve every
  CPython the project supports. Nine were redundant, and cibuildwheel's
  per-version matrix, which is what cibuildwheel is *for*, had nothing
  left to iterate over. It now produces **one `cp310-abi3` wheel per
  platform plus the sdist**. The manylinux container maturin-action
  builds Linux in ships its own Rust toolchain, which retires the
  rustup-in-the-container recipe the cibuildwheel job needed, and
  `--locked` makes the published artifact a build of the committed
  `rust/Cargo.lock`.
- **Two assertions replace the old "every wheel ships an abi3
  extension" check.** A wheel's tag is a property of the distribution and
  can disagree with what the distribution contains — under setuptools-rust
  it did, tagging `cp314-cp314` over a correct `_core.abi3.so`. One
  assertion requires the filename tag set and the `.dist-info/WHEEL`
  `Tag:` lines to agree on `cp310-abi3`; the other requires
  `hazma/_core.abi3.so` to be the only compiled object inside. The wheel
  is then installed and imported on CPython **3.10 and 3.14**, the ends
  of the range the tag claims. The sdist job moves to maturin too and now
  asserts the archive carries `pyproject.toml`, the crate, and its
  lockfile — `twine check` reads metadata only, so an sdist that cannot
  build would have passed it.
- **The trusted-publishing job is untouched** and still gated on
  `github.event_name == 'release'`. That gate becomes load-bearing here:
  `release.yml` also runs on pull requests touching `release.yml` or
  `pyproject.toml`, so an edit to the release pipeline is no longer
  unmeasurable until a release happens (`docs/agents/lessons.md`
  `[unrun-workflow-cannot-close-a-criterion]`). This PR is itself the
  first run of that trigger.
- **`ci.yml` gains `Swatinem/rust-cache@v2`** in the `rust` and `test`
  jobs, keyed on the crate's own `[workspace]` root. One cache per
  operating system serves the whole Python matrix, because abi3 links
  against the limited API and the cargo artifacts therefore do not vary
  with the interpreter. Matrix, steps and commands are otherwise
  unchanged.
- **No library value moves.** The diff is two workflow files and five
  project documents; `git diff origin/master --name-only` returns no path
  under `hazma/`, `rust/` or `test/`.

The task's third criterion, "drop per-version rebuild caching of Cython",
turned out to have nothing to drop — no such caching was ever in
`ci.yml`. That is recorded with its derivation in the task note rather
than quietly marked done.

## Project

`projects/cython-to-rust/` — Task 7.2: Release pipeline (abi3 wheels).

See `projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md`
for implementation detail, decisions, and verification. The phase file's
Prerequisites block is patched with the post-7.2 facts, and Task 7.3's
enumeration gains three stale `[tool.setuptools.package-data]` sites in
the skills that its own Cython-worded grep could not have reached.

## Test plan

- [x] **`release.yml` dispatched on this branch, publish gated.** Both
      runs are kept below, because the red one is the evidence that the
      new assertion can fail — it rejected a *correct* manylinux wheel,
      since a filename's tag fields are compressed sets (PEP 425) and
      `manylinux_2_17_x86_64.manylinux2014_x86_64` is one field standing
      for two `Tag:` lines. Fixed in `346d4292`.

      | Run | manylinux | macOS | sdist | publish |
      | --- | --- | --- | --- | --- |
      | [33283941251](https://github.com/LoganAMorrison/Hazma/actions/runs/33283941251) | failure | success | success | skipped |
      | [33284053186](https://github.com/LoganAMorrison/Hazma/actions/runs/33284053186) | success | success | success | skipped |

      Assertion output from the green run:

      ```text
      manylinux  wheel: hazma-2.1.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
      manylinux  WHEEL Tag: ['cp310-abi3-manylinux2014_x86_64', 'cp310-abi3-manylinux_2_17_x86_64']
      manylinux  extension: hazma/_core.abi3.so
      manylinux  import 3.10  2.1.0 /opt/hostedtoolcache/Python/3.10.21/x64/.../hazma/_core.abi3.so
      manylinux  import 3.14  2.1.0 /opt/hostedtoolcache/Python/3.14.7/x64/.../hazma/_core.abi3.so
      macos      wheel: hazma-2.1.0-cp310-abi3-macosx_11_0_arm64.whl
      macos      WHEEL Tag: ['cp310-abi3-macosx_11_0_arm64']
      macos      extension: hazma/_core.abi3.so
      macos      import 3.10  2.1.0 /Library/Frameworks/Python.framework/Versions/3.10/.../hazma/_core.abi3.so
      macos      import 3.14  2.1.0 /Library/Frameworks/Python.framework/Versions/3.14/.../hazma/_core.abi3.so
      sdist      hazma-2.1.0.tar.gz: 264 members, all build inputs present
      ```

- [x] **The new `pull_request` trigger is exercised by this PR.** Run
      33288783161: the three build jobs appear as PR checks and pass, and
      `Publish to PyPI` reports **skipping**. Until now the
      `github.event_name == 'release'` gate had only been watched skip
      under `workflow_dispatch`; this is it holding on a real
      `pull_request` event, which is the property the trigger's safety
      rests on.

- [x] **Both assertions proved able to fail.** The two `python3` blocks
      were extracted from `release.yml` by regex — not retyped — run
      against locally built artifacts, then against 11 mutants: a dropped
      `Tag:` line, an extra one, a `cp314-cp314` filename, a rewritten
      `Tag:`, an added `_core.cpython-312-darwin.so`, two wheels, zero
      wheels, an sdist without `Cargo.lock`, one without `Cargo.toml`,
      two sdists — plus a synthetic compressed-manylinux wheel that must
      pass. Every failure branch fires; the full table is in the task
      note.

- [x] **`ci.yml` dispatched** (it runs on pushes to master and on pull
      requests, so a branch push does not reach it):
      [33284511292](https://github.com/LoganAMorrison/Hazma/actions/runs/33284511292),
      **all eight jobs success**. Both cache steps executed against
      `/home/runner/work/Hazma/Hazma/rust/target`, and the five Linux
      matrix entries derived one shared key
      (`v0-rust-test-Linux-x64-0b9fd15e`), which is the "one cache per OS"
      claim measured rather than asserted.

- [x] **`scripts/agents/preflight.sh --paths "hazma test" --md "<the five
      changed markdown files>"`**:

      ```text
      PASS   black --check           hazma test
      FAIL   isort --check-only      run `isort hazma test` and re-check
      FAIL   ruff check              see output below
      PASS   cargo fmt --check       rust/
      PASS   cargo clippy            rust/
      PASS   cargo test              rust/
      PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed in 24.58s
      PASS   import hazma            version 2.1.0
      PASS   markdownlint            <the five files>
      SKIP   version bump            not a closing PR (pass --closing)
      PASS   forbidden tokens        none added
      ```

      The two red rows are inherited from the trunk, not introduced:
      `docs/followups/todo/preflight-isort-ruff-red-on-trunk.md` records
      both gates as failing on unmodified trunk code, and
      `git diff origin/master --name-only | grep -E '\.py$|\.rs$'`
      returns nothing, so this diff cannot have moved either count.

- [x] **Measured cost.** Whole-workflow wall clock, `createdAt` to
      `updatedAt`: **16m 30s** for the last cibuildwheel run
      ([31297673951](https://github.com/LoganAMorrison/Hazma/actions/runs/31297673951),
      10 wheels) against **1m 18s** here (2 wheels). Not a controlled
      comparison — different days and runner images, and that run
      installed each of its ten wheels with full dependencies where these
      import-check with `--no-deps` — but the cibuildwheel Linux job alone
      ran 16m 25s of its 16m 30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
