### PR TITLE
fix(spectra): count the pion's prompt electron-neutrino line once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ its magnitude and a pointer to the tracked repair. **Numerical changes go
 under `Changed` with the magnitude stated** — a spectrum that moves is a
 user-facing change even when no signature did.
 
+## [Unreleased]
+
+### Changed
+
+- **The charged pion's prompt `π → e ν` neutrino line was counted twice.**
+  `hazma.spectra.dnde_neutrino_charged_pion` summed two contributions that
+  were meant to partition the pion's decay modes, and both carried the
+  boosted `π → e ν_e` line, so the electron-neutrino row shipped
+  `2 BR(π → e ν_e)` where physics wants one. The muon row was never
+  affected — the `π → e ν_e` half writes nothing there. The line now comes
+  from that half alone. **Only the electron-neutrino row moves, and only
+  downward.** Integrated, the yield falls by exactly
+  `BR(π → e ν_e) = 1.230e-4` neutrinos per pion, 0.0123% of the row.
+  Pointwise the drop is about 5e-5 relative on the plateau where the
+  muon-decay continuum dominates, and **exactly a factor of two** at
+  energies above that continuum's support, where the doubled line was the
+  whole spectrum — at `E_π = 1000` MeV that band runs from 692 to 994 MeV.
+  A pion exactly at rest is unaffected: that branch drops both prompt
+  lines already. `hazma.spectra.dnde_neutrino` moves for any final state
+  containing a charged pion. Details:
+  `docs/followups/todo/neutrino-pion-electron-line-counted-twice.md`.
+
 ## [2.2.0] — 2026-09-06
 
 **Hazma's compiled layer is now Rust.** The twenty Cython extension

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -49,6 +49,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [free-threaded `abi3t` wheels](todo/free-threaded-abi3t-wheels.md) | 2026-08-29 | cython-to-rust retrospective §5 | cross-cutting |
 | [the relic-density Boltzmann solve in Rust](todo/relic-density-odes-in-rust.md) | 2026-08-29 | cython-to-rust retrospective §5 | cross-cutting |
 | [wheels for linux-aarch64 and Windows](todo/wheels-for-aarch64-and-windows.md) | 2026-08-29 | cython-to-rust retrospective §5 | commit |
+| [the charged pion's neutrino continuum loses its quadrature support](todo/neutrino-pion-continuum-loses-its-quadrature-support.md) | 2026-09-06 | parity-pinned-defect-repair Task 10a | cross-cutting |
 
 ## Promoted / Done / Pruned
 

--- a/docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md
+++ b/docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md
@@ -1,0 +1,136 @@
+# The charged pion's neutrino continuum loses its quadrature support
+
+- **Added:** 2026-09-06
+- **Source:** `projects/parity-pinned-defect-repair/task-notes/task-10a-neutrino-pion-line.md`
+- **Scope:** cross-cutting (public spectrum values)
+- **Status:** open
+- **Triggers / blockers:** **corpus re-pinning only.** The Cython twin
+  (`hazma/spectra/_neutrino/_pion.pyx`) was deleted in `cython-to-rust`
+  Task 4.6, so there is no oracle to capture and no deletion wave to beat.
+  The corrected values need none: the repair narrows an integration
+  window to the support the integrand already declares, and the
+  difference is a `scipy.integrate.quad` over the narrowed window, which
+  runs against the committed arrays with no build. Belongs in
+  [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md)
+  alongside the other pinned defects, as a roster entry of its own.
+
+## Why
+
+`hazma.spectra.dnde_neutrino_charged_pion` builds its muon-decay
+continuum by boosting the muon's own neutrino spectrum out of the pion
+frame,
+
+```text
+dN/dE = 1/(2 β γ) ∫_{γE(1−β)}^{γE(1+β)} dE'  (dN/dE')_μ(E', E_μ^rf) / E' ,
+```
+
+and integrates over the whole window. But the integrand is zero above the
+muon-decay endpoint in the pion rest frame — **69.783500 MeV**, measured
+on a 200,001-point sweep of `dnde_neutrino_muon(·, ENG_MU_PI_RF)`, for
+both flavor rows — so for a boosted pion almost all of that window
+contributes nothing:
+
+| `E_π` (MeV) | `E_ν` (MeV) | window (MeV) | width / support |
+| --- | --- | --- | --- |
+| 1395.7039 | 798.21 | [40.01, 1.592e+04] | 228x |
+| 1395.7039 | 1369.1 | [68.63, 2.731e+04] | 390x |
+| 5000 | 412.098 | [5.753, 2.952e+04] | 423x |
+
+QUADPACK's first 21-point rule then places every abscissa outside the
+support, the error estimate agrees that the constant zero it sampled is
+exact, and `quad` returns `0.0` with a successful status. This is the
+same failure mode as
+[`charged-pion-photon-spectrum-misses-the-forward-cone.md`](charged-pion-photon-spectrum-misses-the-forward-cone.md)
+(roster entry A3), one kernel over: there the lost support is a cone in
+`cos θ`, here it is the tail of a boost window.
+
+**What is lost is not a tail correction.** Re-integrating over the window
+clipped at the endpoint recovers, at the three points above,
+`3.047944e-04`, `1.535789e-08` and `5.037573e-04` MeV⁻¹ against a shipped
+electron row of `8.857273e-08`, `8.857273e-08` and `2.460992e-08` — a
+factor of 3,441, 0.17 and 20,470. Where the continuum is lost entirely
+the spectrum is the prompt `π → e ν_e` line and nothing else, which is
+three to four decades below the truth.
+
+The parity corpus pins 14 such positions: 13 in the `values` array of the
+`boosted_strong` block of `spectra.neutrino.charged_pion`
+(`E_π = 1395.7039` MeV, over `E_ν ∈ [798.21, 1369.1]` MeV) and 1 in that
+block's `scalar_values`. They are inside the 215 positions
+`test/parity/deltas.py` declares for roster entry B5, and they are
+exactly the positions where that declaration's relative drop is
+`0.500000000000` — the doubled line was the whole value because the
+continuum was zero.
+
+Both implementations lose the window the same way, which is why parity is
+green: `scipy.integrate.quad` over the unclipped window returns `0.0` too.
+The defect is in the interval, not in the integrator.
+
+## What
+
+Clip the boost window to the integrand's own support before integrating,
+in `rust/src/kernels/neutrino_pion.rs`'s `boost_window` or at its use in
+`dnde_mu_numu`. **The sibling kernel already does this**, which is both
+the precedent and the strongest evidence the omission is a slip:
+`rust/src/kernels/positron_pion.rs:163-164` computes
+
+```rust
+let emin = (gamma * (-beta).mul_add(k, e)).max(ME);
+let emax = (gamma * beta.mul_add(k, e)).min(EMAX_PI_RF);
+```
+
+— both ends clamped to the integrand's support. The neutrino twin clamps
+only `emin`, and only against zero.
+
+Pick the clip from the muon spectrum's endpoint rather than from the
+`π → e ν_e` line's energy: they differ by 7.6e-4 MeV
+(69.783500 against `ENU_E_PI_RF = 69.784260`), and it is the narrower one
+that bounds the integrand. That is the same 8e-4 MeV distinction the A3
+follow-up had to settle between `ENG_GAM_MAX_PIRG` and
+`(m_π² − m_e²)/(2 m_π)`.
+
+Then re-declare: the B5 entry in `test/parity/deltas.py` currently covers
+those 14 positions with an `Additive` relation whose term is the line
+alone. Once the continuum comes back they move again, by a different
+mechanism, so the two either compose into one declaration or the corpus
+positions have to be split between them —
+`projects/parity-pinned-defect-repair/rules.md` rule 7.
+
+## Entry points
+
+- `rust/src/kernels/neutrino_pion.rs` — `boost_window`, and `boost_integral`'s
+  `quad` call
+- `rust/src/kernels/positron_pion.rs:163-164` — the sibling that clips
+- `test/test_core_neutrino.py` — `reference_dnde_neutrino_charged_pion`
+  and `reference_pion_continuum` both integrate over the same unclipped
+  window, so the independent reference reproduces the defect and must be
+  fixed with the kernel
+- `test/parity/deltas.py` — the B5 declaration, whose `0.500000000000`
+  positions are exactly the affected ones
+- `test/parity/data/` — the `boosted_strong` block of
+  `spectra.neutrino.charged_pion`
+- Related project: `projects/parity-pinned-defect-repair/`
+- Sibling defect, same mechanism:
+  [`charged-pion-photon-spectrum-misses-the-forward-cone.md`](charged-pion-photon-spectrum-misses-the-forward-cone.md)
+
+## Risks / open questions
+
+- **How many other kernels boost a bounded spectrum over an unclipped
+  window?** `positron_pion.rs` clips and `photon_pion.rs` is A3's own
+  subject, but the sweep was not done — `neutrino_pion.rs` was found
+  because a repair's magnitude looked wrong, not because anyone looked.
+  Grep the `quad` call sites for an upper limit that is a boost endpoint
+  rather than a support endpoint.
+- **The muon-neutrino row is worse, and the corpus does not catch it.**
+  The measurements above are on the electron row because that is where
+  roster entry B5 made the zero visible, but the same `boost_integral`
+  serves the muon row through `Flavor::Muon`, and there no prompt line
+  masks the loss: at `E_π = 1395.7039`, `E_ν = 798.21` MeV the shipped
+  muon row is **exactly `0.0`** where the clipped integral gives
+  `4.736526e-04` MeV⁻¹. So the repair's blast radius is both rows, not
+  one, and it is larger than the electron-row figures suggest. Whether
+  the same hard zero reaches the muon row at other pinned positions has
+  not been swept.
+- **This moves published numbers by three to four decades on a band**, so
+  it is `minor` at least under [`docs/versioning.md`](../../versioning.md)
+  and needs a `CHANGELOG.md` entry with the magnitude — a much larger one
+  than B5's own.

--- a/docs/followups/todo/neutrino-pion-electron-line-counted-twice.md
+++ b/docs/followups/todo/neutrino-pion-electron-line-counted-twice.md
@@ -3,7 +3,10 @@
 - **Added:** 2026-08-20
 - **Source:** `projects/cython-to-rust/task-notes/phase-04/task-4.6-positron-pion-neutrino.md`
 - **Scope:** cross-cutting (public spectrum values)
-- **Status:** open
+- **Status:** open — **repaired** 2026-09-06 as roster entry B5,
+  `projects/parity-pinned-defect-repair` Task 10a. The file stays here
+  until that project's close (Task 12) moves all eight of its follow-ups
+  to `done/` in one sweep, so the inbound references are repointed once.
 - **Triggers / blockers:** **corpus re-pinning only** — no ordering
   constraint against cython-to-rust Phase 06. The Cython twin
   (`hazma/spectra/_neutrino/_pion.pyx`) is already gone, deleted in
@@ -48,7 +51,10 @@ makes the defect a transcription slip rather than a convention.
 
 Measured on this tree (Task 4.6) at `E_pi = 400` MeV, by subtracting the
 muon-decay continuum recomputed with `scipy.integrate.quad` over the
-ported muon kernel:
+ported muon kernel. The repair turns every `2.0000` below into `1.0000`,
+which `test/test_core_neutrino.py`'s
+`TestPhysics::test_each_prompt_line_is_counted_exactly_once` now asserts
+at the same three energies:
 
 | `E_nu` (MeV) | excess / one line's height | expected |
 | --- | --- | --- |
@@ -66,29 +72,60 @@ Delete the `delta_e` term from the `pi -> mu nu_mu` half — in
 `dnde_e_nue` as the sole source of the line. Then update the docs, the
 two Rust unit tests and the Python test that currently pin the defect.
 
+**Done, 2026-09-06.** The kernel carries one line per decay mode; the
+module docs carry a `# The prompt electron-neutrino line is added once,
+not twice` section in the shape `scalar_decay_photon.rs` uses for the
+same kind of deliberate divergence from the `.pyx`; and
+`test/parity/deltas.py` declares the 215 corpus positions it moves as
+roster entry `B5`, leaving `test/parity/data/` untouched.
+
 **Size of the change to published numbers.** Integrated over energy the
 electron-neutrino yield falls from `BR_mu + 2 BR_e` to `BR_mu + BR_e`,
-i.e. by `1.23e-4` per pion — 0.0123% of the row. Locally it is larger
-where it matters: on the plateau the line occupies, the electron-neutrino
-spectrum falls by 0.06% at `E_pi = 200` MeV and 0.036% at 1000 MeV
-(measured). That is a *shape* change on a narrow band rather than a
-normalization shift, which is the kind a limit calculation notices.
+i.e. by `1.23e-4` per pion — 0.0123% of the row. That figure held when
+Task 10a measured it.
+
+The local figure this paragraph used to give did not, and it was three
+orders of magnitude too small: it said 0.06% at `E_pi = 200` MeV and
+0.036% at 1000 MeV, from points on the low-energy plateau. Above the
+muon-decay continuum's support the doubled line is the *entire*
+spectrum, so the repair halves it exactly — a relative drop of
+`0.500000000000`, at 6 of the 174 moved points of a 2001-point
+`geomspace(1e-4, 1e5)` sweep at `E_pi = 200` MeV and at 241 of 824 at
+`E_pi = 5000` MeV. The median drop over the moved points is 4.7e-5 to
+1.1e-4. So it is a shape change on a band, as this paragraph said, but a
+much sharper one than it claimed.
+
+Those factor-of-two positions turned out to expose a second, larger and
+wholly separate defect — the continuum's quadrature loses its support and
+returns a hard zero, which is why the line was all that was left there.
+Filed as
+[`neutrino-pion-continuum-loses-its-quadrature-support.md`](neutrino-pion-continuum-loses-its-quadrature-support.md).
 
 ## Entry points
 
-- `rust/src/kernels/neutrino_pion.rs` — `dnde_mu_numu`'s `delta_e`, and
-  the module docs' "counted twice" paragraph
+Named as they stand after the repair; the pre-repair names are in
+`projects/parity-pinned-defect-repair/task-notes/task-10a-neutrino-pion-line.md`.
+
+- `rust/src/kernels/neutrino_pion.rs` — `dnde_mu_numu`, and the module
+  docs' "added once, not twice" section
 - `rust/src/kernels/neutrino_pion.rs` tests —
-  `the_electron_line_is_counted_by_both_halves`,
+  `the_electron_line_comes_from_one_half_only` (renamed from
+  `the_electron_line_is_counted_by_both_halves`),
   `the_boost_conserves_neutrino_number_per_flavor`
 - `test/test_core_neutrino.py` —
-  `TestPhysics.test_the_electron_line_is_counted_twice_and_the_muon_line_once`,
-  `test_the_pion_yields_one_muon_neutrino_from_each_of_two_sources`, and
-  the module docstring's "Two declared defects" section
+  `TestPhysics.test_each_prompt_line_is_counted_exactly_once` (renamed
+  from `test_the_electron_line_is_counted_twice_and_the_muon_line_once`),
+  `test_the_pion_yields_one_muon_neutrino_from_each_of_two_sources`,
+  `reference_dnde_neutrino_charged_pion`, and the module docstring's
+  declared-defect section
+- `test/parity/deltas.py` — the `B5` declaration and its closed-form term
 - `test/parity/data/` — the boosted blocks of
-  `spectra.neutrino.charged_pion`
-- Downstream: every `hazma.spectra.dnde_neutrino_*` built on the charged
-  pion, and `hazma/spectra/_nbody.py`'s neutrino path
+  `spectra.neutrino.charged_pion`, unchanged and staying that way
+- Downstream: only `hazma.spectra.dnde_neutrino_charged_pion` moves, plus
+  `hazma/spectra/_nbody.py`'s `dnde_neutrino` for any final state
+  containing one. The other `dnde_neutrino_*` are interpolated off
+  committed tables rather than composed from the pion at runtime, and
+  were verified identical.
 
 ## Risks / open questions
 
@@ -97,9 +134,11 @@ normalization shift, which is the kind a limit calculation notices.
   nu` line exactly once, in one place, so it does not share the defect —
   checked at Task 4.6. Worth re-checking the two mediator positron
   spectrum modules when Phase 06 ports them.
-- **The repair moves a published number**, so it needs a `CHANGELOG.md`
-  entry stating the 0.0123% integrated / 0.06% local figures, and is
-  `minor` at least under `docs/versioning.md`.
+- **The repair moves a published number**, so it needed a `CHANGELOG.md`
+  entry and is `minor` at least under `docs/versioning.md`. Written under
+  `[Unreleased]` by Task 10a, with the 0.0123% integrated figure and the
+  measured local one — a factor of two, not the 0.06% this file
+  originally predicted.
 - A pion **at rest** loses *both* prompt lines instead (the
   `E - m < DBL_EPSILON` branch returns only the muon-decay continuum).
   That is a separate rest-frame-branch question, of the same family as

--- a/projects/parity-pinned-defect-repair/PLAN.md
+++ b/projects/parity-pinned-defect-repair/PLAN.md
@@ -2,7 +2,7 @@
 status: In Progress
 phased: false
 version_bump: minor
-deliverable: The eight parity-pinned numerical defects repaired (B4 landed ahead of the task sequence in PR #87), each with a declared per-array delta asserted against the corpus arrays that pinned the defect — which stay committed
+deliverable: The nine parity-pinned numerical defects repaired (B4 landed ahead of the task sequence in PR #87), each with a declared per-array delta asserted against the corpus arrays that pinned the defect — which stay committed
 created: 2026-08-19
 ---
 
@@ -12,10 +12,12 @@ created: 2026-08-19
 
 ## Goal
 
-Repair the eight live numerical defects the `cython-to-rust` port
-surfaced — seven rostered when this plan was drawn, and B4, found and
+Repair the nine live numerical defects the `cython-to-rust` port
+surfaced — seven rostered when this plan was drawn, B4, found and
 repaired ahead of the task sequence in
-[PR #87](https://github.com/LoganAMorrison/Hazma/pull/87) — and do it
+[PR #87](https://github.com/LoganAMorrison/Hazma/pull/87), and B5, whose
+follow-up was filed the day after this plan and named it as its home
+without a row ever being added — and do it
 under a corpus mechanism that keeps the arrays which
 pinned each defect rather than overwriting them. Every repair ships with
 a **declared delta**: a named statement of which corpus positions move,
@@ -74,7 +76,7 @@ longer racing the port.
 
 **In scope:**
 
-- The eight defects rostered in
+- The nine defects rostered in
   [`references/defect-blast-radius.md`](references/defect-blast-radius.md),
   each repaired in the Rust kernel that now serves it (B4 already is).
 - A delta-declaration layer under `test/parity/` that pins each repair's
@@ -104,7 +106,7 @@ longer racing the port.
 
 ## Numerical impact
 
-**This project moves published numbers, deliberately, eight times**
+**This project moves published numbers, deliberately, nine times**
 (one of them, B4, already landed). That
 is the whole deliverable, and it is what sets `version_bump: minor` —
 no public name, signature, return shape or documented unit changes, but
@@ -131,10 +133,15 @@ measurements:
   low).
 - Both rho spectra at `E_ρ = m_ρ` exactly: divided by `E_γ`, i.e. the
   value changes by a factor of `E_γ` at a single parent energy.
+- Charged-pion **neutrino** spectrum: the electron-neutrino row loses one
+  `BR(π → e ν_e) = 1.230e-4` per pion, 0.0123% integrated; pointwise about
+  5e-5 on the plateau and exactly a factor of two above the muon-decay
+  continuum's support. The muon and tau rows do not move.
 
-Task 12 aggregates the measured figures; the per-defect numbers above are
-the pre-repair estimates the follow-ups recorded, not this project's own
-measurements, and are re-derived by each repair task.
+Task 12 aggregates the measured figures. Every bullet above except the
+last is a pre-repair estimate the follow-up recorded rather than one of
+this project's own measurements, and is re-derived by its repair task;
+the B5 bullet is the measurement, because Task 10a has run.
 
 ## Tasks
 
@@ -153,8 +160,8 @@ the canonical *shape* of each task below.
 
 ## The defects
 
-Seven, labelled **A1–A4** (a live Cython twin, so an oracle capture is on
-the clock) and **B1–B3** (no twin, and no ordering constraint at all).
+Nine, labelled **A1–A4** (a live Cython twin, so an oracle capture is on
+the clock) and **B1–B5** (no twin, and no ordering constraint at all).
 The roster — each defect's follow-up, its twin's fate, the Rust kernel
 that serves it now, and the corpus cases it reaches — is one table, in
 [`references/defect-blast-radius.md`](references/defect-blast-radius.md).
@@ -460,6 +467,48 @@ found the defect (Task 4.1's) now passes against the corrected constant
 rather than recording the inversion, and the Michel spectrum integrates
 to 1 over its support to a stated tolerance.
 
+### Task 10a: Repair B5 — the charged pion's doubled neutrino line
+
+**Objective:** Let `dnde_e_nue` be the sole source of the `π → e ν_e`
+line, so each prompt line is counted once.
+
+**Scope / implementation notes:**
+`rust/src/kernels/neutrino_pion.rs`, the `delta_e` binding in
+`dnde_mu_numu` and its use in the returned `electron` field. Numbered
+between Tasks 10 and 11 rather than appended after Task 12 because the
+close has to come last and this repair has to precede the prose sweep
+that moves its follow-up to `done/`; it depends on Task 1 alone and is
+disjoint from every other defect's blast radius, so it may run in
+parallel with Tasks 3–10. Group B: the Cython twin
+(`hazma/spectra/_neutrino/_pion.pyx`) died in `cython-to-rust` Task 4.6,
+before this roster entry existed, so there is no Task 2 oracle and the
+independent check is the closed form — the boosted line is a rectangle of
+height `BR_e / (2 γ β E_ν^rf)` over `E ∈ (E_rf/(γ(1+β)), E_rf/(γ(1−β)))`,
+which needs neither a kernel nor a build. The port's existing tests state
+the correct physics alongside the shipped defect, so the repair largely
+flips which is asserted — `the_electron_line_is_counted_by_both_halves`
+and `TestPhysics::test_the_electron_line_is_counted_twice_and_the_muon_line_once`
+need renaming as well as re-pointing, per `docs/agents/lessons.md`
+`[test-name-claims-an-unmade-assertion]` (they are
+`the_electron_line_comes_from_one_half_only` and
+`test_each_prompt_line_is_counted_exactly_once` on the repaired tree), and
+`test/test_core_neutrino.py`'s `reference_dnde_neutrino_charged_pion` —
+the independent recomputation that satisfies rule 3 — reproduces the
+doubled line on purpose and has to stop.
+
+**Deliverable / gate:** A declared delta on the **1** case the B5 row of
+[`references/defect-blast-radius.md`](references/defect-blast-radius.md)
+names, `spectra.neutrino.charged_pion`, and on **3** of its 5 blocks:
+`near_rest`, `boosted_mild` and `boosted_strong`. `rest` and
+`rest_plus_eps` must still match their stored arrays under the case's own
+budget — at rest the kernel drops both prompt lines, and one epsilon above
+it no grid point's boost window is wide enough to straddle the line — and
+that is the "moved only what it intended" half of the proof. The
+electron-neutrino row integrates to `BR_μ + BR_e` rather than
+`BR_μ + 2 BR_e`, and the muon row is bit-identical: the asymmetry is what
+makes the pair discriminating, since `dnde_e_nue` never wrote to the muon
+row. `spectra.neutrino.muon` does not move.
+
 ### Task 11: Reconcile the superseded sequencing prose
 
 **Objective:** Leave no live document still telling a reader to wait for
@@ -509,7 +558,8 @@ spectra with no API change is `minor`, and nothing in Tasks 4–10 should
 have raised it, but the check is the point.
 
 **Deliverable / gate:** `scripts/agents/preflight.sh --closing` green;
-`PLAN.md` `status: Complete`; the seven follow-ups still under `todo/` moved to
+`PLAN.md` `status: Complete`; the eight follow-ups still under `todo/` —
+the original seven plus B5's — moved to
 `docs/followups/done/` with their inbound links repointed and the
 revision pinned, per
 [`docs/workflow.md`](../../docs/workflow.md)'s follow-up lifecycle and

--- a/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
+++ b/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
@@ -52,8 +52,10 @@ Two facts the graph makes easy to get wrong:
 - `boost_integrate_linear_interp` is reached **only** by the seven
   tabulated photon spectra. It is not on the muon, pion, rho, positron
   or neutrino paths — those use `boost_beta` / `boost_gamma` /
-  `boost_delta_function`, which this project does not touch. So the
-  boost-window repair does *not* move the mediator spectra.
+  `boost_delta_function`, none of which A1 changes. So the
+  boost-window repair does *not* move the mediator spectra. B5 does touch
+  `boost_delta_function`, but by removing one of its call sites rather
+  than by changing the function, so the two repairs stay disjoint.
 - The rho spectra reach the muon kernel *through* the charged pion — and
   that is **not** enough to put them in A2's radius. This bullet used to
   conclude that it was, and Task 2 measured otherwise: A2's defect sits
@@ -182,6 +184,26 @@ half the repaired kernel's FSR-only spectrum. Declared in
 `test/parity/deltas.py`, which landed with the repair rather than under
 Task 1.
 
+### B5 — the charged pion's doubled neutrino line (1 case)
+
+`spectra.neutrino.charged_pion` — the `near_rest`, `boosted_mild` and
+`boosted_strong` blocks, both value arrays, at the 215 of the case's
+4,305 positions where the boosted `π → e ν_e` line's window straddles
+`ENU_E_PI_RF` (`test/parity/deltas.py`, `MOVED`). **Measured by Task
+10a**, by capturing every block twice — once from a build carrying the
+defect, once from the repaired build — so the pre-existing platform drift
+between the stored corpus and this tree does not enter. Only the electron
+row moves, and only downward; the muon and tau rows are bit-identical.
+
+`rest` and `rest_plus_eps` do not move, for two different reasons: at
+`E_π = m_π` the kernel takes a branch that drops both prompt lines, and
+one epsilon above it `β` is small enough that no grid point's boost
+window straddles the line at all. Found and filed after this roster was
+drawn ([`neutrino-pion-electron-line-counted-twice.md`](../../../docs/followups/todo/neutrino-pion-electron-line-counted-twice.md)),
+which is also why it is disjoint from everything else here: the pion's
+neutrino path reaches `boost_delta_function` and `super::neutrino_muon`,
+neither of which any other roster entry touches.
+
 ### The defects, and which group each is in
 
 Group A still has a live Cython twin and is on the clock for its oracle
@@ -197,20 +219,22 @@ capture; Group B does not, and has no ordering constraint at all.
 | B2 | φ photon lines use the daughter meson's energy | [`phi-photon-lines-use-the-daughter-meson-energy.md`](../../../docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md) | deleted, Task 4.2 | `rust/src/kernels/photon_tables.rs` |
 | B3 | Both rho spectra return the boost integrand at rest | [`rho-rest-frame-branch-returns-the-integrand.md`](../../../docs/followups/todo/rho-rest-frame-branch-returns-the-integrand.md) | deleted, Task 4.5 | `rust/src/kernels/photon_rho.rs` |
 | B4 | Scalar decay spectrum's FSR coefficients are half size | [`scalar-decay-fsr-half-normalized.md`](../../../docs/followups/done/scalar-decay-fsr-half-normalized.md) | deleted, Task 6.2 | `rust/src/kernels/scalar_decay_photon.rs` — **repaired** |
+| B5 | Charged pion's prompt `π → e ν` neutrino line is added twice | [`neutrino-pion-electron-line-counted-twice.md`](../../../docs/followups/todo/neutrino-pion-electron-line-counted-twice.md) | deleted, Task 4.6 | `rust/src/kernels/neutrino_pion.rs` — **repaired** |
 
 ## Coverage arithmetic
 
 The corpus has 41 cases. The rows above name
-7 + 1 + 6 + 6 + 1 + 1 + 2 + 1 = **25 case slots** across eight defects,
-but four of the eight sets are wholly contained in another — derived,
+7 + 1 + 6 + 6 + 1 + 1 + 2 + 1 + 1 = **26 case slots** across nine defects,
+but four of the nine sets are wholly contained in another — derived,
 not eyeballed:
 
 ```text
-B1 ⊆ A1   B2 ⊆ A1   B3 ⊆ A3   B4 ⊆ A3     and A1, A2, A3, A4 are pairwise disjoint
+B1 ⊆ A1   B2 ⊆ A1   B3 ⊆ A3   B4 ⊆ A3
+A1, A2, A3, A4 are pairwise disjoint, and B5 is disjoint from all of them
 ```
 
-So the union is exactly `|A1| + |A2| + |A3| + |A4|` = 7 + 1 + 6 + 6 =
-**20**. Two consequences worth carrying into the tasks. A2 and A3 are
+So the union is `|A1| + |A2| + |A3| + |A4| + |B5|` = 7 + 1 + 6 + 6 + 1 =
+**21**. Two consequences worth carrying into the tasks. A2 and A3 are
 now *disjoint* — A2 reaches only `spectra.photon.muon`, A3 reaches
 exactly the six cases A2 was predicted to share with it — so Task 8
 opens six cases of its own rather than adding positions to ones Task 7
@@ -223,19 +247,24 @@ channel, so Task 8 either proves the two position sets disjoint or
 folds B4's declaration into a composite. And A4 is disjoint from
 everything else, which is what makes Task 10 safe to run in parallel.
 
-Untouched: **21** — the 18 `cross_sections.*`, the 2 `spectra.neutrino.*`
-(no defect on their path; they use `boost_delta_function`, not the
-interpolating integral), and `spectra.photon.neutral_pion` (the π⁰ → γγ
-box reaches neither the muon kernel nor the boost integral). 20 + 21 = 41.
+Untouched: **20** — the 18 `cross_sections.*`, `spectra.neutrino.muon`
+(the muon's own neutrino spectrum has no defect on its path), and
+`spectra.photon.neutral_pion` (the π⁰ → γγ box reaches neither the muon
+kernel nor the boost integral). 21 + 20 = 41. Counts re-derived with the
+command above at Task 10a: 41 cases, 18 of them `cross_sections.*`.
 
 That arithmetic is the cheapest check on this file, and it has now done
-its job twice. Task 2's measurement cut A2 from 7 cases to 1, the slot
-count fell from 30 to 24 and one containment (`A3 ⊆ A2`) inverted into a
-disjointness — but the union stayed at 20, because the six cases A2 lost
-are exactly the six A3 keeps. Then B4 joined the roster with one case
+its job three times. Task 2's measurement cut A2 from 7 cases to 1, the
+slot count fell from 30 to 24 and one containment (`A3 ⊆ A2`) inverted
+into a disjointness — but the union stayed at 20, because the six cases A2
+lost are exactly the six A3 keeps. Then B4 joined the roster with one case
 that was already inside A3's set, so the slot count rose from 24 to 25
-and the union stayed at 20 again. Redo the sum after any measured change
-and make it come out to 41 again rather than patching one cell.
+and the union stayed at 20 again. Then B5 joined with one case that was
+in nobody's set, and this time the union did move — 20 to 21 — and the
+untouched count fell from 21 to 20, taking with it this section's own
+claim that *neither* `spectra.neutrino.*` case had a defect on its path.
+Redo the sum after any measured change and make it come out to 41 again
+rather than patching one cell.
 
 ## The deletion schedule this radius has to beat
 

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -11,7 +11,7 @@
 
 ## Objective
 
-Track cumulative context and live task status across all twelve tasks so
+Track cumulative context and live task status across all thirteen tasks so
 any agent picking up work mid-project has the facts, decisions and open
 questions needed to start without re-discovering them.
 
@@ -32,7 +32,8 @@ section tracks live *status*.
 | 8 | Repair A3 — charged-pion forward cone | 7 | Not started | `task-8-charged-pion-cone.md` |
 | 9 | Repair B3 — rho rest-frame branch | 3, 8 | Not started | `task-9-rho-rest-frame.md` |
 | 10 | Repair A4 — positron-muon normalization | 1, 2 | Not started | `task-10-positron-muon-norm.md` |
-| 11 | Reconcile the superseded sequencing prose | 4–10 | Not started | `task-11-prose-reconciliation.md` |
+| 10a | Repair B5 — charged-pion neutrino line | 1 | **Complete** | `task-10a-neutrino-pion-line.md` |
+| 11 | Reconcile the superseded sequencing prose | 4–10a | Not started | `task-11-prose-reconciliation.md` |
 | 12 | Close — aggregate the drift, bump | 11 | Not started | `task-12-close.md` |
 
 ```text
@@ -40,6 +41,7 @@ section tracks live *status*.
     │        │                │
     ├──► 4 ──┴────────────────┼──► 11 ──► 12
     │        └──► 6 ──────────┤
+    ├──► 10a ─────────────────┤
 2 ──┼──► 7 ──► 8 ──► 9 ───────┤
     └──► 10 ──────────────────┘
 ```
@@ -52,10 +54,11 @@ this project is time-critical.
 
 ## Exit Criteria
 
-- All twelve tasks complete; all eight defects repaired — the seven
+- All thirteen tasks complete; all nine defects repaired — the eight
   follow-ups under `docs/followups/todo/` moved to `docs/followups/done/`
   with inbound links repointed and the revision pinned (B4's already
-  lives there).
+  lives there; B5's is repaired but deliberately still in `todo/`, so the
+  repoint sweep happens once).
 - No live document still sequences any of the seven original repairs
   "after Phase 06 Task 6.4".
 - `git diff --stat -- test/parity/data` empty across the whole project.
@@ -114,6 +117,32 @@ this project is time-critical.
   This bullet named A2 and A3 as the first pair until Task 2 measured
   A2's radius at a single case that is neither rho — its defect is behind
   an at-rest guard no composed caller reaches. A2 now overlaps nothing.
+- **B5 is disjoint from everything else, and reaches one case.** The
+  charged pion's neutrino path uses `boost_delta_function` and
+  `super::neutrino_muon`; no other roster entry touches either. Task 10a
+  measured 215 of the 4,305 pinned values of
+  `spectra.neutrino.charged_pion` moving, in three of its five blocks and
+  in the electron row only. That retires
+  `../references/defect-blast-radius.md`'s claim that neither
+  `spectra.neutrino.*` case had a defect on its path.
+- **Measure a repair against a build carrying the defect, not against the
+  stored corpus.** Task 10a's live-vs-stored comparison reported 556
+  moved values across four blocks including the muon row; the repair
+  moves 215, in three blocks, in one row. The rest is the ulp-level
+  platform drift the case budget already absorbs (`numpy 2.5.1 → 2.5.3`,
+  `scipy 1.18.0 → 1.18.1`, a macOS point release). Capture the blocks
+  twice — defective build, then repaired build — and diff those.
+- **A declared position at exactly 0.500000 is a second defect, not a
+  rounding.** B5's factor-of-two positions are where the muon-decay
+  continuum's own quadrature returns a hard zero: its integrand's support
+  ends at 69.7835 MeV and the boost window runs hundreds of times wider,
+  so every QUADPACK abscissa falls outside it — A3's failure mode, in the
+  neutrino kernel. `rust/src/kernels/positron_pion.rs:163-164` clips both
+  ends of the same kind of window and is the precedent for the fix. Filed
+  as
+  [`neutrino-pion-continuum-loses-its-quadrature-support.md`](../../../docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md);
+  it moves published numbers by three to four decades on a band, far more
+  than B5 itself.
 - **Lesson classes this project is most exposed to**, from
   `docs/agents/lessons.md`: `[exemption-wider-than-its-mechanism]` (a
   declaration written wider than the mechanism that earned it),
@@ -129,7 +158,8 @@ this project is time-critical.
 
 ## Numerical impact so far
 
-**One public value has moved: B4, in PR #87** (bullet below). Task 2
+**Two public values have moved: B4, in PR #87, and B5, in Task 10a**
+(bullets below). Task 2
 shipped no library behavior —
 its four `.pyx` patches exist only inside the capture and are reverted.
 What it produced is the *measurement* each of Tasks 4, 7, 8 and 10 will
@@ -145,6 +175,7 @@ grids:
 | A2 muon endpoint | 7 | **1** of 7 predicted | 4 | n/a (`0.0` → negative) | down; all four values become negative |
 | A3 pion cone | 8 | 6 of 6 predicted | 6359 | 7.77 | both |
 | A4 positron norm | 10 | 6 of 6 predicted | 21,975 | `0.000374207` uniformly | up, at every position |
+| B5 pion neutrino line | 10a — **landed** | 1 of 1 | 215 | exactly 0.5 | down, at every position |
 
 Three things in there are corrections to the plan rather than
 confirmations of it, and Tasks 4, 7 and 8 inherit them: A1's sign is not
@@ -167,6 +198,20 @@ are recorded rather than re-derivable:
   photons per decay at `E_π` = 1000/1396/5000 MeV.
 - **A4**: the Michel spectrum integrates to 1.000000000000 (one ulp) at
   rest and at both boosts; shipped, 0.999625933330.
+- **B5** (repaired in Task 10a): `hazma.spectra.dnde_neutrino_charged_pion`
+  loses one `BR(π → e ν_e) = 1.230e-4` from its electron-neutrino row per
+  pion, 0.0123% of the row integrated. The muon and tau rows are
+  bit-identical, `spectra.neutrino.muon` and the nine tabulated
+  `dnde_neutrino_*` do not move, and `dnde_neutrino` moves only for final
+  states containing a charged pion. Two grids, both taken from a build
+  carrying the defect against the repaired one. On
+  `np.geomspace(1e-4, 1e5, 2001)` at `E_π` = 200, 400, 1000, 5000 MeV the
+  median pointwise drop is 4.7e-5 to 1.1e-4 and the maximum is exactly
+  `0.500000000000`. On the corpus grids it moves 215 of the case's 4,305
+  pinned values, from 4.716e-5 up to that same `0.500000000000` at 14 of
+  them — the positions where the muon-decay continuum's quadrature returns
+  zero. Declared relation held to 3e-12 (measured 1.494e-15).
+  Details in `task-10a-neutrino-pion-line.md`.
 - **B4** (repaired in PR #87, outside the task sequence): the scalar
   decay kernel's FSR-only spectrum at rest was 0.5000000000 × the
   annihilation-side `dnde_xx_to_s_to_ffg` / `dnde_xx_to_s_to_pipig` in
@@ -182,7 +227,10 @@ are recorded rather than re-derivable:
 Tasks 4–10 each move a published spectrum by design, and each records the
 function, the grid and the max shift here in its own PR (`../rules.md`
 rule 10). Task 12 aggregates this section into the `CHANGELOG.md` entry —
-it does not reconstruct it.
+it does not reconstruct it. B4 and B5 have each written their own
+`CHANGELOG.md` entry already, B5's under `[Unreleased]` because 2.2.0 is
+released; Task 12 renames that heading rather than re-deriving it, and
+`preflight.sh --closing` greps for `## [<new version>]`, so it must.
 
 ## Decisions and Implementation Notes
 
@@ -197,6 +245,21 @@ it does not reconstruct it.
   so the layer landed with it. Its case is inside A3's set, so Task 8
   inherits a rule 7 obligation against a declaration that already
   exists.
+- **B5 was rostered rather than repaired ad-hoc** (Task 10a). Its
+  follow-up was filed 2026-08-20, one day after this plan, and its
+  "Triggers / blockers" bullet already named this plan as its home — but
+  no row was added, so the plan counted eight defects against a
+  population of nine. It is numbered **Task 10a** because
+  `scripts/agents/resolve_task.py` sorts on `(\d+(?:\.\d+)*)\s*([a-z]*)`,
+  so a letter suffix inserts between Tasks 10 and 11 without renumbering
+  eleven tasks and their citations; Task 12 has to close last and Task 11
+  sweeps this follow-up, so both sides of the position are forced.
+- **B5's follow-up stays in `todo/` until Task 12** even though the
+  repair has landed, so the inbound-reference repoint
+  (`docs/workflow.md#follow-ups`, and
+  `docs/followups/todo/moved-followups-leave-dangling-inbound-paths.md`)
+  happens once for all eight rather than eight times. Its `Status:` line
+  records the repair and says so.
 - **The seven follow-ups' "Risks" sections were deliberately left
   standing** when their "Triggers / blockers" bullets were corrected, so
   the correction and the plan that justifies it would land in one
@@ -233,6 +296,16 @@ The change that created this project touched only
 `hazma/scalar_mediator/_scalar_mediator_spectra.py`, `CHANGELOG.md`,
 `docs/followups/`, and this project's plan, rules, references, ADR and
 notes — see `task-1-delta-declarations.md`.
+
+### Task 10a
+
+`rust/src/kernels/neutrino_pion.rs`, `test/parity/deltas.py`,
+`test/parity/test_parity.py`, `test/test_core_neutrino.py`,
+`CHANGELOG.md`, `docs/followups/todo/neutrino-pion-electron-line-counted-twice.md`,
+`docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md`
+(new), `docs/followups/README.md`, `../PLAN.md`,
+`../references/defect-blast-radius.md`, this file, and
+`task-10a-neutrino-pion-line.md` (new). `test/parity/data/` untouched.
 
 ## Verification
 
@@ -294,6 +367,12 @@ has no `hazma._core` test probes for the suite to import.
   closed-form model (the defect is an overall factor, so the delta may
   be expressible as one) — but that has to be established, not assumed,
   and the loss recorded rather than papered over.
+- **How many kernels boost a bounded spectrum over an unclipped window?**
+  Task 10a found `neutrino_pion.rs` doing it and `positron_pion.rs`
+  clipping correctly, but only because a repair's magnitude looked wrong.
+  The sweep of the remaining `quad` call sites has not been done —
+  [`neutrino-pion-continuum-loses-its-quadrature-support.md`](../../../docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md)
+  carries it as its own first question.
 - **Should the Task 2 oracles stay committed after `cython-to-rust`
   closes?** They are the last evidence that a repaired value was ever
   checked against a non-Rust implementation. Anticipated ADR.
@@ -321,12 +400,26 @@ has no `hazma._core` test probes for the suite to import.
   verified at `3e01590`.
 - `test/parity/data/` is intact — `python test/parity/generate.py --check`
   verifies it in under a second with no build.
-- B4 (PR #87) is the only repair that has changed a library value;
-  every other corpus array is still compared against its stored value.
+- B4 (PR #87) and B5 (Task 10a) are the repairs that have changed a
+  library value; every other corpus array is still compared against its
+  stored value. `test/parity/deltas.py` declares 36 arrays, and
+  `test_parity.EXPECTED_DECLARED_ARRAYS` is the literal that makes a
+  change to that number show up in a diff.
+- The measurement recipe every remaining repair task needs: capture the
+  corpus blocks from a build carrying the defect, restore the repair,
+  rebuild, capture again, and diff *those* — not the live tree against
+  the stored corpus, which reports the platform drift as if it were the
+  repair (Findings).
 
 **Currently risky / unknown:**
 
 - The blast-radius table is derived from the composition graph, not
-  measured. Treat it as where to look, never as what you will find.
+  measured. Treat it as where to look, never as what you will find. B5 is
+  the sharpest case so far: the table's coverage arithmetic said both
+  `spectra.neutrino.*` cases were untouched, and one of them was not.
+- A repair's own follow-up can understate its magnitude by orders of
+  magnitude. B5's predicted 0.06% local shift measured at a factor of
+  two, because the follow-up sampled only the plateau. Re-derive every
+  figure before quoting it in a `CHANGELOG.md` entry.
 - Every deadline in this plan depends on `cython-to-rust`'s pace, which
   this project does not control and must not assume.

--- a/projects/parity-pinned-defect-repair/task-notes/task-10a-neutrino-pion-line.md
+++ b/projects/parity-pinned-defect-repair/task-notes/task-10a-neutrino-pion-line.md
@@ -1,0 +1,396 @@
+# Task 10a: Repair B5 — the charged pion's doubled neutrino line
+
+**Date:** 2026-09-06
+**Project:** parity-pinned-defect-repair
+**Status:** Complete
+**Plan References:** `../PLAN.md` Task 10a, Scope, Numerical impact;
+`../rules.md` rules 1-7, 10, 11
+**Related ADRs:** `../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`
+**Depends On:** Task 1 (the delta-declaration layer). Not Task 2 — B5's
+Cython twin was deleted before this roster entry existed, so there is no
+oracle to capture.
+
+## Objective
+
+Make `dnde_e_nue` the sole source of the `π → e ν_e` line in
+`rust/src/kernels/neutrino_pion.rs`, so each prompt line is counted once,
+and declare the corpus positions the change moves.
+
+## Exit Criteria
+
+- The `delta_e` binding is gone from `dnde_mu_numu` and from its returned
+  `electron` field; `dnde_e_nue` is unchanged.
+- A declared delta on `spectra.neutrino.charged_pion` and no other case,
+  covering exactly the positions the boosted line reaches. `rest` and
+  `rest_plus_eps` still match their stored arrays under the case's own
+  budget.
+- `git diff --stat -- test/parity/data` empty (rule 1).
+- No tolerance widened (rule 2).
+- An independent oracle: the closed form, owing nothing to the kernel
+  (rule 3).
+- A physics invariant: the electron-neutrino row integrates to
+  `BR_μ + BR_e`, and the muon row is bit-identical (rule 4).
+- The two Rust tests and the two Python tests that pinned the defect are
+  renamed as well as re-pointed
+  (`docs/agents/lessons.md` `[test-name-claims-an-unmade-assertion]`).
+- The magnitude recorded in `CHANGELOG.md` and in the project's
+  "Numerical impact so far" (rule 10).
+
+## Inputs Reviewed
+
+- `docs/followups/todo/neutrino-pion-electron-line-counted-twice.md` —
+  the defect, its entry points, its predicted magnitude.
+- `../PLAN.md` (all sections), `../rules.md`,
+  `../references/corpus-repinning.md` §"Proof obligations",
+  `../references/defect-blast-radius.md`.
+- `../task-notes/README.md` — Tasks table, Findings, Open Questions,
+  Handoff.
+- `rust/src/kernels/neutrino_pion.rs` — module docs, `dnde_mu_numu`,
+  `dnde_e_nue`, `dnde_neutrino_charged_pion`, the test module.
+- `rust/src/boost.rs` — `boost_beta`, `boost_delta_function`.
+- `test/parity/deltas.py`, `test/parity/test_parity.py`
+  (`_assert_declared_delta`), `test/parity/tolerances.py`,
+  `test/parity/cases.py` (`_spectrum_case`, `Block`).
+- `test/test_core_neutrino.py` — the module docstring and `TestPhysics`.
+- `docs/agents/environment.md` — the build recipe and the rebuild trap.
+
+## Findings
+
+- **The corpus radius is one case and three of its five blocks.** 215 of
+  the 4,305 pinned values of `spectra.neutrino.charged_pion` move: 35 in
+  `near_rest`, 69 in `boosted_mild`, 111 in `boosted_strong`, and none in
+  `rest` or `rest_plus_eps`. All 215 are in the electron row and all move
+  down. `spectra.neutrino.muon` does not move, which makes B5 disjoint
+  from every other roster entry and retires this file's claim that
+  neither `spectra.neutrino.*` case had a defect on its path.
+
+- **`rest_plus_eps` is unmoved for a different reason than `rest`.** At
+  `E_π = m_π` the kernel takes the near-rest branch, which drops both
+  prompt lines. One epsilon above it the branch is the boosted one and
+  the line is computed — but `β` is ~1e-8, so the boost window
+  `[γE(1−β), γE(1+β)]` is narrower than the grid's spacing and no
+  sampled energy straddles `ENU_E_PI_RF`. The block is therefore evidence
+  that the declaration is minimal, not evidence that the branch is
+  guarded.
+
+- **The local magnitude the follow-up recorded is three orders of
+  magnitude too small.** It measured 0.06% at `E_π = 200` MeV, from three
+  points on the low-energy plateau. Above the muon-decay continuum's
+  support the doubled line is the *entire* spectrum, so the repair halves
+  it exactly: the relative drop is `0.500000` at 6 of 174 grid points at
+  `E_π = 200` MeV and at 241 of 824 at `E_π = 5000` MeV. Integrated the
+  follow-up's figure stands — one `BR_e` per pion, 0.0123% of the row.
+
+- **The measurement has to isolate the repair from the platform drift.**
+  Comparing the live tree against the stored corpus reports 556 moved
+  values across four blocks, including the muon row; almost all of that
+  is the ulp-level drift the case's own budget already absorbs
+  (`numpy 2.5.1 → 2.5.3`, `scipy 1.18.0 → 1.18.1`, a macOS point
+  release). Capturing the blocks twice — from a build carrying the defect
+  and from the repaired build — gives 215 and only the electron row.
+
+- **Those 50% positions expose a second, pre-existing defect.** Where the
+  drop is exactly one half, the muon-decay continuum's quadrature
+  returned exactly `0.0`: the integrand's support ends at
+  `ENU_E_PI_RF = 69.784260` MeV while the boost window is up to 423x
+  wider, so every QUADPACK abscissa falls outside it. That is the same
+  lost-support failure as A3 and it is untouched by this repair, in the
+  charged pion's *neutrino* kernel rather than its photon one. Filed as
+  [`neutrino-pion-continuum-loses-its-quadrature-support.md`](../../../docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md).
+
+## Decisions and Implementation Notes
+
+- **B5 is a new roster entry, not a new project.** The follow-up was
+  filed 2026-08-20, the day after this plan was drawn, and its "Triggers
+  / blockers" bullet already named this plan as its home — but no row was
+  ever added, so `PLAN.md` said "eight defects" against a population of
+  nine. Repairing it anywhere else would have needed the delta layer that
+  lives here anyway.
+
+- **Numbered `10a`, between Tasks 10 and 11.** `scripts/agents/resolve_task.py`
+  sorts on `(\d+(?:\.\d+)*)\s*([a-z]*)`, so a letter suffix orders after
+  its number without renumbering eleven existing tasks and their inbound
+  citations. The position is forced from both sides: Task 12 has to close
+  last, and Task 11's prose sweep moves this follow-up to `done/`.
+
+- **The declared term is a closed form written from the physics, not a
+  transcription of `boost_delta_function`.** Rule 3 wants an oracle the
+  repair does not share; the boosted line is a rectangle of height
+  `BR_e / (2 γ β E_ν^rf)` over `E ∈ (E_rf/(γ(1+β)), E_rf/(γ(1−β)))`,
+  which is four lines of numpy and needs no probe. It disagrees with the
+  kernel's own `boost_delta_function` by an FMA in the `γ` fold, worth
+  under 1.5e-15 of the compared value.
+
+- **The relation's `rtol = 3e-12` is derived, not fitted.** The
+  comparison denominator `stored + term` is at most 2x smaller than
+  `stored` — the doubled line cannot exceed the value it is part of — so
+  the case's own `PORTED_QUAD_RTOL = 1e-12` is amplified by at most two,
+  plus the closed form's ulp-level disagreement. Measured worst over the
+  215 positions: 1.494e-15.
+
+- **`the_boost_conserves_neutrino_number_per_flavor` cannot see this
+  repair, and now says so.** Its 3e-3 budget is 24x `BR_e` itself, so it
+  pins the continuum's normalization rather than the line count. The
+  discriminating Rust assertion is the new window-edge step check in
+  `the_electron_line_comes_from_one_half_only`; the discriminating Python
+  one is the continuum-subtracted plateau ratio.
+
+## Files Changed
+
+- `rust/src/kernels/neutrino_pion.rs` — the repair, a module-doc section
+  for the deliberate divergence from the `.pyx`, three re-pointed doc
+  comments, and two renamed/re-pointed tests.
+- `test/parity/deltas.py` — the `B5` declaration, its closed-form term,
+  and `B5` added to `REPAIRS`.
+- `test/parity/test_parity.py` — `EXPECTED_DECLARED_ARRAYS` 30 → 36.
+- `test/test_core_neutrino.py` — the module docstring's declared-defect
+  section, `reference_dnde_neutrino_charged_pion` (the independent
+  oracle), and two renamed/re-pointed `TestPhysics` tests.
+- `CHANGELOG.md` — a new `[Unreleased]` section with the magnitude.
+- `docs/followups/todo/neutrino-pion-electron-line-counted-twice.md` —
+  status, and the corrected local magnitude.
+- `docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md`,
+  `docs/followups/README.md` — the second defect this task surfaced.
+- `../PLAN.md`, `../references/defect-blast-radius.md`, `../task-notes/README.md`.
+
+## Verification
+
+Built with
+
+```sh
+uv pip install --python .venv/bin/python -e . \
+    --config-setting build-args="--features test-probes"
+```
+
+confirmed importing from the worktree
+(`hazma/_core.abi3.so` under `.claude/worktrees/focused-lovelace-7b108a`).
+
+```text
+cargo test --manifest-path rust/Cargo.toml --no-default-features \
+    --features test-probes neutrino_pion
+  → test result: ok. 15 passed; 0 failed; 246 filtered out
+
+pytest test/parity -q                → 668 passed, 1 skipped
+                                       (baseline before the repair: the same)
+pytest test/test_core_neutrino.py -q → 58 passed
+
+scripts/agents/preflight.sh --paths "test/parity/deltas.py
+    test/parity/test_parity.py test/test_core_neutrino.py" --md "<8 docs>"
+  → RESULT: PASS, every row green;
+    pytest 2246 passed, 15 skipped, 12 subtests passed
+```
+
+What those cover: the kernel's own branch structure and boost arithmetic
+(15 Rust tests, of which `the_electron_line_comes_from_one_half_only` is
+the repair's); the whole 41-case corpus including the six newly declared
+arrays and the two blocks of the same case that must *not* move; and the
+Python layer's independent recomputation, plateau ratios, per-flavor
+yields, at-rest branch, broadcasting and finiteness.
+
+**Mutation pair (rule 6, proof obligation 2).** Restoring the `delta_e`
+term and re-running:
+
+```text
+cargo test ... neutrino_pion
+  → the_electron_line_comes_from_one_half_only ... FAILED
+    "the mu nu_mu half steps by 0.00000032812679632122553 across the
+     electron line's window edge, so it is carrying a copy of the line
+     (0.00000032812679632122553)"
+  → 14 passed; 1 failed
+```
+
+The step is exactly one line's height, which is the assertion's own
+statement. `the_boost_conserves_neutrino_number_per_flavor` passes with
+the defect restored, which is why its doc comment now says what its
+budget can and cannot see.
+
+Deferred: `scripts/agents/check_doc_citations.py` over the touched docs
+is Task 11's gate, not this one's; the preflight run below is this task's.
+
+## Numerical impact
+
+**One public function moves: `hazma.spectra.dnde_neutrino_charged_pion`,
+electron row only, downward only.** Measured by evaluating every public
+`hazma.spectra.dnde_neutrino_*` and the n-body `dnde_neutrino` on
+`np.geomspace(1e-4, 1e5, 2001)` from a build carrying the defect and from
+the repaired build, and diffing:
+
+| Function | Result |
+| --- | --- |
+| `dnde_neutrino_charged_pion` | moves at `E_π` = 200, 400, 1000, 5000 MeV; unchanged at `E_π = m_π` |
+| `dnde_neutrino_muon` | identical at 105.658, 200, 1000 MeV |
+| the nine tabulated `dnde_neutrino_*` | identical at `m` and `2 m` |
+| `dnde_neutrino(..., ["pi", "pi"])` | moves; `["mu", "mu"]` identical |
+
+| `E_π` (MeV) | positions moved | band (MeV) | median drop | max drop |
+| --- | --- | --- | --- | --- |
+| 200 | 174 / 2001 | 28.44 – 170.8 | 0.0108% | 50.0000% |
+| 400 | 331 / 2001 | 12.68 – 387.3 | 0.0055% | 50.0000% |
+| 1000 | 513 / 2001 | 4.937 – 994.3 | 0.0048% | 50.0000% |
+| 5000 | 824 / 2001 | 0.9806 – 4955 | 0.0047% | 50.0000% |
+
+Integrated, the electron-neutrino yield falls by
+`BR(π → e ν_e) = 1.230e-4` per pion: 1.000141 → 1.000018 at
+`E_π = 200` MeV and 0.988680 → 0.988556 at 1000 MeV by trapezoid on that
+grid, i.e. −0.0123% both times. The muon row's integral is unchanged to
+the last bit. On the corpus grids the same repair moves 215 of 4,305
+pinned values, all in the electron row, all down, at a relative drop
+between 4.716e-5 and exactly 0.500000.
+
+## Open Questions
+
+- **Does the muon-decay continuum's lost quadrature support reach other
+  kernels?** `positron_pion.rs` boosts the same muon spectrum over the
+  same kind of window. Filed as
+  [`neutrino-pion-continuum-loses-its-quadrature-support.md`](../../../docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md),
+  which names that as its own first question rather than assuming it.
+- **Should `[Unreleased]` stay, or fold into Task 12's version heading?**
+  This task added one because 2.2.0 is released and a moved published
+  number cannot wait for the close. Task 12 renames it; `preflight.sh
+  --closing` greps for `## [<new version>]` and would fail on
+  `[Unreleased]`.
+
+## Plan Impact
+
+**Impact Level:** Plan and reference patched.
+
+`PLAN.md` gains Task 10a's canonical shape and counts nine defects rather
+than eight (frontmatter `deliverable`, Goal, Scope, Numerical impact, The
+defects, and Task 12's follow-up count).
+`references/defect-blast-radius.md` gains the B5 radius section and
+roster row, and its coverage arithmetic goes 25 slots / union 20 /
+untouched 21 → 26 / 21 / 20. No ADR: the delta layer, the relation
+vocabulary and the proof obligations all applied unchanged, which is
+ADR-0001 working rather than a new decision.
+
+## Stale-state sweep
+
+Run against this branch after the last prose edit.
+
+### Identifier sweep
+
+```sh
+rg -n --hidden '<identifier>' projects/ docs/ README.md hazma/ test/ \
+    rust/src/ .claude/ .codex/
+```
+
+Listed by file rather than by hit count, since this note is itself one of
+the files the command matches (`[measurement-taken-before-the-task-ended]`).
+
+| Identifier | Files | Disposition |
+| --- | --- | --- |
+| `the_electron_line_is_counted_by_both_halves` (removed) | `PLAN.md`, this note, the B5 follow-up | KEPT — no source file carries it; each of the three names it as the pre-repair name beside the new one |
+| `test_the_electron_line_is_counted_twice_and_the_muon_line_once` (removed) | `PLAN.md`, this note, the B5 follow-up | KEPT — same three, same reason |
+| `the_electron_line_comes_from_one_half_only` (new) | `neutrino_pion.rs`, `PLAN.md`, this note, the B5 follow-up | EDITED — the live name reaches every doc that names the old one |
+| `test_each_prompt_line_is_counted_exactly_once` (new) | `test_core_neutrino.py`, `PLAN.md`, this note, the B5 follow-up | EDITED — same |
+| `_pion_electron_line`, `_B5` (new) | `deltas.py`, this note | KEPT |
+| `EXPECTED_DECLARED_ARRAYS` | `test_parity.py`, `task-notes/README.md`, this note, `task-1-delta-declarations.md` | KEPT — Task 1's note records `= 30` as what Task 1 landed and is dated history |
+
+`delta_e` returns 0 hits in `rust/src/kernels/neutrino_pion.rs`.
+
+### Line-number citation sweep
+
+```sh
+rg -n -e 'neutrino_pion\.rs:[0-9]+' -e 'deltas\.py:[0-9]+' \
+   -e 'test_parity\.py:[0-9]+' -e 'test_core_neutrino\.py:[0-9]+' \
+   -e 'positron_pion\.rs:[0-9]+' projects/ docs/
+```
+
+The only citations into files this task touched are ten
+`test_parity.py:<line>` references in seven `projects/cython-to-rust/`
+task notes. This task's edit to that file replaces one line in place
+(`git diff origin/master --stat` shows `2 +-`), so no line number moved.
+The two new `positron_pion.rs:163-164` citations are into a file this
+task does not touch, and were read back to confirm they are the two
+clipping lines.
+
+`scripts/agents/check_doc_citations.py` over the eight touched docs:
+`docs scanned: 8`, `in-repo citations checked: 0`,
+`external citations skipped: 2` (`hazma/spectra/_neutrino/_pion.pyx`,
+deleted in `cython-to-rust` Task 4.6), `out-of-range or ambiguous: NONE`.
+It bounds-checks `file:line` but not `file:line-line`, which is why the
+`positron_pion.rs` range was checked by hand.
+
+All 119 relative markdown links in the eight touched docs resolve, and
+the repo-wide dangling-follow-up sweep returns the same three
+pre-existing slugs it returned before this task
+(`cross-section-prefactor-threshold-cancellation`,
+`legacy-parameters-width-exponent-bug`,
+`oracle-restore-revisions-for-the-mediator-decay-pyx`), none of them
+this task's.
+
+### Forward-looking phrase sweep
+
+`rg -n '(Task [0-9]+ will|will be added|still pending|today: ?stub)'` over
+`projects/parity-pinned-defect-repair/` and the two follow-ups: no
+occurrences.
+
+### Count sweep
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| "215 of 4,305", this note, `deltas.py`, `defect-blast-radius.md`, README | diff of the two corpus captures | 215 moved, 4305 pinned | OK |
+| "35 in near_rest, 69 in boosted_mild, 111 in boosted_strong" | same | `{'near_rest': 35, 'boosted_mild': 69, 'boosted_strong': 111}` | OK |
+| "36 declared arrays", `EXPECTED_DECLARED_ARRAYS` | `len(deltas.DECLARED_DELTAS)` | 36 (30 B4 + 6 B5) | OK |
+| "41 cases, 18 `cross_sections.*`", `defect-blast-radius.md` | the manifest command that file quotes | 41, 18 | OK |
+| "union 21, untouched 20", `defect-blast-radius.md` | `7+1+6+6+1 = 21`; `18 + 2 = 20`; `21 + 20 = 41` | 41 | OK |
+| "worst 1.494e-15", `deltas.py`'s `why` | `max(abs(live - (stored+term))/abs(stored+term))` over the declared positions | 1.494e-15 | OK |
+| "14 continuum-zero positions", the new follow-up | count of declared positions where `after == 0.5 * before` | 14 | OK |
+| "69.783500 MeV", the new follow-up | 200,001-point sweep of `dnde_neutrino_muon(., ENG_MU_PI_RF)` | 69.783500, both rows | OK |
+| "15 Rust tests", this note | `cargo test ... neutrino_pion` | 15 passed | OK |
+| "668 passed, 1 skipped", this note | `pytest test/parity -q` | 668 passed, 1 skipped | OK |
+| "58 passed", this note | `pytest test/test_core_neutrino.py -q` | 58 passed | OK |
+| "no tests lost" | `grep -c "def test_"` vs `git show origin/master:<file>` | 32/32, 26/26; `#[test]` 15/15 | OK |
+
+### Numerical-impact statement
+
+Every public `hazma.spectra.dnde_neutrino_*` and the n-body
+`dnde_neutrino`, on `np.geomspace(1e-4, 1e5, 2001)` (401 points for the
+n-body), evaluated from a build carrying the defect and from the repaired
+build. **One function moves**: `dnde_neutrino_charged_pion`, electron row
+only, downward only, at four of the five parent energies (unchanged at
+`E_π = m_π`), median drop 4.7e-5 to 1.1e-4 and maximum exactly
+0.500000000000. `dnde_neutrino` moves for `["pi", "pi"]` and not for
+`["mu", "mu"]`. The other eleven functions are bit-identical. Full table
+under `## Numerical impact` above.
+
+### Exit Criteria → test mapping
+
+| Exit criterion | What satisfies it |
+| --- | --- |
+| `delta_e` gone; `dnde_e_nue` unchanged | `git diff origin/master -- rust/src/kernels/neutrino_pion.rs`; `the_electron_line_comes_from_one_half_only` |
+| Declared delta on one case, exactly the positions the line reaches | `test_entry_point_matches_corpus[spectra.neutrino.charged_pion[*]]`, 5 blocks; the 36 other cases compared unchanged |
+| `rest` / `rest_plus_eps` still match stored | the same two block tests, undeclared and green |
+| `git diff --stat -- test/parity/data` empty | ran; empty |
+| No tolerance widened | `git diff --stat -- test/parity/tolerances.py` empty |
+| Independent oracle (rule 3) | `deltas._pion_electron_line` and `test_core_neutrino.reference_dnde_neutrino_charged_pion`, both closed forms |
+| Physics invariant (rule 4) | `test_each_prompt_line_is_counted_exactly_once` (1e-6, continuum subtracted with scipy); `test_the_pion_yields_one_muon_neutrino_from_each_of_two_sources` |
+| Tests renamed, not only re-pointed | the identifier sweep above |
+| Magnitude in `CHANGELOG.md` and "Numerical impact so far" | both written |
+
+### Task-note self-consistency
+
+`**Status:** Complete` matches the Tasks-table cell in
+`task-notes/README.md` (`10a … **Complete**`). Every file named in
+§Files Changed appears in `git diff origin/master --stat` (12 files, two
+of them new). Every function and constant cited in §Findings and
+§Decisions — `dnde_mu_numu`, `dnde_e_nue`, `boost_delta_function`,
+`boost_integral`, `_pion_electron_line`, `PORTED_QUAD_RTOL`,
+`EXPECTED_DECLARED_ARRAYS`, `positron_pion.rs`'s clip — exists in the
+tree at the spelling used.
+
+## Handoff to Next Task
+
+- **B5 is closed and disjoint.** Nothing in Tasks 3-10 shares an array
+  with it, so it constrains no ordering. Task 11 has one more follow-up
+  to sweep to `done/` than its Scope paragraph originally counted, and
+  Task 12 one more magnitude to aggregate — both already patched.
+- **Two blocks of `spectra.neutrino.charged_pion` are deliberately
+  undeclared.** `rest` and `rest_plus_eps` must keep matching their
+  stored arrays; a future repair that moves them has not found a wider
+  B5, it has found something else.
+- **The isolate-the-repair recipe is reusable** and Tasks 4, 7, 8 and 10
+  will need it: capture the corpus blocks from a build with the defect,
+  restore, rebuild, capture again, diff. Comparing against the stored
+  corpus instead reports the platform drift as if it were the repair — it
+  showed 556 moved values here where the repair moves 215.

--- a/rust/src/kernels/neutrino_pion.rs
+++ b/rust/src/kernels/neutrino_pion.rs
@@ -10,11 +10,8 @@
 //! (BR 1.230e-4), and the spectrum is the sum of three terms:
 //!
 //! * the **prompt muon-neutrino line** at [`ENU_MU_PI_RF`], boosted;
-//! * the **prompt electron-neutrino line** at [`ENU_E_PI_RF`], boosted —
-//!   and counted **twice**, once inside [`dnde_mu_numu`] and once inside
-//!   [`dnde_e_nue`], because the `.pyx` sums two `cdef`s that both carry
-//!   it. That is a defect, it is what the corpus pins, and rule 1 keeps
-//!   it: see [`dnde_neutrino_charged_pion`];
+//! * the **prompt electron-neutrino line** at [`ENU_E_PI_RF`], boosted,
+//!   contributed by [`dnde_e_nue`] alone;
 //! * the **muon-decay continuum**, `π → μ ν_μ` followed by
 //!   `μ → e ν̄_e ν_μ`, obtained by boosting [`super::neutrino_muon`]'s
 //!   spectrum out of the pion frame with the massless flat-boost integral
@@ -28,6 +25,22 @@
 //! integrand returns — so a single evaluation of this kernel runs two
 //! adaptive quadratures whose integrand is a closed-form kernel. That is
 //! one level shallower than [`super::photon_rho`]'s nesting.
+//!
+//! # The prompt electron-neutrino line is added once, not twice
+//!
+//! That line is the one place this module does not reproduce the `.pyx`
+//! bit for bit. `_pion.pyx` summed two `cdef`s, `c_dnde_mu_numu_point`
+//! and `c_dnde_e_nue_point`, that were meant to partition the pion's two
+//! decay modes — and the first of them carried a `π → ν_e e` term as well
+//! as its own, so the electron row of the sum came out at `2 BR(π → e
+//! ν_e)` where physics wants one. The muon row was never affected:
+//! `c_dnde_e_nue_point` writes nothing there, which is what makes the
+//! asymmetry a transcription slip rather than a convention. [`dnde_mu_numu`]
+//! therefore carries the `π → μ ν_μ` line alone and [`dnde_e_nue`] is the
+//! sole source of the electron one; see
+//! `docs/followups/todo/neutrino-pion-electron-line-counted-twice.md` for
+//! the measurement. The parity corpus still pins the pre-repair arrays;
+//! `test/parity/deltas.py` declares how the repaired ones relate to them.
 //!
 //! # Why there is not a single `mul_add` here
 //!
@@ -148,11 +161,12 @@ pub fn mu_numu_integrand(e1: f64, flavor: Flavor) -> f64 {
 ///    have no rest-frame representation here. A `NaN` `E_π` fails both
 ///    comparisons and falls through to the boosted branch, where every
 ///    quantity is `NaN`, exactly as in the Cython.
-/// 3. Otherwise both prompt lines, boosted, plus the two quadratures.
+/// 3. Otherwise the prompt `π → μ ν_μ` line, boosted, plus the two
+///    quadratures.
 ///
-/// Note branch 3 carries the `π → e ν_e` line as well as the `π → μ ν_μ`
-/// one, even though this function is named for the muon channel; that is
-/// the double-counting [`dnde_neutrino_charged_pion`] documents.
+/// Branch 3 carries only the line this function is named for. The `.pyx`
+/// added the `π → e ν_e` line here too, on top of the copy
+/// [`dnde_e_nue`] contributes; see the module docs.
 #[must_use]
 // Not a disguised equality test: `epi >= MASS_PI` is already established
 // above, so this is the one-sided "within one epsilon MeV of rest"
@@ -175,12 +189,11 @@ pub fn dnde_mu_numu(enu: f64, epi: f64) -> NeutrinoSpectrumPoint {
     let beta = boost::boost_beta(epi, MASS_PI);
     let (emin, emax, pre) = boost_window(enu, epi);
 
-    let delta_e = BR_PI_TO_E_NUE * boost::boost_delta_function(ENU_E_PI_RF, enu, 0.0, beta);
     let delta_m = BR_PI_TO_MU_NUMU * boost::boost_delta_function(ENU_MU_PI_RF, enu, 0.0, beta);
 
     let weight = pre * BR_PI_TO_MU_NUMU;
     NeutrinoSpectrumPoint {
-        electron: delta_e + weight * boost_integral(emin, emax, Flavor::Electron),
+        electron: weight * boost_integral(emin, emax, Flavor::Electron),
         muon: delta_m + weight * boost_integral(emin, emax, Flavor::Muon),
         tau: 0.0,
     }
@@ -289,18 +302,12 @@ pub fn dnde_e_nue(enu: f64, epi: f64) -> NeutrinoSpectrumPoint {
 ///
 /// The three flavors' `dN/dE` in MeV⁻¹, the tau row always zero.
 ///
-/// **The `π → e ν_e` line is counted twice.** [`dnde_mu_numu`] adds it in
-/// its boosted branch and [`dnde_e_nue`] adds it again, so the
-/// electron-neutrino line in the returned spectrum carries `2 · BR(π → e
-/// ν_e)` where physics wants one. The overweight is `1.23e-4` of the
-/// pion's total neutrino yield and it sits on a narrow plateau, so it does
-/// not visibly change an integrated rate — but it does change the shape
-/// there. This is a live defect in hazma 2.1.0 which the port reproduces
-/// on purpose (`projects/cython-to-rust/rules.md` rule 1: the parity
-/// corpus pins the doubled values, so a repair here fails the gate that
-/// governs the swap) and which
-/// `docs/followups/todo/neutrino-pion-electron-line-counted-twice.md`
-/// tracks.
+/// The two halves partition the pion's decay modes: [`dnde_mu_numu`]
+/// carries the `π → μ ν_μ` line and the muon-decay continuum, and
+/// [`dnde_e_nue`] carries the `π → e ν_e` line, so each prompt line
+/// appears exactly once. hazma 2.1.0 shipped the electron one twice —
+/// the module docs have the history, and `test/parity/deltas.py` declares
+/// how the corpus's stored values relate to these.
 #[must_use]
 pub fn dnde_neutrino_charged_pion(enu: f64, epi: f64) -> NeutrinoSpectrumPoint {
     let mu_nu = dnde_mu_numu(enu, epi);
@@ -404,16 +411,19 @@ mod tests {
         );
     }
 
-    /// The `π → e ν_e` line really is added twice.
+    /// The `π → e ν_e` line comes from [`dnde_e_nue`] and nowhere else.
     ///
-    /// The defect this module's docs declare, asserted rather than
-    /// described: at a lab energy inside the electron line's boosted
-    /// window and outside the muon line's, the total is exactly the sum of
-    /// the two halves, each of which carries the same line. Written as a
-    /// bit-equal identity so a "fix" that removes one copy fails here and
-    /// has to change the docs and the corpus with it.
+    /// The half that partitions the modes, asserted rather than described:
+    /// at a lab energy inside the electron line's boosted window and
+    /// outside the muon line's, `dnde_e_nue` contributes exactly one line
+    /// and `dnde_mu_numu` contributes none. The first half of that is a
+    /// bit-equal identity. The second cannot be, because the continuum
+    /// `dnde_mu_numu` does return there is ~5,000x the line and would
+    /// swamp it in any comparison of totals — so it is asserted at the
+    /// line's window edge instead, where a hidden copy is a step and the
+    /// continuum is smooth.
     #[test]
-    fn the_electron_line_is_counted_by_both_halves() {
+    fn the_electron_line_comes_from_one_half_only() {
         let epi = 400.0;
         // A lab energy inside the electron line's window: the line is at
         // `ENU_E_PI_RF` in the rest frame, so `gamma * ENU_E_PI_RF` is
@@ -426,13 +436,30 @@ mod tests {
             dnde_neutrino_charged_pion(enu, epi).electron.to_bits(),
             (from_mu_half.electron + from_e_half.electron).to_bits()
         );
-        // The two copies are the same number, so the plateau is exactly
-        // twice what one channel would put there.
+        // One copy, from the half named for the channel.
         let beta = crate::boost::boost_beta(epi, MASS_PI);
         let one_line =
             BR_PI_TO_E_NUE * crate::boost::boost_delta_function(ENU_E_PI_RF, enu, 0.0, beta);
         assert_eq!(from_e_half.electron.to_bits(), one_line.to_bits());
-        assert!(from_mu_half.electron > one_line);
+
+        // And the other half carries no line at all, which the sum above
+        // cannot see. A boosted line is a plateau that ends where its
+        // window stops straddling `ENU_E_PI_RF`, so a copy hiding in
+        // `dnde_mu_numu` would show up as a step of `one_line` across that
+        // edge; the muon-decay continuum crosses it smoothly.
+        let gamma = 1.0 / (1.0 - beta * beta).sqrt();
+        let edge = ENU_E_PI_RF / (gamma * (1.0 - beta));
+        let (below, above) = (edge * (1.0 - 1e-9), edge * (1.0 + 1e-9));
+        assert!(
+            dnde_e_nue(below, epi).electron > 0.0 && dnde_e_nue(above, epi).electron == 0.0,
+            "the bracket must straddle the line's upper window edge"
+        );
+        let step = (dnde_mu_numu(above, epi).electron - dnde_mu_numu(below, epi).electron).abs();
+        assert!(
+            step < 1e-6 * one_line,
+            "the mu nu_mu half steps by {step} across the electron line's \
+             window edge, so it is carrying a copy of the line ({one_line})"
+        );
     }
 
     /// The muon-neutrino line appears once, and only in the muon row.
@@ -549,9 +576,8 @@ mod tests {
         }
     }
 
-    /// The boost conserves neutrino number, per flavor, to the accuracy
-    /// the integrator claims — and the doubled line is visible in the
-    /// total.
+    /// The boost conserves neutrino number, per flavor, and each decay
+    /// mode contributes its own branching ratio exactly once.
     ///
     /// The statement about this kernel that owes nothing to the Cython.
     /// Per charged pion the yields are:
@@ -560,8 +586,8 @@ mod tests {
     ///   the muon's own `ν_μ` (`BR_μ`, since
     ///   [`super::neutrino_muon`]'s rows each integrate to exactly one);
     /// * **electron neutrinos** — the muon's `ν̄_e` (`BR_μ`) plus the
-    ///   prompt `π → e ν_e` line, counted **twice** (`2 BR_e`), which is
-    ///   the defect [`dnde_neutrino_charged_pion`] declares.
+    ///   prompt `π → e ν_e` line (`BR_e`). The shipped 2.1.0 kernel
+    ///   counted that line twice and this row summed to `BR_μ + 2 BR_e`.
     ///
     /// Trapezoid on 4_001 points from just above zero to past the highest
     /// endpoint — the grid starts at one step rather than at zero because
@@ -570,7 +596,10 @@ mod tests {
     /// is 3e-3 relative: the spectrum has step discontinuities where each
     /// line's window opens and closes, and a composite rule resolves those
     /// at `O(h)`. That still separates the expected total from any
-    /// factor-of-two error by two decades.
+    /// factor-of-two error by two decades — but it is 24x `BR_e` itself,
+    /// so what this test pins is the continuum's normalization, not how
+    /// many copies of the electron line the row carries. That is
+    /// [`tests::the_electron_line_comes_from_one_half_only`]'s job.
     #[test]
     fn the_boost_conserves_neutrino_number_per_flavor() {
         let epi = 400.0;
@@ -587,9 +616,8 @@ mod tests {
             totals[0] += weight * point.electron;
             totals[1] += weight * point.muon;
         }
-        // The electron row: the muon's nu_e_bar, plus the prompt line
-        // twice (the declared defect).
-        let expected_electron = BR_PI_TO_MU_NUMU + 2.0 * BR_PI_TO_E_NUE;
+        // The electron row: the muon's nu_e_bar, plus the prompt line.
+        let expected_electron = BR_PI_TO_MU_NUMU + BR_PI_TO_E_NUE;
         // The muon row: the muon's nu_mu, plus the prompt line once.
         let expected_muon = BR_PI_TO_MU_NUMU + BR_PI_TO_MU_NUMU;
         for (flavor, (total, expected)) in ["electron", "muon"]

--- a/test/parity/deltas.py
+++ b/test/parity/deltas.py
@@ -45,18 +45,21 @@ that assertion; the declaration cannot outlive the repair it describes.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from hazma import parameters
+
 if TYPE_CHECKING:
     from cases import Block
 
 #: The closed set of repair labels a declaration may carry: the roster in
 #: ``projects/parity-pinned-defect-repair/references/defect-blast-radius.md``.
-REPAIRS = frozenset({"A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4"})
+REPAIRS = frozenset({"A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4", "B5"})
 
 #: The sentinel for "every position the term is non-zero at", resolved
 #: against the term at comparison time. A term that is zero at a position
@@ -184,14 +187,105 @@ _B4 = Delta(
     evidence="docs/followups/done/scalar-decay-fsr-half-normalized.md",
 )
 
-#: Every declared array. The ``mu_mu_only`` blocks of the same case are
-#: deliberately absent: they open no FSR channel and must still match the
-#: stored arrays bit for bit, which is the "moved only what it intended"
-#: half of the proof. Within a declared array the same holds position by
-#: position: wherever the FSR term is zero -- above a channel's endpoint,
-#: below the soft cut, outside the boost window -- `MOVED` leaves the
-#: position at the case's own budget.
+# ---------------------------------------------------------------------------
+# B5 -- the charged pion's prompt "pi -> e nu" neutrino line was added twice
+# ---------------------------------------------------------------------------
+
+#: ``BR(pi -> e nu_e)``, as ``rust/src/constants.rs``'s ``pdg`` module
+#: spells it. A literal because ``hazma.parameters`` has no branching
+#: ratios in it -- the masses the term needs do come from there, and agree
+#: with the crate's ``pdg`` constants bit for bit, which is what keeps the
+#: window decision below on the same side of every grid point.
+BR_PI_TO_E_NUE = 1.230e-4
+
+
+def _pion_electron_line(_fn: Callable[..., Any], block: Block) -> dict[str, np.ndarray]:
+    """Minus one boosted ``pi -> e nu_e`` line, on the block's grids.
+
+    A rest-frame line at ``e0`` boosts to a flat plateau of height
+    ``1 / (2 gamma beta e0)`` across the lab energies whose boost window
+    ``[gamma E (1 - beta), gamma E (1 + beta)]`` straddles ``e0``, and zero
+    elsewhere; the shipped kernel added ``BR_e`` of it in both halves of
+    the sum, so ``stored = repaired + BR_e * plateau``. Only the electron
+    row carries it -- the ``pi -> e nu_e`` half writes nothing to the other
+    two -- so the term is zero everywhere else, and `MOVED` leaves those
+    positions at the case's own budget.
+    """
+    epi = block.params["parent_energy"]
+    mpi = block.params["parent_mass"]
+    e0 = (mpi * mpi - parameters.electron_mass**2) / (2.0 * mpi)
+    ratio = mpi / epi
+    beta = math.sqrt(1.0 - ratio * ratio)
+
+    def line(energies: np.ndarray) -> np.ndarray:
+        # A line has no rest-frame representation and no width to boost,
+        # so a parent at rest carries none -- the same answer, and for the
+        # same reason, as ``boost.boost_delta_function``'s ``beta <= 0``
+        # guard. Without this the height below divides by zero.
+        if beta <= 0.0:
+            return np.zeros_like(energies)
+        gamma = 1.0 / math.sqrt(1.0 - beta * beta)
+        inside = (gamma * energies * (1.0 - beta) < e0) & (
+            e0 < gamma * energies * (1.0 + beta)
+        )
+        return np.where(inside, -BR_PI_TO_E_NUE / (2.0 * gamma * beta * e0), 0.0)
+
+    # Row 0 of a (3, n) values array and column 0 of an (n, 3) scalar one:
+    # both are the electron flavor, `cases` stores the two orientations.
+    terms = {}
+    values = np.zeros((3, block.grid.size), dtype=np.float64)
+    values[0] = line(block.grid)
+    terms["values"] = values
+    probe = block.scalar_probe
+    if probe.size:
+        scalar_values = np.zeros((probe.size, 3), dtype=np.float64)
+        scalar_values[:, 0] = line(probe)
+        terms["scalar_values"] = scalar_values
+    return terms
+
+
+_B5 = Delta(
+    repair="B5",
+    positions=MOVED,
+    relation=Additive(
+        term=_pion_electron_line,
+        rtol=3e-12,
+        why="three times the case's own PORTED_QUAD_RTOL (1e-12), derived "
+        "rather than fitted: the term carries no quadrature, so the only "
+        "slack the relation needs is the platform drift already between the "
+        "stored value and the live one, and the comparison denominator "
+        "stored + term is at most 2x smaller than stored (the doubled line "
+        "cannot exceed the stored value), so that budget is amplified by at "
+        "most two. The closed form's own disagreement with the kernel's "
+        "boost_delta_function -- an FMA in the gamma fold this expression "
+        "does not spell -- adds under 1.5e-15 of the compared value. Worst "
+        "measured over the 215 declared positions: 1.494e-15, in "
+        "boosted_strong.",
+    ),
+    measured="the repair removes exactly one BR_e = 1.230e-4 from the "
+    "electron-neutrino row per pion, and moves 215 of the case's 4,305 pinned "
+    "values, all downward and all in the electron row: 35 in near_rest, 69 in "
+    "boosted_mild, 111 in boosted_strong, and none in rest or rest_plus_eps, "
+    "where beta is too small for any grid point's window to straddle the "
+    "line. The drop runs from 4.716e-5 relative, on the plateau where the "
+    "muon-decay continuum dominates, to exactly 0.500000000000 at the 14 "
+    "positions where that continuum's quadrature returns zero and the "
+    "doubled line was the entire value.",
+    evidence="docs/followups/todo/neutrino-pion-electron-line-counted-twice.md",
+)
+
+#: Every declared array. The two blocks of the same case that are absent --
+#: ``rest`` and ``rest_plus_eps`` -- must still match the stored arrays under
+#: the case's own budget, which is the "moved only what it intended" half of
+#: the B5 proof: at rest the kernel drops both prompt lines, and one epsilon
+#: above it no grid point's boost window is wide enough to straddle the line.
 DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
+    # B4. The ``mu_mu_only`` blocks of this case are deliberately absent:
+    # they open no FSR channel and must still match the stored arrays bit
+    # for bit. Within a declared array the same holds position by position:
+    # wherever the FSR term is zero -- above a channel's endpoint, below the
+    # soft cut, outside the boost window -- `MOVED` leaves the position at
+    # the case's own budget.
     (
         "mediator_spectra.scalar.photon.scalar_mediator_decay_spectrum",
         "ms_250.rest.default",
@@ -342,6 +436,13 @@ DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
         "ms_900.boosted_strong.default",
         "scalar_values",
     ): _B4,
+    # B5.
+    ("spectra.neutrino.charged_pion", "near_rest", "values"): _B5,
+    ("spectra.neutrino.charged_pion", "near_rest", "scalar_values"): _B5,
+    ("spectra.neutrino.charged_pion", "boosted_mild", "values"): _B5,
+    ("spectra.neutrino.charged_pion", "boosted_mild", "scalar_values"): _B5,
+    ("spectra.neutrino.charged_pion", "boosted_strong", "values"): _B5,
+    ("spectra.neutrino.charged_pion", "boosted_strong", "scalar_values"): _B5,
 }
 
 

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -124,7 +124,7 @@ EXPECTED_PORTABILITY_ZEROS = 4
 #: same reason as the two above: the size of the set the gate compares
 #: against something other than the stored corpus is the number worth
 #: defending in a diff.
-EXPECTED_DECLARED_ARRAYS = 30
+EXPECTED_DECLARED_ARRAYS = 36
 
 
 def _drop_unpinnable(

--- a/test/test_core_neutrino.py
+++ b/test/test_core_neutrino.py
@@ -46,22 +46,25 @@ does not:
   **2.3e-14** on the off-corpus sweep. Task 4.6 tightened its budget from
   ``QUAD_RTOL`` (1e-8) to ``PORTED_QUAD_RTOL`` (1e-12) on those numbers.
 
-Two declared defects
---------------------
-Both are live in hazma 2.1.0, both are reproduced on purpose (rule 1: the
-corpus pins them), and both are asserted below rather than described.
+One repair and one declared defect
+----------------------------------
+Both shipped in hazma 2.1.0 and 2.2.0; the first is repaired and the
+second is not. Both are asserted below rather than described.
 
-* **The ``pi -> e nu`` line is counted twice.** ``_pion.pyx`` sums
-  ``c_dnde_mu_numu_point`` and ``c_dnde_e_nue_point``, and *both* add the
-  boosted electron-neutrino line. The overweight is one extra ``BR_e``
-  (1.23e-4) per pion, landing as a 0.03-0.06% excess on the
-  electron-neutrino plateau where the line sits. Tracked in
+* **The ``pi -> e nu`` line was counted twice, and is not any more.**
+  ``_pion.pyx`` summed ``c_dnde_mu_numu_point`` and
+  ``c_dnde_e_nue_point``, and *both* added the boosted electron-neutrino
+  line, so the row carried one extra ``BR_e`` (1.23e-4) per pion. The
+  repaired kernel adds it in ``dnde_e_nue`` alone. The corpus still pins
+  the shipped values; ``test/parity/deltas.py`` declares the 215 it moves
+  as roster entry B5. Tracked in
   ``docs/followups/todo/neutrino-pion-electron-line-counted-twice.md``.
 * **A pion at rest loses both prompt lines.** The ``E - m < DBL_EPSILON``
   branch returns only the muon-decay continuum, because a delta function
-  in the rest frame has no representation here. Not filed separately: it
-  is the same "the rest-frame branch is not the limit of the boosted one"
-  family as the rho's, and unlike the rho's it does not change units.
+  in the rest frame has no representation here. Reproduced on purpose
+  (rule 1: the corpus pins it) and not filed separately: it is the same
+  "the rest-frame branch is not the limit of the boosted one" family as
+  the rho's, and unlike the rho's it does not change units.
 
 What is **not** a defect, and must not be "fixed": ``_neutrino/_muon.pyx``
 applies the Michel normalization the right way round, so both its rows
@@ -270,9 +273,15 @@ def reference_dnde_neutrino_charged_pion(enu: float, epi: float) -> np.ndarray:
     its own reference. The prompt lines are recomputed from the flat-boost
     closed form rather than from ``boost_delta_function``.
 
-    Reproduces the double-counted ``pi -> e nu`` line on purpose: the
-    point of this reference is to check the *boost*, not to disagree with
-    the shipped physics, which :class:`TestPhysics` covers separately.
+    Carries each prompt line once, as the repaired kernel does. hazma
+    2.1.0 doubled the ``pi -> e nu`` one; the line terms here are written
+    from the physics rather than from either implementation, so they are
+    what says which of the two is right.
+
+    The continuum is *not* independent in that sense: it integrates over
+    the same unclipped boost window the kernel uses, so where that window
+    loses the integrand's support both return zero together. See
+    ``docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md``.
     """
     zero = np.zeros(N_FLAVORS)
     if epi < MASS_PI:
@@ -305,8 +314,9 @@ def reference_dnde_neutrino_charged_pion(enu: float, epi: float) -> np.ndarray:
             )[0]
         )
 
-    # The `pi -> e nu` line appears once from each half of the `.pyx`.
-    electron = 2.0 * BR_PI_TO_E_NUE * line(ENU_E_PI_RF) + continuum(0)
+    # One prompt line per decay mode: `pi -> e nu_e` here, `pi -> mu nu_mu`
+    # below. The shipped kernel added the first from both halves of its sum.
+    electron = BR_PI_TO_E_NUE * line(ENU_E_PI_RF) + continuum(0)
     muon = BR_PI_TO_MU_NUMU * line(ENU_MU_PI_RF) + continuum(1)
     return np.array([electron, muon, 0.0])
 
@@ -670,14 +680,17 @@ class TestPhysics:
 
         A charged pion makes a prompt ``nu_mu`` and then the muon makes
         another, so the row carries two per pion. The electron-neutrino
-        row carries one from the muon plus the doubled prompt line, which
-        the next test isolates.
+        row carries one from the muon plus one prompt line, which the next
+        test isolates.
 
         Trapezoid on 20_001 points to past the highest endpoint. Each
         point costs two adaptive quadratures, so the grid is short and the
         budget is 1e-3 relative: the spectrum has step discontinuities
         where each line's window opens and closes, which a composite rule
-        resolves at ``O(h)``.
+        resolves at ``O(h)``. That budget is eight times ``BR_e`` itself,
+        so the electron assertion here pins the continuum's normalization
+        rather than how many copies of the line the row carries; the next
+        test is what counts them.
         """
         epi = 400.0
         gamma = epi / MASS_PI
@@ -688,11 +701,11 @@ class TestPhysics:
             2.0 * BR_PI_TO_MU_NUMU, rel=1e-3
         )
         assert np.trapezoid(values[0], energies) == pytest.approx(
-            BR_PI_TO_MU_NUMU + 2.0 * BR_PI_TO_E_NUE, rel=1e-3
+            BR_PI_TO_MU_NUMU + BR_PI_TO_E_NUE, rel=1e-3
         )
 
-    def test_the_electron_line_is_counted_twice_and_the_muon_line_once(self) -> None:
-        """The declared defect, asserted rather than described.
+    def test_each_prompt_line_is_counted_exactly_once(self) -> None:
+        """The repair, asserted rather than described.
 
         Each boosted prompt line is a flat plateau of height
         ``BR / (2 gamma beta E_rf)`` across the lab energies whose boost
@@ -701,13 +714,15 @@ class TestPhysics:
         subtraction owes nothing to the code under test — leaves exactly
         the plateau.
 
-        What comes out is **2.0000** copies of the ``pi -> e nu`` line and
+        What comes out is **1.0000** copies of the ``pi -> e nu`` line and
         **1.0000** of the ``pi -> mu nu`` one, at every energy inside both
-        windows. The electron excess is the defect: ``_pion.pyx`` sums
-        ``c_dnde_mu_numu_point`` and ``c_dnde_e_nue_point`` and both add
-        it. The muon row has no second copy because ``c_dnde_e_nue_point``
-        writes nothing there, which is what makes the pair of ratios a
-        discriminating test rather than a scale check.
+        windows. hazma 2.1.0 gave **2.0000** for the electron one, because
+        ``_pion.pyx`` summed ``c_dnde_mu_numu_point`` and
+        ``c_dnde_e_nue_point`` and both added it; the muon row never had a
+        second copy, because ``c_dnde_e_nue_point`` writes nothing there.
+        That asymmetry is what makes the pair of ratios a discriminating
+        test rather than a scale check, and it is why both are asserted
+        here rather than only the repaired one.
 
         1e-6 relative, which is what the subtraction supports: the
         continuum is recomputed to scipy's default 1.49e-8 absolute.
@@ -726,8 +741,8 @@ class TestPhysics:
         for enu in (20.0, 30.0, 50.0):
             total = dnde_pion(enu, epi)
             assert total[0] - reference_pion_continuum(enu, epi, 0) == pytest.approx(
-                2.0 * electron_line, rel=1e-6
-            ), f"the pi -> e nu line is not doubled at {enu=}"
+                electron_line, rel=1e-6
+            ), f"the pi -> e nu line is not single at {enu=}"
             assert total[1] - reference_pion_continuum(enu, epi, 1) == pytest.approx(
                 muon_line, rel=1e-6
             ), f"the pi -> mu nu line is not single at {enu=}"


### PR DESCRIPTION
## Summary

- **`hazma.spectra.dnde_neutrino_charged_pion` counted its prompt
  `π → e ν_e` line twice.** The kernel summed two contributions meant to
  partition the pion's decay modes and both carried the boosted line, so
  the electron-neutrino row shipped `2 BR(π → e ν_e)` where physics wants
  one. `dnde_e_nue` is now the sole source. The muon row was never
  affected — the `π → e ν_e` half writes nothing there — and that
  asymmetry is what makes the doubling a transcription slip rather than a
  convention.
- **The numbers move, and only downward, and only in one row.**
  Integrated, the electron-neutrino yield falls by exactly
  `BR(π → e ν_e) = 1.230e-4` per pion — 0.0123% of the row. Pointwise the
  drop is ~5e-5 relative on the plateau where the muon-decay continuum
  dominates, and **exactly a factor of two** above that continuum's
  support, where the doubled line was the whole spectrum (at
  `E_π = 1000` MeV that band runs 692–994 MeV). The repaired value is the
  right one. `dnde_neutrino` moves for any final state containing a
  charged pion; `dnde_neutrino_muon`, the nine tabulated
  `dnde_neutrino_*`, and the muon and tau rows of the charged pion are
  bit-identical, verified on a 2001-point `geomspace(1e-4, 1e5)` grid
  from a build carrying the defect against the repaired one.
- **The corpus keeps its pre-repair arrays.** `test/parity/deltas.py`
  declares the 215 of 4,305 pinned `spectra.neutrino.charged_pion` values
  that move as roster entry B5, against a closed form written from the
  physics rather than transcribed from the kernel it checks. `rest` and
  `rest_plus_eps` stay undeclared and must keep matching, which is the
  "moved only what it intended" half of the proof. `git diff --stat --
  test/parity/data` is empty and no tolerance was widened.
- **The measurement exposed a second, larger defect**, filed rather than
  fixed here: the muon-decay continuum integrates over a boost window up
  to 423× wider than its integrand's support, so QUADPACK places every
  abscissa outside it and returns a hard zero. At `E_π = 1395.7`,
  `E_ν = 798.21` MeV the muon-neutrino row is exactly `0.0` where the
  clipped integral gives `4.736526e-04` MeV⁻¹. The sibling
  `rust/src/kernels/positron_pion.rs:163-164` already clips both ends of
  the same kind of window. See
  `docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md`.

## Project

`projects/parity-pinned-defect-repair/` — Task 10a: Repair B5, the
charged pion's doubled neutrino line.

The follow-up named this plan as its home but was never rostered, so the
plan counted eight defects against a population of nine. This PR seats it
as roster entry **B5** / **Task 10a** — numbered with a letter suffix so
`scripts/agents/resolve_task.py` orders it between Tasks 10 and 11
without renumbering eleven existing tasks and their citations — and
updates the coverage arithmetic in `references/defect-blast-radius.md`
(26 case slots, union 21, untouched 20, summing to the corpus's 41).

See `projects/parity-pinned-defect-repair/task-notes/task-10a-neutrino-pion-line.md`
for implementation detail, decisions, the numerical-impact tables, and
the stale-state sweep.

## Test plan

- [x] `scripts/agents/preflight.sh --paths "test/parity/deltas.py
  test/parity/test_parity.py test/test_core_neutrino.py" --md "<8 docs>"`

  ```text
  RESULT: PASS   (every row green)
  PASS   pytest   2246 passed, 15 skipped, 12 subtests passed in 44.15s
  ```

- [x] `pytest test/parity -q` → `668 passed, 1 skipped` — the same count
  as before the repair, with the six newly declared arrays compared
  against the B5 relation and the other 36 cases against their stored
  values unchanged.

- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features
  --features test-probes neutrino_pion` →
  `test result: ok. 15 passed; 0 failed; 246 filtered out`

- [x] **Mutation pair.** Restoring the `delta_e` term and re-running:

  ```text
  the_electron_line_comes_from_one_half_only ... FAILED
    "the mu nu_mu half steps by 0.00000032812679632122553 across the
     electron line's window edge, so it is carrying a copy of the line
     (0.00000032812679632122553)"

  pytest test/parity -k "spectra.neutrino" → 3 failed, 7 passed
    near_rest / boosted_mild / boosted_strong: does not satisfy the B5 relation
  ```

  And widening the declaration by one unmoved block:

  ```text
  spectra.neutrino.charged_pion[rest].values: the B5 declaration moves
  nothing beyond its own budget here, so it is stale -- narrow it (deltas.py)
  ```

- [x] Declared relation held to `rtol = 3e-12` (three times the case's own
  `PORTED_QUAD_RTOL`, derived from the at-most-2× denominator shrink);
  worst measured over the 215 declared positions is **1.494e-15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)