### PR TITLE
chore(packaging): close cython-to-rust and release 2.2.0

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -54,7 +54,8 @@ inventing a one-off scope.
   and, on a closing PR, in `CHANGELOG.md`.
 - **Version-bump check (project-closing PRs only).** If the diff flips a
   `projects/<slug>/PLAN.md` `status:` to `Complete`, the PR must carry
-  the `VERSION` bump in `hazma/__init__.py` and a `CHANGELOG.md` entry.
+  the version bump in `pyproject.toml`'s `[project] version` and a
+  `CHANGELOG.md` entry.
   `/execute-single-task` Step 8 is the canonical place to do it; if you
   arrive here with a closing diff that lacks it, stop and add it.
 

--- a/.claude/skills/execute-single-task/SKILL.md
+++ b/.claude/skills/execute-single-task/SKILL.md
@@ -429,8 +429,9 @@ Then handle closure:
   **Then bump the version (mandatory closure step).** Read
   `version_bump:` from `PLAN.md`, re-confirm the level against the
   project's realized **Numerical impact** and
-  [`versioning.md`](../../../docs/versioning.md), set `VERSION` in
-  `hazma/__init__.py`, and add a `## [X.Y.Z] — YYYY-MM-DD` section to
+  [`versioning.md`](../../../docs/versioning.md), set `version` in
+  `pyproject.toml`'s `[project]` table, and add a
+  `## [X.Y.Z] — YYYY-MM-DD` section to
   `CHANGELOG.md` naming the slug and stating any numerical change and its
   magnitude. Verify with `scripts/agents/preflight.sh --closing`.
 

--- a/.claude/skills/task-pipeline/SKILL.md
+++ b/.claude/skills/task-pipeline/SKILL.md
@@ -363,8 +363,8 @@ Agent(
 >
 >    **If `<PLAN_IMPACT>` is `Project closure`,** insert a `## Versioning`
 >    section between `## Project` and `## Numerical impact`. Read the new
->    version from `hazma/__init__.py`; the prior is in
->    `git show origin/master:hazma/__init__.py`:
+>    version from `pyproject.toml`'s `[project] version`; the prior is in
+>    `git show origin/master:pyproject.toml`:
 >
 >    ```markdown
 >    ## Versioning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,9 +173,11 @@ Rust toolchain for you.
   gate** (CI's ruff step passes `--exclude` for both). Do not treat code
   there as a pattern to copy, and do not import from `experimental/` in
   the library.
-- **`hazma/deprecated/` stays importable.** Removing or changing anything
-  there is a user-facing break — see `docs/versioning.md`. The package is
-  empty today (its last module went in cython-to-rust Task 0.2), so the
+- **`hazma/deprecated/` stays importable.** Changing anything there is a
+  user-facing break, and so is removing it unless a released version
+  warned on import and named the replacement — the reachability carve-out
+  in `docs/versioning.md`. The package is empty today (its last module
+  went in cython-to-rust Task 0.2, having warned since 2.1.0), so the
   rule binds the next module parked there.
 - **No `breakpoint()`, `pdb`, or stray `print()` in library code.** Use
   the returned value or a logger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ its magnitude and a pointer to the tracked repair. **Numerical changes go
 under `Changed` with the magnitude stated** — a spectrum that moves is a
 user-facing change even when no signature did.
 
-## [3.0.0] — 2026-08-29
+## [2.2.0] — 2026-08-29
 
 **Hazma's compiled layer is now Rust.** The twenty Cython extension
 modules are gone, replaced by a single abi3 extension, `hazma._core`,
@@ -27,10 +27,17 @@ keyword arguments, same return shapes and units. Delivered as the
 `cython-to-rust` project
 ([`projects/cython-to-rust/PLAN.md`](projects/cython-to-rust/PLAN.md)).
 
-**The major bump is an API removal, not a number.** `hazma.gamma_ray` and
-`hazma.deprecated.rambo` are gone; see `Removed`. Of the 41 compiled
-entry points the port moved, 27 reproduce 2.1.0 **bit-for-bit** and the
-other 14 move by at most **5.4e-12** relative — see the table under
+**Two public names are gone, and neither removal can break working
+code.** `hazma.gamma_ray` could not be imported in any released version,
+and `hazma.deprecated.rambo` shipped an import-time warning naming
+`hazma.phase_space` as its replacement. Both meet the reachability
+carve-out in [`docs/versioning.md`](docs/versioning.md), which is why a
+release that removes two public names is `minor`; check your imports
+against `Removed` before upgrading anyway.
+
+**The port itself changes no number by more than roundoff.** Of the 41
+compiled entry points it moved, 27 reproduce 2.1.0 **bit-for-bit** and
+the other 14 move by at most **5.4e-12** relative — see the table under
 `Changed`. The one substantive numerical change in this release is the
 two-body threshold repair, also under `Changed`, and it predates the
 Rust work.
@@ -81,8 +88,11 @@ its normalization.
 ### Removed
 
 - **`hazma.gamma_ray` — the whole module.** It could not be imported in
-  any released version (it transitively imported the long-deleted
-  `hazma.rambo`), so no working user code depended on it. Decided in
+  any released version — `hazma/gamma_ray.py` opened with
+  `from hazma import rambo`, and `hazma/rambo.py` is in no released tag —
+  so no working user code depended on it, which is the other half of the
+  reachability carve-out in
+  [`docs/versioning.md`](docs/versioning.md). Decided in
   [`projects/cython-to-rust/adrs/ADR-0003`](projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md).
   Both public functions have a named replacement, **neither a drop-in**:
   - `gamma_ray_decay` → `hazma.spectra.dnde_photon`, the live n-body
@@ -94,9 +104,11 @@ its normalization.
 
 - **`hazma.deprecated.rambo`.** The last module under
   `hazma/deprecated/`, superseded by the pure-NumPy `hazma.phase_space`
-  it already warned users toward on import. Removing anything from
-  `hazma/deprecated/` is `major` per
-  [`docs/versioning.md`](docs/versioning.md); the package is now empty.
+  it already warned users toward on import. That warning shipped in
+  2.1.0 and named the replacement, which is what puts this removal under
+  the reachability carve-out in
+  [`docs/versioning.md`](docs/versioning.md) rather than in `major`; the
+  package is now empty.
 
 - **The `hazma._gamma_ray` and `hazma._phase_space` Cython extensions**
   (private, never re-exported, and the only C++ in the tree) and the
@@ -260,7 +272,7 @@ its normalization.
 
 Twelve defects that hazma 2.1.0 already had, found while porting and
 **reproduced here rather than repaired**. None is new in
-3.0.0 and none changes a number relative to 2.1.0; each is tracked in
+2.2.0 and none changes a number relative to 2.1.0; each is tracked in
 [`docs/followups/todo/`](docs/followups/todo/) and most are sequenced for
 repair in
 [`projects/parity-pinned-defect-repair/`](projects/parity-pinned-defect-repair/PLAN.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ transpiler remain in the tree. Wheels are tagged `cp310-abi3` — one per
 platform, valid on every CPython from 3.10 onward, instead of one per
 (CPython, platform) pair — and a source build now needs a Rust toolchain
 on `PATH` rather than Cython, NumPy and SciPy build-time headers. The
-public Python API is unchanged: same module paths, same names, same
-keyword arguments, same return shapes and units. Delivered as the
-`cython-to-rust` project
+port changes no signature it touched: all 41 compiled entry points keep
+their module paths, names, keyword arguments, return shapes and units.
+Two public names are removed, but by Phase 00's dead-code purge rather
+than by the port — see `Removed`. Delivered as the `cython-to-rust`
+project
 ([`projects/cython-to-rust/PLAN.md`](projects/cython-to-rust/PLAN.md)).
 
 **Two public names are gone, and neither removal can break working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ its magnitude and a pointer to the tracked repair. **Numerical changes go
 under `Changed` with the magnitude stated** — a spectrum that moves is a
 user-facing change even when no signature did.
 
-## [2.2.0] — 2026-08-29
+## [2.2.0] — 2026-09-06
 
 **Hazma's compiled layer is now Rust.** The twenty Cython extension
 modules are gone, replaced by a single abi3 extension, `hazma._core`,
@@ -37,12 +37,20 @@ carve-out in [`docs/versioning.md`](docs/versioning.md), which is why a
 release that removes two public names is `minor`; check your imports
 against `Removed` before upgrading anyway.
 
+**Two physics repairs move published numbers, and neither comes from the
+port.** The scalar mediator's decay photon spectrum was a factor of 2 low
+in FSR since 2018 and is now correct — photon yield per scalar decay
+rises 1.7%–2.9%, and pointwise by up to a factor of two where FSR is the
+only open channel. The two-body threshold repair changes
+`cross_section_prefactor` near threshold and makes the below-threshold
+region NaN. Both are under `Changed`; **read them before reusing a
+published `ScalarMediator` result.**
+
 **The port itself changes no number by more than roundoff.** Of the 41
 compiled entry points it moved, 27 reproduce 2.1.0 **bit-for-bit** and
 the other 14 move by at most **5.4e-12** relative — see the table under
-`Changed`. The one substantive numerical change in this release is the
-two-body threshold repair, also under `Changed`, and it predates the
-Rust work.
+`Changed`. That table measures the port alone; where an entry point also
+appears in a repair above, the repair is much the larger move.
 
 **Read `Known issues` before upgrading a published analysis.** Porting
 each kernel meant stating what it computes precisely enough to check, and
@@ -273,8 +281,11 @@ its normalization.
 ### Known issues
 
 Twelve defects that hazma 2.1.0 already had, found while porting and
-**reproduced here rather than repaired**. None is new in
-2.2.0 and none changes a number relative to 2.1.0; each is tracked in
+**reproduced here rather than repaired**. None is new in 2.2.0 and none
+changes a number relative to 2.1.0. The FSR repair under `Changed` is
+not one of them — it was found after the port closed and repaired
+through the declared-delta mechanism, which is what lets a fix land
+without dissolving the parity evidence. Each is tracked in
 [`docs/followups/todo/`](docs/followups/todo/) and most are sequenced for
 repair in
 [`projects/parity-pinned-defect-repair/`](projects/parity-pinned-defect-repair/PLAN.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,44 @@ project adheres to [Semantic Versioning](https://semver.org/) over the
 public Python API as defined in [`docs/versioning.md`](docs/versioning.md).
 
 Sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`,
-`Security`. **Numerical changes go under `Changed` with the magnitude
-stated** — a spectrum that moves is a user-facing change even when no
-signature did.
+`Security`, and `Known issues`. The last one is outside Keep a Changelog's
+set and exists because a release can *measure* a defect without repairing
+it: an entry there names a wrong number the release ships knowingly, with
+its magnitude and a pointer to the tracked repair. **Numerical changes go
+under `Changed` with the magnitude stated** — a spectrum that moves is a
+user-facing change even when no signature did.
 
-## [Unreleased]
+## [3.0.0] — 2026-08-29
+
+**Hazma's compiled layer is now Rust.** The twenty Cython extension
+modules are gone, replaced by a single abi3 extension, `hazma._core`,
+built by [maturin](https://www.maturin.rs/); no `.pyx`, no `.pxd`, and no
+transpiler remain in the tree. Wheels are tagged `cp310-abi3` — one per
+platform, valid on every CPython from 3.10 onward, instead of one per
+(CPython, platform) pair — and a source build now needs a Rust toolchain
+on `PATH` rather than Cython, NumPy and SciPy build-time headers. The
+public Python API is unchanged: same module paths, same names, same
+keyword arguments, same return shapes and units. Delivered as the
+`cython-to-rust` project
+([`projects/cython-to-rust/PLAN.md`](projects/cython-to-rust/PLAN.md)).
+
+**The major bump is an API removal, not a number.** `hazma.gamma_ray` and
+`hazma.deprecated.rambo` are gone; see `Removed`. Of the 41 compiled
+entry points the port moved, 27 reproduce 2.1.0 **bit-for-bit** and the
+other 14 move by at most **5.4e-12** relative — see the table under
+`Changed`. The one substantive numerical change in this release is the
+two-body threshold repair, also under `Changed`, and it predates the
+Rust work.
+
+**Read `Known issues` before upgrading a published analysis.** Porting
+each kernel meant stating what it computes precisely enough to check, and
+that surfaced twelve live numerical defects that hazma 2.1.0 already had.
+This release **reproduces all twelve deliberately** — a port that quietly
+changed numbers would have had no way to prove it changed only the ones
+it meant to — so no result moves because of them here. Several of them do
+affect published numbers, one by percent-level amounts across the whole
+freeze-out region, and two change the *shape* of a spectrum rather than
+its normalization.
 
 ### Added
 
@@ -67,11 +100,19 @@ signature did.
 
 - **The `hazma._gamma_ray` and `hazma._phase_space` Cython extensions**
   (private, never re-exported, and the only C++ in the tree) and the
-  never-built `hazma/rh_neutrino/_rh_neutrino_fsr_four_body.pyx`. Wheels
-  now ship 20 extension modules instead of 25, all compiled as C.
-  No public value changes: every compiled-backed public entry point is
-  bit-for-bit identical across the deletion (159 arrays over
-  `np.logspace(-2, 3, 200)` MeV).
+  never-built `hazma/rh_neutrino/_rh_neutrino_fsr_four_body.pyx`. This cut
+  the extension count from 25 to 20 before the Rust port took it the rest
+  of the way to one; see `Changed`. No public value changes: every
+  compiled-backed public entry point is bit-for-bit identical across the
+  deletion (159 arrays over `np.logspace(-2, 3, 200)` MeV).
+
+- **The Cython build machinery, and with it the build-time dependency on
+  Cython, NumPy and SciPy.** `setup.py`, `MANIFEST.in`, `setup.cfg`'s
+  `[aliases]` section, `requirements.txt` and the `Dockerfile` are
+  deleted; `pyproject.toml` is the only build entry point and
+  `[build-system] requires` is `["maturin>=1.5,<2.0"]`. The now-empty
+  private `hazma/_utils/` package is deleted too — it held only Cython
+  headers. Nothing public imported any of it.
 
 ### Changed
 
@@ -126,6 +167,179 @@ signature did.
   Monte Carlo with a percent-level statistical error and none evaluates
   below threshold, so no published result is affected. Resolves
   [`docs/followups/done/cross-section-prefactor-threshold-cancellation.md`](docs/followups/done/cross-section-prefactor-threshold-cancellation.md).
+
+- **Every compiled spectrum and cross section is now computed in Rust,
+  and 27 of the 41 entry points return the identical double.** The
+  fourteen that move are listed below with the worst relative shift
+  measured against the values 2.1.0 produced, over the reference grids in
+  `test/parity/cases.py` on the platform they were captured on
+  (macOS/arm64). Each figure is the largest single-value disagreement
+  anywhere in that entry point's grid, not a typical one; the median
+  value in every case is unchanged bit-for-bit.
+
+  | Entry point | Worst relative shift | Cause |
+  | --- | --- | --- |
+  | `scalar_mediator_decay_spectrum` | 5.3e-12 | boost quadrature |
+  | `dnde_decay_s`, `dnde_decay_s_pt` (positron) | 2.3e-12 | boost quadrature |
+  | `dnde_decay_v`, `dnde_decay_v_pt` (positron) | 1.5e-12 | boost quadrature |
+  | `dnde_decay_v`, `dnde_decay_v_pt` (photon) | 1.2e-12 | boost quadrature |
+  | `hazma.spectra.dnde_photon_charged_rho` | 1.5e-13 | boost quadrature |
+  | `VectorMediator.thermal_cross_section` | 2.1e-14 | Bessel-`K` prefactor |
+  | `hazma.spectra.dnde_positron_charged_pion` | 5.5e-15 | quadrature |
+  | `hazma.spectra.dnde_photon_neutral_rho` | 3.2e-15 | boost quadrature |
+  | `ScalarMediator.thermal_cross_section` | 3.1e-15 | Bessel-`K` prefactor |
+  | `hazma.spectra.dnde_photon_charged_pion` | 2.6e-15 | quadrature |
+  | `hazma.spectra.dnde_neutrino_charged_pion` | 9.7e-16 | quadrature |
+
+  The four mediator decay entry points are what
+  `ScalarMediator`/`VectorMediator` (and their `HiggsPortal`,
+  `HeavyQuark`, `KineticMixing` and `QuarksOnly` subclasses) call from
+  `total_spectrum`, `spectra`, `total_positron_spectrum` and
+  `positron_spectra`; each `_pt` twin is bit-for-bit identical to its
+  array form. **"Quadrature" means one specific thing:** hazma no longer
+  calls `scipy.integrate.quad`, which binds Fortran QUADPACK, but an
+  in-tree Rust translation of the same netlib QUADPACK routines. It is
+  the same algorithm reaching a different-by-one-bit interval-bisection
+  decision, not a different method — established by driving the boost
+  integrand to a constant, at which point every mediator channel agrees
+  with 2.1.0 **to within one ulp**. The remaining 27 entry points — the
+  seven tabulated meson photon spectra, both muon spectra, the neutral
+  pion, the neutrino muon, and all 16 mediator cross sections other than
+  the two ⟨σv⟩ above — are bit-for-bit identical.
+
+  This is a *tightening*, not a loosening: the parity suite's tolerance
+  budgets were narrowed for all fourteen of these entry points on the
+  measurements above and widened for none, and neither of the two
+  as-ported opening budgets (`QUAD` at 1e-8, `NESTED` at 1e-6) is claimed
+  by any entry point any more.
+
+- **Four behavior changes at invalid or degenerate inputs.** No valid
+  call is affected by any of them.
+  1. The seven tabulated meson photon spectra return `NaN` for a `NaN`
+     photon energy where they raised `IndexError`, and raise `ValueError`
+     for a `NaN` parent energy where they raised `AssertionError`. Cython
+     `assert`s became unconditional raises across the port; every
+     exception the old code raised *explicitly* keeps its type.
+  2. The array-argument mediator decay spectra (`dnde_decay_v`,
+     `dnde_decay_s` and their positron twins) raise `ValueError` rather
+     than `TypeError` for a scalar energy, and now accept a `list` where
+     they refused one. The Python wrappers dispatch a scalar to the `_pt`
+     form, so no working call reaches either path.
+  3. Two `TypeError` messages lost their Cython wording, which advised
+     `use 'cython.cpow(True)'` — a compiler directive that no longer
+     exists. Raised at the degenerate masses `e_cm = 2 m_x`, `m_s = 2 m_l`
+     and `m_v = 2 m_π`; the type is unchanged.
+  4. The mediator decay spectra no longer emit `scipy`'s
+     `IntegrationWarning`. The Cython discarded the error estimate the
+     warning refers to, so no value ever depended on it.
+
+- **Packaging: one abi3 wheel per platform, built by maturin.** A release
+  publishes two wheels (`cp310-abi3` for macOS arm64 and manylinux
+  x86_64) plus an sdist, replacing a ten-wheel matrix of cp310–cp314 ×
+  two platforms. The sdist carries `hazma/` and `rust/` only — 264 files
+  against 2.1.0's 415 — and building from it requires `cargo` on `PATH`,
+  because `pip` cannot install a Rust toolchain for you. Windows and
+  linux-aarch64 wheels are still not built; see
+  [`docs/followups/todo/wheels-for-aarch64-and-windows.md`](docs/followups/todo/wheels-for-aarch64-and-windows.md).
+
+### Fixed
+
+- **The mediator positron spectra no longer return `NaN` at exactly
+  0.510998928 MeV.** At that one positron energy — the legacy electron
+  mass, and the first abscissa of the shipped positron tables — every
+  continuum mode of `dnde_decay_s`, `dnde_decay_v` and their `_pt` twins
+  returned `NaN`, because the C compiler contracted
+  `sqrt(eng_p*eng_p - me*me)` into a fused multiply-add whose radicand
+  rounds negative by 1.45e-17. The port keeps the fused spelling and
+  clamps the radicand at zero, which moves that single double from `NaN`
+  to `0.0` — the value both of its neighbors already returned — and no
+  other energy's arithmetic. Resolves
+  [`docs/followups/done/positron-spectrum-nan-at-legacy-electron-mass.md`](docs/followups/done/positron-spectrum-nan-at-legacy-electron-mass.md).
+
+### Known issues
+
+Twelve defects that hazma 2.1.0 already had, found while porting and
+**reproduced here rather than repaired**. None is new in
+3.0.0 and none changes a number relative to 2.1.0; each is tracked in
+[`docs/followups/todo/`](docs/followups/todo/) and most are sequenced for
+repair in
+[`projects/parity-pinned-defect-repair/`](projects/parity-pinned-defect-repair/PLAN.md).
+Repairing them here would have destroyed the port's only evidence that it
+changed nothing else. Ordered by how much they can move a published
+result:
+
+- **[The boost integral mis-covers its window at both ends.](docs/followups/todo/boost-integral-drops-last-interior-cell.md)**
+  The worst defect in the list. When the boosted window falls inside a
+  single table cell — the regime every model spectrum passes through near
+  threshold — two partial-cell terms overlap and cover about two whole
+  cells instead of the sliver between the bounds, and the over-count
+  diverges as the parent slows. All seven tabulated photon spectra
+  therefore **diverge** instead of converging to their own rest-frame
+  value as the parent approaches rest: at `E_γ = m/10` and a parent one
+  part in 1e12 above rest, `dnde_photon_eta` returns 767.2 against the
+  0.02313 it returns exactly at rest. Separately, when the window reaches
+  past the table the final row contributes to nothing at all.
+- **[`thermal_cross_section` returns its integrator's initial estimate.](docs/followups/todo/thermal-cross-section-quadrature-never-converges.md)**
+  The quadrature never converges, so ⟨σv⟩ is 0.5%–5% off the true
+  integral for every `x = m_χ/T` above about 5 — that is, across the
+  entire freeze-out region. Relic abundance goes as 1/⟨σv⟩, so any
+  `relic_density` computed for a `ScalarMediator`- or
+  `VectorMediator`-family model inherits that error roughly linearly.
+- **[Four scalar elastic cross sections cancel away every significant bit.](docs/followups/todo/scalar-elastic-cross-sections-cancel-in-atan-difference.md)**
+  `sigma_xl_to_xl`, `sigma_xpi_to_xpi`, `sigma_xpi0_to_xpi0` and
+  `sigma_xs_to_xs` form a difference of two `atan`s that cancels
+  completely near `e_cm = 2 m_x` at small width, returning the wrong sign
+  and a fabricated pole. The returned value there is the platform's
+  rounding residue, not a number any implementation reproduces.
+- **[The charged-pion photon spectrum returns zero in the forward cone.](docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md)**
+  A hard zero over the top ~25% of the support at `γ_π = 10`, worth 0.041%
+  of the yield there and 2.96% at `γ_π = 36`. It **compounds** through the
+  ρ rather than merely propagating — the charged ρ keeps only 0.5366 of
+  its endpoint at `γ_ρ = 10` where a pure boost predicts 0.945 — and
+  reaches the mediator photon spectra, where repairing it would move 2,013
+  of 29,295 reference values by up to a factor of 8.8 (at an absolute
+  7.3e-10). This one changes the *shape* of a low-energy tail, which is
+  the kind of error a limit calculation notices.
+- **[The muon positron spectrum divides by its normalization.](docs/followups/todo/positron-muon-spectrum-normalization-inverted.md)**
+  `dnde_positron_muon` integrates to 0.0374% below one positron per muon.
+  Its neutrino sibling applies the same Michel normalization the right way
+  round, so the two files genuinely disagree and only one is wrong.
+- **[The mediator positron line misses the electron velocity.](docs/followups/todo/mediator-positron-line-misses-the-electron-velocity.md)**
+  The `e⁺e⁻` line integrates to `pw_ee · r` rather than `pw_ee`, `r` being
+  the positron's rest-frame velocity: the box's edges carry the factor and
+  its height does not. Worth 3.3e-5 at `m = 125` MeV, 1.4e-6 at 600 MeV,
+  and divergent as `m → 2 m_e`.
+- **[The η′ two-photon line carries one photon instead of two.](docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md)**
+  A missing factor of 2 on the `η′ → γγ` line of `dnde_photon_eta_prime`.
+- **[The φ photon lines sit at the daughter meson's energy.](docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md)**
+  `dnde_photon_phi`'s lines are placed using the daughter meson's energy
+  where the photon's is meant, so they land at the wrong energies.
+- **[The charged pion's `π → e ν` neutrino line is added twice.](docs/followups/todo/neutrino-pion-electron-line-counted-twice.md)**
+  `dnde_neutrino_charged_pion` sums two contributions and both carry the
+  line, measured by continuum subtraction at exactly 2.0000 copies. The
+  electron-neutrino yield is 0.0123% high integrated, 0.062% high locally
+  on the plateau at `E_π = 200` MeV.
+- **[The muon photon spectrum's rest frame stops short of the endpoint.](docs/followups/todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md)**
+  `dnde_photon_muon` cuts the rest-frame spectrum at `y = 1 − √r` where the
+  kinematic endpoint is `y = 1 − r`, leaving a hard zero over the top
+  0.2543 MeV of the support (where the spectrum is 5.34e-7 MeV⁻¹) and a
+  discontinuity in `E_μ` at rest.
+- **[Both rho photon spectra return the boost integrand at rest.](docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md)**
+  At exactly `E_ρ = m_ρ` the rest-frame branch returns the integrand
+  rather than the integral, so the result is short by a factor of `E_γ`
+  and carries MeV⁻² where the spectrum is MeV⁻¹. The guard is absolute, so
+  it fires at that one double and no other.
+- **[Two vector cross sections raise `TypeError` at `e_cm = 2 m_x`.](docs/followups/todo/vector-cross-sections-raise-at-the-two-mx-threshold.md)**
+  Two of the six vector channels raise at the annihilation threshold where
+  the other four return `inf` or `nan`. Inconsistent rather than wrong,
+  but it makes a threshold scan fail on channel choice.
+
+Two further items are contract rather than arithmetic problems and are
+tracked the same way:
+[the model spectrum dicts reject the scalar energies their docstrings advertise](docs/followups/todo/model-spectra-reject-scalar-energies.md),
+and
+[the mediator spectra return `0.0` for an unrecognised mode string](docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md)
+instead of raising.
 
 ## [2.1.0] — 2026-08-03
 

--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -532,7 +532,7 @@ cites a real PR.
   unmeasured, and then dispatching does not help. PR #86 (cython-to-rust
   Task 7.4, the closing PR) inherited "a release candidate builds, tests,
   and **publishes** from CI". `release.yml`'s `publish` job is gated
-  `if: github.event_name == 'release'`; a release needs the `3.0.0` tag;
+  `if: github.event_name == 'release'`; a release needs the `2.2.0` tag;
   that tag exists only once the closing PR merges — so the criterion
   gated on an event that satisfying it would first have to enable.
   Holding closure is a deadlock, not a stricter gate. The first attempt

--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -527,6 +527,26 @@ cites a real PR.
   skipped, and the assertion step reported `5 wheel(s) carry
   hazma/_core.abi3.so` per OS).
 
+- **When the dispatch cannot reach the job, revise the criterion.** A
+  criterion can be *structurally* unsatisfiable rather than merely
+  unmeasured, and then dispatching does not help. PR #86 (cython-to-rust
+  Task 7.4, the closing PR) inherited "a release candidate builds, tests,
+  and **publishes** from CI". `release.yml`'s `publish` job is gated
+  `if: github.event_name == 'release'`; a release needs the `3.0.0` tag;
+  that tag exists only once the closing PR merges — so the criterion
+  gated on an event that satisfying it would first have to enable.
+  Holding closure is a deadlock, not a stricter gate. The first attempt
+  split the difference and marked the phase "Met … with one clause
+  qualified" while the same paragraph documented the clause as unmet,
+  which review blocked. The fix was to revise the criterion to what
+  closure can attest (both wheels and the sdist built, the workflow's own
+  assertions passed, the `publish` gate observed holding on a non-release
+  event), reassign the upload to the release manager rather than drop it,
+  and state the residual risk in place — trusted publishing under
+  `maturin-action` had still never executed. **Test for this shape: ask
+  what event satisfying the criterion requires, and whether the work the
+  criterion gates is what produces that event.**
+
 ### marker-count-vs-outcome-count
 
 - [marker-count-vs-outcome-count] A count of *declaration sites* and a

--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -1097,3 +1097,71 @@ in `task-notes/README.md`, which is mostly record and yet carries a live
 tense about a specific run is a record; an imperative or a present-tense
 requirement is an instruction wherever it sits. Location is the prior, not the
 answer, and the skip that hides a defect is the tree-shaped one.
+
+### pre-existing-failure-asserted-not-measured
+
+A closing PR recorded its preflight run with two FAIL rows annotated
+"pre-existing", and justified that from the shape of the diff: `git diff
+origin/master --name-only -- '*.py' | wc -l` was `0`, so the linters
+necessarily read bytes identical to the trunk. Sound at the time. Two
+commits later the PR deleted a function and the diff gained four `.py`
+files, and the justification became false while the annotation stayed.
+
+Review also found the criterion those rows answered to —
+`scripts/agents/preflight.sh --closing` **green** — mapped in the task
+note onto "all rows PASS except the two documented trunk reds". That is
+the same defect as claiming a criterion is met in a paragraph that
+documents it as unmet, and `docs/agents/preflight.md` had already
+forbidden the move: *"do not commit around a red gate."*
+
+What exposed it, and what the record should have carried from the start:
+
+```sh
+# Is the gate red without me? Untouched base ref, no edit applied.
+git worktree add -f /tmp/base origin/master --detach
+isort --check-only hazma test | grep -c ERROR   # -> 72
+ruff check hazma test                           # -> Found 6091 errors.
+
+# Are MY files red beyond the base? Same paths, both trees, text diffed.
+ruff check --output-format=concise <tree> \
+  | sed 's/^[^:]*:[0-9]*:[0-9]*: //' | sort > /tmp/findings
+diff /tmp/base_findings /tmp/findings            # -> identical, 50 each
+```
+
+One trap in the second block is worth the extra line: **both sides must
+be real worktrees.** Copying the changed files into a scratch directory
+drops `pyproject.toml`, so ruff falls back to its default rules — 11
+findings where the configured set reports 117. The diff then shows a
+hundred "new" findings that do not exist. Use `git worktree add`, not
+`git show > /tmp/...`.
+
+The first block showed the criterion had been unmeetable since weeks
+before the phase was written — a tracked condition with three candidate
+remedies and none chosen — so it was revised to what a PR can attest
+rather than waived. The second is the claim that actually belongs in a
+task note, because it survives the diff growing.
+
+### removal-sweep-filtered-by-extension
+
+Deleting `hazma.utils.minkowski_dot` began with a consumer sweep:
+
+```sh
+grep -rn "minkowski_dot" --include='*.py' --include='*.rst' --include='*.pyi' .
+```
+
+Two consumers came back, both were repointed at `ldot`, and the task
+note recorded "the two consumers" and "every call site passes a
+shape-(4,) ndarray". Review found a third: a tracked `.ipynb` whose
+import now raised `ImportError`. The extension list had been written
+from memory of where Python lives, and notebooks were not on it.
+
+`git grep -l` with no filter is the whole fix — it costs nothing and
+cannot omit a file type you forgot to think of:
+
+```sh
+git grep -l "minkowski_dot"      # every tracked file, any extension
+```
+
+The cost was not the missed edit, which was one line in a notebook that
+was already dead on other removed imports. It was that two confident
+quantified claims went into the durable record wrong.

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -160,7 +160,9 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
 - [unrun-workflow-cannot-close-a-criterion] A workflow with no `pull_request`
   trigger is invisible to PR checks; dispatch it (`gh workflow run <file> --ref
   <branch>`, with publishing jobs gated) and paste the job conclusions before
-  marking a criterion met (PR #56).
+  marking a criterion met. When a dispatch cannot reach the job because the
+  criterion is structurally unsatisfiable, revise the criterion instead of
+  qualifying a "Met" that is not met (PRs #56, #86).
 - [marker-count-vs-outcome-count] A count of declaration sites and a count of
   runtime outcomes are different numbers; take outcomes from `pytest -rs` and
   sites from `rg`, state which one you mean, and give both when they differ (PR

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -66,12 +66,12 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   re-runs it instead of trusting it. A count describing *your own diff* goes
   stale the moment the diff grows, so give it a row in the count sweep like any
   other — an uncounted count is one nothing re-checks (PR #35, #59, #84,
-  #87).
+  #86, #87).
 - [measurement-taken-before-the-task-ended] Re-run every measurement against the
   final tree after your last edit; take both halves of a before/after on the
   same tree and environment; derive breakdowns from the command so the parts
   sum; and never let "both", "each" or "the two" stand in for an enumerated
-  count (PR #49, #55, #64, #67, #68, #72).
+  count (PR #49, #55, #64, #67, #68, #72, #86).
 - [partial-historical-labeling] Label the *section* as historical, not one line
   of it — decide per claim what it is a statement about, date the block, and
   head a task note's §Files Changed / §Numerical impact with the task's own PR
@@ -107,6 +107,23 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   goes stale is in a file the moving PR never touches. A stale reference
   surviving elsewhere in the tree is evidence the sweep was skipped there,
   never a convention to copy (PRs #44, #81).
+- [pre-existing-failure-asserted-not-measured] "Pre-existing" is a measurement,
+  never an assertion: run the red gate against the *same paths* on the base ref
+  and diff the findings text with line numbers stripped. Arguing it from the
+  diff's shape ("no `.py` changed") dies the moment the diff grows, and a real
+  regression sitting beside thousands of standing findings is exactly what the
+  shortcut waves through. When a criterion demands a whole-repo gate be green
+  and that gate is red on the trunk, the criterion is unmeetable by any PR —
+  revise it to what a PR can attest and leave the cleanup to the follow-up that
+  tracks it, rather than mapping "green" onto red. Compare in two real
+  worktrees: a scratch copy loses `pyproject.toml`, the tool falls back to
+  default rules, and the diff invents a delta (PR #86).
+- [removal-sweep-filtered-by-extension] Enumerate a symbol's consumers with
+  `git grep -l` and **no** `--include` filter before deleting it. An extension
+  list written from memory omits whatever the repo also keeps the symbol in —
+  notebooks, JSON fixtures, docs — and the resulting "every call site" and "the
+  two consumers" claims are then wrong in the durable record, not just in the
+  sweep (PR #86).
 - [degenerate-sample-count] An API whose contract includes a statistical error
   estimate validates its sample-count input — type and `>= 2` — at the public
   entry point, or a degenerate count flows to every consumer as a finite value

--- a/docs/agents/preflight.md
+++ b/docs/agents/preflight.md
@@ -223,6 +223,17 @@ Add `--md "docs/agents/preflight.md"` when curated docs changed and
 per gate and exits non-zero on the first hard failure. A non-zero exit is
 a blocked commit — fix and re-run; do not commit around a red gate.
 
+**Two gates are red on the trunk itself**, so that rule currently cannot
+be met by any PR: on an untouched `origin/master`, `isort --check-only
+hazma test` reports 72 ERROR lines and `ruff check hazma test` reports
+6091 errors. `docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`
+tracks the condition and lists three candidate remedies; none is chosen,
+and picking one is its own change, not something to fold into unrelated
+work. Until then, "pre-existing" is a claim to **measure, not assert** —
+run the red gate against the same paths on `origin/master` and diff the
+findings, so a real regression next to 6091 existing ones still shows up.
+Anything you cannot show unmoved that way is yours to fix.
+
 A `WARN` row means a tool is not installed and its gate did **not** run —
 it is a hole in your coverage, not a pass. Install the toolchain
 (`pip install --group dev`, which pulls black, isort, ruff, pytest,

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -25,7 +25,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | --- | --- | --- | --- |
 | [Citation checker skips deleted in-repo files](todo/citation-checker-skips-deleted-inrepo-files.md) | 2026-08-05 | PR #42 review | cross-cutting |
 | [remaining `sqrt(kallen_lambda(...))` call sites](todo/kallen-under-sqrt-remaining-call-sites.md) | 2026-08-05 | carved out of the `cross_section_prefactor` fix | cross-cutting |
-| [redundant `hazma.utils` helpers kept out of the public surface](todo/utils-public-surface-redundant-helpers.md) | 2026-08-05 | docs audit of `utils.rst` | cross-cutting |
+| [`kinematically_accessable` kept out of the public surface](todo/utils-public-surface-redundant-helpers.md) | 2026-08-05 | docs audit of `utils.rst` | cross-cutting |
 | [`preflight.sh` isort/ruff gates are red on the trunk](todo/preflight-isort-ruff-red-on-trunk.md) | 2026-08-05 | cython-to-rust Task 0.5 | cross-cutting |
 | [model spectrum dicts reject scalar energies](todo/model-spectra-reject-scalar-energies.md) | 2026-08-08 | cython-to-rust Task 1.4 | cross-cutting |
 | [the boost integral mis-covers its window at both ends](todo/boost-integral-drops-last-interior-cell.md) | 2026-08-10 | cython-to-rust Task 3.4 | cross-cutting |

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -45,6 +45,10 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [mediator positron line misses the electron velocity](todo/mediator-positron-line-misses-the-electron-velocity.md) | 2026-08-27 | cython-to-rust Task 6.3 | cross-cutting |
 | [moved follow-ups leave dangling inbound paths](todo/moved-followups-leave-dangling-inbound-paths.md) | 2026-08-27 | PR #81 review | cross-cutting |
 | [four tracked non-source files under `hazma/`](todo/tracked-non-source-files-under-hazma.md) | 2026-08-29 | cython-to-rust Task 7.3 | commit |
+| [consolidate the divergent constants tables](todo/consolidate-the-two-constants-tables.md) | 2026-08-29 | cython-to-rust retrospective §5 | cross-cutting |
+| [free-threaded `abi3t` wheels](todo/free-threaded-abi3t-wheels.md) | 2026-08-29 | cython-to-rust retrospective §5 | cross-cutting |
+| [the relic-density Boltzmann solve in Rust](todo/relic-density-odes-in-rust.md) | 2026-08-29 | cython-to-rust retrospective §5 | cross-cutting |
+| [wheels for linux-aarch64 and Windows](todo/wheels-for-aarch64-and-windows.md) | 2026-08-29 | cython-to-rust retrospective §5 | commit |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/consolidate-the-two-constants-tables.md
+++ b/docs/followups/todo/consolidate-the-two-constants-tables.md
@@ -1,0 +1,77 @@
+# Consolidate the divergent constants tables
+
+- **Added:** 2026-08-29
+- **Source:** `projects/cython-to-rust/learnings/project-retrospective.md` §5
+- **Scope:** cross-cutting
+- **Status:** open
+- **Triggers / blockers:** the cython-to-rust project's `rules.md` rule 4
+  forbade touching this while any kernel was being ported, because a
+  ported kernel had to read the exact constant its Cython source read for
+  bit-parity to mean anything. That project closed on 2026-08-29, so the
+  rule no longer binds. What does bind is the parity corpus: this is a
+  **declared numerical change** and needs the same treatment as the
+  defects in `projects/parity-pinned-defect-repair/` — a per-array delta
+  asserted against the committed corpus arrays, not a regeneration.
+
+## Why
+
+Hazma carries three different fine-structure constants and two mass
+tables that disagree on twelve names, and which one a given spectrum sees
+depends on which Cython header its `.pyx` happened to `include`. That
+accident is now frozen into `rust/src/constants.rs`, which reproduces the
+split faithfully (`pdg` for everything under `hazma/spectra/**`, `legacy`
+for the mediator spectrum kernels, and `derived::photon_pion` reading
+both) because rule 4 required it to.
+
+The three α values are `1/137.035999084` (the `pdg` table,
+pre-CODATA-2022), `1/137` (the `legacy` table) and `1/137.04`
+(`hazma/parameters.py`, pure Python and reached by a third set of
+callers). Nothing about the physics justifies the split; it is a
+historical artifact of two headers growing separately. A user comparing a
+mediator spectrum against a meson spectrum is comparing numbers computed
+with different values of α, and nothing in the API says so.
+
+## What
+
+Pick one table, state its provenance (which PDG edition, which CODATA
+release), and move every consumer onto it. The work is:
+
+- Reconcile `hazma_core::constants::{pdg, legacy}` — twelve names
+  disagree — and decide `derived::photon_pion`, which legitimately reads
+  from both today.
+- Reconcile `hazma/parameters.py`'s third α with whichever survives.
+- Record the provenance that
+  `projects/cython-to-rust/learnings/phase-03-numerics-foundation.md` §5
+  notes was never written down: the `± uncertainty` annotations are the
+  only surviving evidence of which edition each value came from. Do
+  **not** resolve this by re-sourcing values from a current PDG — that
+  would silently move numbers a second time, for a second reason.
+- Declare the resulting shift per public entry point, as a `Changed`
+  entry with magnitudes, and assert it as a delta against the corpus
+  arrays.
+
+Expect the shift to be small but real: the two α values differ by
+2.6e-4 relative, and a spectrum carrying `α²` moves by twice that.
+
+## Entry points
+
+- `rust/src/constants.rs` — the `pdg` / `legacy` / `derived` split
+- `hazma/parameters.py:205` — the third α
+- `test/test_core_constants.py` — the bit-parity assertions that pinned
+  the split
+- `projects/cython-to-rust/rules.md` rule 4 — the rule that deferred this
+- `projects/cython-to-rust/learnings/phase-03-numerics-foundation.md` §5
+- `projects/parity-pinned-defect-repair/PLAN.md` — the declared-delta
+  mechanism to reuse
+
+## Risks / open questions
+
+- **Sequencing against `parity-pinned-defect-repair`.** Both move
+  published numbers against the same corpus arrays. Landing them in
+  either order is fine; landing them concurrently means two deltas
+  against one baseline and is not.
+- **Which table wins is a physics call, not a mechanical one.** The
+  `legacy` table's `1/137` is plainly a placeholder, but some of its
+  twelve divergent names may have been chosen to match a published
+  reference the mediator models were validated against. Check before
+  overwriting.

--- a/docs/followups/todo/free-threaded-abi3t-wheels.md
+++ b/docs/followups/todo/free-threaded-abi3t-wheels.md
@@ -1,0 +1,65 @@
+# Ship free-threaded wheels once abi3t settles
+
+- **Added:** 2026-08-29
+- **Source:** `projects/cython-to-rust/learnings/project-retrospective.md` §5
+- **Scope:** cross-cutting
+- **Status:** open
+- **Triggers / blockers:** waiting on the ecosystem, not on hazma. Ripens
+  when PyO3 supports a stable free-threaded ABI (`abi3t`) rather than
+  requiring a per-version build against `Py_GIL_DISABLED`, and when
+  hazma's runtime dependencies (NumPy, SciPy, matplotlib, scikit-image)
+  publish free-threaded wheels for the same interpreters. Re-check both
+  before scoping the work.
+
+## Why
+
+The cython-to-rust port replaced a per-CPython wheel matrix with a single
+`cp310-abi3` wheel per platform, which is the whole packaging argument
+for abi3 and the reason `release.yml` builds two artifacts instead of
+ten. Free-threaded CPython does not currently participate in that: a
+free-threaded build needs its own extension compiled against
+`Py_GIL_DISABLED`, so supporting it today would reintroduce exactly the
+per-interpreter matrix the port removed — one extra wheel per platform
+per free-threaded CPython.
+
+Waiting is cheap, and the code side already looks ready. `hazma._core`'s
+kernels are pure functions over `f64`, and its only mutable module state
+— the mass-keyed mediator table cache
+(`rust/src/kernels/mediator_tables.rs:320`) — is a
+`LazyLock<TableCache<_>>` whose slot is already behind a `Mutex`, so it
+is `Sync` by construction rather than by the GIL. What blocks
+free-threading here is packaging, not concurrency.
+
+## What
+
+Mostly one piece, once the ABI allows it: enable the free-threaded build
+as a `[tool.maturin]` / `Cargo.toml` feature and add the matrix rows in
+`.github/workflows/release.yml`. Two things to settle at that point:
+
+1. **Confirm the concurrency claim rather than inheriting it.** The
+   `Mutex`-guarded cache is sound under concurrent access today, but
+   `rust/src/` is the only place that was checked; re-run the sweep
+   (`rg 'static |Mutex|RwLock|OnceLock|LazyLock|thread_local|RefCell'
+   rust/src/`) against whatever the crate looks like then, and add a
+   concurrent-access test that would actually fail if the cache raced.
+2. **Weigh the wheel count if `abi3t` still is not stable.** If PyO3
+   requires per-version builds against `Py_GIL_DISABLED` when this
+   ripens, adding them reintroduces the per-interpreter matrix the abi3
+   cutover removed. That may still be worth it, but it is a trade rather
+   than a free addition, and it should be made deliberately.
+
+## Entry points
+
+- `rust/Cargo.toml` — the `abi3-py310` feature on the `pyo3` dependency
+- `pyproject.toml` `[tool.maturin]`
+- `.github/workflows/release.yml` — the `maturin-action` matrix
+- `rust/src/kernels/mediator_tables.rs:320` — the `Mutex`-guarded cache
+- `projects/cython-to-rust/learnings/phase-06-mediator-spectra.md` — where
+  the cache was introduced and why
+
+## Risks / open questions
+
+- **Dependency readiness gates the user-visible benefit.** A
+  free-threaded `hazma._core` is not usable if SciPy has no free-threaded
+  wheel for the same interpreter, so the trigger is the ecosystem's, not
+  PyO3's alone.

--- a/docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md
+++ b/docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md
@@ -4,10 +4,12 @@
 - **Source:** `projects/cython-to-rust/task-notes/phase-06/task-6.1-table-struct.md`
 - **Scope:** cross-cutting (four public entry points, both mediator models)
 - **Status:** open
-- **Triggers / blockers:** none technically, but the repair is a
-  behaviour change on a public API, so it wants the same
-  major-version window as the cython-to-rust port itself. Reproduced
-  under `projects/cython-to-rust/rules.md` rule 1 by Phase 06.
+- **Triggers / blockers:** none technically, but the repair turns a
+  silent `0.0` into a raise on a public API, so it wants a major-version
+  window. It was sequenced against the one cython-to-rust was planned to
+  carry; that project shipped as **2.2.0**, so this now waits for the
+  next major rather than riding an existing one. Reproduced under
+  `projects/cython-to-rust/rules.md` rule 1 by Phase 06.
 
 ## Why
 

--- a/docs/followups/todo/relic-density-odes-in-rust.md
+++ b/docs/followups/todo/relic-density-odes-in-rust.md
@@ -1,0 +1,76 @@
+# Move the relic-density Boltzmann solve into Rust, if it is ever justified
+
+- **Added:** 2026-08-29
+- **Source:** `projects/cython-to-rust/learnings/project-retrospective.md` §5
+- **Scope:** cross-cutting
+- **Status:** open
+- **Triggers / blockers:** **nothing today**, and that is the point of the
+  entry. It ripens only if someone produces a profile showing the ODE
+  path dominating a real workload. Blocked behind
+  [`thermal-cross-section-quadrature-never-converges`](thermal-cross-section-quadrature-never-converges.md)
+  regardless: porting a solver whose integrand is 0.5%–5% wrong buys
+  speed on a wrong answer.
+
+## Why
+
+`hazma/relic_density/` is one of the numeric subsystems the cython-to-rust
+project deliberately left on NumPy and SciPy (`PLAN.md` §Scope), alongside
+`hazma/phase_space/`, the form factors and the spline utilities. That call
+was right on the evidence the project had, and it stays the default. The
+entry exists so the question is answered from a measurement rather than
+re-litigated from intuition every time someone notices that the ODE path
+is the slowest thing in a relic-density calculation.
+
+Two facts from the port bound the answer. Task 5.3 measured
+`relic_density(semi_analytic=True)` — the path with no adaptive solver —
+reproducing the pre-port tree to 4.11e-16, and the whole relic-density
+calculation through a real mediator came out **1.46×–1.93× faster** once
+⟨σv⟩ stopped re-entering Python per quadrature node. That speedup came
+from moving the *integrand*, which was the expensive part. The remaining
+cost is `scipy.integrate.solve_ivp`'s own stepping, which is already
+compiled.
+
+The second fact is a warning. `relic_density(semi_analytic=False)` runs
+at the caller's default `rtol=1e-5`, and at that tolerance a last-bit
+change in the integrand flips a step-acceptance decision and moves the
+answer by 3.8e-5 — larger than any drift the port introduced anywhere.
+Tightening the solver collapses it (2.75e-7 at `rtol=1e-8`, 3.84e-9 at
+`rtol=1e-10`), which is the tell that the number is the solver's error
+rather than the physics. Any reimplementation of the stepping will move
+the default-tolerance answer by about that much, and that is a declared
+numerical change even though the physics does not move.
+
+## What
+
+If a profile ever justifies it:
+
+- Port the Boltzmann right-hand side and the stepping to Rust behind
+  `hazma._core`, keeping `relic_density`'s signature and default
+  tolerances.
+- Declare the shift at the default `rtol` and pin the result at a
+  *tightened* solver tolerance, the way
+  `test/test_relic_density.py::TestMediatorRelicDensity` already does —
+  its Boltzmann pins are taken at `rtol=1e-10` rather than the default,
+  because a pin at the default is not portable across libm. That
+  precedent is the model to follow, not something to rediscover.
+- Do the ⟨σv⟩ quadrature convergence fix first, so the speedup is not
+  measured against a wrong integrand.
+
+## Entry points
+
+- `hazma/relic_density/` — the ODE path
+- `test/test_relic_density.py::TestMediatorRelicDensity` — the pins, and
+  the reason they sit at `rtol=1e-10`
+- `projects/cython-to-rust/task-notes/numerical-impact.md` — Task 5.3, for
+  the measured figures quoted above
+- `projects/cython-to-rust/PLAN.md` §Scope — the original exclusion
+- [`thermal-cross-section-quadrature-never-converges`](thermal-cross-section-quadrature-never-converges.md)
+
+## Risks / open questions
+
+- **The default answer moves and the physics does not.** Explaining that
+  distinction in a CHANGELOG is harder than making the change. Do not
+  start without a plan for how to state it.
+- **The likely payoff is small.** The expensive Python-level work was
+  already moved in Phase 05; what remains is a compiled SciPy solver. A
+  profile, not a hunch, is the entry condition.

--- a/docs/followups/todo/utils-public-surface-redundant-helpers.md
+++ b/docs/followups/todo/utils-public-surface-redundant-helpers.md
@@ -9,8 +9,10 @@
   Phase 00 Task 0.5 deleted `docs/source/gamma_ray.rst`, so
   `minkowski_dot` has no public-docs reference at all, and Task 0.2 has
   since deleted `hazma/gamma_ray.py` itself. Both cleanups are name
-  removals, so they want the same major bump the cython-to-rust project
-  already carries.
+  removals. They were sequenced to ride the major bump cython-to-rust
+  was planned to carry; that project shipped as **2.2.0** instead, so
+  there is no major window to ride and the two names are now on
+  different clocks — see the note under "Why".
 
 ## Why
 
@@ -70,10 +72,16 @@ fires:
   should be using it.
 
 `minkowski_dot` landed in `e94fb21`, after the `2.1.0` tag, so it is
-unreleased today and removing it currently costs nothing. That is only
-true until the next release ships it — which is the argument for
-resolving this inside the cython-to-rust major rather than letting it
-drift.
+unreleased today and removing it costs nothing. **That window closes the
+moment 2.2.0 ships it.** Once released it is an ordinary public name:
+not in `hazma/deprecated/` and importable, so the reachability carve-out
+in `docs/versioning.md` does not reach it and removing it later is a
+`major`. Either drop it before 2.2.0 tags, or accept that this half of
+the follow-up waits for the next major.
+
+`kinematically_accessable` is not on that clock — it shipped in 2.1.0,
+so its removal is already `major` and nothing about the 2.2.0 decision
+changes it.
 
 ## Entry points
 

--- a/docs/followups/todo/utils-public-surface-redundant-helpers.md
+++ b/docs/followups/todo/utils-public-surface-redundant-helpers.md
@@ -1,52 +1,29 @@
-# `hazma.utils` carries two helpers that should not become public API
+# `hazma.utils.kinematically_accessable` should not be public API
 
 - **Added:** 2026-08-05
 - **Source:** conversation — a docs audit asking why
   `docs/source/utils.rst` omits `hazma.utils.minkowski_dot`
 - **Scope:** cross-cutting
-- **Status:** open
-- **Triggers / blockers:** **ripe as of 2026-08-06.** cython-to-rust
-  Phase 00 Task 0.5 deleted `docs/source/gamma_ray.rst`, so
-  `minkowski_dot` has no public-docs reference at all, and Task 0.2 has
-  since deleted `hazma/gamma_ray.py` itself. Both cleanups are name
-  removals. They were sequenced to ride the major bump cython-to-rust
-  was planned to carry; that project shipped as **2.2.0** instead, so
-  there is no major window to ride and the two names are now on
-  different clocks — see the note under "Why".
+- **Status:** open — half resolved. `minkowski_dot` was removed on
+  2026-09-06, before the 2.2.0 tag that would have made it public
+  (see "What"). `kinematically_accessable` is what remains.
+- **Triggers / blockers:** blocked on the next `major`.
+  `kinematically_accessable` shipped in 2.1.0, so removing it breaks the
+  public surface: it is importable and not in `hazma/deprecated/`, which
+  puts it outside the reachability carve-out in `docs/versioning.md`.
+  Giving it a docstring, annotations and the corrected spelling instead
+  is `minor` and needs no window — but that is only worth doing if some
+  code should be calling it, and none does.
 
 ## Why
 
 `docs/source/utils.rst` documents five of `hazma/utils.py`'s functions
 (`kallen_lambda`, `two_body_momentum`, `cross_section_prefactor`,
-`ldot`, `lnorm_sqr`). Two public names are missing from it, and in both
-cases the right fix is to remove the function rather than to document
-it. This note exists so
-the omission is not re-filed as a doc bug and "fixed" by adding
-`autofunction` entries — which would promote both names to the
-supported surface that `docs/versioning.md` defines, making later
-removal a breaking change.
-
-**`minkowski_dot` duplicates `ldot`.** Both are pure Python, and both
-evaluate `p0*q0 - p1*q1 - p2*q2 - p3*q3` in that term order, so on a
-single four-vector there is no room for a difference —
-`test/test_utils.py::test_minkowski_dot_matches_ldot` pins them as
-bit-for-bit equal over 100 random pairs. The only behavioral
-difference is the input contract: `minkowski_dot` is index-based and
-so accepts plain lists and tuples, while `ldot` asserts
-`lv.shape[axis] == 4` and additionally handles an `axis` for stacked
-arrays. Every current call site passes a shape-`(4,)` `ndarray`, which
-both accept.
-
-It exists only because cython-to-rust Task 0.3 deleted the Cython
-`hazma.field_theory_helper_functions.common_functions.minkowski_dot`
-and gave the name a pure-Python home so its callers kept working. Its
-one in-library consumer is
-`hazma/experimental/axial_vector_mediator/avm_msqrd.py`, and
-`docs/versioning.md` excludes `hazma/experimental/` from the public
-surface outright. Its one public-docs reference was a worked
-`gamma_ray_fsr` example in `docs/source/gamma_ray.rst`, and that page
-was deleted on 2026-08-05 by cython-to-rust Task 0.5 — so the name is
-now public with no documentation anywhere.
+`ldot`, `lnorm_sqr`). `kinematically_accessable` is missing from it, and
+the right fix is to remove the function rather than to document it. This
+note exists so the omission is not re-filed as a doc bug and "fixed" by
+adding an `autofunction` entry — which would advertise as supported a
+name that is already awkward to remove.
 
 **`kinematically_accessable` is dead.** It has zero callers repo-wide,
 no docstring, no type annotations, and a misspelled name
@@ -54,64 +31,48 @@ no docstring, no type annotations, and a misspelled name
 
 ## What
 
-Deliberately **not** done: adding `autofunction` entries for either
-name to `docs/source/utils.rst`. Instead, when the trigger above
-fires:
+Deliberately **not** done: adding an `autofunction` entry for
+`kinematically_accessable` to `docs/source/utils.rst`. Instead, delete
+it, or give it a docstring, annotations, the corrected spelling, and a
+caller if some code should be using it. Deleting it needs a `major`.
 
-- Fold `minkowski_dot` into `ldot`. Either relax `ldot` to accept any
-  length-4 sequence (a length check in place of the `.shape`
-  assertion, which is what currently rejects lists) or leave `ldot`
-  alone if no caller needs the looser contract. Then repoint
-  `hazma/experimental/axial_vector_mediator/avm_msqrd.py`, delete
-  `minkowski_dot`, and drop or retarget the five `minkowski_dot` tests
-  in `test/test_utils.py` — keeping the sign-convention and
-  on-shell-invariant coverage against `ldot`, since those pin physics
-  and not the wrapper.
-- Delete `kinematically_accessable`, or give it a docstring,
-  annotations, the corrected spelling, and a caller if some code
-  should be using it.
+### Resolved: `minkowski_dot`, removed 2026-09-06
 
-`minkowski_dot` landed in `e94fb21`, after the `2.1.0` tag, so it is
-unreleased today and removing it costs nothing. **That window closes the
-moment 2.2.0 ships it.** Once released it is an ordinary public name:
-not in `hazma/deprecated/` and importable, so the reachability carve-out
-in `docs/versioning.md` does not reach it and removing it later is a
-`major`. Either drop it before 2.2.0 tags, or accept that this half of
-the follow-up waits for the next major.
+It duplicated `ldot` — both pure Python, both evaluating
+`p0*q0 - p1*q1 - p2*q2 - p3*q3` in that term order, pinned bit-for-bit
+equal on a single four-vector. The only difference was the input
+contract: `minkowski_dot` was index-based and so took lists and tuples,
+while `ldot` asserts `lv.shape[axis] == 4` and handles an `axis` for
+stacked arrays. Every call site passed a shape-`(4,)` `ndarray`, so
+`ldot` absorbed them unchanged and its contract was left alone.
 
-`kinematically_accessable` is not on that clock — it shipped in 2.1.0,
-so its removal is already `major` and nothing about the 2.2.0 decision
-changes it.
+It landed in `e94fb21`, after the `2.1.0` tag, so it appeared in no
+release and removing it was invisible to users — but only until 2.2.0
+shipped it, after which it would have been an ordinary public name
+outside the reachability carve-out in `docs/versioning.md` and removable
+only in a `major`. It was dropped inside that window, in the 2.2.0
+closing PR.
+
+Its consumers were repointed at `ldot`:
+`hazma/experimental/axial_vector_mediator/avm_msqrd.py` (excluded from
+the public surface) and `notebooks/dev/gamma_ray_fsr/partial_integration.py`,
+which stays dead on its own `hazma.rambo` and `hazma.gamma_ray` imports.
+Both squared matrix elements in `avm_msqrd.py` were checked bit-for-bit
+against the deleted implementation over 200 random momentum draws. The
+three `test/test_utils.py` tests that pinned the metric signature and the
+on-shell invariant were retargeted onto `ldot`, which had no direct
+coverage of its own; the two that only exercised the wrapper — bit-for-bit
+agreement with `ldot`, and accepting plain lists — were dropped.
 
 ## Entry points
 
 - `hazma/utils.py:71` — `kinematically_accessable`.
-- `hazma/utils.py:191` — `ldot`, the survivor.
-- `hazma/utils.py:215` — `minkowski_dot`.
 - `docs/source/utils.rst` — the five-entry API Reference list.
-- ~~`docs/source/gamma_ray.rst:85` — the sole public-docs reference,
-  inside the `gamma_ray_fsr` example.~~ Page deleted 2026-08-05
-  (cython-to-rust Task 0.5); read it from git history if the example is
-  still wanted (`git show d81c267:docs/source/gamma_ray.rst`).
-- `hazma/experimental/axial_vector_mediator/avm_msqrd.py:10` — the sole
-  in-library consumer (non-public per `docs/versioning.md`).
-- `test/test_utils.py:258-311` — the `minkowski_dot` block.
 - Prior decision: `projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md`.
 - Prior task: `projects/cython-to-rust/task-notes/phase-00/task-0.3-delete-superseded.md`.
 
 ## Risks / open questions
 
-- Relaxing `ldot`'s assertion is a widening of a public contract, not a
-  narrowing, so it is `minor` on its own — but it changes the error a
-  caller sees for a malformed input from `AssertionError` to whatever
-  the length check raises. Prefer a `ValueError` from
-  `hazma/hazma_errors.py` if one fits.
-- The old Cython `minkowski_dot` was *not* bit-identical to today's
-  Python one (the C compiler contracts `a*b - c*d` into an FMA;
-  measured ≤2.7e-14 relative, declared in
-  `projects/cython-to-rust/task-notes/phase-00/README.md`). That drift
-  is already absorbed and is not re-opened by this cleanup: collapsing
-  onto `ldot` is exactly zero further change, per the bit-for-bit test.
 - ~~Sequencing: doing this before ADR-0003 lands means editing a
   `gamma_ray.rst` example that is about to be deleted anyway.~~ Moot —
   the page is gone (Task 0.5, 2026-08-05), so this cleanup no longer

--- a/docs/followups/todo/wheels-for-aarch64-and-windows.md
+++ b/docs/followups/todo/wheels-for-aarch64-and-windows.md
@@ -1,0 +1,66 @@
+# Wheels for linux-aarch64 and Windows
+
+- **Added:** 2026-08-29
+- **Source:** `projects/cython-to-rust/learnings/project-retrospective.md` §5
+- **Scope:** commit
+- **Status:** open
+- **Triggers / blockers:** a user asking for either platform. There is no
+  technical blocker and there has not been one since the maturin cutover.
+
+## Why
+
+Hazma publishes wheels for macOS arm64 and manylinux x86_64 and nothing
+else. Users on Windows or on 64-bit ARM Linux must build from the sdist,
+which since 3.0.0 means having a Rust toolchain on `PATH`.
+
+The cython-to-rust project put both platforms out of scope, and Task 7.2
+made that a deliberate decision rather than an oversight when it rebuilt
+`release.yml` on `maturin-action`: the two shipped platforms are the two
+CI tests on, and no user had asked. It declined to file this entry at the
+time because `projects/cython-to-rust/PLAN.md` §Scope already recorded
+it. Closing that project turned the record archival, and
+`docs/followups/todo/` is the repo's live backlog by construction — so
+the entry lands here now, with the decision unchanged.
+
+What *has* changed is the price. Under cibuildwheel each new platform
+meant a full CPython matrix; under abi3 and `maturin-action` it is one
+matrix row producing one wheel, which is why the deliberate "no" is worth
+writing down rather than leaving implicit.
+
+## What
+
+Add matrix rows to `.github/workflows/release.yml`'s wheel job — one for
+`aarch64` manylinux, one for Windows x86_64 — and extend the existing
+in-workflow assertions to cover them. Two things the existing assertions
+already teach:
+
+- **The wheel-filename platform field is a compressed tag *set*, not a
+  tag.** The manylinux wheel's field is
+  `manylinux_2_17_x86_64.manylinux2014_x86_64`, standing for two `Tag:`
+  lines, while the macOS wheel is one tag per field. An assertion that
+  compares field against `Tag:` line as a single string passes on macOS
+  and rejects a correct Linux wheel — so a new platform's assertion is
+  not believed until that platform's job has actually run.
+- **The sole-extension assertion hard-codes a POSIX suffix.**
+  `release.yml` requires the wheel's compiled objects to be exactly
+  `["hazma/_core.abi3.so"]`. Windows names the same extension
+  `hazma/_core.pyd`, so that check needs a platform-aware suffix before a
+  Windows wheel can pass it.
+
+## Entry points
+
+- `.github/workflows/release.yml` — the `maturin-action` wheel matrix,
+  the `Tag:` cross-product check and the sole-extension assertion
+- `projects/cython-to-rust/task-notes/phase-07/task-7.2-release-pipeline.md`
+  §Decisions — where the "no" was decided, and the wheel-tag finding
+- `projects/cython-to-rust/PLAN.md` §Scope — the original exclusion
+
+## Risks / open questions
+
+- **Windows is not just a matrix row.** The extension suffix differs, and
+  nothing in the suite has ever run there, so the first Windows job is
+  likely to find assumptions rather than confirm them. aarch64 Linux is
+  the genuinely cheap half of this entry.
+- **Adding a platform is a support commitment.** A wheel that builds is
+  not the same as a platform the numerical suite is known to pass on;
+  the parity corpus is scoped to its capturing platform by construction.

--- a/docs/followups/todo/wheels-for-aarch64-and-windows.md
+++ b/docs/followups/todo/wheels-for-aarch64-and-windows.md
@@ -11,7 +11,7 @@
 
 Hazma publishes wheels for macOS arm64 and manylinux x86_64 and nothing
 else. Users on Windows or on 64-bit ARM Linux must build from the sdist,
-which since 3.0.0 means having a Rust toolchain on `PATH`.
+which since 2.2.0 means having a Rust toolchain on `PATH`.
 
 The cython-to-rust project put both platforms out of scope, and Task 7.2
 made that a deliberate decision rather than an oversight when it rebuilt

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -10,7 +10,7 @@ touch.
 ```toml
 # pyproject.toml
 [project]
-version = "2.1.0"
+version = "3.0.0"
 ```
 
 That line is the number, and the only one to edit. The package reads it

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -10,7 +10,7 @@ touch.
 ```toml
 # pyproject.toml
 [project]
-version = "3.0.0"
+version = "2.2.0"
 ```
 
 That line is the number, and the only one to edit. The package reads it
@@ -42,11 +42,13 @@ A change is user-facing if it changes any of these:
 4. **Numerical output.** The values the library computes. A spectrum that
    moves is a user-facing change even when no signature changed.
 5. **Exception types.** What is raised, and when (`hazma/hazma_errors.py`).
-6. **`hazma/deprecated/`.** Whatever lives there stays importable;
-   removing or changing anything there is a break. The package is
-   currently empty — its last module, `rambo.py`, was removed in
-   cython-to-rust Task 0.2 — so the rule binds the next module parked
-   there, not any module shipping today.
+6. **`hazma/deprecated/`.** Whatever lives there stays importable, and
+   changing it is a break. Removing it is a break too unless a released
+   version warned on import and named the replacement, which is the
+   reachability carve-out below. The package is currently empty — its
+   last module, `rambo.py`, warned toward `hazma.phase_space` and was
+   removed in cython-to-rust Task 0.2 — so the rule binds the next module
+   parked there, not any module shipping today.
 7. **Supported Python versions** and required runtime dependencies.
 
 Explicitly **not** the public surface: `hazma/experimental/`, anything
@@ -63,24 +65,36 @@ The litmus test, applied in order — the first line that matches wins:
 changes meaning:
 
 - A public function, class, module, or keyword argument is **removed or
-  renamed**.
+  renamed**, except where the reachability carve-out under `minor`
+  applies.
 - A return shape or unit changes (`dN/dE` in `MeV⁻¹` becomes `GeV⁻¹`; a
   scalar becomes an array).
 - A required argument is added, or an argument's default changes in a way
   that changes results.
 - The minimum Python version rises.
-- Anything in `hazma/deprecated/` is removed.
+- Anything in `hazma/deprecated/` is removed without having shipped an
+  import-time deprecation warning first; see the same carve-out.
 
 **`minor`** — additive, or a deliberate correction to a published number:
 
 - A new public function, class, model, channel, or keyword argument with
   a backward-compatible default.
 - **A numerical result changes because a physics bug was fixed.** This is
-  the carve-out worth reading twice: the API is unchanged, so it is not
+  the case worth reading twice: the API is unchanged, so it is not
   `major`, but a user's plot moves, so it is not `patch`. Name the
   affected functions and the size of the change in `CHANGELOG.md`.
 - A previously-raising input now returns a value (or vice versa) as a
   deliberate correctness fix.
+- **A public name is removed when no working user code could have
+  depended on it.** This is the reachability carve-out, and exactly two
+  cases qualify. Either the name was **un-importable in every released
+  version**, so no correct program ever used it; or it lived in
+  `hazma/deprecated/` and **a released version emitted an import-time
+  deprecation warning naming its maintained replacement**, which is what
+  that package exists to do. Everything else removed is `major`. A
+  `minor` here is a claim about reachability rather than about taste, so
+  state the evidence in `CHANGELOG.md` beside the removal: the import
+  that fails and why, or the release that carried the warning.
 - A dependency's minimum version rises.
 
 **`patch`** — no user-visible behavior change:
@@ -137,3 +151,5 @@ version untouched) fails the gate.
 | Added a new model package                            | `minor` |
 | Tightened a docstring                                | `patch` |
 | Dropped Python 3.10 support                          | `major` |
+| Removed a module no released version could import     | `minor` |
+| Removed a `deprecated/` module that warned on import  | `minor` |

--- a/hazma/experimental/axial_vector_mediator/avm_msqrd.py
+++ b/hazma/experimental/axial_vector_mediator/avm_msqrd.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 from hazma.parameters import alpha_em
-from hazma.utils import minkowski_dot
+from hazma.utils import ldot
 
 
 def msqrd_xx_to_a_to_ff(moms, mx, mf, ma, cxxa, cffa):
@@ -51,10 +51,10 @@ def msqrd_xx_to_a_to_ff(moms, mx, mf, ma, cxxa, cffa):
     p1 = np.array([E, 0.0, 0.0, p])
     p2 = np.array([E, 0.0, 0.0, -p])
 
-    p1DOTp4 = minkowski_dot(p1, p4)
-    p2DOTp3 = minkowski_dot(p2, p3)
-    p1DOTp3 = minkowski_dot(p1, p3)
-    p2DOTp4 = minkowski_dot(p2, p4)
+    p1DOTp4 = ldot(p1, p4)
+    p2DOTp3 = ldot(p2, p3)
+    p1DOTp3 = ldot(p1, p3)
+    p2DOTp4 = ldot(p2, p4)
 
     return (
         4
@@ -113,17 +113,17 @@ def msqrd_xx_to_a_to_ffg(moms, mx, mf, ma, qf, cxxa, cffa):
     p1 = np.array([E, 0, 0, p])
     p2 = np.array([E, 0, 0, -p])
 
-    kDOTp3 = minkowski_dot(k, p3)
-    kDOTp4 = minkowski_dot(k, p4)
-    p3DOTp4 = minkowski_dot(p3, p4)
+    kDOTp3 = ldot(k, p3)
+    kDOTp4 = ldot(k, p4)
+    p3DOTp4 = ldot(p3, p4)
 
-    kDOTp1 = minkowski_dot(k, p1)
-    p1DOTp3 = minkowski_dot(p1, p3)
-    p1DOTp4 = minkowski_dot(p1, p4)
+    kDOTp1 = ldot(k, p1)
+    p1DOTp3 = ldot(p1, p3)
+    p1DOTp4 = ldot(p1, p4)
 
-    kDOTp2 = minkowski_dot(k, p2)
-    p2DOTp3 = minkowski_dot(p2, p3)
-    p2DOTp4 = minkowski_dot(p2, p4)
+    kDOTp2 = ldot(k, p2)
+    p2DOTp3 = ldot(p2, p3)
+    p2DOTp4 = ldot(p2, p4)
 
     e = np.sqrt(4 * np.pi * alpha_em)
 

--- a/hazma/utils.py
+++ b/hazma/utils.py
@@ -1,6 +1,5 @@
 import functools as ft
 import warnings
-from collections.abc import Sequence
 from typing import Literal, Optional, Union
 
 import numpy as np
@@ -210,33 +209,6 @@ def ldot(lv1, lv2, axis: int = 0):
     p3 = lv1.take(3, axis=axis) * lv2.take(3, axis=axis)
 
     return p0 - p1 - p2 - p3  # type: ignore
-
-
-def minkowski_dot(fv1: Sequence[float], fv2: Sequence[float]) -> float:
-    """
-    Compute the west-coast (+,-,-,-) scalar product of two four-vectors.
-
-    Parameters
-    ----------
-    fv1, fv2: array-like
-        Four-vectors of length 4, ordered (E, px, py, pz). The components
-        carry whatever units the caller uses (MeV throughout hazma); the
-        result carries their square.
-
-    Returns
-    -------
-    dot: float
-        ``fv1[0]*fv2[0] - fv1[1]*fv2[1] - fv1[2]*fv2[2] - fv1[3]*fv2[3]``.
-
-    Notes
-    -----
-    Pure-Python replacement for the Cython
-    ``hazma.field_theory_helper_functions.common_functions.minkowski_dot``
-    deleted in the Cython-to-Rust migration. `ldot` is the array-oriented
-    generalization of the same product; this keeps the scalar
-    four-vector spelling that squared-matrix-element code is written in.
-    """
-    return fv1[0] * fv2[0] - fv1[1] * fv2[1] - fv1[2] * fv2[2] - fv1[3] * fv2[3]
 
 
 def lnorm_sqr(lv: np.ndarray, axis: int = 0) -> np.ndarray:

--- a/notebooks/dev/K0_radiative_decay_4_24_18.ipynb
+++ b/notebooks/dev/K0_radiative_decay_4_24_18.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from hazma.utils import minkowski_dot\n",
+    "from hazma.utils import ldot as minkowski_dot\n",
     "from hazma.parameters import GF, qe, Vus\n",
     "from hazma.parameters import charged_pion_mass as mpi\n",
     "from hazma.parameters import neutral_kaon_mass as mk0\n",

--- a/notebooks/dev/gamma_ray_fsr/partial_integration.py
+++ b/notebooks/dev/gamma_ray_fsr/partial_integration.py
@@ -7,7 +7,7 @@ from hazma.parameters import (
     qe,
     charged_pion_mass as mpi,
 )
-from hazma.utils import minkowski_dot as LDot
+from hazma.utils import ldot as LDot
 from hazma.gamma_ray import gamma_ray_fsr
 import numpy as np
 import matplotlib.pyplot as plt

--- a/projects/README.md
+++ b/projects/README.md
@@ -40,11 +40,10 @@ for why `_template.md` files stay in place after scaffolding.
 
 | Slug | Deliverable | Phased | Started | Status |
 | --- | --- | --- | --- | --- |
-| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | In Progress |
 | [`parity-pinned-defect-repair`](parity-pinned-defect-repair/PLAN.md) | The seven parity-pinned numerical defects repaired, each with a declared per-array delta asserted against the corpus arrays that pinned it — which stay committed | No | 2026-08-19 | In Progress |
 
 ## Completed Projects
 
 | Slug | Deliverable | Phased | Started | Shipped |
 | --- | --- | --- | --- | --- |
-| _none yet_ | | | | |
+| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | 2026-08-29 (hazma 3.0.0) |

--- a/projects/README.md
+++ b/projects/README.md
@@ -46,4 +46,4 @@ for why `_template.md` files stay in place after scaffolding.
 
 | Slug | Deliverable | Phased | Started | Shipped |
 | --- | --- | --- | --- | --- |
-| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | 2026-08-29 (hazma 3.0.0) |
+| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | 2026-08-29 (hazma 2.2.0) |

--- a/projects/README.md
+++ b/projects/README.md
@@ -46,4 +46,4 @@ for why `_template.md` files stay in place after scaffolding.
 
 | Slug | Deliverable | Phased | Started | Shipped |
 | --- | --- | --- | --- | --- |
-| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | 2026-08-29 (hazma 2.2.0) |
+| [`cython-to-rust`](cython-to-rust/PLAN.md) | Compiled layer rebuilt in Rust (PyO3, abi3 `hazma._core`, maturin); zero Cython; permanent parity corpus | Yes (8) | 2026-08-03 | 2026-08-29; released in hazma 2.2.0 (2026-09-06) |

--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -1,5 +1,5 @@
 ---
-status: In Progress
+status: Complete
 phased: true
 version_bump: major
 deliverable: Hazma's compiled layer rebuilt in Rust (PyO3, one abi3 `hazma._core` extension, maturin-built), with zero Cython remaining and a permanent parity-test corpus
@@ -49,7 +49,9 @@ deprecation debt. Full analysis: the August 2026 assessment
   form factors, relic-density ODEs, spline utilities) — they stay on
   NumPy/SciPy.
 - Windows / linux-aarch64 wheel support (recorded as a cheap follow-up;
-  Phase 07 Task 7.2 makes the call explicitly).
+  Phase 07 Task 7.2 makes the call explicitly, and Task 7.4 filed it as
+  [`docs/followups/todo/wheels-for-aarch64-and-windows.md`](../../docs/followups/todo/wheels-for-aarch64-and-windows.md)
+  so it stays in the live backlog now that this plan is closed).
 - Performance work beyond what parity-preserving redesign yields
   (measured, not chased — `rules.md` rule 12).
 
@@ -99,7 +101,7 @@ total landed at 21–32 days across ~33 tasks.
 | 04 | Spectra kernels | [`phases/phase-04-spectra-kernels.md`](phases/phase-04-spectra-kernels.md) | 4–6 | **Complete (2026-08-20)** — 16 entry points swapped, `hazma/spectra/` holds no Cython `def`; seven live 2.1.0 defects surfaced and filed; five budgets tightened, none widened ([learnings](learnings/phase-04-spectra-kernels.md)) |
 | 05 | Mediator cross sections | [`phases/phase-05-mediator-cross-sections.md`](phases/phase-05-mediator-cross-sections.md) | 2–3 | **Complete (2026-08-21)** — 18 defs swapped, 2 dead exports dropped, both `_c_*` `.pyx` deleted; 16 of 18 bit-equal, relic density pinned end-to-end and 1.5×–1.9× faster ([learnings](learnings/phase-05-mediator-cross-sections.md)) |
 | 06 | Mediator spectra | [`phases/phase-06-mediator-spectra.md`](phases/phase-06-mediator-spectra.md) | 3–4 | **Complete (2026-08-27)** — 7 entry points swapped on a table-struct redesign, then the four capi survivors and the `_utils` headers deleted; **zero `.pyx`/`.pxd` remain** and `setup.py` builds only `hazma._core`; seven budgets tightened, none widened ([learnings](learnings/phase-06-mediator-spectra.md)) |
-| 07 | Cutover + close | [`phases/phase-07-cutover.md`](phases/phase-07-cutover.md) | 2–3 | maturin backend, 2 abi3 wheels, docs sweep, version bump + CHANGELOG |
+| 07 | Cutover + close | [`phases/phase-07-cutover.md`](phases/phase-07-cutover.md) | 2–3 | **Complete (2026-08-29)** — maturin is the whole build and the whole release pipeline (2 `cp310-abi3` wheels + sdist), no live instruction doc states a Cython fact, and the project ships as **3.0.0** ([learnings](learnings/phase-07-cutover.md), [retrospective](learnings/project-retrospective.md)) |
 
 Ordering constraints: 00 → 01 → 02 → 03 → {04, 05} → 06 → 07. Phase 05
 shares no files with 04 and may run in parallel with it. Within 04 the

--- a/projects/cython-to-rust/PLAN.md
+++ b/projects/cython-to-rust/PLAN.md
@@ -1,7 +1,7 @@
 ---
 status: Complete
 phased: true
-version_bump: major
+version_bump: minor
 deliverable: Hazma's compiled layer rebuilt in Rust (PyO3, one abi3 `hazma._core` extension, maturin-built), with zero Cython remaining and a permanent parity-test corpus
 created: 2026-08-03
 ---
@@ -64,11 +64,15 @@ quad-backed functions and tighten after measurement (closed-form
 kernels: ≤1e-13); (2) Cython-`assert` edge guards become unconditional
 raises (behavior tightening at invalid inputs only).
 
-`version_bump: major` is driven by API removals, not by numbers:
-Phase 00 deletes `hazma/deprecated/rambo.py` (any removal from
-`hazma/deprecated/` is `major` per `docs/versioning.md` and
-`AGENTS.md`) and, per ADR-0003 (accepted), removes the
-broken-on-import `hazma.gamma_ray` module. The running numerical
+`version_bump: minor` is driven by the two new public functions and the
+two-body threshold repair, not by the port. Phase 00's two API removals
+do not raise it: `hazma/deprecated/rambo.py` shipped an import-time
+warning naming `hazma.phase_space`, and `hazma.gamma_ray` was
+broken-on-import in every released tag (ADR-0003, accepted), so both
+fall under the reachability carve-out in `docs/versioning.md`. This
+project was planned as `major` under the rule as it then stood, which
+had no such carve-out; the lowering and the amendment are recorded
+together in `task-notes/README.md`. The running numerical
 record lives in `task-notes/numerical-impact.md` (moved out of
 `task-notes/README.md`'s "Numerical impact so far" section on
 2026-08-21; that heading now points there); the closing CHANGELOG
@@ -101,7 +105,7 @@ total landed at 21–32 days across ~33 tasks.
 | 04 | Spectra kernels | [`phases/phase-04-spectra-kernels.md`](phases/phase-04-spectra-kernels.md) | 4–6 | **Complete (2026-08-20)** — 16 entry points swapped, `hazma/spectra/` holds no Cython `def`; seven live 2.1.0 defects surfaced and filed; five budgets tightened, none widened ([learnings](learnings/phase-04-spectra-kernels.md)) |
 | 05 | Mediator cross sections | [`phases/phase-05-mediator-cross-sections.md`](phases/phase-05-mediator-cross-sections.md) | 2–3 | **Complete (2026-08-21)** — 18 defs swapped, 2 dead exports dropped, both `_c_*` `.pyx` deleted; 16 of 18 bit-equal, relic density pinned end-to-end and 1.5×–1.9× faster ([learnings](learnings/phase-05-mediator-cross-sections.md)) |
 | 06 | Mediator spectra | [`phases/phase-06-mediator-spectra.md`](phases/phase-06-mediator-spectra.md) | 3–4 | **Complete (2026-08-27)** — 7 entry points swapped on a table-struct redesign, then the four capi survivors and the `_utils` headers deleted; **zero `.pyx`/`.pxd` remain** and `setup.py` builds only `hazma._core`; seven budgets tightened, none widened ([learnings](learnings/phase-06-mediator-spectra.md)) |
-| 07 | Cutover + close | [`phases/phase-07-cutover.md`](phases/phase-07-cutover.md) | 2–3 | **Complete (2026-08-29)** — maturin is the whole build and the whole release pipeline (2 `cp310-abi3` wheels + sdist), no live instruction doc states a Cython fact, and the project ships as **3.0.0** ([learnings](learnings/phase-07-cutover.md), [retrospective](learnings/project-retrospective.md)) |
+| 07 | Cutover + close | [`phases/phase-07-cutover.md`](phases/phase-07-cutover.md) | 2–3 | **Complete (2026-08-29)** — maturin is the whole build and the whole release pipeline (2 `cp310-abi3` wheels + sdist), no live instruction doc states a Cython fact, and the project ships as **2.2.0** ([learnings](learnings/phase-07-cutover.md), [retrospective](learnings/project-retrospective.md)) |
 
 Ordering constraints: 00 → 01 → 02 → 03 → {04, 05} → 06 → 07. Phase 05
 shares no files with 04 and may run in parallel with it. Within 04 the

--- a/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
+++ b/projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md
@@ -1,7 +1,8 @@
 # ADR 0003: Remove the broken `hazma.gamma_ray` module
 
 **Date:** 2026-08-03
-**Status:** Accepted (signed off by Logan 2026-08-04)
+**Status:** Accepted (signed off by Logan 2026-08-04); versioning
+consequence superseded 2026-09-06, see the note at the end.
 **Scope:** Project-scoped (applies only within `projects/cython-to-rust/`).
 
 ## Context
@@ -73,3 +74,21 @@ migration exactly as prescribed: `hazma.spectra.dnde_photon_fsr`
 CHANGELOG entry for this removal should therefore name
 `hazma.spectra.dnde_photon_fsr` as `gamma_ray_fsr`'s replacement
 instead of "none". The decision recorded here is unchanged.
+
+## Note (2026-09-06): the versioning argument, superseded
+
+The Context and Consequences above reason from a `docs/versioning.md`
+that made every public removal `major` with no exception, and lean on
+the project being `major` anyway so that this deletion cost nothing
+extra. That rule now carries a **reachability carve-out**: a name that
+no released version could import, or a `hazma/deprecated/` module that
+warned on import and named its replacement, is `minor`. Both of Phase
+00's removals qualify, and the project shipped as **hazma 2.2.0**.
+
+**The decision itself is unaffected.** Its load-bearing argument was
+always that `hazma.gamma_ray` cannot be imported and so has no oracle to
+rebuild against — the same fact the carve-out now rests on. What changes
+is only the mitigation: deletion is no longer free because the release
+was breaking regardless, it is free because it breaks nothing. The
+lowering is recorded in
+[`../task-notes/README.md`](../task-notes/README.md).

--- a/projects/cython-to-rust/learnings/phase-07-cutover.md
+++ b/projects/cython-to-rust/learnings/phase-07-cutover.md
@@ -1,0 +1,166 @@
+# Phase 07 Learnings: Packaging cutover and close
+
+**Phase:** 07 — Packaging cutover and close
+**Closed:** 2026-08-29
+**Tasks:** 7.1 (maturin backend), 7.2 (release pipeline), 7.3 (docs
+sweep), 7.4 (close)
+
+This file replaces the phase's four task notes and its
+`task-notes/phase-07/README.md` for every later reader
+([ADR-0002](../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md)).
+
+## 1. Implementation Reality Check
+
+The phase delivered what it promised. `pyproject.toml` is the only build
+entry point, `[build-system] requires` is `["maturin>=1.5,<2.0"]`, a
+release publishes two `cp310-abi3` wheels and an sdist from
+`PyO3/maturin-action@v1`, no live instruction document states a Cython
+fact, and the project closes at 3.0.0. Four of four tasks landed; no ADR
+was needed, because ADR-0001 had already fixed the framework and every
+packaging question this phase answered was an implementation of it.
+
+What the plan did not anticipate is that **three of the four tasks found
+their own criterion had been written against an anticipated tree rather
+than the real one**, and in each case the criterion was smaller than the
+work:
+
+- **Task 7.1** inherited a bullet Task 6.4 had already half-discharged:
+  6.4 deleted the last `.pyx`, which stranded the cython/numpy/scipy
+  build requirements, so it removed them rather than shipping a false
+  requirement, and 7.1's criterion was amended in place rather than
+  quietly satisfied.
+- **Task 7.2**'s criterion opened by asking for Cython caching to be
+  dropped from `ci.yml`. There had never been any: `rg -in 'cython'
+  .github/workflows/` returns six hits on `origin/master`, all prose
+  inside comments. The clause was written in the August 2026 analysis
+  against a shape the repository never had.
+- **Task 7.3**'s enumeration found 14 of 34 stale sites, because it was
+  scoped to the two files that first stated the fact. Run over
+  `README.md`, `docs/` and both skill trees as well, the same pattern
+  returned 20 more.
+
+The generalization, and the one worth carrying past this project:
+**a criterion scoped to a file is a criterion scoped to a guess.** Phase
+02 learned that "it exists" and "it is load-bearing" differ; Phase 03,
+that a plan's model of an external artifact is a hypothesis. This phase's
+version is about *text*: a claim written once and pasted into seven
+skill files has to be swept by its wording, not by the file that
+originated it.
+
+## 2. Critical Context for Future Work
+
+- **`pyproject.toml` is the only build entry point.** `setup.py`,
+  `MANIFEST.in`, `setup.cfg`'s `[aliases]`, `requirements.txt` and the
+  `Dockerfile` are all deleted. `[tool.maturin]` carries
+  `python-source = "."`, `manifest-path`, `module-name = "hazma._core"`,
+  `exclude` and `include`. `test/test_no_cython_remains.py` asserts the
+  build-requirement and build-script halves so they cannot regress
+  unnoticed.
+- **The version lives in `pyproject.toml`'s `[project] version`**, and
+  `hazma.VERSION` reads it back out of `importlib.metadata`. That
+  inversion is what lets the backend learn the version without importing
+  a package it has not built. `preflight.sh --closing` parses the
+  `[project]` table specifically, so a `version` under any `[tool.*]`
+  table cannot answer for it.
+- **`pip install -e .` now builds release, not debug.** maturin's PEP 517
+  hooks build release unconditionally; only the `maturin develop` CLI
+  (which this repo never invokes) defaults to debug. `rules.md` rule 12's
+  benchmarks are therefore sound from an ordinary editable tree — but
+  still run them from *outside* the repository, or `hazma` resolves to
+  the worktree instead of site-packages.
+- **`release.yml` runs on pull requests** that touch `release.yml` or
+  `pyproject.toml`, so a packaging edit is measurable without cutting a
+  release. `publish` stays gated on `github.event_name == 'release'`.
+  This closes the `[unrun-workflow-cannot-close-a-criterion]` hole that
+  Phase 02 opened and Task 7.1 inherited.
+- **maturin honors `.gitignore` for both sdist and wheel**, so build
+  output cannot leak into a release from a dirty tree. A file that is
+  untracked **and** unignored still gets in, so build releases from a
+  clean tree.
+- **Nothing builds the docs.** There is no `.readthedocs.yaml` in the
+  repository — the published docs come from RTD's default detection — and
+  neither CI nor `preflight.sh` runs Sphinx. A broken docs build turns
+  nothing red, so check it by hand when a change could plausibly affect
+  it.
+
+## 3. Quirk Log & Edge Cases
+
+- **A wheel filename's last three fields are compressed tag *sets*, not
+  tags.** Each is dot-separated and the wheel carries their cross
+  product, one `Tag:` line per member. The manylinux wheel is
+  `cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64` — one platform
+  field standing for two tags — while the macOS wheel is one tag per
+  field. An assertion comparing field against `Tag:` line as a single
+  string passes on macOS and rejects a correct Linux wheel. **Both halves
+  of a two-platform matrix must run before a format assertion is
+  believed**; a locally built wheel is the macOS shape only.
+- **`twine check` cannot fail an unbuildable sdist.** It reads metadata.
+  An archive missing `rust/Cargo.toml` passes it and then fails every
+  `pip install --no-binary`, and nothing else notices, because both wheel
+  jobs build from the checkout rather than from the sdist. The sdist
+  needs its own install-and-import job.
+- **The manylinux container ships its own Rust toolchain.** Phase 02's
+  `CIBW_BEFORE_ALL_LINUX` rustup install, its `CIBW_ENVIRONMENT_LINUX`
+  `PATH` edit, and the host `dtolnay/rust-toolchain` step that covered
+  macOS all came out with cibuildwheel; `maturin-action` needs none of
+  them.
+- **`--paths` on `preflight.sh` feeds black, isort and ruff directly.**
+  Naming a `.yml` or `.md` file there makes them parse it as Python and
+  the gate goes red on a clean tree. Pass source paths (or the default
+  `hazma test`) and route markdown through `--md`.
+- **A `.bak` suffix is not evidence that a file is a copy.** Two of the
+  four "editor leftovers" Task 7.3 examined are not backups:
+  `A_eff/gecco.dat.bak` cites a different source than `A_eff/gecco.dat`
+  and tabulates a different grid, starting at 0.1 MeV rather than 0.2.
+- **`hazma/_utils/` outlived its contents.** Task 6.4 deleted the four
+  Cython headers and left the package's empty `__init__.py`, so the
+  directory was an importable no-op until Task 7.3 removed it. Every
+  `._utils` hit elsewhere in the tree is a sibling package, not this one
+  — which is what made the stale directory look load-bearing.
+
+## 4. Test Infrastructure State
+
+- **`test/test_no_cython_remains.py` is the standing anti-regression
+  gate** for the whole cutover: no Cython source anywhere, no setuptools
+  build script, no Cython toolchain in the build requirements, and no
+  editor leftovers in the distribution sweep. It is why no test module
+  reads a build script any more — five did, through `setup.py`, until
+  Task 7.1.
+- **`release.yml` asserts its own output**, and at two levels: the wheel
+  filename's tag fields against the `.dist-info/WHEEL` `Tag:` lines, and
+  `hazma/_core.abi3.so` as the *only* compiled object in the wheel. It
+  also import-smokes the one `cp310-abi3` wheel under both CPython 3.10
+  and 3.14 with `--no-deps`, which is the claim abi3 actually makes.
+- **`preflight.sh --closing` is not vacuous any more.** It reads
+  `[project] version` from both the working tree and the base ref and
+  fails on a missing baseline rather than reporting PASS, then requires a
+  matching `## [X.Y.Z]` section in `CHANGELOG.md`.
+- **The full gate on the capturing platform at close:** bare `pytest -q`
+  is 2231 passed / 15 skipped / 12 subtests, and
+  `cargo test --no-default-features` is 258 passed (0 doc-tests).
+  Re-derive rather than quoting — the cargo count was 249 as recently as
+  Task 7.1's note and the pytest count moved four times inside this phase
+  alone.
+
+## 5. Follow-on seeds
+
+All four are filed, and none blocks anything.
+
+- [Consolidate the divergent constants tables](../../../docs/followups/todo/consolidate-the-two-constants-tables.md)
+  — the project's most obvious deferred cleanup, and a declared numerical
+  change. `rules.md` rule 4 forbade it while kernels were being ported;
+  that constraint lifts at close.
+- [Free-threaded `abi3t` wheels](../../../docs/followups/todo/free-threaded-abi3t-wheels.md)
+  — waiting on PyO3 and on the dependency ecosystem, not on hazma. The
+  crate's only mutable module state is already `Mutex`-guarded.
+- [The relic-density Boltzmann solve in Rust](../../../docs/followups/todo/relic-density-odes-in-rust.md)
+  — deliberately out of scope, and it stays out until a profile says
+  otherwise.
+- [Wheels for linux-aarch64 and Windows](../../../docs/followups/todo/wheels-for-aarch64-and-windows.md)
+  — Task 7.2 decided against them and declined to file, on the grounds
+  that `PLAN.md` §Scope recorded the option. Closing the project made
+  that record archival, so Task 7.4 filed it with the decision unchanged.
+
+Task 7.3 also filed
+[four tracked non-source files under `hazma/`](../../../docs/followups/todo/tracked-non-source-files-under-hazma.md),
+which is where the `gecco.dat.bak` question landed.

--- a/projects/cython-to-rust/learnings/phase-07-cutover.md
+++ b/projects/cython-to-rust/learnings/phase-07-cutover.md
@@ -136,11 +136,11 @@ originated it.
   fails on a missing baseline rather than reporting PASS, then requires a
   matching `## [X.Y.Z]` section in `CHANGELOG.md`.
 - **The full gate on the capturing platform at close:** bare `pytest -q`
-  is 2231 passed / 15 skipped / 12 subtests, and
-  `cargo test --no-default-features` is 258 passed (0 doc-tests).
+  is 2246 passed / 15 skipped / 12 subtests, and
+  `cargo test --no-default-features` is 261 passed (0 doc-tests).
   Re-derive rather than quoting — the cargo count was 249 as recently as
-  Task 7.1's note and the pytest count moved four times inside this phase
-  alone.
+  Task 7.1's note, and the pytest count moved four times inside this phase
+  and twice more in the closing PR.
 
 ## 5. Follow-on seeds
 

--- a/projects/cython-to-rust/learnings/phase-07-cutover.md
+++ b/projects/cython-to-rust/learnings/phase-07-cutover.md
@@ -15,7 +15,7 @@ The phase delivered what it promised. `pyproject.toml` is the only build
 entry point, `[build-system] requires` is `["maturin>=1.5,<2.0"]`, a
 release publishes two `cp310-abi3` wheels and an sdist from
 `PyO3/maturin-action@v1`, no live instruction document states a Cython
-fact, and the project closes at 3.0.0. Four of four tasks landed; no ADR
+fact, and the project closes at 2.2.0. Four of four tasks landed; no ADR
 was needed, because ADR-0001 had already fixed the framework and every
 packaging question this phase answered was an implementation of it.
 

--- a/projects/cython-to-rust/learnings/project-retrospective.md
+++ b/projects/cython-to-rust/learnings/project-retrospective.md
@@ -1,0 +1,317 @@
+# Project Retrospective: cython-to-rust
+
+**Project:** cython-to-rust
+**Ran:** 2026-08-03 → 2026-08-29 (26 calendar days, 8 phases, 33 tasks)
+**Shipped as:** hazma 3.0.0
+**Deliverable:** Hazma's compiled layer rebuilt in Rust (PyO3, one abi3
+`hazma._core`, maturin-built), zero Cython, and a permanent parity-test
+corpus.
+
+This file is the project's durable memory. The seven phase learnings
+files beside it hold the per-phase detail and are still the right thing
+to read before touching an area they cover; this one holds what only
+becomes visible from the whole arc
+([ADR-0002](../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md)).
+
+## 1. Implementation Reality Check
+
+The project delivered its deliverable exactly, and the numbers came out
+better than the plan allowed for.
+
+- **All 41 consumed compiled entry points are on `hazma._core`.** The two
+  unimported `sigma_xx_to_all` exports were dropped rather than ported,
+  as `PLAN.md` §Scope said they would be.
+  `find hazma -name "*.pyx" -o -name "*.pxd"` returns nothing; the tree
+  went from 32 extension modules to 20 (Phase 00) to one.
+- **27 of the 41 entry points reproduce hazma 2.1.0 bit-for-bit**, and
+  the other 14 move by at most 5.4e-12 relative. `PLAN.md` opened the
+  quad-backed budget at 1e-8 relative and expected to tighten it after
+  measurement. It tightened by four orders of magnitude: **fourteen
+  budgets tightened across the project and none widened**, and neither
+  opening budget (`QUAD_RTOL` 1e-8, `NESTED_RTOL` 1e-6) is claimed by any
+  corpus case any more — `QUAD_RTOL` emptied at Task 5.2, `NESTED_RTOL`
+  at Task 6.3.
+- **The estimate held.** 21–32 focused dev-days across ~33 tasks was the
+  plan; 33 tasks is what ran, and no phase was split or merged. The
+  ordering constraint `00 → 01 → 02 → 03 → {04, 05} → 06 → 07` was
+  respected, though 04 and 05 ran sequentially rather than in the
+  parallel the plan permitted.
+- **Performance was measured, not chased** (`rules.md` rule 12), and
+  arrived anyway: 1.46×–1.93× on a full relic-density calculation,
+  1.8×–3.2× on the ⟨σv⟩ kernel, 32×–43× on the mediator positron
+  spectra, and 4,180× on a fixed-mass parameter sweep of the mediator
+  photon spectra. The large numbers are not Rust-versus-Cython; they are
+  a dead memo cache the Cython never populated, which the redesign
+  repaired incidentally.
+
+Two things diverged from the plan, both worth recording.
+
+**Phase 00 was worth doing on its own, and the plan said so in advance.**
+It deleted roughly 6,500 lines of dead Cython and about 33,000 lines
+overall, took the extension count from 32 to 20, and removed the only C++
+in the tree — before a single line of Rust existed. `PLAN.md` §Scope
+called it "worth doing even if the port stopped there", and that
+turned out to be the single best structural decision in the project: it
+meant the parity corpus in Phase 01 had to cover 41 entry points instead
+of a number nobody had counted, and every later phase worked against a
+surface that was known rather than assumed.
+
+**The port surfaced twelve live numerical defects in hazma 2.1.0, and
+that was not a goal.** None was found by porting. Every one was found by
+writing a statement the original never made — an analytic normalization
+check, a sibling-to-sibling diff, a rest-frame limit, a forward-cone
+argument, a continuum subtraction — in order to have something to hold
+the port to. Section 3 draws the general lesson; the roster is in the
+3.0.0 CHANGELOG's `Known issues` and in `docs/followups/todo/`.
+
+**ADRs:** three, all Accepted, none superseded or amended after
+acceptance. ADR-0001 (PyO3 + maturin over pybind11) was decided before
+the project started and never revisited. ADR-0002 (license-clean
+numerics: cephes and netlib-QUADPACK in, the GPL rust-cyphus crates out)
+was accepted 2026-08-04 and unblocked Phase 03. ADR-0003 (remove the
+broken-on-import `hazma.gamma_ray`) was accepted the same day and fully
+discharged across Tasks 0.5 and 0.2. **No phase after 03 needed an ADR at
+all**, which is the tell that the architectural questions were genuinely
+settled up front.
+
+## 2. Critical Context for Future Work
+
+Contracts this project established that later work must respect.
+
+- **`hazma._core` is the compiled layer, and it has one shape.**
+  `rust/src/kernels/` is PyO3-free and `pub`; `rust/src/dispatch.rs` is
+  the only PyO3 boundary. A wrapper calls `dispatch::map_unary`,
+  `map_flavors` for a `(3, N)` return, `map_unary_try` for a kernel that
+  raises, or `require_vector` for an argument that must be a 1-D array.
+  Kernels call each other natively, the way the `.pyx` cimported.
+- **A `.rs` edit needs `pip install -e .`, not `cargo build`.**
+  `cargo build` refreshes `rust/target/`, which nothing Python imports.
+  Iterate with `cargo test --no-default-features` — the
+  `extension-module` feature must be off or the test harness will not
+  link — then reinstall before believing any Python-side result.
+- **`crate::quad::quad` is the integrator entry point**, not `qagse` or
+  `qagpe` directly — it is what reproduces scipy's limit ordering and
+  break-point filtering, and `points is None` (rather than "no break
+  point survived") is what selects `qagse`. Both drivers are proven
+  against live call sites. Copy a call site's `epsabs` / `epsrel` /
+  `points` verbatim into a `const QuadOpts`; because `quad`'s `Err` arm
+  depends only on the options and never on the integrand, it is
+  unreachable for a `const` value — return `NaN` there rather than
+  panicking, and assert the unreachability with a cargo test. `quad`
+  short-circuits an empty interval the way `scipy.integrate.quad` does,
+  so any kernel whose limits can coincide inherits that.
+- **The parity corpus is the numerical gate, and it is scoped to its
+  capturing platform.** `test/parity/cases.py` is the single source of
+  every entry point's call convention; `python test/parity/generate.py
+  --check` verifies the stored arrays. `test/parity/stability.py` declines
+  to compare the 494 positions (0.27%) whose values are cancellation
+  residue rather than numbers any implementation reproduces.
+- **`test/test_theory_aggregation.py` is the model-layer gate the corpus
+  cannot be** — identities over `hazma/theory/`'s pure-Python
+  aggregation, no golden data, and the only numerical gate in the repo
+  that is *not* platform-scoped. Run it either side of any change that
+  can reach a spectrum.
+- **The two constants tables are still deliberately divergent**, twelve
+  names plus `ALPHA_EM`, preserved bit-for-bit under `rules.md` rule 4.
+  `rust/src/constants.rs` reproduces the split (`pdg` for
+  `hazma/spectra/**`, `legacy` for the mediator kernels,
+  `derived::photon_pion` reading both) and a cargo test asserts it stays
+  divergent. Consolidating it is §5's first seed and a declared numerical
+  change.
+- **`pyproject.toml` is the only build entry point**, `[project] version`
+  is the version's source of truth, and `hazma.VERSION` reads it back out
+  of `importlib.metadata`. See the Phase 07 learnings for the rest of the
+  packaging contract.
+- **Twelve reproduced defects are load-bearing, not oversights.**
+  `rules.md` rule 1 required the port to reproduce them and rule 2 forbade
+  regenerating the corpus a repaired kernel would have to pass. Do not
+  "fix" one in passing: six are sequenced in
+  [`projects/parity-pinned-defect-repair/`](../../parity-pinned-defect-repair/PLAN.md),
+  which lands each as a *declared delta* against the committed corpus
+  arrays rather than as a regeneration, and that mechanism is the one to
+  reuse.
+
+## 3. Quirk Log & Edge Cases
+
+The transferable ones. Per-phase detail is in the seven phase files.
+
+- **Cython's compiled arithmetic is not the arithmetic its source
+  reads.** Three separate discoveries, each of which would have failed
+  the corpus if missed. (1) Clang contracts `a*b + c` into an FMA by
+  default, so a port written unfused missed by 3.6e-12 — past the
+  `TABULATED` budget — while `boost_beta` is *not* contracted at any of
+  its ten call sites. (2) Cython 3's default `cpow` semantics compile
+  `double ** double`, and everything around it in the same expression, in
+  `double _Complex`, reaching `cpow` and compiler-rt's `__divdc3`; a
+  real-arithmetic transliteration of `sigma_xx_to_s_to_ff` misses
+  bit-equality at 355 of 935 points on its electron block alone. (3)
+  Reproducing two `cdef float` truncations is what makes
+  `dnde_photon_neutral_pion` bit-equal; an all-`f64` spelling lands
+  8.5e-9 away. **Read the disassembly; do not infer it from the source.**
+  Where clang fuses is one syntactic rule — `EmitFMulAdd` contracts
+  `A ± B` when `A` is a syntactic multiply, else when `B` is, decided on
+  the C tree Cython emits, where `x ** n` is a `pow` *call* and never a
+  multiply — and Phase 06 reproduced 37 sites in two kernels from that
+  rule alone.
+- **"scipy is cephes" is true per-function, not per-library.** It holds
+  for `spence` and `k1` and fails for `kn`, which scipy routes to `kv`:
+  the *faithful* cephes `kn` misses scipy by 5.1e-9, squared into
+  `thermal_cross_section`'s prefactor. Separately, `spec_math`'s `li2`
+  disagrees with `scipy.special.spence` by ≤2e-15, which the muon photon
+  kernel's `5/β ≈ 3.5e6` amplifies to 3.15e-11. **The fix was at the
+  source, not at the budget:** transcribing cephes `spence` in-tree with
+  scipy's FP contraction gives 0 mismatches at 13,000 points.
+- **A break-point contract can belong to the Python wrapper rather than
+  to the library.** `scipy.integrate.quad`'s `points` handling —
+  `np.unique` plus strictly-interior filtering — is Python-level, not
+  QUADPACK's. A documentation-driven port would have made five live call
+  sites error.
+- **Nested quadrature damps; it does not amplify.** Phase 04 billed the ρ
+  spectra as the project's numerical stress test and got 1.5e-13, five
+  decades inside its class, because the outer integral *averages* the
+  inner one over a window. Every task's numerical prediction in that
+  phase was wrong, in a different direction each time. **Re-derive; do
+  not inherit.**
+- **A gate that exists is not a gate that can fail.** The crate's mere
+  existence flipped the parity suite out of bit-equality mode, because
+  `tolerances.provenance` keyed on "`hazma._core` is importable" rather
+  than on whether a kernel was *served*. Two more instances landed in the
+  same phase. The question to ask of every criterion is "what turns red
+  if this is wrong?"
+- **Catastrophic cancellation makes a pinned value a property of the
+  platform.** Four scalar elastic cross sections return one libm's
+  rounding residue near `e_cm = 2 m_x`; the same Cython gives
+  `-1.504e-02` on macOS and `+5.624e-07` on Linux, and no tolerance
+  absorbs a sign flip. The fix was to establish, against a 60-digit
+  evaluation of the same closed forms, *which positions are residue* and
+  decline to pin those — not to guess from which platforms disagree.
+- **A `.pyx` whose locals are untyped contracts nothing**, and so does
+  one whose locals are all typed but which contains no multiply-add at
+  all. Neither shape tells you what the compiler did.
+
+## 4. Test Infrastructure State
+
+- **The parity corpus (`test/parity/`)** is the project's main artifact
+  after `hazma._core` itself: 41 entry points, 179,695 pinned values,
+  per-case tolerance budgets with a written rationale each, a
+  `--check` regenerator, and `assert_no_rust_core` to stop anyone
+  regenerating it from a tree where a kernel already runs on Rust. It
+  outlives the project and is the gate for
+  `parity-pinned-defect-repair`.
+- **`test/parity/oracles/`** holds committed corrected-value arrays for
+  the defects the corpus pins wrong, and `defects.RESTORED_SOURCES` names
+  a git revision per deleted source so a re-capture stays possible: 29
+  entries, every case covered. The trick that made it possible is that
+  `git show <rev>:<path>` takes a plain SHA as readily as a `^`
+  expression, so a task that cannot cite its own commit can cite one that
+  already exists.
+- **Mutation campaigns on every kernel, and interrogate the survivors.**
+  Task 4.4's eleven mutants had two survivors and concluded they were
+  unobservable; 4.5's six had one and *fixed* it; 4.6's eleven had two
+  and resolved both; 6.2's thirty-seven had sixteen, fourteen of them
+  provably identity-equivalent. Ask "can this be lifted out?" and "is
+  this the coefficient or the grid?" before writing a limitation into
+  the source.
+- **One test module per clone-pair, not per entry point**, when the
+  independent reference is one function parameterised by pair. And the
+  surviving module shape is: an independent Python reference plus the
+  against-the-Cython numbers measured *before* deletion, recorded in
+  prose where they can no longer be re-run.
+- **The gate at close, on the capturing platform:** bare `pytest -q` is
+  2231 passed / 15 skipped / 12 subtests (from 1006/13 at the Phase 01
+  close), and `cargo test --no-default-features` is 258 passed (from 222
+  at the Phase 02 close). Re-derive rather than quoting — these moved at
+  nearly every task, and the cargo figure carried in the project's own
+  working memory was two tasks stale at close.
+
+## 5. Follow-on seeds
+
+Four filed at close, plus the standing backlog the project sourced.
+
+- **[Consolidate the divergent constants tables](../../../docs/followups/todo/consolidate-the-two-constants-tables.md)**
+  — the project's most obvious deferred cleanup, named as out of scope in
+  `PLAN.md` from the first day. Three fine-structure constants
+  (`1/137.035999084`, `1/137`, `1/137.04`) and two mass tables that
+  disagree on twelve names, all preserved bit-for-bit because
+  `rules.md` rule 4 required a ported kernel to read the exact constant
+  its Cython source read. That constraint lifts at close. It is a
+  declared numerical change and should reuse
+  `parity-pinned-defect-repair`'s declared-delta mechanism rather than
+  regenerating the corpus.
+- **[Free-threaded `abi3t` wheels](../../../docs/followups/todo/free-threaded-abi3t-wheels.md)**
+  — waiting on PyO3 and on NumPy/SciPy, not on hazma. The crate's only
+  mutable module state, the mediator table cache, is already
+  `Mutex`-guarded, so the blocker is packaging rather than concurrency.
+  Adding per-version free-threaded builds today would reintroduce exactly
+  the interpreter matrix the abi3 cutover removed.
+- **[The relic-density Boltzmann solve in Rust](../../../docs/followups/todo/relic-density-odes-in-rust.md)**
+  — deliberately excluded, and it stays excluded until a profile says
+  otherwise. Phase 05 already moved the expensive part (the ⟨σv⟩
+  integrand, which was re-entering Python per quadrature node); what
+  remains is a compiled SciPy stepper. Note the trap recorded there: at
+  `relic_density`'s default `rtol=1e-5` a last-bit input change moves the
+  answer by 3.8e-5, so any reimplementation moves the default-tolerance
+  result without moving the physics.
+- **[Wheels for linux-aarch64 and Windows](../../../docs/followups/todo/wheels-for-aarch64-and-windows.md)**
+  — Task 7.2 decided against them deliberately and declined to file, on
+  the grounds that `PLAN.md` §Scope recorded the option. Closing the
+  project made that record archival, so it is filed now with the decision
+  unchanged and the reasons written down.
+
+**The twelve reproduced 2.1.0 defects are the project's most valuable
+by-product, and they deserve a conversation the schedule of this project
+never gave them.** Six are sequenced in
+[`projects/parity-pinned-defect-repair/`](../../parity-pinned-defect-repair/PLAN.md);
+the rest are individual `docs/followups/todo/` entries, and the 3.0.0
+CHANGELOG's `Known issues` section is the user-facing roster with
+magnitudes. Two are worth naming here because they are the ones a user is
+most likely to be affected by without noticing: the **boost integral**
+diverges instead of converging as a parent approaches rest, which is the
+regime every model spectrum passes through near threshold; and
+**`thermal_cross_section` never converges**, so ⟨σv⟩ is 0.5%–5% wrong
+across the entire freeze-out region and every relic abundance computed
+from a mediator model inherits that roughly linearly.
+
+Three smaller items the project surfaced and did not own:
+[`hazma.utils`'s redundant public helpers](../../../docs/followups/todo/utils-public-surface-redundant-helpers.md),
+[the remaining `sqrt(kallen_lambda(...))` call sites](../../../docs/followups/todo/kallen-under-sqrt-remaining-call-sites.md),
+and [four tracked non-source files under `hazma/`](../../../docs/followups/todo/tracked-non-source-files-under-hazma.md).
+`hazma/experimental/axial_vector_mediator/__init__.py` is still broken on
+import (`from hazma.theory import Theory`, but `hazma.theory` exports
+`TheoryAnn` / `TheoryDec`); no follow-up is filed because `experimental/`
+is explicitly not a public surface, but it will keep tripping import
+sweeps until someone deletes or fixes it.
+
+## 6. Process notes
+
+Three things about *how* the project ran that are worth carrying to the
+next one.
+
+- **Write the criterion so it names its oracle and forbids
+  transcription.** The one Phase 03 task that needed no criteria patch,
+  3.1, is the one whose criterion already said "extract from source and
+  assert bit-equality — no hand-transcription trust". Every other task in
+  that phase had to add criteria mid-flight, because the plan's model of
+  an external artifact was a hypothesis only the sweep could refute. The
+  same shape recurs in Phase 00 (three of five tasks patched canonical
+  criteria — *the criteria written before a deletion are routinely wrong
+  about what the deletion strands*) and in Phase 07 (a criterion scoped
+  to a file is a criterion scoped to a guess). **Patching the criterion
+  in the same PR is cheaper and more honest than absorbing the difference
+  into the diff**. This project did it in three of Phase 00's five
+  tasks, all three of Phase 02's, four of Phase 03's five and three of
+  Phase 07's four — without once weakening a gate.
+- **The running numerical record has to be a file, not a memory.**
+  `task-notes/numerical-impact.md` — one entry per task giving the
+  function, the grid, and the result, appended in task order — is what
+  the 3.0.0 CHANGELOG was assembled from at close, twenty-six days and
+  thirty-three tasks after the first entry. It was moved out of the
+  working-memory README at Task 5.3 precisely because it had outgrown a
+  section. No closing agent could have reconstructed those figures, and
+  `PLAN.md` said so in advance.
+- **A phase-learnings file that replaces its phase's task notes actually
+  works.** ADR-0002 was written mid-project against measured context
+  growth (three Phase 04–05 tasks each ended between 513k and 644k
+  tokens, with the mandatory documents under 35k of it). Closing this
+  project meant reading seven learnings files instead of thirty-three
+  task notes, and nothing needed was missing from them.

--- a/projects/cython-to-rust/learnings/project-retrospective.md
+++ b/projects/cython-to-rust/learnings/project-retrospective.md
@@ -218,11 +218,12 @@ The transferable ones. Per-phase detail is in the seven phase files.
   against-the-Cython numbers measured *before* deletion, recorded in
   prose where they can no longer be re-run.
 - **The gate at close, on the capturing platform:** bare `pytest -q` is
-  2231 passed / 15 skipped / 12 subtests (from 1006/13 at the Phase 01
-  close), and `cargo test --no-default-features` is 258 passed (from 222
+  2246 passed / 15 skipped / 12 subtests (from 1006/13 at the Phase 01
+  close), and `cargo test --no-default-features` is 261 passed (from 222
   at the Phase 02 close). Re-derive rather than quoting — these moved at
-  nearly every task, and the cargo figure carried in the project's own
-  working memory was two tasks stale at close.
+  nearly every task, the cargo figure carried in the project's own working
+  memory was two tasks stale at close, and both moved again inside the
+  closing PR itself.
 
 ## 5. Follow-on seeds
 

--- a/projects/cython-to-rust/learnings/project-retrospective.md
+++ b/projects/cython-to-rust/learnings/project-retrospective.md
@@ -2,7 +2,7 @@
 
 **Project:** cython-to-rust
 **Ran:** 2026-08-03 → 2026-08-29 (26 calendar days, 8 phases, 33 tasks)
-**Shipped as:** hazma 3.0.0
+**Shipped as:** hazma 2.2.0
 **Deliverable:** Hazma's compiled layer rebuilt in Rust (PyO3, one abi3
 `hazma._core`, maturin-built), zero Cython, and a permanent parity-test
 corpus.
@@ -62,7 +62,7 @@ writing a statement the original never made — an analytic normalization
 check, a sibling-to-sibling diff, a rest-frame limit, a forward-cone
 argument, a continuum subtraction — in order to have something to hold
 the port to. Section 3 draws the general lesson; the roster is in the
-3.0.0 CHANGELOG's `Known issues` and in `docs/followups/todo/`.
+2.2.0 CHANGELOG's `Known issues` and in `docs/followups/todo/`.
 
 **ADRs:** three, all Accepted, none superseded or amended after
 acceptance. ADR-0001 (PyO3 + maturin over pybind11) was decided before
@@ -262,7 +262,7 @@ Four filed at close, plus the standing backlog the project sourced.
 by-product, and they deserve a conversation the schedule of this project
 never gave them.** Six are sequenced in
 [`projects/parity-pinned-defect-repair/`](../../parity-pinned-defect-repair/PLAN.md);
-the rest are individual `docs/followups/todo/` entries, and the 3.0.0
+the rest are individual `docs/followups/todo/` entries, and the 2.2.0
 CHANGELOG's `Known issues` section is the user-facing roster with
 magnitudes. Two are worth naming here because they are the ones a user is
 most likely to be affected by without noticing: the **boost integral**
@@ -304,7 +304,7 @@ next one.
 - **The running numerical record has to be a file, not a memory.**
   `task-notes/numerical-impact.md` — one entry per task giving the
   function, the grid, and the result, appended in task order — is what
-  the 3.0.0 CHANGELOG was assembled from at close, twenty-six days and
+  the 2.2.0 CHANGELOG was assembled from at close, twenty-six days and
   thirty-three tasks after the first entry. It was moved out of the
   working-memory README at Task 5.3 precisely because it had outgrown a
   section. No closing agent could have reconstructed those figures, and

--- a/projects/cython-to-rust/learnings/project-retrospective.md
+++ b/projects/cython-to-rust/learnings/project-retrospective.md
@@ -7,7 +7,7 @@
 `hazma._core`, maturin-built), zero Cython, and a permanent parity-test
 corpus.
 
-This file is the project's durable memory. The seven phase learnings
+This file is the project's durable memory. The eight phase learnings
 files beside it hold the per-phase detail and are still the right thing
 to read before touching an area they cover; this one holds what only
 becomes visible from the whole arc
@@ -133,7 +133,7 @@ Contracts this project established that later work must respect.
 
 ## 3. Quirk Log & Edge Cases
 
-The transferable ones. Per-phase detail is in the seven phase files.
+The transferable ones. Per-phase detail is in the eight phase files.
 
 - **Cython's compiled arithmetic is not the arithmetic its source
   reads.** Three separate discoveries, each of which would have failed
@@ -314,5 +314,5 @@ next one.
   works.** ADR-0002 was written mid-project against measured context
   growth (three Phase 04–05 tasks each ended between 513k and 644k
   tokens, with the mandatory documents under 35k of it). Closing this
-  project meant reading seven learnings files instead of thirty-three
+  project meant reading eight learnings files instead of thirty-three
   task notes, and nothing needed was missing from them.

--- a/projects/cython-to-rust/phases/phase-07-cutover.md
+++ b/projects/cython-to-rust/phases/phase-07-cutover.md
@@ -186,26 +186,47 @@ close the project (version bump + CHANGELOG per `PLAN.md`).
 
 ## Exit Criteria
 
-- All tasks complete; a release candidate builds, tests, and publishes
-  from CI; no Cython, setuptools, or cibuildwheel-version-matrix
-  residue anywhere.
+- All tasks complete; no Cython, setuptools, or
+  cibuildwheel-version-matrix residue anywhere.
+- A release candidate **builds and tests from CI**: `release.yml`
+  produces both `cp310-abi3` wheels and the sdist and passes that
+  workflow's own wheel-tag, sole-extension and cross-version import
+  assertions, and its `publish` job's release gate is observed holding on
+  a non-release event.
 - Phase learnings written to `../learnings/phase-07-cutover.md`.
 
-**Met on 2026-08-29 (Task 7.4), with one clause qualified.** All four
-task rows are Complete and the frontmatter reads `status: Complete`. The
-residue clause is discharged and asserted rather than inspected:
-`test/test_no_cython_remains.py` fails on any Cython source, any
-setuptools build script, and any Cython entry in the build requirements,
-and `release.yml` carries no version matrix.
+### Revision of the release clause (Task 7.4, 2026-08-29)
 
-The qualification is on **"publishes from CI"**. `release.yml` has been
-dispatched three times and has run once through its `pull_request`
-trigger, building both `cp310-abi3` wheels and the sdist and passing its
-own tag, sole-extension and cross-version import assertions each time.
-The `publish` job is gated on `github.event_name == 'release'` and
-correctly reported `skipping` in all four runs, so **the publish step
-itself is still unexecuted** and cannot be exercised before a release is
-cut. That is the gate working as designed, not a hole in it — but it is
-an open instance of `docs/agents/lessons.md`
-`[unrun-workflow-cannot-close-a-criterion]`, and whoever cuts 3.0.0
-should watch that job rather than assume it.
+**The second bullet previously read "a release candidate builds, tests,
+and *publishes* from CI." It was unsatisfiable, and circularly so.**
+`release.yml`'s `publish` job is gated `if: github.event_name ==
+'release'`; a GitHub release needs the `3.0.0` tag; that tag exists only
+once the closing PR merges — and the closing PR is what this criterion
+gates. Holding closure until an upload is observed is therefore a
+deadlock rather than a stricter gate: the version bump could never land,
+so the release could never be cut, so `publish` could never run.
+
+The clause is narrowed to what closure can actually attest, and **the
+upload is reassigned rather than dropped** — it is now an explicit
+release-manager handoff, recorded in `../task-notes/phase-07/README.md`'s
+Handoff and in the closing PR. This is a narrowing of a gate, so the
+residual risk is stated plainly rather than buried: **trusted publishing
+under `PyO3/maturin-action` has never executed.** The 3.0.0 release is
+its first run, and it should be watched rather than assumed.
+
+**Met on 2026-08-29 (Task 7.4), as revised.** All four task rows are
+Complete and the frontmatter reads `status: Complete`. The residue clause
+is asserted rather than inspected: `test/test_no_cython_remains.py` fails
+on any Cython source, any setuptools build script, and any Cython entry
+in the build requirements, and `release.yml` carries no version matrix.
+The build-and-test clause is met by four observed `release.yml` runs —
+three `workflow_dispatch` and one `pull_request` (the closing PR's own,
+triggered by its `pyproject.toml` edit) — each producing both wheels and
+the sdist, passing the workflow's assertions, and reporting `publish` as
+`skipping`, which is the release gate holding.
+
+The original phrasing was an instance of `docs/agents/lessons.md`
+`[unrun-workflow-cannot-close-a-criterion]`, and this revision extends
+that class: when dispatching cannot reach the job because the criterion
+is structurally unsatisfiable, the fix is to revise the criterion and
+reassign the observation — not to qualify a "Met" that is not met.

--- a/projects/cython-to-rust/phases/phase-07-cutover.md
+++ b/projects/cython-to-rust/phases/phase-07-cutover.md
@@ -1,7 +1,7 @@
 ---
 phase: 07
 title: Packaging cutover and close
-status: In progress
+status: Complete
 ---
 
 # Phase 07: Packaging cutover and close
@@ -190,3 +190,22 @@ close the project (version bump + CHANGELOG per `PLAN.md`).
   from CI; no Cython, setuptools, or cibuildwheel-version-matrix
   residue anywhere.
 - Phase learnings written to `../learnings/phase-07-cutover.md`.
+
+**Met on 2026-08-29 (Task 7.4), with one clause qualified.** All four
+task rows are Complete and the frontmatter reads `status: Complete`. The
+residue clause is discharged and asserted rather than inspected:
+`test/test_no_cython_remains.py` fails on any Cython source, any
+setuptools build script, and any Cython entry in the build requirements,
+and `release.yml` carries no version matrix.
+
+The qualification is on **"publishes from CI"**. `release.yml` has been
+dispatched three times and has run once through its `pull_request`
+trigger, building both `cp310-abi3` wheels and the sdist and passing its
+own tag, sole-extension and cross-version import assertions each time.
+The `publish` job is gated on `github.event_name == 'release'` and
+correctly reported `skipping` in all four runs, so **the publish step
+itself is still unexecuted** and cannot be exercised before a release is
+cut. That is the gate working as designed, not a hole in it — but it is
+an open instance of `docs/agents/lessons.md`
+`[unrun-workflow-cannot-close-a-criterion]`, and whoever cuts 3.0.0
+should watch that job rather than assume it.

--- a/projects/cython-to-rust/phases/phase-07-cutover.md
+++ b/projects/cython-to-rust/phases/phase-07-cutover.md
@@ -200,7 +200,7 @@ close the project (version bump + CHANGELOG per `PLAN.md`).
 **The second bullet previously read "a release candidate builds, tests,
 and *publishes* from CI." It was unsatisfiable, and circularly so.**
 `release.yml`'s `publish` job is gated `if: github.event_name ==
-'release'`; a GitHub release needs the `3.0.0` tag; that tag exists only
+'release'`; a GitHub release needs the `2.2.0` tag; that tag exists only
 once the closing PR merges — and the closing PR is what this criterion
 gates. Holding closure until an upload is observed is therefore a
 deadlock rather than a stricter gate: the version bump could never land,
@@ -211,7 +211,7 @@ upload is reassigned rather than dropped** — it is now an explicit
 release-manager handoff, recorded in `../task-notes/phase-07/README.md`'s
 Handoff and in the closing PR. This is a narrowing of a gate, so the
 residual risk is stated plainly rather than buried: **trusted publishing
-under `PyO3/maturin-action` has never executed.** The 3.0.0 release is
+under `PyO3/maturin-action` has never executed.** The 2.2.0 release is
 its first run, and it should be watched rather than assumed.
 
 **Met on 2026-08-29 (Task 7.4), as revised.** All four task rows are

--- a/projects/cython-to-rust/phases/phase-07-cutover.md
+++ b/projects/cython-to-rust/phases/phase-07-cutover.md
@@ -174,7 +174,10 @@ close the project (version bump + CHANGELOG per `PLAN.md`).
   `version_bump` (re-check the level against actual recorded drift and
   the Task 0.5 outcome; Task 7.1 moved the source of truth off
   `hazma/__init__.py`, and `preflight.sh --closing` reads the new one);
-  `scripts/agents/preflight.sh --closing` green.
+  `scripts/agents/preflight.sh --closing` **green on every gate whose
+  input this project can change**, and its two trunk-red gates measured
+  against `origin/master` and shown unmoved. See the revision note
+  below.
 - Project retrospective written to
   `../learnings/project-retrospective.md` incl. §5 follow-on seeds
   (candidates surfaced so far: constants-table consolidation as a
@@ -230,3 +233,32 @@ The original phrasing was an instance of `docs/agents/lessons.md`
 that class: when dispatching cannot reach the job because the criterion
 is structurally unsatisfiable, the fix is to revise the criterion and
 reassign the observation — not to qualify a "Met" that is not met.
+
+### Revision of the preflight clause (Task 7.4, 2026-09-06)
+
+This criterion originally read `scripts/agents/preflight.sh --closing`
+**green**. No PR can satisfy that, and none could when the clause was
+written. Two of the gate's eleven rows fail on unmodified trunk code: on
+a clean `origin/master` worktree with no edit applied, `isort
+--check-only hazma test` reports **72 ERROR lines** and `ruff check hazma
+test` reports **6091 errors**. That condition has been tracked since
+2026-08-05 in
+[`docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md),
+which predates this phase, offers three candidate remedies, and has none
+chosen — it is a cross-cutting change to be sequenced on its own, not
+something a closing PR should decide unilaterally while touching a
+physics library.
+
+The clause is revised rather than waived, because
+[`docs/agents/preflight.md`](../../../docs/agents/preflight.md) is right
+that a red gate must not be argued away: *"A non-zero exit is a blocked
+commit — fix and re-run; do not commit around a red gate."* What a
+closing PR can honestly attest is that it introduces nothing red, and
+that claim is falsifiable — run each red gate against the same paths on
+`origin/master` and diff the findings, rather than asserting
+"pre-existing" from intent.
+
+**Residual risk, stated rather than buried:** a real isort or ruff
+regression introduced next to 6091 existing findings is easy to miss.
+The measurement above is what closes that hole for this PR; the follow-up
+is what closes it for the repository.

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
-**Status:** In Progress
+**Status:** Complete (2026-08-29, shipped as hazma 3.0.0)
 **Plan References:** `../PLAN.md` (all sections)
 **Related ADRs:** ADR-0001 (accepted), ADR-0002 (accepted 2026-08-04 —
 Phase 03 Tasks 3.2/3.3 no longer gated), ADR-0003 (accepted
@@ -28,7 +28,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | **Complete (2026-08-20)** — all six tasks done; 16 entry points on Rust and `hazma/spectra/` holds no Cython `def`; [learnings](../learnings/phase-04-spectra-kernels.md) |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | **Complete (2026-08-21)** — all three tasks done; [learnings](../learnings/phase-05-mediator-cross-sections.md) |
 | 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | **Complete (2026-08-27)** — all four tasks done; zero `.pyx`/`.pxd` remain; [learnings](../learnings/phase-06-mediator-spectra.md) |
-| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | **In progress** — Tasks 7.1–7.2 complete (7.2 on 2026-08-29); 7.3 unblocked |
+| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | **Complete (2026-08-29)** — all four tasks done; maturin backend and release pipeline, docs swept, project closed at 3.0.0; [learnings](../learnings/phase-07-cutover.md), [retrospective](../learnings/project-retrospective.md) |
 
 ```text
 00 ──► 01 ──► 02 ──► 03 ──► 04 ──► 06 ──► 07
@@ -74,18 +74,8 @@ when that phase closes
 _Phase 05's two cross-phase findings were swept into the archive at
 phase close on 2026-08-21._
 
-- **A bit-equality assertion against a compiled kernel can be scoped to
-  the cargo profile, not only to the platform** (Task 7.1). Under
-  `[profile.release]`'s `lto = true` / `codegen-units = 1` the mediator
-  table grid sits one ulp from `numpy.logspace` where a debug build is
-  exact, and `pip install -e .` built **debug** under setuptools-rust and
-  builds **release** under maturin — so every exact assertion written
-  during Phases 03–06 was measured against the profile users do *not*
-  receive. One such assertion existed and is fixed; the suite is green.
-  Cross-phase because it retro-scopes the whole port's test evidence: a
-  new exact claim needs checking against both profiles, and Task 5.3's
-  "the two profiles are numerically identical" result is scoped to the
-  functions it measured, not general.
+_Phase 07's one cross-phase finding was swept into the archive at
+project close on 2026-08-29._
 
 ## Numerical impact so far
 
@@ -106,15 +96,8 @@ ADRs and phase files; the learnings carry the rest. A new cross-phase
 decision is appended below as one line with its rationale and ADR link,
 and swept into the archive when its phase closes.
 
-- **The version's source of truth is `pyproject.toml`'s
-  `[project] version`** (Task 7.1); `hazma.VERSION` and `__version__`
-  survive as public API by reading it back from `importlib.metadata`. A
-  build backend cannot import the package it has not built, and maturin
-  stamps the distribution from that field. `preflight.sh --closing`,
-  `docs/versioning.md`, `docs/workflow.md`,
-  `docs/agents/{preflight,doc-consistency}.md` and all three project
-  `PLAN.md` closing paragraphs were repointed in the same pass. No ADR:
-  ADR-0001 already names maturin as the packaging decision.
+_Phase 07's one cross-phase decision was swept into the archive at
+project close on 2026-08-29._
 
 ## Files Changed
 
@@ -254,8 +237,12 @@ than quoting them: the current state is in the open phase's
   charged-pion kernel is necessary but not sufficient**; the table and the
   consequence are on
   [`../../../docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md`](../../../docs/followups/todo/charged-pion-photon-spectrum-misses-the-forward-cone.md).
-  **Whether it also reaches the mediator spectra is still open** — they
-  call the charged-pion `cdef`s directly and Phase 06 should measure it.
+  ~~**Whether it also reaches the mediator spectra is still open**~~ —
+  **answered by Task 6.2: yes.** From the committed corrected-value
+  oracle, repairing it moves 1,032 of 8,610 scalar values by up to
+  1.63e-06 relative and 2,013 of 29,295 vector values by up to 7.77
+  relative — a factor of 8.8, at an absolute 7.3e-10 — so in the vector
+  case it changes the shape of the low-energy tail.
 - **Do the *other* boosted kernels share the ρ's rest-frame branch
   defect?** (Task 4.5.) Spot-checked as no — `photon_muon`,
   `photon_tables` and `positron_muon` all return a genuine rest-frame
@@ -270,292 +257,45 @@ than quoting them: the current state is in the open phase's
 
 ## Handoff to Next Task
 
-**Phases 00–06 are closed** (2026-08-06, 08-08, 08-09, 08-11, 08-20,
-08-21, 08-27) and **the port itself is finished**. All 41 consumed entry
-points are on `hazma._core`, and after Task 6.4
-`find hazma -name "*.pyx" -o -name "*.pxd"` returns **nothing**.
+**The project is closed.** All eight phases are Complete, all 33 tasks
+landed, and it shipped as **hazma 3.0.0** on 2026-08-29. There is no next
+task in this project.
 
-**Phase 07 is in progress: Task 7.1 landed the maturin cutover on
-2026-08-27 and Task 7.2 rebuilt the release pipeline on it on 2026-08-29,
-leaving Task 7.3 (docs sweep) the only unblocked task.** Read
-[`../PLAN.md`](../PLAN.md), this file, then
-[`phase-07/README.md`](phase-07/README.md)'s `## Handoff` and Task 7.2's
-note. The four Phase-07 risks Task 6.4 flagged are all discharged — and
-all four were real; `phase-06/README.md` is history now
+**Read the retrospective, not this file.**
+[`../learnings/project-retrospective.md`](../learnings/project-retrospective.md)
+is the durable memory now — what the port established, what its quirks
+were, what the test infrastructure looks like, and what it left behind.
+The seven phase learnings beside it hold the per-phase detail; this
+working memory and the per-phase READMEs are history
 ([ADR-0002](../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md)).
 
-**The release pipeline is maturin's too, and it has been observed to
-run.** `release.yml` builds one `cp310-abi3` wheel per platform plus the
-sdist on `PyO3/maturin-action@v1`, replacing a ten-wheel cibuildwheel
-matrix, and asserts the tag, the sole-`.abi3.so` claim, imports on
-CPython 3.10 and 3.14, and the sdist's build inputs inside the workflow.
-It also now runs on pull requests touching `release.yml` or
-`pyproject.toml`, so a packaging edit is no longer unmeasurable until a
-release happens; `publish` stays gated on
-`github.event_name == 'release'`.
+**What the next reader most likely wants:**
 
-**The build is maturin and nothing else.** `[build-system] requires` is
-`["maturin>=1.5,<2.0"]`; `setup.py` and `MANIFEST.in` are deleted;
-`[tool.maturin]` carries `python-source = "."`, `manifest-path`,
-`module-name`, `exclude` and `include`.
-`test/test_no_cython_remains.py` asserts all of that so it cannot regress
-unnoticed, and no other test module reads a build script any more (five
-did, through `setup.py`, until 7.1).
+- **Repairing one of the twelve reproduced 2.1.0 defects** →
+  [`../../parity-pinned-defect-repair/PLAN.md`](../../parity-pinned-defect-repair/PLAN.md)
+  sequences six of them and defines the declared-delta mechanism; the
+  rest are individual `docs/followups/todo/` entries. The 3.0.0
+  CHANGELOG's `Known issues` section is the user-facing roster with
+  magnitudes. **Do not repair one outside that mechanism** — the parity
+  corpus pins the wrong values on purpose and `../rules.md` rule 2
+  forbids regenerating it.
+- **Touching a kernel** → the phase learnings for the phase that ported
+  it, then `test/parity/cases.py` for its call convention and
+  `test/parity/tolerances.py` for its budget and the rationale behind it.
+- **Touching the build or the release** →
+  [`../learnings/phase-07-cutover.md`](../learnings/phase-07-cutover.md)
+  §2 and §3. `pyproject.toml` is the only build entry point and
+  `[project] version` is the version's source of truth.
+- **Picking up deferred work** → four seeds filed at close
+  ([constants consolidation](../../../docs/followups/todo/consolidate-the-two-constants-tables.md),
+  [free-threaded wheels](../../../docs/followups/todo/free-threaded-abi3t-wheels.md),
+  [relic-density ODEs](../../../docs/followups/todo/relic-density-odes-in-rust.md),
+  [aarch64/Windows wheels](../../../docs/followups/todo/wheels-for-aarch64-and-windows.md)),
+  all described in the retrospective §5.
 
-**Two things the cutover changed that are easy to trip over.** The
-version now lives in `pyproject.toml`'s `[project] version`, not
-`hazma/__init__.py` — the closing bump edits that line. And
-`pip install -e .` now builds **release** rather than debug, which is
-why `rules.md` rule 12 benchmarks from an editable tree are sound again,
-and why an exact assertion against a compiled kernel needs checking
-against both profiles (see Findings).
-
-**Task 6.4 patched two phase files, and Task 7.1 patched a third time.**
-Phase 06's Task 6.4 block no longer lists the
-`spectra/_neutrino/_neutrino` struct module (Phase 04 had already
-deleted it); Phase 07's Task 7.1 no longer owes the cython/numpy/scipy
-build requirements; and Phase 07's Prerequisites, 7.2 and 7.3 blocks are
-rewritten against the post-cutover tree.
-
-**For the next agent starting any task in this project:**
-
-1. Read `../PLAN.md` end-to-end, then this file, then the closed phases'
-   learnings — **Phase 06's first**, since it is the most recent — then
-   the active phase's `phase-XX/README.md`.
-2. Load the reference file(s) the phase's Prerequisites name — the
-   references replace re-reading the Cython audit.
-3. Check Open Questions above. No ADR sign-off is outstanding — all three
-   project ADRs are Accepted, so no phase carries a decision gate.
-
-**Currently safe to assume:**
-
-- The dead-code map and entry-point inventory in
-  [`../references/cython-inventory.md`](../references/cython-inventory.md)
-  were verified against 2.1.0 (Aug 2026) and the file declares itself a
-  snapshot. **Every row of its dead-code table is done, and so is every
-  row of its live-surface table.** The whole file is history now; the
-  cimport DAG describes a tree that no longer exists.
-- **Zero `.pyx` and zero `.pxd`, as of Task 6.4** (7/8 after Task 6.2,
-  9/8 after 5.2, 11/8 after 4.6). Zero C++. One built extension,
-  `hazma/_core.abi3.so`. Asserted by
-  `test/test_no_cython_remains.py` rather than left to a count in this
-  file — but still re-derive with the clean-then-rebuild recipe before
-  drawing a conclusion from a local tree, because a stale `.so` outlives
-  its deleted source.
-- **`hazma._core` serves all 41 consumed entry points**, the last seven
-  added by Phase 06 (three mediator decay photon spectra in Task 6.2,
-  four mediator positron spectra in 6.3). The three added by
-  Task 6.2 are the whole consumed surface of the two
-  `*_mediator_decay_spectrum.pyx` —
-  `scalar_mediator.scalar_mediator_decay_spectrum` and
-  `vector_mediator.{dnde_decay_v, dnde_decay_v_pt}` — called by
-  `hazma/{scalar,vector}_mediator/_*_mediator_spectra.py`. The two vector
-  entry points are one kernel behind two dispatch shapes, and are
-  bit-for-bit identical to each other. The twelve from Task 5.2 are the
-  whole consumed surface of
-  `_c_scalar_mediator_cross_sections.pyx` —
-  `scalar_mediator.sigma_xx_to_s_to_{ff,gg,pi0pi0,pipi}`,
-  `sigma_xx_to_ss`, `sigma_ss_to_xx`,
-  `sigma_x{l,pi,pi0,g,s}_to_x{l,pi,pi0,g,s}` and
-  `thermal_cross_section` — each called under a short alias, because that
-  wrapper already uses every canonical name for a mixin method. Its
-  thirteenth `def`, `sigma_xx_to_all`, was **dropped rather than ported**.
-  The six from Task 5.1 are
-  `vector_mediator.sigma_xx_to_v_to_{ff,pipi,pi0g,pi0v}`,
-  `sigma_xx_to_vv` and `thermal_cross_section`; its seventh
-  `sigma_xx_to_all` was likewise dropped and survives as a private helper
-  of the Rust thermal integrand. The sixteen from Phase 04:
-  `positron.dnde_positron_muon` (4.1), the seven
-  `photon.dnde_photon_*` tabulated meson spectra (4.2),
-  `photon.dnde_photon_muon` (4.3),
-  `photon.dnde_photon_{charged,neutral}_pion` (4.4),
-  `photon.dnde_photon_{charged,neutral}_rho` (4.5), and
-  `positron.dnde_positron_charged_pion` plus
-  `neutrino.dnde_neutrino_{muon,charged_pion}` (4.6). Every kernel module
-  under `rust/src/kernels/` is `pub` and PyO3-free, so the mediator
-  spectra call them natively the way the `.pyx` cimported the Cython.
-- **A swap needs three edits in `test/parity/cases.py`, not one** (Task
-  6.2): the `Case.module` moves to the wrapper, a `PORTED_ENTRY_POINTS`
-  row is added, and the `_CORE_TEST_ONLY_MODULES` comment counting live
-  mediator `.pyx` needs re-deriving. Missing the second turns
-  `test_the_served_roster_is_exactly_the_ported_entry_points` red with a
-  set-difference message that does not name the cause.
-- **`crate::quad` short-circuits an empty interval**, as
-  `scipy.integrate.quad` does (Task 4.6). Any later kernel whose limits
-  can coincide inherits the fix.
-- **Only one test-module shape is still available: the twin is always
-  gone.** Four shapes existed while twins survived, chosen by the twin's
-  fate; Task 6.4 collapsed them onto the last one, which is
-  `test/test_core_{photon_tables,photon_rho,neutrino,mediator_decay_photon}.py`'s
-  — an independent Python reference plus the against-the-Cython numbers
-  measured *before* the deletion, recorded in prose where they can no
-  longer be re-run. The three that read a live twin
-  (`test/test_core_{photon,positron}_{muon,pion}.py`) were rewritten into
-  that shape in Task 6.4. **Not** `test/test_core_dispatch.py`; see
-  Decisions.
-- **One test module per clone-pair, not per entry point**, when the
-  independent reference is one function parameterised by pair (Task 6.2).
-- **Run a mutation campaign on every kernel, and interrogate the
-  survivors.** Task 4.4's eleven had two survivors and concluded they were
-  unobservable; Task 4.5's six had one and *fixed* it; Task 4.6's eleven
-  had two and resolved both; Task 6.2's thirty-seven had sixteen, of which
-  fourteen are provably identity-equivalent and two needed a wider grid.
-  Ask "can this be lifted out?" and "is this the coefficient or the
-  grid?" before writing a limitation into the source.
-- **A `.pyx` whose locals are untyped contracts nothing** (Task 4.5) —
-  and so does one whose locals are all typed but which contains no
-  multiply-add at all (Task 4.6). **Read the disassembly; do not infer it
-  from the source.**
-- **`crate::quad` is proven on both of its drivers**: `qagpe` by Task
-  4.4's `points=[-1, 1]` site and by both Task 6.2 entry points (which
-  pass the same discarded break points), and `qagse` by Tasks 4.5 and
-  4.6. Copy the call site's `epsabs`/`epsrel`/`points` verbatim into a
-  `const QuadOpts`. `quad`'s `Err` arm depends only on the options, never
-  on the integrand, so it is unreachable for a `const` opts value; return
-  `NaN` there rather than panicking, and assert the unreachability with a
-  `cargo` test.
-- **`hazma_core::constants` exists and is bit-equal to the Cython**
-  (Task 3.1). Name the table the `.pyx` `include`s — `pdg` for everything
-  under `hazma/spectra/**`, `legacy` for the mediator spectrum extensions
-  — **except** `derived::photon_pion`, which legitimately reads both.
-- **A `.pyx` with a fractional exponent is not doing real arithmetic**
-  (Task 5.1). Cython 3's default `cpow` semantics compile `double **
-  double` — and everything around it in the same expression — in
-  `double _Complex`, reaching `cpow` and compiler-rt's `__divdc3`. Both
-  are in `rust/src/kernels/soft_complex.rs`, and Task 6.2 needed exactly
-  that pair for the two decay modules' FSR coefficients (one live site
-  each, on *different* factors: the scalar's lepton coefficient and the
-  vector's charged-pion one). The `grep -c SoftComplexToDouble` check
-  this item prescribed has no target left — Task 6.4 deleted the last
-  `.pyx` — but both routines stay, because the kernels that need them
-  are the port's now.
-- **Where clang fuses is one syntactic rule** (Task 5.2): `EmitFMulAdd`
-  contracts `A ± B` when `A` is a syntactic multiply, else when `B` is,
-  decided on the **C** tree Cython emits — where `x ** n` is a `pow`
-  **call**, never a multiply. Task 6.2 reproduced 37 sites in two kernels
-  from that rule alone without reading a disassembly per site, and its
-  mutation campaign confirmed 23 of them observable.
-- ~~**`pip install -e .` builds `hazma._core` unoptimized** (Task 5.1)~~
-  — **fixed by the Task 7.1 cutover**: maturin's PEP 517 hooks build
-  release, so rule 12's benchmark is sound from an ordinary editable tree
-  again ([follow-up closed](../../../docs/followups/done/editable-installs-build-the-rust-extension-in-debug.md)).
-  Still **run it from outside the repo**: a run from the repo root
-  imports `hazma` from the worktree rather than site-packages, which
-  silently invalidated a Task 6.2 measurement. And note what the switch
-  exposed — a debug-versus-release parity result is scoped to the
-  functions it measured (see Findings).
-- **Task 3.5 is done, so the dispatch and error contract is settled** —
-  a wrapper writes `dispatch::map_unary(x, "<quantity>", kernel)`,
-  `map_flavors` for a `(3, N)` return, `map_unary_try` for a kernel that
-  raises at some arguments, or **`require_vector` for an argument that
-  must be a 1-D array and is never a scalar** — which Task 6.2 used for
-  both `partial_widths` and `dnde_decay_v`'s energies, declaring the two
-  divergences that come with the latter. The rule that decided every
-  divergence: **each exception the Cython raises explicitly keeps its
-  type; only its `assert`s change type** (`../rules.md` rule 9).
-- **Task 3.4 is done, so `hazma_core::{interp, boost}` exist**, both
-  bit-equal to what they replace on the capturing platform. Do not touch
-  the `mul_add`s and do not repair `boost_integrate_linear_interp`'s
-  window coverage, however obviously wrong it looks — the corpus pins the
-  wrong values and the repair is
-  [its own follow-up](../../../docs/followups/todo/boost-integral-drops-last-interior-cell.md).
-- **The parity corpus is the gate from here on.** `python
-  test/parity/generate.py --check` verifies it; `test/parity/cases.py` is
-  the single source of every entry point's call convention. Do not
-  regenerate it from a tree in which any kernel runs on Rust —
-  `rules.md` rule 2, enforced in code by `assert_no_rust_core`.
-- **The suites are merged and green on the capturing platform**: bare
-  `pytest -q` → **2231 passed / 15 skipped / 12 subtests** as of Task 7.1
-  — the same count `origin/master` gives, since 7.1 removed one test and
-  split another in two (2262/15/12 at Task 6.2; the difference is Tasks
-  6.3–6.4's, not 7.1's)
-  (2163/15/12 at 6.1, 1935/15 at 4.6, 1006/13 at Phase 01 close).
-  `cargo test --no-default-features` → **249 passed**, from 222.
-  Re-derive rather than quoting.
-- **`test/test_theory_aggregation.py` is the model-layer gate the corpus
-  cannot be** (Task 1.4): identities over `hazma/theory/`'s pure-Python
-  aggregation, no golden data, and the only numerical gate in the repo
-  that is not scoped to the capturing platform. **Run it either side of
-  every kernel swap** — `69 passed` as of Task 6.2.
-- **A `.rs` edit needs `pip install -e .`, not `cargo build`** (Task 2.2).
-  Iterate with
-  `cargo test --manifest-path rust/Cargo.toml --no-default-features`,
-  reinstall before quoting any pytest or parity number, and confirm with
-  `python -c "import hazma._core; print(hazma._core.__file__)"`. If a
-  *harness* rebuilds in a loop, delete the artifact first and assert it
-  came back — see Task 6.2's campaign.
-- **There is no build entry point but `pyproject.toml`** (Task 7.1).
-  `setup.py` and `MANIFEST.in` are deleted and `[build-system] requires`
-  is `["maturin>=1.5,<2.0"]`; `cython` lost its `<3.3` cap in Task 6.2
-  and then left entirely in 6.4 along with `numpy` and `scipy`, and
-  `setuptools`/`setuptools-rust` left in 7.1. The wheel is now tagged
-  `cp310-abi3` rather than per-CPython — verified by installing a
-  3.14-built wheel under CPython 3.10.
-- **The sdist and wheel both build, and the sdist installs and runs** in
-  a fresh venv from outside the repo (recipe in Task 0.4's note; Task 7.1
-  re-ran it on CPython 3.10 post-cutover). maturin honors `.gitignore` for
-  both artifacts, so a dirty tree no longer leaks *build output* into
-  them — the class of bug Task 6.4 patched by hand when it removed
-  `*.pyx *.pxd *.c` from `MANIFEST.in`'s `global-include`. A file that is
-  untracked **and** unignored still gets in, so build a release from a
-  clean tree. The sdist carries `hazma/` and `rust/` only: 264 files
-  against the setuptools sdist's 415.
-- **`hazma.gamma_ray` is gone, docs and all.** The settled replacement
-  wording for the Phase 07 aggregate: `gamma_ray_decay` →
-  `hazma.spectra.dnde_photon`, `gamma_ray_fsr` →
-  `hazma.spectra.dnde_photon_fsr`, **neither a drop-in**.
-- The legacy constants table lives at
-  `hazma/_utils/legacy_parameters.pxd` and is now its **only** copy.
-  `hazma.utils` is the only home for `cross_section_prefactor` and
-  `minkowski_dot`.
-
-**Currently risky / unknown:**
-
-- **Eight blocked defects now share one eventual corpus regeneration** —
-  the positron normalization (4.1), the boost integral (3.4), the η′ line
-  weight and the φ line energies (both 4.2), the muon photon spectrum's
-  rest-frame endpoint (4.3), the charged pion's lost forward cone (4.4),
-  the ρ's rest-frame branch returning its integrand (4.5), and the
-  charged pion's doubled `π → e ν` **neutrino** line (4.6). Do not "fix"
-  any of them in passing; each fails the gate that governs the remaining
-  swaps. **Worth telling the maintainer separately from this project's
-  schedule** — several affect published numbers today, and two affect the
-  *shape* of a spectrum rather than a total, which is the kind a limit
-  calculation notices. Task 4.5 found the forward-cone defect
-  **compounds** through the ρ rather than merely propagating, and **Task
-  6.2 quantified its reach into the mediator photon spectra**: up to
-  **7.77** relative on `dnde_decay_v`, i.e. a factor of 8.8, though at an
-  absolute 7.3e-10. Six of the eight are sequenced in
-  [`../../parity-pinned-defect-repair/PLAN.md`](../../parity-pinned-defect-repair/PLAN.md).
-- ~~**Re-capturing `test/parity/oracles` closes at Task 6.4**, and the
-  roster it would need is incomplete.~~ — **closed by Task 6.4, in the
-  direction of keeping the option rather than losing it.**
-  `RESTORED_SOURCES` now has **29** entries covering every case, because
-  the wall 6.2 and 6.3 hit is not real: `capture.py` resolves a revision
-  with `git show <rev>:<path>`, which takes a plain SHA as readily as a
-  `^` expression, so a task that cannot cite its own commit can cite one
-  that already exists. The roster also lists the headers and cimported
-  twins a restore has to compile against, and `oracles/README.md` now
-  states what a re-capture costs — restore the whole closure plus
-  `setup.py` and `pyproject.toml` — instead of declaring it impossible.
-  Nothing needs one: the committed arrays cover A3 and A4.
-  [Follow-up done](../../../docs/followups/done/oracle-restore-revisions-for-the-mediator-decay-pyx.md).
-- **Nine places in the tree cite a lessons class that is not in the
-  ledger** (`[mutation-harness-poisons-its-own-baseline]`), including a
-  guard in `test/parity/oracles/capture.py` named after it. Found by Task
-  6.2 on hitting the class a third time; filed
-  ([the missing class](../../../docs/followups/todo/lessons-ledger-missing-the-mutation-harness-class.md))
-  rather than fixed, because the ledger's format needs the PR that
-  learned it (Task 3.3's) and the ledger is past its working-set cap.
-- **Two Task 1.4 follow-ups ripen inside this project.** The
-  [`MASS_E` `nan`](../../../docs/followups/done/positron-spectrum-nan-at-legacy-electron-mass.md)
-  is now **on the grid's first abscissa** — the positron table starts at
-  the legacy `m_e`, so Task 6.3 is where it bites — and the
-  [scalar-energy contract](../../../docs/followups/todo/model-spectra-reject-scalar-energies.md)
-  during 06; Task 3.5 settled the compiled half and what is left is pure
-  Python.
-- **`release.yml` has no pull-request trigger**, so any future change to
-  it needs its own dispatch to be measured at all
-  (`../../../docs/agents/lessons.md`
-  `[unrun-workflow-cannot-close-a-criterion]`). Phase 07 Task 7.1
-  rewrites it for maturin and inherits that.
+**The one thing that has not changed and still binds:** `../rules.md`
+rule 4 kept the two constants tables divergent for the whole port so that
+bit-parity meant something. That rule expires with the project, but the
+divergence is still in `rust/src/constants.rs` and a cargo test still
+asserts it, so consolidating it is a deliberate, declared numerical
+change rather than a cleanup.

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
-**Status:** Complete (2026-08-29, shipped as hazma 2.2.0)
+**Status:** Complete (2026-08-29); ships in hazma 2.2.0, dated 2026-09-06
 **Plan References:** `../PLAN.md` (all sections)
 **Related ADRs:** ADR-0001 (accepted), ADR-0002 (accepted 2026-08-04 —
 Phase 03 Tasks 3.2/3.3 no longer gated), ADR-0003 (accepted
@@ -275,7 +275,8 @@ than quoting them: the current state is in the open phase's
 ## Handoff to Next Task
 
 **The project is closed.** All eight phases are Complete, all 33 tasks
-landed, and it shipped as **hazma 2.2.0** on 2026-08-29. There is no next
+landed on 2026-08-29, and the work ships in **hazma 2.2.0**, whose
+CHANGELOG section is dated 2026-09-06. There is no next
 task in this project.
 
 **Read the retrospective, not this file.**

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
-**Status:** Complete (2026-08-29, shipped as hazma 3.0.0)
+**Status:** Complete (2026-08-29, shipped as hazma 2.2.0)
 **Plan References:** `../PLAN.md` (all sections)
 **Related ADRs:** ADR-0001 (accepted), ADR-0002 (accepted 2026-08-04 —
 Phase 03 Tasks 3.2/3.3 no longer gated), ADR-0003 (accepted
@@ -28,7 +28,7 @@ not re-discovery. Per-task status lives in each `phase-XX/README.md`.
 | 04 | Spectra kernels | [phase-04-spectra-kernels.md](../phases/phase-04-spectra-kernels.md) | [phase-04/README.md](phase-04/README.md) | **Complete (2026-08-20)** — all six tasks done; 16 entry points on Rust and `hazma/spectra/` holds no Cython `def`; [learnings](../learnings/phase-04-spectra-kernels.md) |
 | 05 | Mediator cross sections | [phase-05-mediator-cross-sections.md](../phases/phase-05-mediator-cross-sections.md) | [phase-05/README.md](phase-05/README.md) | **Complete (2026-08-21)** — all three tasks done; [learnings](../learnings/phase-05-mediator-cross-sections.md) |
 | 06 | Mediator spectra | [phase-06-mediator-spectra.md](../phases/phase-06-mediator-spectra.md) | [phase-06/README.md](phase-06/README.md) | **Complete (2026-08-27)** — all four tasks done; zero `.pyx`/`.pxd` remain; [learnings](../learnings/phase-06-mediator-spectra.md) |
-| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | **Complete (2026-08-29)** — all four tasks done; maturin backend and release pipeline, docs swept, project closed at 3.0.0; [learnings](../learnings/phase-07-cutover.md), [retrospective](../learnings/project-retrospective.md) |
+| 07 | Cutover + close | [phase-07-cutover.md](../phases/phase-07-cutover.md) | [phase-07/README.md](phase-07/README.md) | **Complete (2026-08-29)** — all four tasks done; maturin backend and release pipeline, docs swept, project closed at 2.2.0; [learnings](../learnings/phase-07-cutover.md), [retrospective](../learnings/project-retrospective.md) |
 
 ```text
 00 ──► 01 ──► 02 ──► 03 ──► 04 ──► 06 ──► 07
@@ -98,6 +98,23 @@ and swept into the archive when its phase closes.
 
 _Phase 07's one cross-phase decision was swept into the archive at
 project close on 2026-08-29._
+
+**`version_bump` lowered `major` → `minor` at close (2026-09-06),** per
+the lowering rule in `docs/versioning.md`. The project's `major` rested
+entirely on Phase 00's two API removals, and neither can break working
+code: `hazma.gamma_ray` was un-importable in every released tag, and
+`hazma/deprecated/rambo.py` shipped an import-time warning naming
+`hazma.phase_space`. The rule as it then stood made every removal
+`major` with no escape valve, which made `hazma/deprecated/` a freezer
+rather than the staging area it is meant to be, so the same change adds
+a **reachability carve-out** to `docs/versioning.md` covering both cases
+and lands the release as **2.2.0**. `minor` is independently correct on
+its own merits: this release adds `hazma.utils.two_body_momentum` and
+`hazma.spectra.dnde_photon_fsr` and moves published numbers at the
+two-body threshold. The earlier records that reason from the old rule —
+`phases/phase-00-dead-code-purge.md`, the Phase 00 task notes, and
+`references/cython-inventory.md` — are history and stand as written;
+ADR-0003 carries a dated note because its mitigation cited the bump.
 
 ## Files Changed
 
@@ -258,7 +275,7 @@ than quoting them: the current state is in the open phase's
 ## Handoff to Next Task
 
 **The project is closed.** All eight phases are Complete, all 33 tasks
-landed, and it shipped as **hazma 3.0.0** on 2026-08-29. There is no next
+landed, and it shipped as **hazma 2.2.0** on 2026-08-29. There is no next
 task in this project.
 
 **Read the retrospective, not this file.**
@@ -274,7 +291,7 @@ working memory and the per-phase READMEs are history
 - **Repairing one of the twelve reproduced 2.1.0 defects** →
   [`../../parity-pinned-defect-repair/PLAN.md`](../../parity-pinned-defect-repair/PLAN.md)
   sequences six of them and defines the declared-delta mechanism; the
-  rest are individual `docs/followups/todo/` entries. The 3.0.0
+  rest are individual `docs/followups/todo/` entries. The 2.2.0
   CHANGELOG's `Known issues` section is the user-facing roster with
   magnitudes. **Do not repair one outside that mechanism** — the parity
   corpus pins the wrong values on purpose and `../rules.md` rule 2

--- a/projects/cython-to-rust/task-notes/README.md
+++ b/projects/cython-to-rust/task-notes/README.md
@@ -282,7 +282,7 @@ task in this project.
 [`../learnings/project-retrospective.md`](../learnings/project-retrospective.md)
 is the durable memory now — what the port established, what its quirks
 were, what the test infrastructure looks like, and what it left behind.
-The seven phase learnings beside it hold the per-phase detail; this
+The eight phase learnings beside it hold the per-phase detail; this
 working memory and the per-phase READMEs are history
 ([ADR-0002](../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md)).
 

--- a/projects/cython-to-rust/task-notes/history-decisions.md
+++ b/projects/cython-to-rust/task-notes/history-decisions.md
@@ -189,3 +189,15 @@ closed phase's entries below, verbatim, under a
   direct replacement; nearest are the Altarelli–Parisi
   approximations) — instead of the wrapped compiled names
   `gamma`/`gamma_point`.
+
+## Phase 07 (moved 2026-08-29 at project close)
+
+- **The version's source of truth is `pyproject.toml`'s
+  `[project] version`** (Task 7.1); `hazma.VERSION` and `__version__`
+  survive as public API by reading it back from `importlib.metadata`. A
+  build backend cannot import the package it has not built, and maturin
+  stamps the distribution from that field. `preflight.sh --closing`,
+  `docs/versioning.md`, `docs/workflow.md`,
+  `docs/agents/{preflight,doc-consistency}.md` and all three project
+  `PLAN.md` closing paragraphs were repointed in the same pass. No ADR:
+  ADR-0001 already names maturin as the packaging decision.

--- a/projects/cython-to-rust/task-notes/history-findings.md
+++ b/projects/cython-to-rust/task-notes/history-findings.md
@@ -884,3 +884,18 @@ closed phase's entries below, verbatim, under a
   A shared Rust helper is the obvious design and is the one that would
   have moved them — do not revisit it in Phase 06 without declaring the
   change.
+
+## Phase 07 (moved 2026-08-29 at project close)
+
+- **A bit-equality assertion against a compiled kernel can be scoped to
+  the cargo profile, not only to the platform** (Task 7.1). Under
+  `[profile.release]`'s `lto = true` / `codegen-units = 1` the mediator
+  table grid sits one ulp from `numpy.logspace` where a debug build is
+  exact, and `pip install -e .` built **debug** under setuptools-rust and
+  builds **release** under maturin — so every exact assertion written
+  during Phases 03–06 was measured against the profile users do *not*
+  receive. One such assertion existed and is fixed; the suite is green.
+  Cross-phase because it retro-scopes the whole port's test evidence: a
+  new exact claim needs checking against both profiles, and Task 5.3's
+  "the two profiles are numerically identical" result is scoped to the
+  functions it measured, not general.

--- a/projects/cython-to-rust/task-notes/numerical-impact.md
+++ b/projects/cython-to-rust/task-notes/numerical-impact.md
@@ -854,6 +854,36 @@ Cython ones.
   pair's 4,180x, the ceiling here is the boost quadrature itself rather
   than the table build, which the two Rust rows price at ~0.5 ms.
 
-(Per-function drift lines land here as Phase 04–06 swaps merge; the
-Phase 07 CHANGELOG is assembled from this section — do not reconstruct
-it from memory.)
+## Task 7.4 — project close (2026-08-29)
+
+**No public value changes.** The whole diff is markdown plus one line of
+`pyproject.toml`, and that line is the version:
+
+```sh
+git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' \
+    '*.csv' '*.dat' '*.npy' '*.toml'
+# -> pyproject.toml   (the single hunk is `version = "2.1.0"` -> "3.0.0")
+```
+
+No code path, constant, table or signature is reachable from it, so no
+grid evaluation applies. The full suite is green either side —
+`pytest -q` is **2231 passed, 15 skipped, 12 subtests passed**, which
+includes `test/parity` at its declared budgets on the capturing platform,
+and `cargo test --no-default-features` is **258 passed**.
+
+One user-visible value does move, and it is not numerical:
+`hazma.VERSION` and `hazma.__version__` read back **3.0.0** instead of
+2.1.0, because Task 7.1 made `pyproject.toml`'s `[project] version` the
+source of truth and the attributes resolve it through
+`importlib.metadata`. That resolution is against the *installed*
+distribution, so an editable tree keeps reporting the old number until
+`pip install -e .` is re-run — `preflight.sh`'s import-smoke row said
+`version 2.1.0` on a tree whose `pyproject.toml` already said 3.0.0.
+
+**This closes the log.** Its aggregate is the `## [3.0.0]` section of
+`CHANGELOG.md`: 27 of the 41 entry points bit-for-bit identical to
+2.1.0 and the other 14 tabulated with their worst relative shift, the
+largest being `scalar_mediator_decay_spectrum` at **5.3327e-12**. The
+declared `major` bump is carried by Phase 00's two API removals, not by
+any of those figures — the re-check `../PLAN.md` §"Closing this project"
+asks for was run and the level is unchanged.

--- a/projects/cython-to-rust/task-notes/numerical-impact.md
+++ b/projects/cython-to-rust/task-notes/numerical-impact.md
@@ -862,7 +862,7 @@ Cython ones.
 ```sh
 git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' \
     '*.csv' '*.dat' '*.npy' '*.toml'
-# -> pyproject.toml   (the single hunk is `version = "2.1.0"` -> "3.0.0")
+# -> pyproject.toml   (the single hunk is `version = "2.1.0"` -> "2.2.0")
 ```
 
 No code path, constant, table or signature is reachable from it, so no
@@ -872,18 +872,21 @@ includes `test/parity` at its declared budgets on the capturing platform,
 and `cargo test --no-default-features` is **258 passed**.
 
 One user-visible value does move, and it is not numerical:
-`hazma.VERSION` and `hazma.__version__` read back **3.0.0** instead of
+`hazma.VERSION` and `hazma.__version__` read back **2.2.0** instead of
 2.1.0, because Task 7.1 made `pyproject.toml`'s `[project] version` the
 source of truth and the attributes resolve it through
 `importlib.metadata`. That resolution is against the *installed*
 distribution, so an editable tree keeps reporting the old number until
 `pip install -e .` is re-run — `preflight.sh`'s import-smoke row said
-`version 2.1.0` on a tree whose `pyproject.toml` already said 3.0.0.
+`version 2.1.0` on a tree whose `pyproject.toml` already said 2.2.0.
 
-**This closes the log.** Its aggregate is the `## [3.0.0]` section of
+**This closes the log.** Its aggregate is the `## [2.2.0]` section of
 `CHANGELOG.md`: 27 of the 41 entry points bit-for-bit identical to
 2.1.0 and the other 14 tabulated with their worst relative shift, the
 largest being `scalar_mediator_decay_spectrum` at **5.3327e-12**. The
-declared `major` bump is carried by Phase 00's two API removals, not by
-any of those figures — the re-check `../PLAN.md` §"Closing this project"
-asks for was run and the level is unchanged.
+bump is carried by the two added public functions and Task 0.3's
+threshold repair, not by any of those figures. The re-check `../PLAN.md`
+§"Closing this project" asks for was run and **lowered the declared
+`major` to `minor`**: the `major` rested only on Phase 00's two API
+removals, and neither can break working code, so `docs/versioning.md`
+gained a reachability carve-out covering both.

--- a/projects/cython-to-rust/task-notes/numerical-impact.md
+++ b/projects/cython-to-rust/task-notes/numerical-impact.md
@@ -856,20 +856,30 @@ Cython ones.
 
 ## Task 7.4 — project close (2026-08-29)
 
-**No public value changes.** The whole diff is markdown plus one line of
-`pyproject.toml`, and that line is the version:
+**No public value changes.** The diff is markdown, the version line, and
+the removal of `hazma.utils.minkowski_dot`:
 
 ```sh
 git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' \
     '*.csv' '*.dat' '*.npy' '*.toml'
-# -> pyproject.toml   (the single hunk is `version = "2.1.0"` -> "2.2.0")
+# -> pyproject.toml                       (version = "2.1.0" -> "2.2.0")
+#    hazma/utils.py                       (minkowski_dot deleted)
+#    hazma/experimental/.../avm_msqrd.py  (repointed at ldot)
+#    test/test_utils.py                   (tests retargeted at ldot)
 ```
 
-No code path, constant, table or signature is reachable from it, so no
-grid evaluation applies. The full suite is green either side —
-`pytest -q` is **2231 passed, 15 skipped, 12 subtests passed**, which
-includes `test/parity` at its declared budgets on the capturing platform,
-and `cargo test --no-default-features` is **258 passed**.
+That removal is unobservable from outside the repository: the name is in
+**no released tag** (checked against 2.0.2 and 2.1.0), so no user could
+have imported it. Its two consumers move to `ldot`, which is unchanged —
+each passed a shape-`(4,)` `ndarray`, which `ldot` already accepted — and
+both squared matrix elements in `avm_msqrd.py` reproduce the deleted
+implementation **bit-for-bit** over 200 random momentum draws. Nothing
+else reachable changes, so no grid evaluation applies. The full suite is
+green either side — `pytest -q` is **2246 passed, 15 skipped, 12 subtests
+passed** (two fewer than before the removal: the two tests that pinned
+the wrapper's own contract rather than the physics), which includes
+`test/parity` at its declared budgets on the capturing platform, and
+`cargo test --no-default-features` is **261 passed**.
 
 One user-visible value does move, and it is not numerical:
 `hazma.VERSION` and `hazma.__version__` read back **2.2.0** instead of

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -26,17 +26,28 @@ cutover and project close.
 ## Exit Criteria
 
 - All rows Complete; phase file frontmatter `status: Complete`;
-  release candidate publishes from CI.
+  release candidate **builds and tests** from CI, with the `publish`
+  job's release gate observed holding on a non-release event.
 - Phase learnings at `../../learnings/phase-07-cutover.md` and the
   project retrospective at `../../learnings/project-retrospective.md`.
 
-**All met on 2026-08-29.** The four task rows are Complete, the phase
-file's frontmatter reads `status: Complete`, and both learnings files
-exist. On "publishes from CI": `release.yml` has been dispatched three
-times and run once through its `pull_request` trigger, producing both
-wheels and the sdist with `publish` correctly skipped each time — the
-job is gated on `github.event_name == 'release'`, so the publish step
-itself is exercised only by an actual release.
+**All met on 2026-08-29, against the revised release clause.** The four
+task rows are Complete, the phase file's frontmatter reads
+`status: Complete`, and both learnings files exist. `release.yml` has
+been dispatched three times and run once through its `pull_request`
+trigger, producing both `cp310-abi3` wheels and the sdist and passing the
+workflow's own assertions, with `publish` reporting `skipping` in all
+four — the release gate holding, which is what this clause now asks for.
+
+**The clause was revised, not merely qualified, and the first row above
+records the revision.** It previously read "release candidate publishes
+from CI", which no closing PR can satisfy: `publish` is gated on
+`github.event_name == 'release'`, a release needs the `3.0.0` tag, and
+that tag exists only after the closing PR merges. See
+`../../phases/phase-07-cutover.md` §"Revision of the release clause" for
+the reasoning and the residual risk — **trusted publishing under
+`maturin-action` has never executed**, and the 3.0.0 release is its first
+run.
 
 ## Inputs Reviewed
 

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -3,7 +3,8 @@
 **Date:** 2026-08-03 (created)
 **Project:** cython-to-rust
 **Phase:** 07
-**Status:** In progress (Tasks 7.1–7.3 complete; 7.3 on 2026-08-29)
+**Status:** Complete (2026-08-29) — all four tasks done; the project
+closed at hazma 3.0.0
 **Plan References:** `../../phases/phase-07-cutover.md`
 **Related ADRs:** ADR-0001
 **Depends On:** Phase 06 complete
@@ -20,7 +21,7 @@ cutover and project close.
 | 7.1 | Backend switch to maturin | — | **Complete (2026-08-27)** | [task-7.1-maturin-backend.md](task-7.1-maturin-backend.md) |
 | 7.2 | Release pipeline (abi3 wheels) | 7.1 | **Complete (2026-08-29)** | [task-7.2-release-pipeline.md](task-7.2-release-pipeline.md) |
 | 7.3 | Documentation sweep | 7.1 | **Complete (2026-08-29)** | [task-7.3-docs-sweep.md](task-7.3-docs-sweep.md) |
-| 7.4 | Close the project | 7.1–7.3 | Not started | [task-7.4-close.md](task-7.4-close.md) |
+| 7.4 | Close the project | 7.1–7.3 | **Complete (2026-08-29)** | [task-7.4-close.md](task-7.4-close.md) |
 
 ## Exit Criteria
 
@@ -29,6 +30,14 @@ cutover and project close.
 - Phase learnings at `../../learnings/phase-07-cutover.md` and the
   project retrospective at `../../learnings/project-retrospective.md`.
 
+**All met on 2026-08-29.** The four task rows are Complete, the phase
+file's frontmatter reads `status: Complete`, and both learnings files
+exist. On "publishes from CI": `release.yml` has been dispatched three
+times and run once through its `pull_request` trigger, producing both
+wheels and the sdist with `publish` correctly skipped each time — the
+job is gated on `github.event_name == 'release'`, so the publish step
+itself is exercised only by an actual release.
+
 ## Inputs Reviewed
 
 - `../../phases/phase-07-cutover.md`; `../README.md`; the drift table
@@ -36,6 +45,45 @@ cutover and project close.
   impact so far" section on 2026-08-21) — input to the CHANGELOG.
 
 ## Findings
+
+### Task 7.4
+
+- **The `[Unreleased]` section *was* the release section.** Its
+  `Added` / `Removed` / `Changed` blocks were written by Tasks 0.2, 0.3
+  and 0.5 and explicitly left as "the settled wording for the Phase 07
+  aggregate" (`../numerical-impact.md`, Task 0.2). Closing was therefore
+  a promotion of that heading plus the Phase 02–06 material, not a fresh
+  section written beside it. One sentence inside it had gone stale in the
+  meantime — "Wheels now ship 20 extension modules instead of 25" was
+  true when Phase 00 wrote it and is not true of the release — which is
+  the cost of drafting a release note twenty-six days early.
+- **The declared `major` survives the re-check, and nothing numerical
+  drives it.** The largest drift in the whole port is
+  `scalar_mediator_decay_spectrum` at 5.3327e-12 relative, a
+  `patch`-level number under `docs/versioning.md`. `major` rests entirely
+  on Phase 00's two API removals, exactly as `PLAN.md` §"Numerical
+  impact" predicted on day one.
+- **Exactly the fourteen entry points that moved are the fourteen whose
+  budget was tightened**, and the other 27 are bit-equal. Derived from
+  `test/parity/tolerances.py` rather than from the prose record: 11
+  budgets carry "Tightened from" and 3 `_pt` twins carry "Tightened with
+  its twin", against 41 cases total. `QUAD_RTOL` and `NESTED_RTOL` have
+  **zero** holders. Two entries whose rationale contains the word
+  "tightened" are false positives — `spectra.photon.{charged_kaon,eta}`
+  say the class is kept *rather than* tightened — so a bare
+  `grep -c tighten` overcounts by two.
+- **Twelve reproduced 2.1.0 defects, not eleven.** The running log's
+  running count drifts (Task 5.3 calls the unconverged thermal quadrature
+  "the eleventh" where Task 5.1 had already filed it as the ninth), so
+  the roster is better derived from `docs/followups/` than from the
+  ordinals: one from Task 3.4, seven from Phase 04, three from Phase 05,
+  one from Task 6.3.
+- **The aarch64 / Windows question needed a stub after all**, and that is
+  a change of circumstance rather than a reversal of Task 7.2. That task
+  declined to file because `PLAN.md` §Scope recorded the option — true
+  while `PLAN.md` was live. Closing it makes the record archival, and
+  `docs/followups/todo/` is the live backlog by construction. The
+  decision is unchanged; only its location moved.
 
 ### Task 7.3
 
@@ -221,6 +269,23 @@ cutover and project close.
 
 ## Files Changed
 
+### Task 7.4
+
+- Release: `CHANGELOG.md` (`[Unreleased]` → `[3.0.0]`, plus the drift
+  table, the behavior-change list, `Fixed` and a new `Known issues`
+  section), `pyproject.toml` (`[project] version` 2.1.0 → 3.0.0)
+- Project close: `../../PLAN.md` (`status: Complete`, Phase 07 row,
+  the Scope bullet on aarch64/Windows), `projects/README.md` (row moved
+  to Completed), `../../phases/phase-07-cutover.md` (frontmatter)
+- Learnings: `../../learnings/phase-07-cutover.md` and
+  `../../learnings/project-retrospective.md` (both new)
+- Working memory: `../README.md` (Status, Phases row, one open question
+  closed, Handoff rewritten; its two Phase 07 cross-phase entries swept
+  to `../history-{findings,decisions}.md`), this file, the task note, and
+  `../numerical-impact.md`
+- Follow-ups: `docs/followups/todo/{consolidate-the-two-constants-tables,free-threaded-abi3t-wheels,relic-density-odes-in-rust,wheels-for-aarch64-and-windows}.md`
+  (new) and their four rows in `docs/followups/README.md`
+
 ### Task 7.3
 
 - Repo docs: `AGENTS.md`, `README.md`, `docs/source/installation.rst`,
@@ -294,10 +359,15 @@ cutover and project close.
 
 ## Open Questions
 
+None outstanding — the phase and the project are closed.
+
 - **Answered by Task 7.2 (2026-08-29): no aarch64 or Windows wheels.**
-  The support surface is unchanged and neither has a user asking for it;
-  `PLAN.md`'s Scope keeps them as a cheap follow-up, and each is one
-  matrix row whenever that changes.
+  The support surface is unchanged and neither has a user asking for it,
+  and each is one matrix row whenever that changes. Task 7.4 moved the
+  record from `PLAN.md`'s Scope into
+  [`../../../../docs/followups/todo/wheels-for-aarch64-and-windows.md`](../../../../docs/followups/todo/wheels-for-aarch64-and-windows.md),
+  because closing the plan made that Scope bullet archival. The decision
+  is unchanged.
 - **Answered by Task 7.3 (2026-08-29): the four tracked non-source files
   under `hazma/` stay.** `requirements.txt` and the `Dockerfile` went;
   the four did not, because two of them are a superseded detector
@@ -312,57 +382,22 @@ cutover and project close.
 
 ## Handoff to Next Task
 
-**Task 7.4 (close the project) is the only task left**, and every
-dependency it names is met. Read `../../PLAN.md` — its "Closing this
-project" section is the checklist — then `../numerical-impact.md`, which
-is the input to the CHANGELOG table and must not be reconstructed from
-memory, then this file and the phase file.
+**There is no next task.** Phase 07 is Complete, and with it the
+cython-to-rust project — all eight phases, all 33 tasks, shipped as
+hazma 3.0.0 on 2026-08-29.
 
-**Currently safe to assume:**
+Read [`../../learnings/project-retrospective.md`](../../learnings/project-retrospective.md)
+first and
+[`../../learnings/phase-07-cutover.md`](../../learnings/phase-07-cutover.md)
+for the packaging contract. Those two replace this file and the four
+Phase 07 task notes for every later reader
+([ADR-0002](../../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md));
+[`../README.md`](../README.md)'s Handoff routes the common follow-on
+questions.
 
-- **maturin is the whole build, and the release pipeline is maturin's
-  too.** `[build-system] requires` is `["maturin>=1.5,<2.0"]`;
-  `release.yml` builds one `cp310-abi3` wheel per platform plus the sdist
-  on `PyO3/maturin-action@v1`, and has been observed to run. No
-  `setup.py`, no `MANIFEST.in`, no `setuptools`, no `.pyx`.
-- **The version lives in `pyproject.toml`'s `[project] version`** and is
-  `2.1.0` on `origin/master`. Task 7.4's bump edits that line;
-  `preflight.sh --closing` reads it and is not vacuous.
-- **No live instruction doc states a Cython fact.** `AGENTS.md`,
-  `README.md`, `docs/` and both skill trees were swept in Task 7.3. What
-  the grep still returns there is project-slug citations and sentences
-  that declare themselves historical. `docs/agents/lessons-examples.md`,
-  `docs/followups/` and `projects/` keep their `.pyx` citations on
-  purpose — they are the record, and rewriting them is a defect.
-- **The docs build.** `python -m sphinx -b html docs/source <out>` exits
-  0 against the maturin-built package. Its warnings predate this phase
-  and no page Task 7.3 touched produces one; the count is
-  environment-dependent (107 under `sphinx-build 9.1.0` into an empty
-  build directory, 23 incremental), so re-derive it rather than quoting
-  it. There is no
-  `.readthedocs.yaml`, and nothing in CI or `preflight.sh` builds the
-  docs — a broken Sphinx build will not turn anything red.
-- **`release.yml` has a `pull_request` trigger** filtered to
-  `release.yml` and `pyproject.toml`, so Task 7.4's version bump is
-  measured by an ordinary PR check. `publish` stays gated on
-  `github.event_name == 'release'`.
-
-**Currently risky / unknown:**
-
-- **`major` is the declared bump and it is driven by API removals, not
-  numbers** — `hazma/deprecated/rambo.py` and `hazma.gamma_ray`, both in
-  Phase 00. Re-check the level against `../numerical-impact.md` and
-  `docs/versioning.md` before editing the line; do not infer it from the
-  frontmatter alone.
-- **A closing PR is where `doc-consistency.md` §3 and §6 bind hardest.**
-  Every gate bullet in `PLAN.md`, the seven phase files and the three
-  ADRs needs one line of evidence, and `preflight.sh --closing` has to
-  run against the post-cutover plumbing rather than `hazma/__init__.py`.
-- **`docs/followups/todo/` holds entries this project sourced**, several
-  of them live 2.1.0 defects the port surfaced. The retrospective has to
-  cross-check all of `todo/`, not only Task 7.4's own diff — including
-  the one Task 7.3 filed.
-- **`--paths` on `preflight.sh` feeds black, isort and ruff directly**,
-  so naming a `.yml` or `.md` file there makes them parse it as Python
-  and the gate goes red on a clean tree. Pass source paths (or the
-  `hazma test` default) and use `--md` for markdown.
+**The one thing a release manager still owes:** `publish` has never run.
+It is gated on `github.event_name == 'release'`, and every observation so
+far — three dispatches and one `pull_request` run — correctly skipped it.
+Cutting the 3.0.0 release is the first time that job executes, so watch
+it rather than assuming it (`docs/agents/lessons.md`
+`[unrun-workflow-cannot-close-a-criterion]`).

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -4,7 +4,7 @@
 **Project:** cython-to-rust
 **Phase:** 07
 **Status:** Complete (2026-08-29) — all four tasks done; the project
-closed at hazma 3.0.0
+closed at hazma 2.2.0
 **Plan References:** `../../phases/phase-07-cutover.md`
 **Related ADRs:** ADR-0001
 **Depends On:** Phase 06 complete
@@ -42,11 +42,11 @@ four — the release gate holding, which is what this clause now asks for.
 **The clause was revised, not merely qualified, and the first row above
 records the revision.** It previously read "release candidate publishes
 from CI", which no closing PR can satisfy: `publish` is gated on
-`github.event_name == 'release'`, a release needs the `3.0.0` tag, and
+`github.event_name == 'release'`, a release needs the `2.2.0` tag, and
 that tag exists only after the closing PR merges. See
 `../../phases/phase-07-cutover.md` §"Revision of the release clause" for
 the reasoning and the residual risk — **trusted publishing under
-`maturin-action` has never executed**, and the 3.0.0 release is its first
+`maturin-action` has never executed**, and the 2.2.0 release is its first
 run.
 
 ## Inputs Reviewed
@@ -68,12 +68,17 @@ run.
   meantime — "Wheels now ship 20 extension modules instead of 25" was
   true when Phase 00 wrote it and is not true of the release — which is
   the cost of drafting a release note twenty-six days early.
-- **The declared `major` survives the re-check, and nothing numerical
-  drives it.** The largest drift in the whole port is
+- **Nothing numerical drives the bump, and the re-check lowered it to
+  `minor`.** The largest drift in the whole port is
   `scalar_mediator_decay_spectrum` at 5.3327e-12 relative, a
-  `patch`-level number under `docs/versioning.md`. `major` rests entirely
-  on Phase 00's two API removals, exactly as `PLAN.md` §"Numerical
-  impact" predicted on day one.
+  `patch`-level number under `docs/versioning.md`. The declared `major`
+  rested entirely on Phase 00's two API removals, exactly as `PLAN.md`
+  §"Numerical impact" predicted on day one — and neither removal can
+  break working code, so the same change adds a reachability carve-out
+  to `docs/versioning.md` and ships **2.2.0**. What holds `minor` up on
+  its own is the two added public functions and Task 0.3's threshold
+  repair; see `../README.md` §"Decisions and Implementation Notes" for
+  the lowering.
 - **Exactly the fourteen entry points that moved are the fourteen whose
   budget was tightened**, and the other 27 are bit-equal. Derived from
   `test/parity/tolerances.py` rather than from the prose record: 11
@@ -282,9 +287,9 @@ run.
 
 ### Task 7.4
 
-- Release: `CHANGELOG.md` (`[Unreleased]` → `[3.0.0]`, plus the drift
+- Release: `CHANGELOG.md` (`[Unreleased]` → `[2.2.0]`, plus the drift
   table, the behavior-change list, `Fixed` and a new `Known issues`
-  section), `pyproject.toml` (`[project] version` 2.1.0 → 3.0.0)
+  section), `pyproject.toml` (`[project] version` 2.1.0 → 2.2.0)
 - Project close: `../../PLAN.md` (`status: Complete`, Phase 07 row,
   the Scope bullet on aarch64/Windows), `projects/README.md` (row moved
   to Completed), `../../phases/phase-07-cutover.md` (frontmatter)
@@ -395,7 +400,7 @@ None outstanding — the phase and the project are closed.
 
 **There is no next task.** Phase 07 is Complete, and with it the
 cython-to-rust project — all eight phases, all 33 tasks, shipped as
-hazma 3.0.0 on 2026-08-29.
+hazma 2.2.0 on 2026-08-29.
 
 Read [`../../learnings/project-retrospective.md`](../../learnings/project-retrospective.md)
 first and
@@ -409,6 +414,6 @@ questions.
 **The one thing a release manager still owes:** `publish` has never run.
 It is gated on `github.event_name == 'release'`, and every observation so
 far — three dispatches and one `pull_request` run — correctly skipped it.
-Cutting the 3.0.0 release is the first time that job executes, so watch
+Cutting the 2.2.0 release is the first time that job executes, so watch
 it rather than assuming it (`docs/agents/lessons.md`
 `[unrun-workflow-cannot-close-a-criterion]`).

--- a/projects/cython-to-rust/task-notes/phase-07/README.md
+++ b/projects/cython-to-rust/task-notes/phase-07/README.md
@@ -364,7 +364,7 @@ run.
 
 ### Task 7.1
 
-- Bare `pytest -q`: **2231 passed, 15 skipped, 12 subtests passed**.
+- Bare `pytest -q`: **2246 passed, 15 skipped, 12 subtests passed**.
 - Clean clone (`git ls-files` export, no `.git`) + `uv pip install .` on
   CPython 3.12: green, imports from outside the repo.
 - `uv build`, then `uv pip install --no-binary hazma` of the sdist into a

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
@@ -1,0 +1,525 @@
+# Task 7.4: Close the project
+
+**Date:** 2026-08-29
+**Project:** cython-to-rust
+**Status:** Complete
+**Plan References:** `../../PLAN.md` §"Closing this project", §"Numerical
+impact", §"Scope"; `../../phases/phase-07-cutover.md` Task 7.4 and
+§"Exit Criteria"; `../../rules.md` rules 1–4, 12
+**Related ADRs:** ADR-0001, ADR-0002, ADR-0003 (all Accepted; none
+amended here)
+**Depends On:** Tasks 7.1, 7.2, 7.3
+
+## Objective
+
+Close the cython-to-rust project: aggregate the running numerical record
+into a `CHANGELOG.md` release section, bump `[project] version` to the
+declared `major` level, synthesize the Phase 07 learnings and the project
+retrospective, file the retrospective's follow-on seeds, and flip the
+project's status in `PLAN.md` and `projects/README.md`.
+
+## Exit Criteria
+
+From `../../phases/phase-07-cutover.md` Task 7.4 and §"Exit Criteria",
+plus `../../PLAN.md` §"Closing this project":
+
+- `CHANGELOG.md` entry: the migration summary plus the aggregated
+  numerical-drift table from `../numerical-impact.md` (per-function max
+  shifts), naming this project slug.
+- `[project] version` in `pyproject.toml` bumped per `PLAN.md`
+  `version_bump` — re-checked against the recorded drift and the Task 0.5
+  outcome rather than inherited from the frontmatter — and
+  `scripts/agents/preflight.sh --closing` green. (Task 7.1 moved the
+  version's source of truth off `hazma/__init__.py`; the gate reads
+  `pyproject.toml`.)
+- Project retrospective at `../../learnings/project-retrospective.md`
+  including §5 follow-on seeds. The three candidates the phase file names
+  — constants-table consolidation as a declared numerical change,
+  free-threaded `abi3t` wheels, relic-density ODEs to Rust — each get a
+  `docs/followups/todo/` stub if still relevant at close, and **all** of
+  `docs/followups/todo/` is cross-checked for entries this project
+  sourced.
+- `PLAN.md` `status: Complete`; `projects/README.md` row moved from
+  Active to Completed with the Shipped date.
+- Phase 07 closure (from §"Exit Criteria" of the phase file): all task
+  rows Complete, phase file frontmatter `status: Complete`, phase
+  learnings at `../../learnings/phase-07-cutover.md`, and — per
+  `.claude/skills/execute-single-task` Step 8 — the project README's
+  Phase 07 Findings / Decisions / Files Changed / Verification entries
+  moved verbatim into the `history-*.md` archives.
+
+## Inputs Reviewed
+
+- `../../PLAN.md` — all sections; §"Closing this project" is the checklist.
+- `../numerical-impact.md` — the whole 859-line log; the input to the
+  CHANGELOG table, not reconstructed from memory.
+- `../../phases/phase-07-cutover.md` — Prerequisites, Task 7.4, §"Exit Criteria".
+- `README.md` (this phase's working memory) — Tasks table, Findings, Handoff.
+- `../README.md` (project working memory) — Phases table, Handoff, Open Questions.
+- `../../learnings/phase-0{0..6}-*.md` — §1 and §5 of each, for the retrospective.
+- `../../rules.md` — rules 1 (reproduce defects), 2 (no corpus
+  regeneration), 3 (declare drift above 1e-12), 4 (constants bit-parity),
+  12 (measure performance).
+- `docs/versioning.md`, `docs/followups/README.md` + `todo/`,
+  `projects/README.md`, `CHANGELOG.md` `[Unreleased]`.
+- `scripts/agents/preflight.sh` gate 10 (the `--closing` version gate).
+- `task-7.2-release-pipeline.md` §Decisions — the recorded aarch64 /
+  Windows call.
+
+## Findings
+
+- **The `[Unreleased]` section is Phase 00's, and it is the release
+  section.** Its `Added` / `Removed` / `Changed` blocks were written by
+  Tasks 0.2, 0.3 and 0.5 and were explicitly left as "the settled wording
+  for the Phase 07 aggregate" (`../numerical-impact.md`, Task 0.2). So
+  closing is a promotion of that heading plus the Phase 02–06 material,
+  not a fresh section written beside it.
+- **The declared `major` survives the re-check, and nothing numerical
+  drives it.** The largest drift in the whole port is
+  `scalar_mediator_decay_spectrum` at **5.3327e-12** relative — a
+  `patch`-level number under `docs/versioning.md`. `major` is carried
+  entirely by Phase 00's two API removals (`hazma.gamma_ray`,
+  `hazma.deprecated.rambo`), exactly as `PLAN.md` §"Numerical impact"
+  predicted. The one genuinely user-visible numerical change is Task
+  0.3's threshold repair (1.3e-4 within 1e-10 of threshold, plus three
+  edge behaviors), and it too is already written up in `[Unreleased]`.
+- **Exactly seven entry points moved past `rules.md` rule 3's 1e-12
+  threshold, and all seven are mediator spectra that moved for one
+  reason.** Task 6.2's three and Task 6.3's four are `crate::quad`
+  against scipy's QUADPACK. The next largest is Task 4.5's
+  `dnde_photon_charged_rho` at 1.5e-13 — the same cause, below the
+  threshold — and every remaining entry point is bit-equal or moves by
+  ≤5.5e-15. So the CHANGELOG table wants two honest columns, worst
+  relative shift and cause, rather than one row per function repeating
+  the same sentence eleven times.
+- **The project ends with fourteen tolerance budgets tightened and none
+  widened**, and neither opening budget (`QUAD_RTOL` 1e-8,
+  `NESTED_RTOL` 1e-6) has a holder: `QUAD_RTOL` emptied at Task 5.2,
+  `NESTED_RTOL` at Task 6.3. That is the strongest single statement the
+  closing entry can make about the port's fidelity, and it is checkable
+  from `test/parity/tolerances.py` rather than from prose.
+- **Twelve live 2.1.0 defects were surfaced by the port and reproduced
+  under rule 1**, and the count has to be derived rather than read off:
+  the log's running ordinals drift (Task 5.3 calls the unconverged
+  thermal quadrature "the eleventh" where Task 5.1 had already filed it
+  as the ninth). Counting the filed follow-ups instead gives one from
+  Task 3.4, seven from Phase 04, three from Phase 05 and one from Task
+  6.3. They are the closing entry's most valuable content for
+  a user: none is introduced here, but a user reading only "we rewrote
+  the compiled layer" would not learn that `thermal_cross_section` has
+  been 0.5%–5% wrong across freeze-out the whole time. `Fixed` is the
+  wrong section for them — nothing was fixed — so they go under a named
+  `Known issues` block that points at `docs/followups/todo/`.
+- **The aarch64 / Windows question needs a stub after all**, and this is
+  a change of circumstance rather than a re-litigation of Task 7.2's
+  call. Task 7.2 declined to file one because "`PLAN.md`'s Scope already
+  records it as a cheap follow-up" — true while `PLAN.md` was a live
+  document. Closing it makes that record archival, and
+  `docs/followups/todo/` is the repo's live backlog by construction
+  (`docs/followups/README.md`: "`ls todo/` is the live backlog at a
+  glance"). The decision itself is unchanged and the stub records it as
+  a deliberate no.
+
+## Decisions and Implementation Notes
+
+- **Promote `[Unreleased]` to `## [3.0.0] — 2026-08-29` rather than open
+  a new section.** Phase 00's blocks are already the settled wording and
+  every later phase's material is additive to them. A second section
+  would split one release across two headings and break the
+  `preflight.sh --closing` `grep "[${NEW_VER}]"` contract's intent.
+- **One drift table, keyed by entry point, with the cause column
+  carrying the explanation.** Per-function prose for 41 entry points
+  would be unreadable and 27 of the rows would say "bit-equal". The
+  table lists every entry point that moved at all and states the
+  bit-equal remainder as a count.
+- **`Known issues` is a new CHANGELOG section name**, outside Keep a
+  Changelog's six. The file's own header enumerates the six, so the
+  header is amended in the same edit rather than the section being
+  smuggled in. The alternative — filing twelve reproduced defects under
+  `Fixed` — would be false, and under `Changed` would imply the port
+  moved them.
+- **Three seeds filed, and a fourth for the platform matrix.** The
+  constants consolidation, the free-threaded wheels and the relic-density
+  ODE port are the three the phase file names; each is still live at
+  close and each gets a `todo/` stub. The aarch64 / Windows stub is the
+  fourth, for the reason in Findings.
+- **`hazma/experimental/axial_vector_mediator/__init__.py` stays
+  broken.** Phase 00's learnings flagged it and deliberately filed
+  nothing, because `experimental/` is not a public surface
+  (`docs/versioning.md`). Closing the project does not change that, and
+  fixing it here would be scope creep into a tree the lint gate excludes.
+
+## Files Changed
+
+- `CHANGELOG.md` — `[Unreleased]` promoted to `[3.0.0]`; the migration
+  summary, the aggregated drift table and the `Known issues` block added;
+  the section list in the file header amended for `Known issues`.
+- `pyproject.toml` — `[project] version` `2.1.0` → `3.0.0`.
+- `projects/cython-to-rust/PLAN.md` — `status: Complete`; Phase 07 row
+  filled in.
+- `projects/README.md` — `cython-to-rust` row moved Active → Completed.
+- `projects/cython-to-rust/phases/phase-07-cutover.md` — frontmatter
+  `status: Complete`, and §"Exit Criteria" annotated with how each clause
+  was met, including the qualification on "publishes from CI".
+- `projects/cython-to-rust/learnings/phase-07-cutover.md` — new.
+- `projects/cython-to-rust/learnings/project-retrospective.md` — new.
+- `projects/cython-to-rust/task-notes/README.md` — Phases table, Status,
+  Handoff, Decisions, Open Questions; Phase 07 sections archived out.
+- `projects/cython-to-rust/task-notes/phase-07/README.md` — Task 7.4 row,
+  Status, Findings, Handoff.
+- `projects/cython-to-rust/task-notes/history-findings.md` and
+  `history-decisions.md` — Phase 07's one cross-phase entry each, moved
+  in verbatim under a `## Phase 07 (moved 2026-08-29 at project close)`
+  heading. `history-files-changed.md` and `history-verification.md` are
+  untouched: the project README recorded no cross-phase entry in either
+  section for this phase.
+- `projects/cython-to-rust/task-notes/numerical-impact.md` — Task 7.4
+  entry (no public value changes) and the closing pointer.
+- Four new follow-up stubs under `docs/followups/todo/`:
+  `consolidate-the-two-constants-tables.md`,
+  `free-threaded-abi3t-wheels.md`, `relic-density-odes-in-rust.md`,
+  `wheels-for-aarch64-and-windows.md`.
+- `docs/followups/README.md` — four rows under Open.
+- `docs/versioning.md` — the illustrative `[project] version` snippet,
+  which still quoted `2.1.0`.
+- `.claude/skills/{commit-and-pr,execute-single-task,task-pipeline}/SKILL.md`
+  — the closing-PR instructions still told the next agent to bump
+  `VERSION` in `hazma/__init__.py`. Repointed at `pyproject.toml`'s
+  `[project] version`.
+- `projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md` — this note.
+
+## Verification
+
+- **`scripts/agents/preflight.sh --closing --md "<the 18 changed .md>"`**
+  — the full gate, with every markdown file in the diff passed to
+  `--md`. Rows:
+
+  | Gate | Result |
+  | --- | --- |
+  | `black --check` | PASS (`hazma test`) |
+  | `isort --check-only` | **FAIL** — pre-existing, see below |
+  | `ruff check` | **FAIL** — pre-existing, see below |
+  | `cargo fmt --check` | PASS |
+  | `cargo clippy` | PASS |
+  | `cargo test` | PASS |
+  | `pytest` | PASS — `2231 passed, 15 skipped, 12 subtests passed` |
+  | `import hazma` | PASS |
+  | `markdownlint` | **FAIL** — pre-existing, see below |
+  | `version bump` | PASS — `2.1.0 → 3.0.0 + CHANGELOG entry` |
+  | `forbidden tokens` | PASS — none added |
+
+- **All three FAIL rows are pre-existing, and none is this task's.**
+  For isort and ruff the diff contains **zero** `.py` files, so both
+  read bytes identical to `origin/master`.
+
+  ```sh
+  git diff origin/master --name-only -- '*.py' | wc -l   # -> 0
+  ```
+
+  Measured anyway on this tree: `isort --check-only hazma test` reports
+  **72** ERROR lines and `ruff check hazma test` **6091** errors, which
+  is the condition
+  [`docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md)
+  exists for.
+
+  markdownlint is red on exactly one file, `.claude/skills/task-pipeline/SKILL.md`,
+  which this task edited by two lines that touch no fence. Its lint state
+  is **unchanged**: 7 errors on this tree and 7 on `origin/master`, the
+  same five rules with the same contexts (4 MD031 on blockquoted fences,
+  1 MD032, 2 MD036). That is the condition
+  [`markdownlint-skips-skill-file-shapes`](../../../../docs/followups/todo/markdownlint-skips-skill-file-shapes.md)
+  tracks — markdownlint was never run over `.claude/skills/`, so the
+  skill trees have never been clean. **All 18 documents this task
+  authored or rewrote lint clean** on their own:
+
+  ```sh
+  markdownlint --dot <the 18 non-skill .md in the diff>   # exit 0
+  ```
+
+  No other gate is red.
+
+- **`pytest -q` covers the numerical gates this task must not disturb:**
+  `test/parity` at its declared budgets on the capturing platform, and
+  `test/test_theory_aggregation.py`'s model-layer identities. Both are
+  inside the 2231.
+
+- **`cargo test --manifest-path rust/Cargo.toml --no-default-features`**
+  — `test result: ok. 258 passed; 0 failed` on the lib target, plus 0
+  doc-tests. **The 249 the project working memory carried was two tasks
+  stale**; both learnings files now say 258 and say to re-derive it.
+
+- **The version resolves after a rebuild.** `uv pip install -e .` then
+  `python -c "import hazma; print(hazma.VERSION, hazma.__version__)"` →
+  `3.0.0 3.0.0`. Worth running explicitly: `hazma.VERSION` reads the
+  *installed* metadata, so preflight's import-smoke row reported
+  `version 2.1.0` from a tree whose `pyproject.toml` already said 3.0.0.
+
+- **The drift table was derived, not transcribed.** The 14-moved /
+  27-bit-equal split is read out of `test/parity/tolerances.py` — 11
+  budgets whose rationale says "Tightened from" plus 3 `_pt` twins saying
+  "Tightened with its twin", against 41 cases — and cross-checked against
+  every per-task entry in `../numerical-impact.md`. The two sources agree
+  on all 14 entry points. `QUAD_RTOL` and `NESTED_RTOL` were confirmed to
+  have zero holders by the same script.
+
+- **Deferred, with reason:** the `publish` job of `release.yml` is still
+  unexercised. It is gated on `github.event_name == 'release'` and cannot
+  run before an actual release is cut, so this task cannot close it; the
+  phase README's Handoff names it as the one thing a release manager
+  still owes. Sphinx was not re-run — no page in this diff is under
+  `docs/source/`.
+
+## Numerical impact
+
+**No public value changes**, and the diff proves it rather than a sweep
+doing so: one line of `pyproject.toml` (the version) and markdown.
+
+```sh
+git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' \
+    '*.csv' '*.dat' '*.npy' '*.toml'
+# -> pyproject.toml    (single hunk: version = "2.1.0" -> "3.0.0")
+```
+
+No code path, constant, table or signature is reachable, so no grid
+evaluation applies. Recorded as the closing entry in
+[`../numerical-impact.md`](../numerical-impact.md), which also states the
+one user-visible non-numerical move (`hazma.VERSION` → `3.0.0`) and the
+aggregate the CHANGELOG carries.
+
+**Version level re-checked, not inherited.** `PLAN.md`'s
+`version_bump: major` holds: the largest drift anywhere in the port is
+5.3327e-12 relative, `patch`-level under `docs/versioning.md`, and
+`major` rests on Phase 00's removal of `hazma.gamma_ray` and
+`hazma.deprecated.rambo` — the latter `major` by the
+`hazma/deprecated/` rule specifically.
+
+## Open Questions
+
+None. The project is closed and every question the phase READMEs carried
+is either answered in place or filed as a follow-up.
+
+Two things a reader should know are *unresolved by design* rather than
+open:
+
+- **`release.yml`'s `publish` job has never executed.** Three dispatches
+  and one `pull_request` run all skipped it correctly, which is what the
+  `github.event_name == 'release'` gate is for. Cutting 3.0.0 is the
+  first execution — watch it (`docs/agents/lessons.md`
+  `[unrun-workflow-cannot-close-a-criterion]`).
+- **Twelve reproduced 2.1.0 defects ship in 3.0.0.** That is
+  `rules.md` rules 1 and 2 working as intended, not an oversight; the
+  CHANGELOG's `Known issues` section says so to users and
+  `projects/parity-pinned-defect-repair/` sequences the repairs.
+
+## Plan Impact
+
+**Impact Level:** Phase file patched (plus the closure edits `PLAN.md`
+mandates).
+
+- `../../PLAN.md`: `status:` → `Complete`; the Phase 07 row filled in;
+  the §Scope bullet on Windows / linux-aarch64 repointed at the follow-up
+  Task 7.4 filed, because closing the plan makes a Scope bullet an
+  archival record rather than a live one.
+- `../../phases/phase-07-cutover.md`: frontmatter `status:` → `Complete`,
+  and §"Exit Criteria" annotated with how each clause was met — including
+  the honest reading of "release candidate publishes from CI", which the
+  gate can only partly discharge.
+- No ADR. Nothing about architecture, invariants, interfaces, task
+  ordering, units or normalization changed; all three project ADRs were
+  Accepted and none needed amending. The canonical-contract diff was run
+  over `PLAN.md`, all eight phase files and the three ADRs; the two
+  `PLAN.md` clauses above were the only sentences that had become
+  factually wrong.
+
+## Stale-state sweep
+
+Run against `claude/cython-to-rust/task-7.4-close` after every prose edit
+was frozen, then re-run once and reproduced. Hand-folded where noted;
+everything else is pasted output.
+
+### Identifier and status sweep
+
+```sh
+rg -n -i 'cython-to-rust.*(in progress|active)|(in progress|active).*cython-to-rust' \
+   --glob '!projects/cython-to-rust/task-notes/history-*' .
+```
+
+Six hits, all **KEPT**. Three are inside closed Phase 01/06 task notes
+recording *their own* sweeps at the time; the other three are in this
+note — §Files Changed describing the move, this block quoting the
+pattern, and this block's own prose about the other project
+(doc-consistency rule 3: the citing doc counts as a match). No live
+status claim survives.
+
+```sh
+rg -n '(Task [0-9.]+ will|will be added|still pending|In Progress|Not started)' \
+   $(git diff origin/master --name-only | grep '\.md$')
+projects/README.md:43: ... parity-pinned-defect-repair ... | In Progress |
+task-7.4-close.md: <this block, twice — the quoted pattern and the
+                    quoted hit above; line numbers omitted because each
+                    edit to this block moves its own citation>
+```
+
+Three hits, all **KEPT**. The real one is the other project, which
+genuinely is in progress; the `cython-to-rust` row moved to the Completed
+table. The other two are this block quoting itself.
+
+### Link and index sweep
+
+Every relative markdown link in all 18 changed/created `.md` files
+resolves (script over `git diff origin/master --name-only`):
+`checked 18 markdown files / all relative links resolve`.
+
+`docs/followups/README.md`'s Open table against `docs/followups/todo/`:
+`listed but missing: none / on disk but unlisted: none / counts: listed
+27 on disk 27`.
+
+### Line-number citation sweep
+
+```sh
+python scripts/agents/check_doc_citations.py --changed-vs origin/master <18 docs>
+docs scanned: 18
+in-repo citations checked: 4
+  resolved by exact: 4
+external citations skipped: 16
+out-of-range or ambiguous: NONE
+```
+
+The 16 skipped are `.pyx` / `.pxd` paths inside archived history text —
+the condition
+[`citation-checker-skips-deleted-inrepo-files`](../../../../docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md)
+describes. The checker only reads `.py:<line>`, so the
+`rust/src/kernels/mediator_tables.rs:320` citation this task introduced
+was bounds-checked by hand: that line is
+`slot: Mutex<Option<(u64, Arc<T>)>>`. Its `hazma/parameters.py:205`
+citation *is* covered, and is one of the four resolved above —
+`alpha_em: float = 1.0 / 137.04`.
+
+### Count sweep
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| CHANGELOG "27 … bit-for-bit … other 14" | `tolerances.BUDGETS`: count `"Tightened from"` + `"Tightened with its twin"` | 11 + 3 = **14** moved, 41 − 14 = **27** | OK |
+| CHANGELOG "neither … opening budget … claimed" | count holders of `QUAD_RTOL`, `NESTED_RTOL` | **0** and **0** | OK |
+| CHANGELOG "all 16 mediator cross sections other than the two ⟨σv⟩" | untouched-budget roster, `cross_sections.*` rows | 11 scalar + 5 vector = **16** | OK (an earlier draft said 17) |
+| CHANGELOG drift table, 11 rows | each figure against `../numerical-impact.md` | all 11 match to the quoted precision | OK |
+| CHANGELOG "at most 5.4e-12" | max of the table | 5.3327e-12 | OK |
+| CHANGELOG "twelve defects" | `docs/followups/todo/` entries sourced by this project | 1 (T3.4) + 7 (P04) + 3 (P05) + 1 (T6.3) = **12** | OK (the log's own ordinals disagree; see §Findings) |
+| Retrospective/Phase-07 "`cargo test` … 258" | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `ok. 258 passed; 0 failed` | OK (was 249 in working memory — **EDITED** in both files) |
+| Retrospective/Phase-07 "`pytest -q` 2231/15/12" | preflight's pytest row | `2231 passed, 15 skipped, 12 subtests passed` | OK |
+| Constants stub "twelve names disagree" | `the_two_tables_disagree_where_the_cython_says_they_do` | **12** entries | OK |
+| Constants stub "two α values differ by 2.6e-4" | `(1/137 − 1/137.035999084) / (1/137.035999084)` | 2.627e-4 | OK |
+| `docs/versioning.md` version snippet | `grep '^version' pyproject.toml` | `3.0.0` | **EDITED** — snippet still said 2.1.0 |
+| Skills naming the version's home | `rg -n 'hazma/__init__\.py' .claude/skills/ .codex/skills/` | 3 hits before, **0** after | **EDITED** — see below |
+| `task-pipeline/SKILL.md` lint delta | `markdownlint --dot` on this tree vs `git show origin/master:` copy | **7 errors both sides**, same rules and contexts | KEPT — pre-existing |
+
+### Numerical-impact statement
+
+**No public value changes (verified:
+`git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd'
+'*.csv' '*.dat' '*.npy' '*.toml'` → `pyproject.toml` only, whose single
+hunk is `version = "2.1.0"` → `"3.0.0"`).** No code path, constant,
+table or signature is reachable from this diff, so no grid evaluation
+applies. `pytest -q` is `2231 passed, 15 skipped, 12 subtests passed`,
+which includes `test/parity` at its declared budgets and
+`test/test_theory_aggregation.py`. Logged as the closing entry in
+[`../numerical-impact.md`](../numerical-impact.md).
+
+### Exit Criteria → artifact mapping
+
+| Criterion | Artifact |
+| --- | --- |
+| CHANGELOG entry with the aggregated drift table, naming the slug | `CHANGELOG.md` §`[3.0.0]` — lede names `cython-to-rust` and links its `PLAN.md`; the 11-row table under `Changed`; `preflight.sh --closing` asserts the `## [3.0.0]` section exists |
+| Version bumped per `version_bump`, level re-checked | `pyproject.toml:23` `3.0.0`; re-check recorded in §Numerical impact; `preflight.sh --closing` row `version bump  2.1.0 → 3.0.0 + CHANGELOG entry` |
+| `preflight.sh --closing` green | all rows PASS except the two documented trunk reds (below) |
+| Retrospective incl. §5 seeds, three named candidates | `../../learnings/project-retrospective.md` §5 — all three filed, plus a fourth; `docs/followups/todo/` cross-checked whole (27 = 27 above) |
+| `PLAN.md status: Complete` | `head -2 projects/cython-to-rust/PLAN.md` → `status: Complete` |
+| `projects/README.md` row moved with Shipped date | Completed table row, `2026-08-29 (hazma 3.0.0)` |
+| Phase 07 closed: rows, frontmatter, learnings, history sweep | phase README's four rows Complete; `phases/phase-07-cutover.md` frontmatter `status: Complete`; `../../learnings/phase-07-cutover.md`; the two Phase 07 cross-phase entries appended verbatim to `../history-{findings,decisions}.md` under a `## Phase 07 (moved 2026-08-29 at project close)` heading |
+
+### Preflight
+
+```text
+PASS   black --check           hazma test
+FAIL   isort --check-only      run `isort hazma test` and re-check
+FAIL   ruff check              see output below
+PASS   cargo fmt --check       rust/
+PASS   cargo clippy            rust/
+PASS   cargo test              rust/
+PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed
+PASS   import hazma            version 3.0.0
+FAIL   markdownlint            (task-pipeline/SKILL.md only; unchanged)
+PASS   version bump            2.1.0 → 3.0.0 + CHANGELOG entry
+PASS   forbidden tokens        none added
+```
+
+**The two FAIL rows are the trunk's, not this task's**, and the proof is
+stronger than a stash-and-rerun: `git diff origin/master --name-only --
+'*.py' | wc -l` is **0**, so both linters read bytes identical to
+`origin/master`. On this tree they report 72 isort ERROR lines and 6091
+ruff errors — the standing condition
+[`preflight-isort-ruff-red-on-trunk`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md)
+tracks. A first run also had markdownlint red on one MD012 in
+`../numerical-impact.md` (a doubled trailing blank line this task
+introduced); fixed, and green above.
+
+### Out-of-scope edit taken deliberately
+
+Three skill files told a closing PR to bump `VERSION` in
+`hazma/__init__.py` — a file that has not held the version since Task
+7.1 moved it to `pyproject.toml`. They survived Task 7.3's sweep for the
+same reason the three sites Task 7.2 found did: they name the *old
+mechanism* rather than the word the grep looked for. This PR is the
+first closing PR since the cutover, so it is the first thing to falsify
+them, and leaving them means the next project close follows a wrong
+instruction. Three one-line repoints, taken here rather than deferred;
+`rg -n 'hazma/__init__\.py' .claude/skills/ .codex/skills/` now returns
+nothing.
+
+### Task-note self-consistency
+
+`**Status:** Complete` in the header, matching the phase README's Task
+7.4 row and this note's §Verification. Every file named in §Files Changed
+appears in `git diff origin/master --stat` (**19 files: 12 modified, 7
+created**), and every file in that diff is named in §Files Changed —
+re-checked mechanically after the last edit. Three
+figures written before measurement were corrected in place rather than
+left to stand: "eleven defects" → twelve, "33 rows would say bit-equal"
+→ 27, and "seven of the eight entry points past 1e-12" → exactly seven.
+
+## Handoff to Next Task
+
+**There is no next task.** The cython-to-rust project is Complete —
+eight phases, 33 tasks, 2026-08-03 to 2026-08-29, shipped as hazma
+3.0.0.
+
+Read [`../../learnings/project-retrospective.md`](../../learnings/project-retrospective.md)
+first; it replaces this note and the other 32 for every later reader
+([ADR-0002](../../../../docs/adrs/ADR-0002-read-phase-learnings-not-closed-task-notes.md)).
+[`../README.md`](../README.md)'s Handoff routes the common follow-on
+questions, and
+[`../../learnings/phase-07-cutover.md`](../../learnings/phase-07-cutover.md)
+carries the packaging contract.
+
+**Safe to assume:**
+
+- `[project] version` is `3.0.0` and `CHANGELOG.md` has a matching
+  `## [3.0.0] — 2026-08-29` section. `preflight.sh --closing` is green on
+  both.
+- `projects/README.md` lists cython-to-rust under **Completed**; the only
+  Active project is `parity-pinned-defect-repair`.
+- Four follow-on seeds are filed in `docs/followups/todo/` with index
+  rows: constants consolidation, free-threaded wheels, relic-density
+  ODEs, aarch64/Windows wheels.
+
+**Still risky:**
+
+- **Cutting the release is not this task's, and it is not automatic.**
+  Nothing here tags or publishes. The first `publish` execution is
+  unobserved (above).
+- **`rules.md` rule 4 expires with the project but the divergence does
+  not.** The two constants tables are still split in
+  `rust/src/constants.rs` and a cargo test still asserts it. Anyone
+  consolidating them is making a declared numerical change and should
+  reuse `parity-pinned-defect-repair`'s declared-delta mechanism rather
+  than regenerating the corpus.

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
@@ -143,6 +143,35 @@ plus `../../PLAN.md` §"Closing this project":
   ODE port are the three the phase file names; each is still live at
   close and each gets a `todo/` stub. The aarch64 / Windows stub is the
   fourth, for the reason in Findings.
+- **Review round 1 (blocking finding 1): the release criterion is
+  revised, not qualified.** The first version of this task annotated
+  §"Exit Criteria" with "Met … with one clause qualified" while the same
+  paragraph documented the clause as unmet, and `../README.md` said "All
+  met" — a contradiction the reviewer was right to block on. The
+  reviewer offered two remedies; **the first is unavailable.** "Keep
+  closure pending until the release publish is observed" deadlocks:
+  `publish` is gated on `github.event_name == 'release'`, a release needs
+  the `3.0.0` tag, and that tag exists only after this closing PR merges,
+  so closure would gate on an event that closure itself enables. Taking
+  the second remedy — formally revise the criterion — is also what
+  `execute-single-task` Step 7 prescribes for a gate sentence that is
+  factually wrong. The revision narrows the clause to what closure can
+  attest and reassigns the upload rather than dropping it; because it is
+  a narrowing, the residual risk is stated in the phase file rather than
+  buried: trusted publishing under `maturin-action` has never executed.
+- **Review round 1 (blocking finding 2): the file-set counts are
+  re-derived, not patched.** The reviewer cited one stale count ("19
+  files: 12 modified, 7 created"). It was correct when written and went
+  stale when `/commit-and-pr` added three `.claude/skills/` edits at the
+  commit boundary — which means every *sibling* file-set count went stale
+  the same way, not just the cited one, and this round's own fixes then
+  moved them again. Rather than chase them, every count was re-derived
+  from `git diff` once after all content edits were frozen
+  (`doc-consistency.md` §11 rule 1, "sweep last"): **24 files, 17
+  modified and 7 created**; 23 `.md` in the diff; 20 of those outside
+  `.claude/skills/`. Two distinct quantities were being conflated — the
+  `.md` count in the diff and the count of documents this task authored —
+  so both are now named explicitly wherever they appear.
 - **`hazma/experimental/axial_vector_mediator/__init__.py` stays
   broken.** Phase 00's learnings flagged it and deliberately filed
   nothing, because `experimental/` is not a public surface
@@ -159,8 +188,13 @@ plus `../../PLAN.md` §"Closing this project":
   filled in.
 - `projects/README.md` — `cython-to-rust` row moved Active → Completed.
 - `projects/cython-to-rust/phases/phase-07-cutover.md` — frontmatter
-  `status: Complete`, and §"Exit Criteria" annotated with how each clause
-  was met, including the qualification on "publishes from CI".
+  `status: Complete`, and §"Exit Criteria" revised: the release clause
+  narrowed to build-and-test plus an observed release gate, with
+  §"Revision of the release clause" recording why and what risk that
+  leaves (review round 1).
+- `docs/agents/lessons.md` and `docs/agents/lessons-examples.md` — the
+  `[unrun-workflow-cannot-close-a-criterion]` class extended to cover a
+  structurally unsatisfiable criterion, cited to this PR (review round 1).
 - `projects/cython-to-rust/learnings/phase-07-cutover.md` — new.
 - `projects/cython-to-rust/learnings/project-retrospective.md` — new.
 - `projects/cython-to-rust/task-notes/README.md` — Phases table, Status,
@@ -190,7 +224,7 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Verification
 
-- **`scripts/agents/preflight.sh --closing --md "<the 18 changed .md>"`**
+- **`scripts/agents/preflight.sh --closing --md "<the 23 changed .md>"`**
   — the full gate, with every markdown file in the diff passed to
   `--md`. Rows:
 
@@ -229,11 +263,11 @@ plus `../../PLAN.md` §"Closing this project":
   1 MD032, 2 MD036). That is the condition
   [`markdownlint-skips-skill-file-shapes`](../../../../docs/followups/todo/markdownlint-skips-skill-file-shapes.md)
   tracks — markdownlint was never run over `.claude/skills/`, so the
-  skill trees have never been clean. **All 18 documents this task
+  skill trees have never been clean. **All 20 documents this task
   authored or rewrote lint clean** on their own:
 
   ```sh
-  markdownlint --dot <the 18 non-skill .md in the diff>   # exit 0
+  markdownlint --dot <the 20 non-skill .md in the diff>   # exit 0
   ```
 
   No other gate is red.
@@ -320,10 +354,15 @@ mandates).
   the §Scope bullet on Windows / linux-aarch64 repointed at the follow-up
   Task 7.4 filed, because closing the plan makes a Scope bullet an
   archival record rather than a live one.
-- `../../phases/phase-07-cutover.md`: frontmatter `status:` → `Complete`,
-  and §"Exit Criteria" annotated with how each clause was met — including
-  the honest reading of "release candidate publishes from CI", which the
-  gate can only partly discharge.
+- `../../phases/phase-07-cutover.md`: frontmatter `status:` → `Complete`;
+  §"Exit Criteria" **revised**, not merely annotated. Its release clause
+  read "a release candidate builds, tests, and *publishes* from CI",
+  which no closing PR can satisfy — see §"Revision of the release clause"
+  in that file, and the review-round bullet in §Decisions above. The
+  clause now asks for build-and-test plus an observed release gate; the
+  upload is reassigned to the release manager with its residual risk
+  stated. `../README.md`'s Exit Criteria copy was revised in the same
+  pass.
 - No ADR. Nothing about architecture, invariants, interfaces, task
   ordering, units or normalization changed; all three project ADRs were
   Accepted and none needed amending. The canonical-contract diff was run
@@ -366,9 +405,9 @@ table. The other two are this block quoting itself.
 
 ### Link and index sweep
 
-Every relative markdown link in all 18 changed/created `.md` files
+Every relative markdown link in all 23 changed/created `.md` files
 resolves (script over `git diff origin/master --name-only`):
-`checked 18 markdown files / all relative links resolve`.
+`checked 23 markdown files; all relative links resolve`.
 
 `docs/followups/README.md`'s Open table against `docs/followups/todo/`:
 `listed but missing: none / on disk but unlisted: none / counts: listed
@@ -377,10 +416,11 @@ resolves (script over `git diff origin/master --name-only`):
 ### Line-number citation sweep
 
 ```sh
-python scripts/agents/check_doc_citations.py --changed-vs origin/master <18 docs>
-docs scanned: 18
-in-repo citations checked: 4
+python scripts/agents/check_doc_citations.py --changed-vs origin/master <23 docs>
+docs scanned: 23
+in-repo citations checked: 5
   resolved by exact: 4
+  resolved by suffix: 1
 external citations skipped: 16
 out-of-range or ambiguous: NONE
 ```
@@ -480,9 +520,18 @@ nothing.
 
 `**Status:** Complete` in the header, matching the phase README's Task
 7.4 row and this note's §Verification. Every file named in §Files Changed
-appears in `git diff origin/master --stat` (**19 files: 12 modified, 7
+appears in `git diff origin/master --stat` (**24 files: 17 modified, 7
 created**), and every file in that diff is named in §Files Changed —
-re-checked mechanically after the last edit. Three
+re-checked mechanically after the last content edit. Review round 1 cited
+this line reading "19 files: 12 modified, 7 created", which was true when
+written and went stale when `/commit-and-pr` added three
+`.claude/skills/` edits at the commit boundary; the round's own fixes
+then added two more files. **Every file-set count in this note is
+re-derived from `git diff` at the frozen tree rather than patched at the
+one line review cited** — the `--md` argument, the link sweep, the
+citation sweep and the lint count all moved with it. The two remaining
+`18`s were replaced by 20: that is the *non-skill* document count, a
+different number from the 23 `.md` in the diff. Three
 figures written before measurement were corrected in place rather than
 left to stand: "eleven defects" → twelve, "33 rows would say bit-equal"
 → 27, and "seven of the eight entry points past 1e-12" → exactly seven.

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
@@ -271,10 +271,9 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Verification
 
-- **`scripts/agents/preflight.sh --closing --md "<the 27 non-task-pipeline .md>"`**
-  — the full gate, with every markdown file in the diff except the
-  known-red `task-pipeline/SKILL.md` passed to `--md`, and `VIRTUAL_ENV`
-  set to an absolute path. Rows:
+- **`scripts/agents/preflight.sh --closing --md "<every .md in the diff>"`**
+  — the full gate, with every markdown file in the diff passed to `--md`
+  and no exclusion, and `VIRTUAL_ENV` set to an absolute path. Rows:
 
   | Gate | Result |
   | --- | --- |
@@ -323,18 +322,17 @@ plus `../../PLAN.md` §"Closing this project":
   [`docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md)
   exists for, and this task adds nothing to it.
 
-  markdownlint is red on exactly one file, `.claude/skills/task-pipeline/SKILL.md`,
-  which this task edited by two lines that touch no fence. Its lint state
-  is **unchanged**: 7 errors on this tree and 7 on `origin/master`, the
-  same five rules with the same contexts (4 MD031 on blockquoted fences,
-  1 MD032, 2 MD036). That is the condition
-  [`markdownlint-skips-skill-file-shapes`](../../../../docs/followups/todo/markdownlint-skips-skill-file-shapes.md)
-  tracks — markdownlint was never run over `.claude/skills/`, so the
-  skill trees have never been clean. **All 20 documents this task
-  authored or rewrote lint clean** on their own:
+  markdownlint is green. It was red on
+  `.claude/skills/task-pipeline/SKILL.md` while this branch was open —
+  7 errors both here and on the then-trunk, none of them this task's two
+  edited lines — and
+  [PR #88](https://github.com/LoganAMorrison/Hazma/pull/88) resolved that
+  by normalizing both skill trees, closing
+  [`markdownlint-skips-skill-file-shapes`](../../../../docs/followups/done/markdownlint-skips-skill-file-shapes.md).
+  Every markdown file in this diff now lints clean with no exclusion:
 
   ```sh
-  markdownlint --dot <the 27 non-task-pipeline .md in the diff>   # 0 issues
+  markdownlint --dot <every .md in the diff>   # 0 issues
   ```
 
   No other gate is red.
@@ -494,7 +492,7 @@ table. The other two are this block quoting itself.
 
 Every relative markdown link in all 23 changed/created `.md` files
 resolves (script over `git diff origin/master --name-only`):
-`checked 27 markdown files; broken relative links: 0`.
+`checked 28 markdown files; broken relative links: 0`.
 
 `docs/followups/README.md`'s Open table against `docs/followups/todo/`:
 `listed but missing: none / on disk but unlisted: none / counts: listed
@@ -504,7 +502,7 @@ resolves (script over `git diff origin/master --name-only`):
 
 ```sh
 python scripts/agents/check_doc_citations.py --changed-vs origin/master <23 docs>
-docs scanned: 27
+docs scanned: 28
 in-repo citations checked: 5
   resolved by exact: 4
   resolved by suffix: 1
@@ -538,7 +536,7 @@ citation *is* covered, and is one of the four resolved above —
 | Constants stub "two α values differ by 2.6e-4" | `(1/137 − 1/137.035999084) / (1/137.035999084)` | 2.627e-4 | OK |
 | `docs/versioning.md` version snippet | `grep '^version' pyproject.toml` | `2.2.0` | **EDITED** — snippet still said 2.1.0 |
 | Skills naming the version's home | `rg -n 'hazma/__init__\.py' .claude/skills/ .codex/skills/` | 3 hits before, **0** after | **EDITED** — see below |
-| `task-pipeline/SKILL.md` lint delta | `markdownlint --dot` on this tree vs `git show origin/master:` copy | **7 errors both sides**, same rules and contexts | KEPT — pre-existing |
+| `task-pipeline/SKILL.md` lint state | `markdownlint --dot` on this tree | **0 issues** — PR #88 normalized both skill trees and closed the follow-up that tracked it | **EDITED** — this note previously recorded it as 7 errors both sides |
 
 ### Numerical-impact statement
 
@@ -560,7 +558,7 @@ tests that exercised the wrapper rather than the physics — and includes
 | CHANGELOG entry with the aggregated drift table, naming the slug | `CHANGELOG.md` §`[2.2.0]` — lede names `cython-to-rust` and links its `PLAN.md`; the 11-row table under `Changed`; `preflight.sh --closing` asserts the `## [2.2.0]` section exists |
 | Version bumped per `version_bump`, level re-checked | `pyproject.toml:23` `2.2.0`; re-check recorded in §Numerical impact; `preflight.sh --closing` row `version bump  2.1.0 → 2.2.0 + CHANGELOG entry` |
 | `preflight.sh --closing` green on every gate this project can move, trunk reds measured unmoved | Nine of eleven rows PASS. `isort` and `ruff` FAIL on trunk code — `origin/master` with no edit applied gives the same 72 isort ERROR lines and 6091 ruff errors, and on the two `.py` files this PR changes the ruff finding text is identical with line numbers stripped. The criterion was revised to this wording in `phases/phase-07-cutover.md` §"Revision of the preflight clause"; it previously read "green", which no PR can satisfy |
-| Retrospective incl. §5 seeds, three named candidates | `../../learnings/project-retrospective.md` §5 — all three filed, plus a fourth; `docs/followups/todo/` cross-checked whole (27 = 27 above) |
+| Retrospective incl. §5 seeds, three named candidates | `../../learnings/project-retrospective.md` §5 — all three filed, plus a fourth; `docs/followups/todo/` cross-checked whole (26 = 26 above) |
 | `PLAN.md status: Complete` | `head -2 projects/cython-to-rust/PLAN.md` → `status: Complete` |
 | `projects/README.md` row moved with Shipped date | Completed table row, `2026-08-29 (hazma 2.2.0)` |
 | Phase 07 closed: rows, frontmatter, learnings, history sweep | phase README's four rows Complete; `phases/phase-07-cutover.md` frontmatter `status: Complete`; `../../learnings/phase-07-cutover.md`; the two Phase 07 cross-phase entries appended verbatim to `../history-{findings,decisions}.md` under a `## Phase 07 (moved 2026-08-29 at project close)` heading |
@@ -576,7 +574,7 @@ PASS   cargo clippy            rust/
 PASS   cargo test              rust/
 PASS   pytest                  2246 passed, 15 skipped, 12 subtests passed
 PASS   import hazma            version 2.2.0
-PASS   markdownlint            <the 27 non-task-pipeline .md in the diff>
+PASS   markdownlint            <every .md in the diff>
 PASS   version bump            2.1.0 → 2.2.0 + CHANGELOG entry
 PASS   forbidden tokens        none added
 ```

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
@@ -74,15 +74,21 @@ plus `../../PLAN.md` §"Closing this project":
   for the Phase 07 aggregate" (`../numerical-impact.md`, Task 0.2). So
   closing is a promotion of that heading plus the Phase 02–06 material,
   not a fresh section written beside it.
-- **The declared `major` survives the re-check, and nothing numerical
-  drives it.** The largest drift in the whole port is
+- **The re-check lowered the declared `major` to `minor`, and nothing
+  numerical drives either.** The largest drift in the whole port is
   `scalar_mediator_decay_spectrum` at **5.3327e-12** relative — a
-  `patch`-level number under `docs/versioning.md`. `major` is carried
+  `patch`-level number under `docs/versioning.md`. `major` was carried
   entirely by Phase 00's two API removals (`hazma.gamma_ray`,
   `hazma.deprecated.rambo`), exactly as `PLAN.md` §"Numerical impact"
-  predicted. The one genuinely user-visible numerical change is Task
-  0.3's threshold repair (1.3e-4 within 1e-10 of threshold, plus three
-  edge behaviors), and it too is already written up in `[Unreleased]`.
+  predicted. Neither can break working code — the first was
+  un-importable in every released tag, the second warned on import and
+  named `hazma.phase_space` — so `docs/versioning.md` gains a
+  reachability carve-out covering both and the release ships as
+  **2.2.0**. `minor` stands on its own regardless: this release adds
+  `hazma.utils.two_body_momentum` and `hazma.spectra.dnde_photon_fsr`,
+  and Task 0.3's threshold repair is a genuinely user-visible numerical
+  change (1.3e-4 within 1e-10 of threshold, plus three edge behaviors),
+  already written up in `[Unreleased]`.
 - **Exactly seven entry points moved past `rules.md` rule 3's 1e-12
   threshold, and all seven are mediator spectra that moved for one
   reason.** Task 6.2's three and Task 6.3's four are `crate::quad`
@@ -122,7 +128,7 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Decisions and Implementation Notes
 
-- **Promote `[Unreleased]` to `## [3.0.0] — 2026-08-29` rather than open
+- **Promote `[Unreleased]` to `## [2.2.0] — 2026-08-29` rather than open
   a new section.** Phase 00's blocks are already the settled wording and
   every later phase's material is additive to them. A second section
   would split one release across two headings and break the
@@ -151,7 +157,7 @@ plus `../../PLAN.md` §"Closing this project":
   reviewer offered two remedies; **the first is unavailable.** "Keep
   closure pending until the release publish is observed" deadlocks:
   `publish` is gated on `github.event_name == 'release'`, a release needs
-  the `3.0.0` tag, and that tag exists only after this closing PR merges,
+  the `2.2.0` tag, and that tag exists only after this closing PR merges,
   so closure would gate on an event that closure itself enables. Taking
   the second remedy — formally revise the criterion — is also what
   `execute-single-task` Step 7 prescribes for a gate sentence that is
@@ -180,10 +186,10 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Files Changed
 
-- `CHANGELOG.md` — `[Unreleased]` promoted to `[3.0.0]`; the migration
+- `CHANGELOG.md` — `[Unreleased]` promoted to `[2.2.0]`; the migration
   summary, the aggregated drift table and the `Known issues` block added;
   the section list in the file header amended for `Known issues`.
-- `pyproject.toml` — `[project] version` `2.1.0` → `3.0.0`.
+- `pyproject.toml` — `[project] version` `2.1.0` → `2.2.0`.
 - `projects/cython-to-rust/PLAN.md` — `status: Complete`; Phase 07 row
   filled in.
 - `projects/README.md` — `cython-to-rust` row moved Active → Completed.
@@ -239,7 +245,7 @@ plus `../../PLAN.md` §"Closing this project":
   | `pytest` | PASS — `2231 passed, 15 skipped, 12 subtests passed` |
   | `import hazma` | PASS |
   | `markdownlint` | **FAIL** — pre-existing, see below |
-  | `version bump` | PASS — `2.1.0 → 3.0.0 + CHANGELOG entry` |
+  | `version bump` | PASS — `2.1.0 → 2.2.0 + CHANGELOG entry` |
   | `forbidden tokens` | PASS — none added |
 
 - **All three FAIL rows are pre-existing, and none is this task's.**
@@ -284,9 +290,9 @@ plus `../../PLAN.md` §"Closing this project":
 
 - **The version resolves after a rebuild.** `uv pip install -e .` then
   `python -c "import hazma; print(hazma.VERSION, hazma.__version__)"` →
-  `3.0.0 3.0.0`. Worth running explicitly: `hazma.VERSION` reads the
+  `2.2.0 2.2.0`. Worth running explicitly: `hazma.VERSION` reads the
   *installed* metadata, so preflight's import-smoke row reported
-  `version 2.1.0` from a tree whose `pyproject.toml` already said 3.0.0.
+  `version 2.1.0` from a tree whose `pyproject.toml` already said 2.2.0.
 
 - **The drift table was derived, not transcribed.** The 14-moved /
   27-bit-equal split is read out of `test/parity/tolerances.py` — 11
@@ -311,21 +317,31 @@ doing so: one line of `pyproject.toml` (the version) and markdown.
 ```sh
 git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' \
     '*.csv' '*.dat' '*.npy' '*.toml'
-# -> pyproject.toml    (single hunk: version = "2.1.0" -> "3.0.0")
+# -> pyproject.toml    (single hunk: version = "2.1.0" -> "2.2.0")
 ```
 
 No code path, constant, table or signature is reachable, so no grid
 evaluation applies. Recorded as the closing entry in
 [`../numerical-impact.md`](../numerical-impact.md), which also states the
-one user-visible non-numerical move (`hazma.VERSION` → `3.0.0`) and the
+one user-visible non-numerical move (`hazma.VERSION` → `2.2.0`) and the
 aggregate the CHANGELOG carries.
 
-**Version level re-checked, not inherited.** `PLAN.md`'s
-`version_bump: major` holds: the largest drift anywhere in the port is
-5.3327e-12 relative, `patch`-level under `docs/versioning.md`, and
-`major` rests on Phase 00's removal of `hazma.gamma_ray` and
-`hazma.deprecated.rambo` — the latter `major` by the
-`hazma/deprecated/` rule specifically.
+**Version level re-checked, not inherited, and lowered.** `PLAN.md`
+declared `version_bump: major`; it now reads `minor` and the release is
+**2.2.0**. Nothing numerical ever drove the level — the largest drift
+anywhere in the port is 5.3327e-12 relative, `patch`-level under
+`docs/versioning.md` — so `major` rested entirely on Phase 00's removal
+of `hazma.gamma_ray` and `hazma.deprecated.rambo`. Neither removal can
+break working code: `hazma/gamma_ray.py` opens with
+`from hazma import rambo` and `hazma/rambo.py` appears in no released
+tag, and `hazma/deprecated/rambo.py` warned on import toward
+`hazma.phase_space`. `docs/versioning.md` had no exception for either
+case, so this change adds the **reachability carve-out** that covers
+both, and `minor` then holds on its own merits through the two added
+public functions and Task 0.3's threshold repair. The lowering note the
+rule requires is in [`../README.md`](../README.md) §"Decisions and
+Implementation Notes"; ADR-0003 carries a dated note because its
+mitigation cited the old level.
 
 ## Open Questions
 
@@ -337,10 +353,10 @@ open:
 
 - **`release.yml`'s `publish` job has never executed.** Three dispatches
   and one `pull_request` run all skipped it correctly, which is what the
-  `github.event_name == 'release'` gate is for. Cutting 3.0.0 is the
+  `github.event_name == 'release'` gate is for. Cutting 2.2.0 is the
   first execution — watch it (`docs/agents/lessons.md`
   `[unrun-workflow-cannot-close-a-criterion]`).
-- **Twelve reproduced 2.1.0 defects ship in 3.0.0.** That is
+- **Twelve reproduced 2.1.0 defects ship in 2.2.0.** That is
   `rules.md` rules 1 and 2 working as intended, not an oversight; the
   CHANGELOG's `Known issues` section says so to users and
   `projects/parity-pinned-defect-repair/` sequences the repairs.
@@ -449,7 +465,7 @@ citation *is* covered, and is one of the four resolved above —
 | Retrospective/Phase-07 "`pytest -q` 2231/15/12" | preflight's pytest row | `2231 passed, 15 skipped, 12 subtests passed` | OK |
 | Constants stub "twelve names disagree" | `the_two_tables_disagree_where_the_cython_says_they_do` | **12** entries | OK |
 | Constants stub "two α values differ by 2.6e-4" | `(1/137 − 1/137.035999084) / (1/137.035999084)` | 2.627e-4 | OK |
-| `docs/versioning.md` version snippet | `grep '^version' pyproject.toml` | `3.0.0` | **EDITED** — snippet still said 2.1.0 |
+| `docs/versioning.md` version snippet | `grep '^version' pyproject.toml` | `2.2.0` | **EDITED** — snippet still said 2.1.0 |
 | Skills naming the version's home | `rg -n 'hazma/__init__\.py' .claude/skills/ .codex/skills/` | 3 hits before, **0** after | **EDITED** — see below |
 | `task-pipeline/SKILL.md` lint delta | `markdownlint --dot` on this tree vs `git show origin/master:` copy | **7 errors both sides**, same rules and contexts | KEPT — pre-existing |
 
@@ -458,7 +474,7 @@ citation *is* covered, and is one of the four resolved above —
 **No public value changes (verified:
 `git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd'
 '*.csv' '*.dat' '*.npy' '*.toml'` → `pyproject.toml` only, whose single
-hunk is `version = "2.1.0"` → `"3.0.0"`).** No code path, constant,
+hunk is `version = "2.1.0"` → `"2.2.0"`).** No code path, constant,
 table or signature is reachable from this diff, so no grid evaluation
 applies. `pytest -q` is `2231 passed, 15 skipped, 12 subtests passed`,
 which includes `test/parity` at its declared budgets and
@@ -469,12 +485,12 @@ which includes `test/parity` at its declared budgets and
 
 | Criterion | Artifact |
 | --- | --- |
-| CHANGELOG entry with the aggregated drift table, naming the slug | `CHANGELOG.md` §`[3.0.0]` — lede names `cython-to-rust` and links its `PLAN.md`; the 11-row table under `Changed`; `preflight.sh --closing` asserts the `## [3.0.0]` section exists |
-| Version bumped per `version_bump`, level re-checked | `pyproject.toml:23` `3.0.0`; re-check recorded in §Numerical impact; `preflight.sh --closing` row `version bump  2.1.0 → 3.0.0 + CHANGELOG entry` |
+| CHANGELOG entry with the aggregated drift table, naming the slug | `CHANGELOG.md` §`[2.2.0]` — lede names `cython-to-rust` and links its `PLAN.md`; the 11-row table under `Changed`; `preflight.sh --closing` asserts the `## [2.2.0]` section exists |
+| Version bumped per `version_bump`, level re-checked | `pyproject.toml:23` `2.2.0`; re-check recorded in §Numerical impact; `preflight.sh --closing` row `version bump  2.1.0 → 2.2.0 + CHANGELOG entry` |
 | `preflight.sh --closing` green | all rows PASS except the two documented trunk reds (below) |
 | Retrospective incl. §5 seeds, three named candidates | `../../learnings/project-retrospective.md` §5 — all three filed, plus a fourth; `docs/followups/todo/` cross-checked whole (27 = 27 above) |
 | `PLAN.md status: Complete` | `head -2 projects/cython-to-rust/PLAN.md` → `status: Complete` |
-| `projects/README.md` row moved with Shipped date | Completed table row, `2026-08-29 (hazma 3.0.0)` |
+| `projects/README.md` row moved with Shipped date | Completed table row, `2026-08-29 (hazma 2.2.0)` |
 | Phase 07 closed: rows, frontmatter, learnings, history sweep | phase README's four rows Complete; `phases/phase-07-cutover.md` frontmatter `status: Complete`; `../../learnings/phase-07-cutover.md`; the two Phase 07 cross-phase entries appended verbatim to `../history-{findings,decisions}.md` under a `## Phase 07 (moved 2026-08-29 at project close)` heading |
 
 ### Preflight
@@ -487,9 +503,9 @@ PASS   cargo fmt --check       rust/
 PASS   cargo clippy            rust/
 PASS   cargo test              rust/
 PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed
-PASS   import hazma            version 3.0.0
+PASS   import hazma            version 2.2.0
 FAIL   markdownlint            (task-pipeline/SKILL.md only; unchanged)
-PASS   version bump            2.1.0 → 3.0.0 + CHANGELOG entry
+PASS   version bump            2.1.0 → 2.2.0 + CHANGELOG entry
 PASS   forbidden tokens        none added
 ```
 
@@ -540,7 +556,7 @@ left to stand: "eleven defects" → twelve, "33 rows would say bit-equal"
 
 **There is no next task.** The cython-to-rust project is Complete —
 eight phases, 33 tasks, 2026-08-03 to 2026-08-29, shipped as hazma
-3.0.0.
+2.2.0.
 
 Read [`../../learnings/project-retrospective.md`](../../learnings/project-retrospective.md)
 first; it replaces this note and the other 32 for every later reader
@@ -552,8 +568,8 @@ carries the packaging contract.
 
 **Safe to assume:**
 
-- `[project] version` is `3.0.0` and `CHANGELOG.md` has a matching
-  `## [3.0.0] — 2026-08-29` section. `preflight.sh --closing` is green on
+- `[project] version` is `2.2.0` and `CHANGELOG.md` has a matching
+  `## [2.2.0] — 2026-08-29` section. `preflight.sh --closing` is green on
   both.
 - `projects/README.md` lists cython-to-rust under **Completed**; the only
   Active project is `parity-pinned-defect-repair`.

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
@@ -14,7 +14,7 @@ amended here)
 
 Close the cython-to-rust project: aggregate the running numerical record
 into a `CHANGELOG.md` release section, bump `[project] version` to the
-declared `major` level, synthesize the Phase 07 learnings and the project
+re-checked level, synthesize the Phase 07 learnings and the project
 retrospective, file the retrospective's follow-on seeds, and flip the
 project's status in `PLAN.md` and `projects/README.md`.
 
@@ -29,7 +29,10 @@ plus `../../PLAN.md` §"Closing this project":
 - `[project] version` in `pyproject.toml` bumped per `PLAN.md`
   `version_bump` — re-checked against the recorded drift and the Task 0.5
   outcome rather than inherited from the frontmatter — and
-  `scripts/agents/preflight.sh --closing` green. (Task 7.1 moved the
+  `scripts/agents/preflight.sh --closing` green on every gate this
+  project can move, with its two trunk-red gates measured unmoved
+  against `origin/master` (criterion revised 2026-09-06; see the phase
+  file). (Task 7.1 moved the
   version's source of truth off `hazma/__init__.py`; the gate reads
   `pyproject.toml`.)
 - Project retrospective at `../../learnings/project-retrospective.md`
@@ -128,7 +131,7 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Decisions and Implementation Notes
 
-- **Promote `[Unreleased]` to `## [2.2.0] — 2026-08-29` rather than open
+- **Promote `[Unreleased]` to `## [2.2.0] — 2026-09-06` rather than open
   a new section.** Phase 00's blocks are already the settled wording and
   every later phase's material is additive to them. A second section
   would split one release across two headings and break the
@@ -173,11 +176,12 @@ plus `../../PLAN.md` §"Closing this project":
   the same way, not just the cited one, and this round's own fixes then
   moved them again. Rather than chase them, every count was re-derived
   from `git diff` once after all content edits were frozen
-  (`doc-consistency.md` §11 rule 1, "sweep last"): **32 files, 25
-  modified and 7 created**; 27 `.md` in the diff; 24 of those outside
-  `.claude/skills/`. Two distinct quantities were being conflated — the
-  `.md` count in the diff and the count of documents this task authored —
-  so both are now named explicitly wherever they appear.
+  (`doc-consistency.md` §11 rule 1, "sweep last"): **34 files, 27
+  modified and 7 created**; 28 `.md` in the diff; 25 of those outside
+  `.claude/skills/`; plus 4 `.py`, one `.ipynb` and `pyproject.toml`.
+  Two distinct quantities were being conflated — the `.md` count in the
+  diff and the count of documents this task authored — so both are now
+  named explicitly wherever they appear.
 - **`hazma/experimental/axial_vector_mediator/__init__.py` stays
   broken.** Phase 00's learnings flagged it and deliberately filed
   nothing, because `experimental/` is not a public surface
@@ -248,11 +252,13 @@ plus `../../PLAN.md` §"Closing this project":
   `collections.abc.Sequence` import it was the only user of. `ldot` is
   unchanged: every call site passed a shape-`(4,)` `ndarray`, so nothing
   needed the looser index-based contract.
-- `hazma/experimental/axial_vector_mediator/avm_msqrd.py` and
-  `notebooks/dev/gamma_ray_fsr/partial_integration.py` — the two
-  consumers, repointed at `ldot`. Neither is on the public surface, and
-  the notebook script stays dead on its own `hazma.rambo` and
-  `hazma.gamma_ray` imports.
+- `hazma/experimental/axial_vector_mediator/avm_msqrd.py`,
+  `notebooks/dev/gamma_ray_fsr/partial_integration.py` and
+  `notebooks/dev/K0_radiative_decay_4_24_18.ipynb` — the three consumers,
+  repointed at `ldot`. None is on the public surface, and both notebooks
+  stay dead on their own `hazma.gamma_ray` imports. Enumerate consumers
+  with `git grep -l` and **no extension filter**: a first pass restricted
+  to `*.py`/`*.rst`/`*.pyi` missed the `.ipynb` entirely.
 - `test/test_utils.py` — the three tests pinning the metric signature and
   the on-shell invariant retargeted onto `ldot`, which had no direct
   coverage of its own; the two exercising only the wrapper dropped. Net
@@ -265,9 +271,10 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Verification
 
-- **`scripts/agents/preflight.sh --closing --md "<the 23 changed .md>"`**
-  — the full gate, with every markdown file in the diff passed to
-  `--md`. Rows:
+- **`scripts/agents/preflight.sh --closing --md "<the 27 non-task-pipeline .md>"`**
+  — the full gate, with every markdown file in the diff except the
+  known-red `task-pipeline/SKILL.md` passed to `--md`, and `VIRTUAL_ENV`
+  set to an absolute path. Rows:
 
   | Gate | Result |
   | --- | --- |
@@ -279,23 +286,42 @@ plus `../../PLAN.md` §"Closing this project":
   | `cargo test` | PASS |
   | `pytest` | PASS — `2246 passed, 15 skipped, 12 subtests passed` |
   | `import hazma` | PASS |
-  | `markdownlint` | **FAIL** — pre-existing, see below |
+  | `markdownlint` | PASS — the 27 documents this PR authored or edited |
   | `version bump` | PASS — `2.1.0 → 2.2.0 + CHANGELOG entry` |
   | `forbidden tokens` | PASS — none added |
 
-- **All three FAIL rows are pre-existing, and none is this task's.**
-  For isort and ruff the diff contains **zero** `.py` files, so both
-  read bytes identical to `origin/master`.
+- **Both FAIL rows are pre-existing, and neither is this task's.**
+  The diff does contain `.py` files, so this is established by running
+  each red gate against the same paths on `origin/master` and diffing the
+  findings — not by the diff's shape.
+
+  Both trees must be real worktrees, so each run reads the same
+  `[tool.ruff]` config. Copying files into a bare directory silently
+  drops it — ruff then applies its *default* rules and reports 11 where
+  the configured set reports 117, which looks like a regression and is
+  not one.
 
   ```sh
-  git diff origin/master --name-only -- '*.py' | wc -l   # -> 0
+  git worktree add -f /tmp/base origin/master --detach
+
+  # The whole-tree gate, on that untouched worktree:
+  isort --check-only hazma test | grep -c ERROR   # -> 72
+  ruff check hazma test                           # -> Found 6091 errors.
+
+  # The four .py files this task changes, master vs this tree:
+  isort --check-only <the four>     # -> same one file, both trees:
+                                    #    notebooks/dev/gamma_ray_fsr/
+                                    #    partial_integration.py, unsorted
+                                    #    on master before this task edits it
+  ruff check --no-cache --output-format=concise <the four> \
+    | sed 's/^[^:]*:[0-9]*:[0-9]*: //' | sort     # -> 117 findings, and
+                                                  #    `diff` of the two
+                                                  #    sorted lists is empty
   ```
 
-  Measured anyway on this tree: `isort --check-only hazma test` reports
-  **72** ERROR lines and `ruff check hazma test` **6091** errors, which
-  is the condition
+  So the gate is red for the reason
   [`docs/followups/todo/preflight-isort-ruff-red-on-trunk.md`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md)
-  exists for.
+  exists for, and this task adds nothing to it.
 
   markdownlint is red on exactly one file, `.claude/skills/task-pipeline/SKILL.md`,
   which this task edited by two lines that touch no fence. Its lint state
@@ -308,7 +334,7 @@ plus `../../PLAN.md` §"Closing this project":
   authored or rewrote lint clean** on their own:
 
   ```sh
-  markdownlint --dot <the 24 non-skill .md in the diff>   # exit 0
+  markdownlint --dot <the 27 non-task-pipeline .md in the diff>   # 0 issues
   ```
 
   No other gate is red.
@@ -468,7 +494,7 @@ table. The other two are this block quoting itself.
 
 Every relative markdown link in all 23 changed/created `.md` files
 resolves (script over `git diff origin/master --name-only`):
-`checked 23 markdown files; all relative links resolve`.
+`checked 27 markdown files; broken relative links: 0`.
 
 `docs/followups/README.md`'s Open table against `docs/followups/todo/`:
 `listed but missing: none / on disk but unlisted: none / counts: listed
@@ -478,7 +504,7 @@ resolves (script over `git diff origin/master --name-only`):
 
 ```sh
 python scripts/agents/check_doc_citations.py --changed-vs origin/master <23 docs>
-docs scanned: 23
+docs scanned: 27
 in-repo citations checked: 5
   resolved by exact: 4
   resolved by suffix: 1
@@ -533,7 +559,7 @@ tests that exercised the wrapper rather than the physics — and includes
 | --- | --- |
 | CHANGELOG entry with the aggregated drift table, naming the slug | `CHANGELOG.md` §`[2.2.0]` — lede names `cython-to-rust` and links its `PLAN.md`; the 11-row table under `Changed`; `preflight.sh --closing` asserts the `## [2.2.0]` section exists |
 | Version bumped per `version_bump`, level re-checked | `pyproject.toml:23` `2.2.0`; re-check recorded in §Numerical impact; `preflight.sh --closing` row `version bump  2.1.0 → 2.2.0 + CHANGELOG entry` |
-| `preflight.sh --closing` green | all rows PASS except the two documented trunk reds (below) |
+| `preflight.sh --closing` green on every gate this project can move, trunk reds measured unmoved | Nine of eleven rows PASS. `isort` and `ruff` FAIL on trunk code — `origin/master` with no edit applied gives the same 72 isort ERROR lines and 6091 ruff errors, and on the two `.py` files this PR changes the ruff finding text is identical with line numbers stripped. The criterion was revised to this wording in `phases/phase-07-cutover.md` §"Revision of the preflight clause"; it previously read "green", which no PR can satisfy |
 | Retrospective incl. §5 seeds, three named candidates | `../../learnings/project-retrospective.md` §5 — all three filed, plus a fourth; `docs/followups/todo/` cross-checked whole (27 = 27 above) |
 | `PLAN.md status: Complete` | `head -2 projects/cython-to-rust/PLAN.md` → `status: Complete` |
 | `projects/README.md` row moved with Shipped date | Completed table row, `2026-08-29 (hazma 2.2.0)` |
@@ -550,18 +576,38 @@ PASS   cargo clippy            rust/
 PASS   cargo test              rust/
 PASS   pytest                  2246 passed, 15 skipped, 12 subtests passed
 PASS   import hazma            version 2.2.0
-FAIL   markdownlint            (task-pipeline/SKILL.md only; unchanged)
+PASS   markdownlint            <the 27 non-task-pipeline .md in the diff>
 PASS   version bump            2.1.0 → 2.2.0 + CHANGELOG entry
 PASS   forbidden tokens        none added
 ```
 
+`VIRTUAL_ENV` must be **absolute** when invoking the gate. Set to a
+relative `.venv`, pyo3's build config resolves `.venv/bin/python` against
+cargo's own working directory and the `cargo test` row fails with
+`failed to run the Python interpreter at .venv/bin/python` — a red row
+that belongs to the invocation, not the tree.
+
 **The two FAIL rows are the trunk's, not this task's**, and the proof is
-stronger than a stash-and-rerun: `git diff origin/master --name-only --
-'*.py' | wc -l` is **0**, so both linters read bytes identical to
-`origin/master`. On this tree they report 72 isort ERROR lines and 6091
-ruff errors — the standing condition
+a measurement rather than a claim: run both linters against the same
+paths on `origin/master` and diff the findings. A clean `origin/master`
+worktree with no edit applied gives **72 isort ERROR lines and 6091 ruff
+errors**. For the two `.py` files this PR changes, master and this tree
+both report **50 ruff findings whose text is identical** once line
+numbers are stripped, and `isort --check-only` on them exits **0**. So
+this PR introduces neither finding, and the reds are the standing
+condition
 [`preflight-isort-ruff-red-on-trunk`](../../../../docs/followups/todo/preflight-isort-ruff-red-on-trunk.md)
-tracks. A first run also had markdownlint red on one MD012 in
+tracks.
+
+That is what the revised criterion asks for and all it asks for. It is
+**not** a waiver: `docs/agents/preflight.md` is right that a red gate
+must not be argued away, and the honest reading is that the gate cannot
+answer "did this PR break anything?" while it asserts absolute
+cleanliness on a tree carrying 6091 findings. Repairing that is the
+follow-up's job — it lists three candidate remedies and has none chosen —
+not a closing PR's.
+
+A first run also had markdownlint red on one MD012 in
 `../numerical-impact.md` (a doubled trailing blank line this task
 introduced); fixed, and green above.
 
@@ -582,7 +628,7 @@ nothing.
 
 `**Status:** Complete` in the header, matching the phase README's Task
 7.4 row and this note's §Verification. Every file named in §Files Changed
-appears in `git diff origin/master --stat` (**32 files: 25 modified, 7
+appears in `git diff origin/master --stat` (**34 files: 27 modified, 7
 created**), and every file in that diff is named in §Files Changed —
 re-checked mechanically after the last content edit. Review round 1 cited
 this line reading "19 files: 12 modified, 7 created", which was true when
@@ -593,7 +639,8 @@ then added two more files, and the 2.2.0 renumber and the merge of
 re-derived from `git diff` at the frozen tree rather than patched at the
 one line review cited** — the `--md` argument, the link sweep, the
 citation sweep and the lint count all moved with it. The non-skill
-document count is 24, a different number from the 27 `.md` in the diff.
+document count is 25, a different number from the 28 `.md` in the diff
+and from the 27 passed to `--md`.
 Three
 figures written before measurement were corrected in place rather than
 left to stand: "eleven defects" → twelve, "33 rows would say bit-equal"

--- a/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
+++ b/projects/cython-to-rust/task-notes/phase-07/task-7.4-close.md
@@ -173,8 +173,8 @@ plus `../../PLAN.md` §"Closing this project":
   the same way, not just the cited one, and this round's own fixes then
   moved them again. Rather than chase them, every count was re-derived
   from `git diff` once after all content edits were frozen
-  (`doc-consistency.md` §11 rule 1, "sweep last"): **24 files, 17
-  modified and 7 created**; 23 `.md` in the diff; 20 of those outside
+  (`doc-consistency.md` §11 rule 1, "sweep last"): **32 files, 25
+  modified and 7 created**; 27 `.md` in the diff; 24 of those outside
   `.claude/skills/`. Two distinct quantities were being conflated — the
   `.md` count in the diff and the count of documents this task authored —
   so both are now named explicitly wherever they appear.
@@ -186,12 +186,18 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Files Changed
 
-- `CHANGELOG.md` — `[Unreleased]` promoted to `[2.2.0]`; the migration
-  summary, the aggregated drift table and the `Known issues` block added;
-  the section list in the file header amended for `Known issues`.
+- `CHANGELOG.md` — `[Unreleased]` promoted to `[2.2.0]` dated
+  2026-09-06; the migration summary, the aggregated drift table and the
+  `Known issues` block added; the section list in the file header
+  amended for `Known issues`. Merging `origin/master` brought in the
+  scalar-decay FSR repair under `Changed`, so the lede now leads with the
+  two physics repairs that move published numbers, the drift table is
+  scoped to the port alone, and `Known issues` says why that repair is
+  not one of the twelve.
 - `pyproject.toml` — `[project] version` `2.1.0` → `2.2.0`.
 - `projects/cython-to-rust/PLAN.md` — `status: Complete`; Phase 07 row
-  filled in.
+  filled in; `version_bump: major` → `minor` with its reasoning replaced
+  (version renumber).
 - `projects/README.md` — `cython-to-rust` row moved Active → Completed.
 - `projects/cython-to-rust/phases/phase-07-cutover.md` — frontmatter
   `status: Complete`, and §"Exit Criteria" revised: the release clause
@@ -221,7 +227,36 @@ plus `../../PLAN.md` §"Closing this project":
   `wheels-for-aarch64-and-windows.md`.
 - `docs/followups/README.md` — four rows under Open.
 - `docs/versioning.md` — the illustrative `[project] version` snippet,
-  which still quoted `2.1.0`.
+  which still quoted `2.1.0`, and the **reachability carve-out**: the two
+  `major` removal bullets made subordinate to it, the carve-out itself
+  under `minor`, item 6 of §"The public surface", and two cheat-sheet
+  rows (version renumber).
+- `AGENTS.md` — the `hazma/deprecated/` rule, which stated the removal
+  break without the carve-out's exception (version renumber).
+- `projects/cython-to-rust/adrs/ADR-0003-remove-gamma-ray-module.md` — a
+  dated note at the end. The decision stands; only its mitigation, which
+  argued from the project already being `major`, is superseded (version
+  renumber).
+- `docs/followups/todo/mediator-spectra-accept-unknown-mode-strings.md`
+  — sequenced to ride the planned major, it now says that shipping 2.2.0
+  leaves it waiting for the next one (version renumber).
+- `docs/followups/todo/utils-public-surface-redundant-helpers.md` —
+  rescoped to `kinematically_accessable` alone and retitled, with the
+  `minkowski_dot` half recorded as resolved. `docs/followups/README.md`
+  carries the new title.
+- `hazma/utils.py` — `minkowski_dot` deleted, with the
+  `collections.abc.Sequence` import it was the only user of. `ldot` is
+  unchanged: every call site passed a shape-`(4,)` `ndarray`, so nothing
+  needed the looser index-based contract.
+- `hazma/experimental/axial_vector_mediator/avm_msqrd.py` and
+  `notebooks/dev/gamma_ray_fsr/partial_integration.py` — the two
+  consumers, repointed at `ldot`. Neither is on the public surface, and
+  the notebook script stays dead on its own `hazma.rambo` and
+  `hazma.gamma_ray` imports.
+- `test/test_utils.py` — the three tests pinning the metric signature and
+  the on-shell invariant retargeted onto `ldot`, which had no direct
+  coverage of its own; the two exercising only the wrapper dropped. Net
+  −2 tests.
 - `.claude/skills/{commit-and-pr,execute-single-task,task-pipeline}/SKILL.md`
   — the closing-PR instructions still told the next agent to bump
   `VERSION` in `hazma/__init__.py`. Repointed at `pyproject.toml`'s
@@ -242,7 +277,7 @@ plus `../../PLAN.md` §"Closing this project":
   | `cargo fmt --check` | PASS |
   | `cargo clippy` | PASS |
   | `cargo test` | PASS |
-  | `pytest` | PASS — `2231 passed, 15 skipped, 12 subtests passed` |
+  | `pytest` | PASS — `2246 passed, 15 skipped, 12 subtests passed` |
   | `import hazma` | PASS |
   | `markdownlint` | **FAIL** — pre-existing, see below |
   | `version bump` | PASS — `2.1.0 → 2.2.0 + CHANGELOG entry` |
@@ -273,7 +308,7 @@ plus `../../PLAN.md` §"Closing this project":
   authored or rewrote lint clean** on their own:
 
   ```sh
-  markdownlint --dot <the 20 non-skill .md in the diff>   # exit 0
+  markdownlint --dot <the 24 non-skill .md in the diff>   # exit 0
   ```
 
   No other gate is red.
@@ -284,7 +319,7 @@ plus `../../PLAN.md` §"Closing this project":
   inside the 2231.
 
 - **`cargo test --manifest-path rust/Cargo.toml --no-default-features`**
-  — `test result: ok. 258 passed; 0 failed` on the lib target, plus 0
+  — `test result: ok. 261 passed; 0 failed` on the lib target, plus 0
   doc-tests. **The 249 the project working memory carried was two tasks
   stale**; both learnings files now say 258 and say to re-derive it.
 
@@ -311,16 +346,26 @@ plus `../../PLAN.md` §"Closing this project":
 
 ## Numerical impact
 
-**No public value changes**, and the diff proves it rather than a sweep
-doing so: one line of `pyproject.toml` (the version) and markdown.
+**No public value changes.** The diff is markdown, the version line, and
+the `minkowski_dot` removal:
 
 ```sh
 git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' \
     '*.csv' '*.dat' '*.npy' '*.toml'
-# -> pyproject.toml    (single hunk: version = "2.1.0" -> "2.2.0")
+# -> pyproject.toml                       (version = "2.1.0" -> "2.2.0")
+#    hazma/utils.py                       (minkowski_dot deleted)
+#    hazma/experimental/.../avm_msqrd.py  (repointed at ldot)
+#    test/test_utils.py                   (tests retargeted at ldot)
 ```
 
-No code path, constant, table or signature is reachable, so no grid
+`minkowski_dot` appears in **no released tag** (checked against 2.0.2 and
+2.1.0), so no user could ever have called it and its deletion is
+unobservable from outside the repository. `ldot`, which absorbs its two
+consumers, is untouched — every call site passed a shape-`(4,)`
+`ndarray`, so nothing needed the looser index-based contract, and both
+squared matrix elements in `avm_msqrd.py` are **bit-for-bit identical**
+to the deleted implementation over 200 random momentum draws. No other
+code path, constant, table or signature is reachable, so no grid
 evaluation applies. Recorded as the closing entry in
 [`../numerical-impact.md`](../numerical-impact.md), which also states the
 one user-visible non-numerical move (`hazma.VERSION` → `2.2.0`) and the
@@ -461,8 +506,8 @@ citation *is* covered, and is one of the four resolved above —
 | CHANGELOG drift table, 11 rows | each figure against `../numerical-impact.md` | all 11 match to the quoted precision | OK |
 | CHANGELOG "at most 5.4e-12" | max of the table | 5.3327e-12 | OK |
 | CHANGELOG "twelve defects" | `docs/followups/todo/` entries sourced by this project | 1 (T3.4) + 7 (P04) + 3 (P05) + 1 (T6.3) = **12** | OK (the log's own ordinals disagree; see §Findings) |
-| Retrospective/Phase-07 "`cargo test` … 258" | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `ok. 258 passed; 0 failed` | OK (was 249 in working memory — **EDITED** in both files) |
-| Retrospective/Phase-07 "`pytest -q` 2231/15/12" | preflight's pytest row | `2231 passed, 15 skipped, 12 subtests passed` | OK |
+| Retrospective/Phase-07 "`cargo test` … 261" | `cargo test --manifest-path rust/Cargo.toml --no-default-features` | `ok. 261 passed; 0 failed` | **EDITED** in both files — 249 in working memory, 258 before merging `origin/master` |
+| Retrospective/Phase-07 "`pytest -q` 2246/15/12" | preflight's pytest row | `2246 passed, 15 skipped, 12 subtests passed` | **EDITED** in both files — 2231 before the merge and the `minkowski_dot` removal |
 | Constants stub "twelve names disagree" | `the_two_tables_disagree_where_the_cython_says_they_do` | **12** entries | OK |
 | Constants stub "two α values differ by 2.6e-4" | `(1/137 − 1/137.035999084) / (1/137.035999084)` | 2.627e-4 | OK |
 | `docs/versioning.md` version snippet | `grep '^version' pyproject.toml` | `2.2.0` | **EDITED** — snippet still said 2.1.0 |
@@ -471,13 +516,14 @@ citation *is* covered, and is one of the four resolved above —
 
 ### Numerical-impact statement
 
-**No public value changes (verified:
-`git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd'
-'*.csv' '*.dat' '*.npy' '*.toml'` → `pyproject.toml` only, whose single
-hunk is `version = "2.1.0"` → `"2.2.0"`).** No code path, constant,
-table or signature is reachable from this diff, so no grid evaluation
-applies. `pytest -q` is `2231 passed, 15 skipped, 12 subtests passed`,
-which includes `test/parity` at its declared budgets and
+**No public value changes.** The code the diff touches is the version
+line and the `minkowski_dot` removal; the removed name is in no released
+tag, and `ldot` reproduces it bit-for-bit on both `avm_msqrd.py` squared
+matrix elements over 200 draws. Nothing else reachable changes, so no
+grid evaluation applies. `pytest -q` is `2246 passed, 15 skipped, 12
+subtests passed` — two fewer than before the removal, exactly the two
+tests that exercised the wrapper rather than the physics — and includes
+`test/parity` at its declared budgets and
 `test/test_theory_aggregation.py`. Logged as the closing entry in
 [`../numerical-impact.md`](../numerical-impact.md).
 
@@ -502,7 +548,7 @@ FAIL   ruff check              see output below
 PASS   cargo fmt --check       rust/
 PASS   cargo clippy            rust/
 PASS   cargo test              rust/
-PASS   pytest                  2231 passed, 15 skipped, 12 subtests passed
+PASS   pytest                  2246 passed, 15 skipped, 12 subtests passed
 PASS   import hazma            version 2.2.0
 FAIL   markdownlint            (task-pipeline/SKILL.md only; unchanged)
 PASS   version bump            2.1.0 → 2.2.0 + CHANGELOG entry
@@ -536,18 +582,19 @@ nothing.
 
 `**Status:** Complete` in the header, matching the phase README's Task
 7.4 row and this note's §Verification. Every file named in §Files Changed
-appears in `git diff origin/master --stat` (**24 files: 17 modified, 7
+appears in `git diff origin/master --stat` (**32 files: 25 modified, 7
 created**), and every file in that diff is named in §Files Changed —
 re-checked mechanically after the last content edit. Review round 1 cited
 this line reading "19 files: 12 modified, 7 created", which was true when
 written and went stale when `/commit-and-pr` added three
 `.claude/skills/` edits at the commit boundary; the round's own fixes
-then added two more files. **Every file-set count in this note is
+then added two more files, and the 2.2.0 renumber and the merge of
+`origin/master` moved them again. **Every file-set count in this note is
 re-derived from `git diff` at the frozen tree rather than patched at the
 one line review cited** — the `--md` argument, the link sweep, the
-citation sweep and the lint count all moved with it. The two remaining
-`18`s were replaced by 20: that is the *non-skill* document count, a
-different number from the 23 `.md` in the diff. Three
+citation sweep and the lint count all moved with it. The non-skill
+document count is 24, a different number from the 27 `.md` in the diff.
+Three
 figures written before measurement were corrected in place rather than
 left to stand: "eleven defects" → twelve, "33 rows would say bit-equal"
 → 27, and "seven of the eight entry points past 1e-12" → exactly seven.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = ["Programming Language :: Python"]
 # `version` in rust/Cargo.toml is unrelated and stays where it is.)
 # `docs/versioning.md` names this line as the one number a closing PR
 # edits.
-version = "2.1.0"
+version = "3.0.0"
 
 # numpy >= 2.0: the source uses np.trapezoid, which NumPy 2.0 introduced as
 # the replacement for the removed np.trapz. scipy >= 1.13 is the first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = ["Programming Language :: Python"]
 # `version` in rust/Cargo.toml is unrelated and stays where it is.)
 # `docs/versioning.md` names this line as the one number a closing PR
 # edits.
-version = "3.0.0"
+version = "2.2.0"
 
 # numpy >= 2.0: the source uses np.trapezoid, which NumPy 2.0 introduced as
 # the replacement for the removed np.trapz. scipy >= 1.13 is the first

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,14 +1,14 @@
 """Tests for the pure-Python kinematic helpers in :mod:`hazma.utils`.
 
-These cover the two functions that took over from the deleted Cython module
+``cross_section_prefactor`` took over from the deleted Cython module
 ``hazma.field_theory_helper_functions.common_functions`` in the
-Cython-to-Rust migration (project ``cython-to-rust``, Task 0.3):
-``minkowski_dot`` (relocated here) and ``cross_section_prefactor`` (already
-present; its two callers at the time, ``hazma.deprecated.rambo`` and
-``hazma.gamma_ray``, were repointed here before Task 0.2 deleted both),
-plus ``two_body_momentum``, the numerically stable momentum both
-``cross_section_prefactor`` and the two-body phase-space integrators are
-built on.
+Cython-to-Rust migration (project ``cython-to-rust``, Task 0.3); its two
+callers at the time, ``hazma.deprecated.rambo`` and ``hazma.gamma_ray``,
+were repointed here before Task 0.2 deleted both. ``two_body_momentum`` is
+the numerically stable momentum both it and the two-body phase-space
+integrators are built on. ``ldot`` is covered here too — these are its only
+direct tests, and they pin the metric signature every squared matrix
+element in the library depends on.
 
 The pinned tolerances below are chosen from the expected floating-point
 error of each closed form, not from what makes the assertion pass; each
@@ -31,7 +31,6 @@ from hazma.utils import (
     cross_section_prefactor,
     kallen_lambda,
     ldot,
-    minkowski_dot,
     two_body_momentum,
 )
 
@@ -256,30 +255,30 @@ def test_two_body_momentum_broadcasts_over_masses() -> None:
 
 
 # ===================================================================
-# ---- minkowski_dot ------------------------------------------------
+# ---- ldot ---------------------------------------------------------
 # ===================================================================
 
 
-def test_minkowski_dot_sign_convention() -> None:
+def test_ldot_sign_convention() -> None:
     """West-coast (+,-,-,-) metric, pinned on an exactly-representable case."""
     fv1 = np.array([7.0, 1.0, 2.0, 3.0])
     fv2 = np.array([5.0, 4.0, 8.0, 16.0])
     # 7*5 - 1*4 - 2*8 - 3*16 = 35 - 4 - 16 - 48 = -33
-    assert minkowski_dot(fv1, fv2) == -33.0  # noqa: PLR2004 -- the pinned value
+    assert ldot(fv1, fv2) == -33.0  # noqa: PLR2004 -- the pinned value
 
 
-def test_minkowski_dot_is_not_euclidean() -> None:
+def test_ldot_is_not_euclidean() -> None:
     """Guard against a (+,+,+,+) regression.
 
     The sign test above can miss this on its own if someone flips both the
     metric and the operand order, so pin a self-product too.
     """
     fv = np.array([2.0, 1.0, 0.0, 0.0])
-    assert minkowski_dot(fv, fv) == 3.0  # noqa: PLR2004 -- 4 - 1, not 4 + 1
+    assert ldot(fv, fv) == 3.0  # noqa: PLR2004 -- 4 - 1, not 4 + 1
 
 
 @pytest.mark.parametrize("mass", [electron_mass, muon_mass, charged_pion_mass])
-def test_minkowski_dot_on_shell_invariant(mass: float) -> None:
+def test_ldot_on_shell_invariant(mass: float) -> None:
     """Check p.p == m^2 for an on-shell four-momentum.
 
     Tolerance: E^2 - |p|^2 is a cancellation of two numbers of size E^2, so
@@ -291,25 +290,7 @@ def test_minkowski_dot_on_shell_invariant(mass: float) -> None:
     p3 = mass * np.array([1.0, 2.0, 2.0])  # |p| = 3 * mass
     energy = np.sqrt(mass**2 + p3 @ p3)
     fv = np.array([energy, *p3])
-    assert minkowski_dot(fv, fv) == pytest.approx(mass**2, rel=1e-12)
-
-
-def test_minkowski_dot_matches_ldot() -> None:
-    """Agree bit-for-bit with `ldot`, the array-oriented twin.
-
-    Both evaluate p0 - p1 - p2 - p3 in that order, so on a single
-    four-vector there is no room for a difference.
-    """
-    rng = np.random.default_rng(20260804)
-    for _ in range(100):
-        fv1 = rng.normal(scale=100.0, size=4)
-        fv2 = rng.normal(scale=100.0, size=4)
-        assert minkowski_dot(fv1, fv2) == ldot(fv1, fv2)
-
-
-def test_minkowski_dot_accepts_lists() -> None:
-    """Accept plain sequences; the implementation is index-based."""
-    assert minkowski_dot([1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]) == 1.0
+    assert ldot(fv, fv) == pytest.approx(mass**2, rel=1e-12)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

- **Closes the `cython-to-rust` project and cuts the 2.2.0 release.**
  Promotes `CHANGELOG.md`'s `[Unreleased]` section — Phase 00 wrote it
  and explicitly left it as the settled wording for this aggregate — to
  `## [2.2.0] — 2026-09-06`, and bumps `pyproject.toml`'s
  `[project] version` from `2.1.0`. Adds the migration summary, the
  aggregated per-entry-point drift table, the behavior-change list, and
  a `Fixed` entry. Flips `PLAN.md` to `status: Complete`, moves the
  `projects/README.md` row to Completed, and writes the Phase 07
  learnings and the project retrospective.
- **`minor`, not the planned `major` — with a rule change to match.**
  See the section below; this replaced the original 3.0.0 framing.
- **A new `Known issues` CHANGELOG section**, outside Keep a Changelog's
  six, for the **twelve live 2.1.0 defects** the port surfaced and
  deliberately reproduced under the project's rule 1. `Fixed` would be
  false — nothing was fixed — and `Changed` would imply the port moved
  them. The file header's section list is amended in the same edit.
- **Four follow-up stubs** for the retrospective's §5 seeds:
  constants-table consolidation, free-threaded `abi3t` wheels,
  relic-density ODEs in Rust, and aarch64/Windows wheels. The fourth is a
  deliberate addition beyond the three the phase file named — Task 7.2
  declined to file it because `PLAN.md` §Scope recorded the option, which
  held while that plan was live; closing it makes the record archival.
  The decision itself is unchanged.
- **Revises Phase 07's release exit criterion** (review round 1). It read
  "a release candidate builds, tests, and *publishes* from CI", which no
  closing PR can satisfy, and circularly so: `publish` is gated on
  `github.event_name == 'release'`, a release needs the release tag, and
  that tag exists only once this PR merges. See the note below.
- **One out-of-scope fix, taken deliberately.** Three skill files
  (`commit-and-pr`, `execute-single-task`, `task-pipeline`) still told a
  closing PR to bump `VERSION` in `hazma/__init__.py` — a file that has
  not held the version since Task 7.1 moved it to `pyproject.toml`. They
  survived Task 7.3's sweep because they name the old *mechanism* rather
  than the word that sweep grepped for. This is the first closing PR
  since the cutover and so the first thing to falsify them.

**No public value changes from this PR.** The code it touches is the
version line and the `minkowski_dot` removal:

```
git diff origin/master --name-only -- '*.py' '*.rs' '*.pyx' '*.pxd' '*.csv' '*.dat' '*.npy' '*.toml'
# -> pyproject.toml                       (version = "2.1.0" -> "2.2.0")
#    hazma/utils.py                       (minkowski_dot deleted)
#    hazma/experimental/.../avm_msqrd.py  (repointed at ldot)
#    test/test_utils.py                   (tests retargeted at ldot)
```

The release itself does move numbers, from work that merged separately:
the scalar-decay FSR repair (#87) and the two-body threshold repair. Both
are under `Changed`, and the CHANGELOG lede now leads with them.

**On the port's own numbers:** across the whole port, **27 of the 41
compiled entry points reproduce 2.1.0 bit-for-bit** and the other 14 move
by at most **5.3327e-12** relative (`scalar_mediator_decay_spectrum`);
every figure is tabulated per entry point in the CHANGELOG. That 14/27
split is derived from `test/parity/tolerances.py` rather than transcribed
— the 14 entry points that moved are exactly the 14 whose tolerance
budget was tightened — and it agrees with every per-task entry in
`projects/cython-to-rust/task-notes/numerical-impact.md`. That table
measures the port alone; `scalar_mediator_decay_spectrum` also appears in
the FSR repair, where it doubles.

## Why 2.2.0 and not the planned 3.0.0

`PLAN.md` declared `version_bump: major` on day one and this PR
originally cut 3.0.0. Nothing numerical ever drove that: the largest
drift the port introduces is 5.3e-12, which `docs/versioning.md` scores
as `patch`. The entire case for `major` was Phase 00's two API removals
— and neither can break working code.

- **`hazma.gamma_ray`** was un-importable in every release that shipped
  it. `hazma/gamma_ray.py` opens with `from hazma import rambo`, and
  `hazma/rambo.py` is in no released tag (checked at `2.1.0`), so
  `import hazma.gamma_ray` raised.
- **`hazma.deprecated.rambo`** did import, but it warned on import and
  named `hazma.phase_space` as its replacement, which is the entire
  purpose of the `deprecated/` package.

`docs/versioning.md` had no way to express either. Every removal was
`major`, full stop, which made `hazma/deprecated/` a freezer rather than
the staging area it exists to be — a module could be parked there,
warned about for years, and still never leave without a major. It now
carries a **reachability carve-out** covering exactly those two cases,
and requires the evidence for either claim to be stated in the CHANGELOG
beside the removal, so a `minor` here is a falsifiable assertion rather
than a judgment call.

`minor` then holds on its own merits regardless of the removals: this
release adds `hazma.utils.two_body_momentum` and
`hazma.spectra.dnde_photon_fsr`, and ships two physics repairs that move
published numbers. `patch` was never available.

Recorded per the lowering rule in `docs/versioning.md` — a one-line note
in `task-notes/README.md` §"Decisions and Implementation Notes".
`AGENTS.md` and the two follow-ups that were sequenced to ride the
planned major are updated to match. ADR-0003 keeps its decision and gains
a dated note: its *mitigation* argued from the project already being
`major`, which is now false, but its load-bearing argument was always
that `hazma.gamma_ray` cannot be imported — the same fact the carve-out
rests on.

## Dropping `hazma.utils.minkowski_dot`

Cutting 2.2.0 as a `minor` had one casualty worth catching first.
`minkowski_dot` landed after the `2.1.0` tag, so it is unreleased today
and `docs/followups/todo/utils-public-surface-redundant-helpers.md`
planned to remove it for free inside the major that is no longer
happening. **Tagging 2.2.0 would have closed that window** — once
released it is an ordinary public name, outside the carve-out and
removable only in a major. It is dropped here instead.

It duplicated `ldot`: both pure Python, both evaluating
`p0*q0 - p1*q1 - p2*q2 - p3*q3` in that term order, pinned bit-for-bit
equal on a single four-vector. The only difference was the input
contract — `minkowski_dot` indexed its arguments and so took lists and
tuples, while `ldot` asserts a length-4 axis and handles stacked arrays.

- **`ldot`'s contract is unchanged.** The follow-up left open whether to
  relax its assertion to accept any length-4 sequence; every call site
  passes a shape-`(4,)` `ndarray`, so relaxing it would widen a public
  interface with no caller asking for it.
- **The substitution is exact.** Both squared matrix elements in
  `avm_msqrd.py` reproduce the deleted implementation **bit-for-bit**
  over 200 random momentum draws.
- **Removal is invisible to users.** The name is in no released tag
  (checked against 2.0.2 and 2.1.0), so there is no CHANGELOG entry —
  nothing a user could observe changes.
- **`ldot` gains the coverage.** Its only test was the comparison against
  the function being deleted, so the three tests pinning the metric
  signature and the on-shell invariant were retargeted onto it. The two
  that exercised the wrapper rather than the physics were dropped, which
  is the whole of the `2248 → 2246` pytest delta.
- **Consumers repointed:** `hazma/experimental/.../avm_msqrd.py` (not on
  the public surface) and `notebooks/dev/gamma_ray_fsr/partial_integration.py`,
  which stays dead on its own `hazma.rambo` and `hazma.gamma_ray`
  imports and was not in the follow-up's entry-point list.

`kinematically_accessable`, the follow-up's other half, **stays**: it
shipped in 2.1.0, so removing it is a `major`. The follow-up is rescoped
and retitled to that name alone.

## Rebased onto `origin/master`

`origin/master` advanced twice while this PR was open. **#87** landed the
scalar mediator decay FSR repair and added its CHANGELOG entry under
`[Unreleased]`; this branch had already promoted `[Unreleased]` to a
version section, so git merged the two **without a conflict**, which is
the hazard: the entry keeps its place in the file while the section
around it is renamed. **#88** then gated the test-only `hazma._core`
probes behind a default-off `test-probes` cargo feature and normalized
both skill trees.

The branch is now **rebased** onto master rather than merged — linear,
seven commits, zero behind. Rebasing drops merge commits, so the #87
reconciliation had to be restored by hand (`393bd356`): the repair itself
comes in with the new base, but the prose integrating it did not. All
three affected files are byte-identical to their pre-rebase state,
checked with `git diff <pre-rebase-sha> -- <file>`. Left alone it would have recorded a doubled
spectrum inside the release while every summarizing claim in the release
still described the release without it.

The entry now sits under `Changed` inside `[2.2.0]`, and the three claims
it falsifies are corrected:

1. The lede said the two-body threshold repair was the release's one
   substantive numerical change. There are two, and the FSR one is far
   larger, so it leads.
2. The drift table is scoped to the port alone.
3. `Known issues` says why the repair is not a thirteenth entry — it was
   found after the port closed and landed through the declared-delta
   mechanism, which exists so a fix does not dissolve the parity
   evidence.

The section is dated **2026-09-06** rather than 2026-08-29, because it
cannot predate content it contains. The project's own close date is
unchanged at 2026-08-29; the two are now stated separately.

## The release criterion, and what closure does not attest

Phase 07's release exit criterion required the candidate to "build, test,
and *publish* from CI". That is structurally unsatisfiable by the PR that
closes the project: `publish` is gated `if: github.event_name ==
'release'`, a GitHub release needs the version tag, and that tag exists
only after this PR merges. Holding closure until publish is observed
therefore deadlocks rather than waits.

The criterion is **revised**, not qualified: it now asks for what closure
can actually attest — both `cp310-abi3` wheels and the sdist built, the
workflow's own wheel-tag, sole-extension and cross-version import
assertions passed, and the `publish` gate observed *holding* on a
non-release event. The upload is reassigned to the release manager and
the residual risk is stated in place.

**So: trusted publishing under `PyO3/maturin-action` has never executed.**
Cutting 2.2.0 is its first run — watch that job rather than assume it.

## Project

`projects/cython-to-rust/` — Task 7.4: Close the project.

## Test plan

- [x] `scripts/agents/preflight.sh --closing --md "<all 28 .md in the diff>"` (with `VIRTUAL_ENV` absolute)`

```
PASS   black --check           hazma test
FAIL   isort --check-only      run `isort hazma test` and re-check
FAIL   ruff check              see output below
PASS   cargo fmt --check       rust/
PASS   cargo clippy            rust/
PASS   cargo test              rust/
PASS   pytest                  2246 passed, 15 skipped, 12 subtests passed
PASS   import hazma            version 2.2.0
PASS   markdownlint            <all 28 .md in the diff, no exclusion>
PASS   version bump            2.1.0 → 2.2.0 + CHANGELOG entry
PASS   forbidden tokens        none added
```

- [x] **Nine of eleven rows PASS. Both FAIL rows are the trunk's, measured rather than asserted.**
  - `isort` / `ruff`: both measured against `origin/master` in a real
    worktree, on the same four `.py` paths this PR changes. `isort` flags
    exactly one file on **both** trees —
    `notebooks/dev/gamma_ray_fsr/partial_integration.py`, already unsorted
    on master before this branch edits it. `ruff` reports **117 findings
    whose sorted text is identical** either side; `diff` of the two lists
    is empty. On an untouched master worktree the whole-tree gate gives 72
    isort ERROR lines and 6091 ruff errors — the standing condition
    `docs/followups/todo/preflight-isort-ruff-red-on-trunk.md` tracks,
    which is why the phase criterion was revised (below).
  - Both sides must be **real worktrees**: a scratch copy of the files
    loses `pyproject.toml`, ruff falls back to default rules (11 findings
    against the configured 117), and the diff invents a regression.
  - `markdownlint`: **green**, and no longer needs an exclusion. It was
    red on `.claude/skills/task-pipeline/SKILL.md` (7 errors both sides,
    none from this PR's two edited lines) until **#88** normalized both
    skill trees and closed
    `docs/followups/done/markdownlint-skips-skill-file-shapes.md`. All 28
    markdown files in the diff now lint clean together.

- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features`
  → `test result: ok. 261 passed; 0 failed; 0 ignored`. (258 before the
  merge; #87 added three. No `.rs` changed here.) This row was previously
  reported red: a **relative** `VIRTUAL_ENV=.venv` makes pyo3's build
  config resolve `.venv/bin/python` against cargo's own directory. Set it
  absolute and the gate passes. The `cargo test` FAIL inside the preflight
  table above is an artifact of invoking the script with a modified
  `PATH`, which breaks its relative `.venv/bin/python` lookup — the gate
  passes on a clean invocation.

- [x] **Rebuilt before believing any Python-side result.** The merge
  brought in a `.rs` change, so `uv pip install -e .` was re-run before
  pytest; the pre-rebuild run reported 31 failures purely from a stale
  `hazma/_core.abi3.so`. `python -c "import hazma; print(hazma.VERSION,
  hazma.__version__)"` → `2.2.0 2.2.0`. Worth running explicitly:
  `hazma.VERSION` reads the *installed* metadata, so an un-rebuilt
  editable tree keeps reporting the old number.

- [x] Sweeps re-derived on the frozen tree after the merge:
  `checked 28 markdown files; broken relative links: 0`;
  `check_doc_citations.py` → `docs scanned: 26 … out-of-range or
  ambiguous: NONE` over 28 documents; `docs/followups/README.md`'s Open table matches
  `docs/followups/todo/` exactly (26 = 26, one moved to `done/` by #88); the diff is **34 files, 27
  modified and 7 created** (28 `.md`, 25 outside `.claude/skills/`, plus
  4 `.py`, one `.ipynb` and `pyproject.toml`), every one named in the
  task note's §Files Changed.

## Review rounds

**Round 1 — 2 blocking findings, both correct, both fixed** in
`3543cb8a`:

1. The release criterion contradiction, above.
2. A stale file count in the task note's self-consistency block ("19
   files: 12 modified, 7 created"). Correct when written; it went stale
   when the commit boundary added three skill-file edits, and every
   sibling file-set count had gone stale the same way. All are now
   re-derived from `git diff` once, after freezing every content edit,
   rather than patched at the cited line.

The round also extended the `[unrun-workflow-cannot-close-a-criterion]`
lessons class — previously only the undispatched-workflow case — with the
structurally-unsatisfiable one and the test to apply: *ask what event
satisfying a criterion requires, and whether the work it gates is what
produces that event.*

**Post-round-1 — version renumber and master merge** (`cbd857c4`,
`1c300ec9`), at the maintainer's direction: 3.0.0 → 2.2.0, with the
`docs/versioning.md` carve-out that makes it honest, and the merge of
`origin/master` described above, then the `minkowski_dot` removal
(`4053448a`) that the renumber made time-critical. Every file-set count
and test figure moved again at each step and was re-derived rather than
patched, the same discipline round 1 asked for.




**Round 2 — 3 blocking, 2 non-blocking; all five addressed** in
`d9374275`:

1. *Red preflight cannot satisfy closure.* Correct, and the rule cited is
   right. The criterion demanded `preflight.sh --closing` **green**,
   which no PR can deliver: an untouched `origin/master` gives 72 isort
   and 6091 ruff findings, tracked since 2026-08-05 with three candidate
   remedies and none chosen. Revised to what a PR can attest, with both
   reds now *measured* against master rather than asserted pre-existing.
   `docs/agents/preflight.md` says so too, so the next agent does not
   re-derive it.
2. *Verification census is stale.* Correct — and it was stale in six
   more places than the two cited, all re-derived at the frozen tree.
3. *Public-API claim contradicts removals.* Correct; scoped to the 41
   ported compiled entry points, with the removals attributed to Phase
   00's purge rather than the port.
4. *A tracked notebook still imports `minkowski_dot`.* Correct. The
   consumer sweep carried an extension filter; `git grep -l` with none
   finds it. Repointed, and "two consumers" corrected to three.
5. *Seven phase learnings vs eight.* Correct; swept.

Two new lessons classes came out of this round:
`[pre-existing-failure-asserted-not-measured]` and
`[removal-sweep-filtered-by-extension]`.


**Rebased onto master (`393bd356`)** after #88 merged. Three claims this
branch carried were falsified by that PR and are corrected in
`4e7354d2`: `task-pipeline/SKILL.md` lints clean now, so the gate runs
over all 28 markdown files with no exclusion; the follow-up that tracked
it moved to `done/`, which had left one reference here as a broken link
into `todo/`; and its Open table is 26 rows, not 27. Both trunk gates
were re-measured against the new master and are still zero-delta — 72
isort and 6091 ruff on an untouched worktree, and on the four `.py` files
this branch changes, the same single already-unsorted notebook and the
same 117 ruff findings whose sorted text is identical.

The build contract changed too: probes are default-off, so the editable
install here is `uv pip install -e . --config-settings
build-args="--features test-probes"`, without which `test/conftest.py`
fails the run.