### PR TITLE
fix(spectra): cover the boost integral's window at both ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ user-facing change even when no signature did.
 
 ### Changed
 
+- **The boost integral mis-covered its window at both ends, and all seven
+  tabulated photon spectra move.** `hazma.spectra.dnde_photon_eta`,
+  `dnde_photon_eta_prime`, `dnde_photon_omega`, `dnde_photon_phi`,
+  `dnde_photon_charged_kaon`, `dnde_photon_long_kaon` and
+  `dnde_photon_short_kaon` boost a tabulated rest-frame spectrum by
+  integrating it over the window the boost opens. Two errors in that
+  coverage, both now repaired. Its interior trapezoid ran to an exclusive
+  upper index while the upper partial-cell term began at the inclusive
+  one, so one whole cell was covered by nothing — and under the clamp
+  that applies when the window reaches past the table, the table's final
+  row contributed to no term at all. Where **both** bounds fell inside a
+  single cell the two partial-cell terms overlapped instead, covering
+  about two whole cells rather than the sliver between the bounds; that
+  over-count is `cell width / window width` and diverges as the parent
+  slows. **The sign therefore splits by regime rather than being
+  uniform.** Near threshold the spectra were far too high and now
+  converge: at a parent one part in 1e12 above rest they returned 6,500x
+  to 33,000x their own rest-frame value at `E_γ = m/10`, and now agree
+  with it to better than 1% over `E_γ` from `m/20` to `3m/10`. Away from
+  threshold they were slightly low and now rise — over the 10,045 values
+  the parity corpus pins, by a median 3.3% at `γ = 1.05`, 0.22% at
+  `γ = 2` and 7.1e-5 at `γ = 10`, and by up to 98.7%. In total 4,154 of
+  those 10,045 values move. A parent **exactly** at rest is unaffected:
+  all seven kernels short-circuit to the rest-frame spectrum before the
+  integral, so it never runs at `β = 0`. `hazma.spectra.dnde_photon` and
+  every model `total_spectrum` move for any final state containing one of
+  the seven. Details:
+  `docs/followups/todo/boost-integral-drops-last-interior-cell.md`.
 - **The charged pion's prompt `π → e ν` neutrino line was counted twice.**
   `hazma.spectra.dnde_neutrino_charged_pion` summed two contributions that
   were meant to partition the pion's decay modes, and both carried the
@@ -356,7 +384,9 @@ result:
   value as the parent approaches rest: at `E_γ = m/10` and a parent one
   part in 1e12 above rest, `dnde_photon_eta` returns 767.2 against the
   0.02313 it returns exactly at rest. Separately, when the window reaches
-  past the table the final row contributes to nothing at all.
+  past the table the final row contributes to nothing at all. Repaired
+  after this release — see `Unreleased`, which carries the measurement
+  over the parity corpus and the fix.
 - **[`thermal_cross_section` returns its integrator's initial estimate.](docs/followups/done/thermal-cross-section-quadrature-never-converges.md)**
   The quadrature never converges, so ⟨σv⟩ is off the true integral for
   every `x = m_χ/T` above about 5 — that is, across the entire freeze-out

--- a/docs/followups/todo/boost-integral-drops-last-interior-cell.md
+++ b/docs/followups/todo/boost-integral-drops-last-interior-cell.md
@@ -3,7 +3,10 @@
 - **Added:** 2026-08-10
 - **Source:** cython-to-rust Task 3.4 (the interp + boost port)
 - **Scope:** cross-cutting
-- **Status:** open
+- **Status:** open — **repaired** 2026-09-07 as roster entry A1,
+  `projects/parity-pinned-defect-repair` Task 4. The file stays here
+  until that project's close (Task 12) moves all of its follow-ups to
+  `done/` in one sweep, so the inbound references are repointed once.
 - **Triggers / blockers:** **capture the corrected values BEFORE the
   deletion wave that strands them** — the deadline is on the oracle, not
   on the fix. The parity corpus does pin the current values, and
@@ -45,7 +48,8 @@ is clamped to `x[-1]` and `ihigh` becomes the last index, so the upper
 partial-cell term is skipped entirely and **the table's final row
 contributes to no term at all**. Replacing it with a value six orders of
 magnitude larger leaves the answer bit-identical — checked against the
-live Cython, `test/test_core_boost.py::TestDroppedInteriorCell`.
+live Cython, and now inverted in
+`test/test_core_boost.py::TestWindowCoverage`.
 
 This is a real error in a published number, not a rounding artifact. On a
 hand-computable case (`x = y = [1, 2, 3, 4]`, `beta = 0.6`, `E = 2.2`)
@@ -88,8 +92,11 @@ above — one cell out of a wide window, systematically low.
 
 The parity corpus pins these values, faithfully: its `rest_plus_eps`
 block sits exactly in the divergent regime. That is the corpus doing its
-job (it records what the Cython returns, not what is correct), and it is
-why the repair has to regenerate the corpus in the same change.
+job (it records what the Cython returns, not what is correct). The repair
+therefore lands as a declared delta against those arrays rather than as a
+regeneration — see
+[`projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`](../../../projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md),
+which supersedes the regeneration this file's "What" section asks for.
 
 Note `references/cython-inventory.md` already lists "off-by-one index
 pairing in `boost_integrate_linear_interp_massive`" under *dead* code.
@@ -132,15 +139,16 @@ allows).
 - `rust/src/boost.rs` — `boost_integrate_linear_interp`, where the
   behavior is reproduced with the reasoning in its
   `# Faithfulness notes`.
-- `test/test_core_boost.py::TestDroppedInteriorCell` — the pin to invert
-  when this is fixed.
+- `test/test_core_boost.py::TestWindowCoverage` — the pin, inverted: it
+  now asserts both hand-computable cases at their correct values.
 - `projects/cython-to-rust/task-notes/phase-03/task-3.4-interp-boost.md`
   — how it was found and the numbers above.
 - `test/parity/tolerances.py` — the `TABULATED` budget class, which is
   what these seven cases are graded against.
-- `test/test_core_photon_tables.py::TestPhysics::test_the_boost_integral_still_diverges_near_threshold`
-  — the same defect pinned through a public entry point, added when the
-  seven tabulated spectra moved to Rust (Task 4.2).
+- `test/test_core_photon_tables.py::TestPhysics::test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum`
+  — the acceptance test this file proposed, over all seven channels. It
+  pinned the divergence through a public entry point when the seven
+  tabulated spectra moved to Rust (Task 4.2), and now pins the limit.
 - Sibling defects, same class and same blocker:
   [`positron-muon-spectrum-normalization-inverted.md`](positron-muon-spectrum-normalization-inverted.md),
   [`eta-prime-two-photon-line-missing-factor-two.md`](eta-prime-two-photon-line-missing-factor-two.md),

--- a/projects/parity-pinned-defect-repair/PLAN.md
+++ b/projects/parity-pinned-defect-repair/PLAN.md
@@ -133,9 +133,14 @@ measurements:
 - Muon photon spectrum: the rest-frame branch regains the last 0.25 MeV
   to the endpoint.
 - Positron muon spectrum: normalization moves by `R_FACTOR²`.
-- Boost integral: the seven tabulated photon spectra rise by the dropped
-  cell; systematic and one-signed (they are currently always slightly
-  low).
+- Boost integral: all seven tabulated photon spectra move, and **the sign
+  splits by regime rather than being one-signed**. Near threshold the
+  shipped values are 6,500x to 33,000x too high and now converge to their
+  own rest-frame spectrum; away from it they were low by the dropped cell
+  and rise, by a median 3.3% at `γ = 1.05` falling to 7.1e-5 at `γ = 10`.
+  4,154 of the 10,045 pinned positions move; a parent exactly at rest does
+  not. Measured by Task 4; the follow-up's "systematically low" reading
+  described only the second regime.
 - Both rho spectra at `E_ρ = m_ρ` exactly: divided by `E_γ`, i.e. the
   value changes by a factor of `E_γ` at a single parent energy.
 - Charged-pion **neutrino** spectrum: the electron-neutrino row loses one

--- a/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
+++ b/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
@@ -95,12 +95,24 @@ python3 -c "import json; m=json.load(open('test/parity/data/manifest.json')); \
 `spectra.photon.short_kaon`.
 
 Blocks: the three boosted blocks and `rest_plus_eps`. **Measured by
-Task 2**, which is what the instruction below asked for: `rest` moves 0
-of its 1750 positions, because all seven callers short-circuit to the
-rest-frame spectrum before the integral and so it never runs at β = 0.
-The sign splits by block rather than being uniform — `rest_plus_eps`
-moves down at all 1156 positions, the boosted blocks up at 2997 of 2998.
-`../task-notes/task-2-cython-oracles.md` has the table.
+Task 2 and confirmed against the repaired kernel by Task 4**, which is
+what the instruction below asked for: `rest` moves 0 of its 1841
+positions, because all seven callers short-circuit to the rest-frame
+spectrum before the integral and so it never runs at β = 0. The sign
+splits by block rather than being uniform — `rest_plus_eps` moves down at
+all 1156 positions, the boosted blocks up at 2997 of 2998.
+`../task-notes/task-4-boost-window.md` has the per-block and per-case
+tables; `task-2-cython-oracles.md` has the capture they were predicted
+from, and states that 1841 as 1750.
+
+```sh
+python3 -c "import sys; sys.path.insert(0, 'test/parity'); import numpy as np, deltas; \
+  import json; m = json.load(open('test/parity/data/manifest.json')); \
+  print(sum(np.load('test/parity/data/' + m['cases'][n]['file'])[a['key']].size \
+    for n in deltas.A1_CASES for b in m['cases'][n]['blocks'] \
+    if b['label'] == 'rest' for k, a in b['arrays'].items() \
+    if k in ('values', 'scalar_values')))"
+```
 
 ### A2 — muon photon rest-frame endpoint (1 case, predicted 7)
 

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -25,7 +25,7 @@ section tracks live *status*.
 | 1 | Delta-declaration layer | — | **Complete** — landed in PR #87 with the B4 repair; ADR-0001 | `task-1-delta-declarations.md` |
 | 2 | Capture the corrected-value oracles | — | **Complete** | `task-2-cython-oracles.md` |
 | 3 | Closed-form delta models (B1–B3) | 1 | **Complete** — models in `deltas.DELTA_MODELS`, keys land with the repairs | `task-3-closed-form-deltas.md` |
-| 4 | Repair A1 — boost integral window | 1, 2 | Not started | `task-4-boost-window.md` |
+| 4 | Repair A1 — boost integral window | 1, 2 | **Complete** | `task-4-boost-window.md` |
 | 5 | Repair B1 — η′ line weight | 3, 4 | Not started | `task-5-eta-prime-line.md` |
 | 6 | Repair B2 — φ line energies | 3, 4 | Not started | `task-6-phi-lines.md` |
 | 7 | Repair A2 — muon photon endpoint | 1, 2 | Not started | `task-7-photon-muon-endpoint.md` |
@@ -190,6 +190,29 @@ this project is time-critical.
   also needed `THERMAL_LIMIT` above `quad`'s default of 50: at 50, 33 of
   the 540 thermal positions exhausted the subdivision table and came
   back flagged. A criterion that binds has to be reachable.
+- **A capture-backed `Reference` needs the entry point to name its
+  case.** `Delta` is one object per roster label — `test_parity`'s
+  `test_every_declaration_points_at_a_delta_model` compares by `id` — so
+  a repair spanning seven cases cannot close a case name over its
+  relation. The corpus manifest's `entry_point` cannot resolve it either:
+  it records where each case was *captured* from, which for every Group A
+  case is a `.pyx` the port deleted. `cases.build_cases()` is the live
+  authority, and `test/parity/oracle_reference.py` maps
+  `(module, qualname)` through it for A2, A3 and A4 as well.
+- **A declaration written as `MOVED` over a whole block is a wall for the
+  next repair that lands on the same array.** A1 covers all four non-rest
+  blocks of `eta_prime` and `phi`, which is every array B1 and B2 move.
+  There is no second key to add — one key, one `Delta` — so those repairs
+  compose their relation with A1's rather than declaring beside it.
+  Foreseen by `../rules.md` rule 7; what was not foreseen is that the
+  mechanism makes the wrong answer inexpressible rather than merely
+  forbidden.
+- **A physics invariant may have to switch off an unrepaired
+  faithfulness item to be about the repair.** The boost's yield identity
+  `∫dE dN/dE = ∫dx y(x)` fails by 5.6% on any table with a nonzero first
+  row, because the below-table `1/E` tail — still reproduced from the
+  Cython, not repaired — adds photons the table does not contain. A table
+  vanishing at `x[0]` zeroes that term and leaves the identity exact.
 - **Four call sites shared B6's defect and only two were in Rust.** The
   two pure-Python ones (`hazma/relic_density/_thermal_functions.py`, the
   GeV vector model) were never ported, so a Rust-only repair would have
@@ -198,8 +221,28 @@ this project is time-critical.
 
 ## Numerical impact so far
 
-**Three public values have moved: B4 in PR #87, B5 in Task 10a, and B6
-in Task 13** (bullets below).
+**Four public values have moved: B4 in PR #87, B5 in Task 10a, B6 in
+Task 13, and A1 in Task 4** (bullets below).
+
+**A1 — all seven tabulated photon spectra.** Measured on the corpus's
+own grids (10,045 positions, 35 blocks) against a build carrying the
+defect, which reproduced the stored arrays bit for bit, so the whole move
+is the repair. 4,154 positions move and **the sign splits by block**:
+
+| Block | γ | moved / pinned | Magnitude |
+| --- | --- | --- | --- |
+| `rest` | 1 | 0 / 1841 | no caller reaches the integral at β = 0 |
+| `rest_plus_eps` | 1 + 1e-12 | 1156 / 2051, all **down** | shipped a median **9,768x** and up to **360,507x** too high |
+| `near_rest` | 1.05 | 1130 / 2051, all up | median +3.34e-02, max +98.7% |
+| `boosted_mild` | 2 | 1028 / 2051, all up | median +2.19e-03 |
+| `boosted_strong` | 10 | 840 / 2051, 839 up | median +7.09e-05 |
+
+Off the corpus grid, the limit that says the window is now covered: at a
+parent one part in 1e12 above rest all seven agree with their own
+rest-frame spectrum to better than 1% over `E_γ` from `m/20` to `3m/10`,
+against the 6,500x–33,000x the follow-up measured. The repaired kernel
+reproduces Task 2's Cython oracle **bit for bit** at all 10,045
+positions. Details: `task-4-boost-window.md`.
 
 **B6 — both mediator `thermal_cross_section`, and `relic_density`
 through them.** Measured on the two corpus cases' own grids (570
@@ -231,7 +274,7 @@ grids:
 
 | Defect | Repair task | Cases moved | Positions moved | Largest relative shift | Direction |
 | --- | --- | --- | --- | --- | --- |
-| A1 boost window | 4 | 7 of 7 predicted | 4154 | ~1.0 (shipped up to 9,800× high near threshold) | **both** — down in `rest_plus_eps`, up in the boosted blocks |
+| A1 boost window | 4 — **landed** | 7 of 7 predicted | 4154 | ~1.0 (shipped a median 9,768× and up to 360,507× high near threshold) | **both** — down in `rest_plus_eps`, up in the boosted blocks |
 | A2 muon endpoint | 7 | **1** of 7 predicted | 4 | n/a (`0.0` → negative) | down; all four values become negative |
 | A3 pion cone | 8 | 6 of 6 predicted | 6359 | 7.77 | both |
 | A4 positron norm | 10 | 6 of 6 predicted | 21,975 | `0.000374207` uniformly | up, at every position |
@@ -306,6 +349,16 @@ it, and
 
 ## Decisions and Implementation Notes
 
+- **Group A repairs are `Reference` relations reading the Task 2
+  capture** (Task 4), not `Additive` or `Exact`: each defect is a lost or
+  doubled term of a quadrature, which no transform of the stored array
+  rebuilds. `test/parity/oracle_reference.py` is the single reader for
+  all four.
+- **A relation's budget is the case's own where the port is bit-faithful**
+  (Task 4): A1 carries `tolerances.TABULATED_RTOL` = 1e-12 against a
+  measured 0.0, because the capture is one platform's and the declared
+  positions must not be held looser *or* tighter than the undeclared ones
+  beside them.
 - **The corpus is extended, not regenerated.** The committed arrays stay
   as the record of what 2.1.0 shipped; each repair adds a declared delta
   against them. Rationale and schema in
@@ -416,6 +469,19 @@ library or build file, and `test/parity/data/` untouched.
 `../references/defect-blast-radius.md`, this file, and
 `task-10a-neutrino-pion-line.md` (new). `test/parity/data/` untouched.
 
+### Task 4 (A1)
+
+`rust/src/boost.rs` (the repair, the rewritten faithfulness notes, the
+renamed coverage test, a yield invariant, a tightened budget),
+`test/parity/oracle_reference.py` (new — the Group A captures as a
+relation, and the reader A2/A3/A4 reuse), `test/parity/deltas.py`,
+`test/parity/test_parity.py` (`EXPECTED_DECLARED_ARRAYS` 42 → 98),
+`test/parity/tolerances.py`, `test/test_core_boost.py`,
+`test/test_core_photon_tables.py`, `CHANGELOG.md`,
+`docs/followups/todo/boost-integral-drops-last-interior-cell.md`,
+`../PLAN.md`, `../references/defect-blast-radius.md`, this file, and
+`task-4-boost-window.md` (new). `test/parity/data/` untouched.
+
 ### Task 13 (B6)
 
 `rust/src/kernels/vector_xs.rs`, `rust/src/kernels/scalar_xs.rs`
@@ -474,10 +540,14 @@ has no `hazma._core` test probes for the suite to import.
 
 ## Open Questions
 
-- **Does the boost integral run at β = 0?** If the tabulated kernels
-  short-circuit at rest, A1's declaration excludes every `rest` block
-  and the case count in `../references/defect-blast-radius.md` shifts.
-  Measured in Task 4, not assumed.
+- **Do B1's and B2's declared arrays collapse into A1's?** Answered in
+  part, and it is now the sharpest question in the project. A1 declares
+  `MOVED` on all four non-rest blocks of `spectra.photon.eta_prime` and
+  `spectra.photon.phi`, both suffixes, so every array B1 and B2 land on
+  already carries a declaration. `../rules.md` rule 7 forbids an overlap
+  and `DECLARED_DELTAS` maps one key to one `Delta`, so Tasks 5 and 6
+  build one composite relation per shared array rather than adding keys.
+  `task-4-boost-window.md`'s handoff has the mechanics.
 - **Do A2's and A3's declared positions on the two rho cases actually
   overlap, or only appear to?** They are different mechanisms (an
   endpoint guard and a lost quadrature support) reaching the same arrays
@@ -501,11 +571,6 @@ has no `hazma._core` test probes for the suite to import.
   Tasks 5, 6 and 9 measure the real figure and tighten; a repair needing
   a *wider* one has found something Task 3 did not model (`rules.md`
   rule 2).
-- **Do B1's and B2's positions overlap A1's on the same arrays?** Both
-  land on arrays Task 4 also moves, and rule 7 forbids an overlap. The
-  mechanisms are disjoint — `boost_delta_function` against
-  `boost_integrate_linear_interp` — but the position sets have not been
-  intersected. Tasks 5 and 6 inherit that as a gate.
 - **Should the Task 2 oracles stay committed after `cython-to-rust`
   closes?** They are the last evidence that a repaired value was ever
   checked against a non-Rust implementation. Anticipated ADR.
@@ -529,27 +594,33 @@ has no `hazma._core` test probes for the suite to import.
 
 **Currently safe to assume:**
 
-- The four Group A `.pyx` twins are present and buildable on this tree,
-  verified at `3e01590`.
+- The four Group A `.pyx` twins are gone; `test/parity/oracles/data/`
+  is what stands in for them, and `test/parity/oracle_reference.py` is
+  the reader that turns a capture into a `deltas.Reference`. Task 4 is
+  the worked precedent for A2, A3 and A4 — they need no new machinery.
 - `test/parity/data/` is intact — `python test/parity/generate.py --check`
   verifies it in under a second with no build.
-- B4 (PR #87), B5 (Task 10a) and B6 (Task 13) are the repairs that have
-  changed a library value; every other corpus array is still compared
-  against its stored value. `test/parity/deltas.py` declares 42 arrays —
-  30 for B4, 6 for B5, 6 for B6 — and
+- B4 (PR #87), B5 (Task 10a), B6 (Task 13) and A1 (Task 4) are the
+  repairs that have changed a library value; every other corpus array is
+  still compared against its stored value. `test/parity/deltas.py`
+  declares 98 arrays — 30 for B4, 6 for B5, 6 for B6, 56 for A1 — and
   `test_parity.EXPECTED_DECLARED_ARRAYS` is the literal that makes a
   change to that number show up in a diff.
 - The measurement recipe every remaining repair task needs: capture the
   corpus blocks from a build carrying the defect, restore the repair,
   rebuild, capture again, and diff *those* — not the live tree against
   the stored corpus, which reports the platform drift as if it were the
-  repair (Findings).
+  repair (Findings). On this worktree Task 4's defective build
+  reproduced the stored corpus bit for bit on all 10,045 A1 positions,
+  so the two agreed; that is this platform, not a general fact.
 - B1, B2 and B3 have finished, corpus-checked delta models in
-  `deltas.DELTA_MODELS`. Tasks 5, 6 and 9 fix the kernel, add the
-  `DECLARED_DELTAS` keys pointing at those models, and bump
-  `EXPECTED_DECLARED_ARRAYS`; the key lists and position counts are in
-  `task-3-closed-form-deltas.md`'s handoff, to be re-derived after
-  Task 4 rather than pasted.
+  `deltas.DELTA_MODELS`, and B3's arrays are still undeclared, so Task 9
+  adds keys and bumps `EXPECTED_DECLARED_ARRAYS` in the ordinary way.
+  **Tasks 5 and 6 cannot**: A1 already declares every array B1 and B2
+  move, and one key holds one `Delta`, so those two compose with A1's
+  relation instead — `task-4-boost-window.md`'s handoff has the
+  mechanics, and the position counts in `task-3-closed-form-deltas.md`
+  are to be re-derived against the repaired kernel rather than pasted.
 - The delta layer now carries three relations. A new repair picks
   `Additive` when the physics names the term, `Exact` when a closed form
   transforms the stored array, and `Reference` when only a second

--- a/projects/parity-pinned-defect-repair/task-notes/task-4-boost-window.md
+++ b/projects/parity-pinned-defect-repair/task-notes/task-4-boost-window.md
@@ -1,0 +1,426 @@
+# Task 4: Repair A1 — the boost integral window
+
+**Date:** 2026-09-07
+**Project:** parity-pinned-defect-repair
+**Status:** Complete
+**Plan References:** `../PLAN.md` "Task 4", "Numerical impact"; `../rules.md`
+rules 1–7, 10, 11
+**Related ADRs:** `../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`
+**Depends On:** Task 1 (the delta layer), Task 2 (the Cython oracle)
+
+## Objective
+
+Cover `[x[ihigh-1], x[ihigh]]` and stop dropping the table's final row in
+`boost_integrate_linear_interp`, and declare the resulting delta on the
+seven tabulated photon cases the A1 row names — and on nothing else.
+
+## Exit Criteria
+
+- Declared deltas on all seven cases of the A1 row of
+  `../references/defect-blast-radius.md`, and on no other corpus array.
+- The repaired value reproduces Task 2's Cython oracle within the
+  function's existing budget.
+- The measured sign matches `../PLAN.md`'s Task 4 gate: `rest_plus_eps`
+  down at all 1,156 positions, the three boosted blocks up at 2,997 of
+  2,998, `rest` unmoved.
+- Every other corpus case unchanged against its original stored array.
+- A physics invariant the corpus cannot supply (`../rules.md` rule 4).
+- `git diff --stat -- test/parity/data` empty (`../rules.md` rule 1).
+
+## Inputs Reviewed
+
+- `../PLAN.md` (Task 4, Numerical impact, Scope), `../rules.md`, the head
+  of `task-notes/README.md`.
+- `../references/defect-blast-radius.md` §A1; `../references/corpus-repinning.md`
+  is implemented by `test/parity/deltas.py`, which was read instead.
+- `../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`.
+- `../task-notes/task-2-cython-oracles.md` §A1 and the per-block sign table.
+- `test/parity/oracles/patches/A1-boost-integral-window.patch` — the
+  repair, stated exactly, on the Cython the oracle was captured from.
+- `docs/followups/todo/boost-integral-drops-last-interior-cell.md`.
+- `rust/src/boost.rs`, `test/test_core_boost.py`,
+  `test/test_core_photon_tables.py`, `test/parity/{deltas,test_parity,
+  tolerances,stability}.py`, `test/parity/oracles/capture.py`.
+- `docs/agents/lessons.md` — `[exemption-wider-than-its-mechanism]`,
+  `[measured-tree-vs-imported-module]`, `[test-name-claims-an-unmade-assertion]`.
+
+## Findings
+
+- **The repair is two lines of algorithm, not three.** The follow-up asks
+  to "re-derive the upper partial-cell term so the two do not overlap".
+  It needs no re-derivation: that term already anchors on `x[ihigh]`, so
+  making the interior sum inclusive of `x[ihigh]` is enough to make the
+  two meet exactly. The Task 2 patch had already reached the same
+  conclusion and says so in its own comment; the "What" section of the
+  follow-up is the stale half.
+- **The repaired Rust reproduces the Cython oracle bit for bit at all
+  10,045 positions**, and the unrepaired Rust reproduced the corpus bit
+  for bit at the same 10,045. So this platform contributes no drift to
+  either comparison, and the whole 4,154-position move is the repair.
+  That also settles the FMA question the single-cell branch raises: the
+  Cython's generated C contracts the new branch exactly as it contracts
+  the two partial-cell terms beside it, so spelling it with `mul_add` in
+  Rust — as the siblings are — is what reproduces it.
+- **`ilow > ihigh` can only mean `ihigh == ilow - 1`.** `ilow` is the
+  first node at or above `lb` and `ihigh` is at least `first - 1` where
+  `first` is the first node at or above `ub`; with `lb <= ub` that gives
+  `ihigh >= ilow - 1`. The `usize` underflow the branch looks like it
+  invites cannot happen either: `first == 0` requires `ub == x[0]`
+  exactly, and the 1e-6 edge test keeps `ihigh` at 0 there.
+- **The two `rest`-block exclusions are one fact, and it is now
+  measured.** No caller reaches the integral at `β = 0` — all seven
+  short-circuit at `E − m < DBL_EPSILON` — so all 1,841 `rest` positions
+  are undeclared and still gated at the case's own budget. That closes
+  the README's open question, which Task 2 had answered from the capture
+  and this task confirms against the repaired kernel.
+- **The yield invariant needs a table that vanishes at `x[0]`.** The
+  below-table `1/E` tail is an extrapolation *below* the tabulated
+  support and is still reproduced from the Cython rather than repaired,
+  so it adds photons the table does not contain. With `y[0] = 0` the tail
+  term is identically zero and `∫dE dN/dE = ∫dx y(x)` holds to the outer
+  rule's discretization error. A table with a nonzero first row would
+  have been testing the extrapolation instead.
+- **A `Reference` relation reading a committed capture needs the entry
+  point to identify its case**, because `Delta` is one object per roster
+  label (`test_parity.test_every_declaration_points_at_a_delta_model`
+  compares by `id`) while a capture is keyed by case. The corpus
+  manifest's `entry_point` cannot do it — it records where each case was
+  *captured* from, which for all seven is a `.pyx` the port deleted.
+  `cases.build_cases()` is the live authority, and reading it keeps the
+  case list derived rather than transcribed.
+
+## Decisions and Implementation Notes
+
+- **The single-cell case is an `else` branch, not an early return.** The
+  Cython patch returns early; structuring it as `if ilow > ihigh { … }
+  else { … }` around the three existing terms makes the mutual exclusion
+  structural instead of implied, and keeps one `/(2γβ)` at the end.
+  Bit-identical either way — control flow only.
+- **`oracle_reference.py` is a new sibling module rather than a function
+  in `deltas.py`.** A1–A4 all need exactly this reader, and it is file
+  I/O against a committed capture rather than a closed form, which is the
+  kind of thing `thermal_reference.py` is already a precedent for.
+- **The relation's `rtol` is `tolerances.TABULATED_RTOL` (1e-12), not
+  zero.** The measured agreement is exact, but the capture is one
+  platform's; a libm that moves the boost integral must be held here
+  exactly as tightly as the undeclared positions of the same array are,
+  and no tighter (`../rules.md` rule 2 forbids the other direction).
+- **The follow-up stays in `docs/followups/todo/`**, matching B5's
+  precedent: the project's Exit Criteria repoint all inbound links in one
+  sweep at Task 12. Its status line, its two dangling test references and
+  its superseded "regenerate the corpus" prescription are corrected in
+  place.
+- **`TestDroppedInteriorCell` is renamed, not deleted.** Its two tests
+  assert the same two hand-computable cases at their correct values, so
+  the name had to move with the assertion
+  (`[test-name-claims-an-unmade-assertion]`).
+- **`a_flat_table_boosts_to_the_log_of_the_window`'s budget tightened
+  1e-4 → 1e-9.** Its own doc comment said the 1e-4 existed to let the
+  dropped cell through. With the cell covered, what remains is the
+  composite trapezoid error `(h²/12)(f′(ub) − f′(lb))` = 9.6e-10
+  absolute, 5.1e-10 relative, measured.
+
+## Files Changed
+
+- `rust/src/boost.rs` — the repair (an inclusive interior sum and the
+  single-cell closed form), a rewritten `# Faithfulness notes`, the
+  renamed coverage test, a new yield invariant, and the tightened
+  flat-table budget.
+- `test/parity/oracle_reference.py` (new) — the Group A captures as a
+  `deltas.Reference`.
+- `test/parity/deltas.py` — the `A1` declaration, its 56 keys, `A1` in
+  `DELTA_MODELS`, and the module's relation roster, which had not
+  mentioned `Reference` since Task 13 added it.
+- `test/parity/test_parity.py` — `EXPECTED_DECLARED_ARRAYS` 42 → 98.
+- `test/parity/tolerances.py` — the `TABULATED` class's account of the
+  algorithm, which now has a third closed form.
+- `test/test_core_boost.py` — `integrate_reference` repaired in lockstep
+  (it is the independent oracle for the kernel), `TestDroppedInteriorCell`
+  → `TestWindowCoverage` inverted, `TestTrapezoidSummation`'s expectation,
+  and two doc cross-references.
+- `test/test_core_photon_tables.py` — `MIN_THRESHOLD_DIVERGENCE` →
+  `MAX_THRESHOLD_MISS` + `THRESHOLD_FRACTIONS`, and the divergence pin
+  inverted into the convergence acceptance test over all seven channels.
+- `CHANGELOG.md` — an `[Unreleased] Changed` entry with the magnitudes,
+  and a pointer on the 2.2.0 `Known issues` entry.
+- `docs/followups/todo/boost-integral-drops-last-interior-cell.md` —
+  status, the two renamed tests, and the superseded regeneration.
+- `../PLAN.md` — the "Numerical impact" bullet, which still said the
+  shift was one-signed.
+- `../task-notes/README.md` — status, findings, numerical impact, open
+  questions, files changed, handoff.
+
+## Numerical impact
+
+**Public values move, by design.** The measurement is the corpus itself,
+taken against a build carrying the defect rather than against the stored
+arrays, per the README's recipe: the defective build reproduced the
+stored corpus at **all 10,045** A1 positions, so every difference below
+is the repair.
+
+```sh
+# The whole corpus, 41 cases / 179,695 pinned values:
+pytest test/parity -q                      → 687 passed, 1 skipped
+```
+
+Only the 4,154 declared positions moved; every other case is still
+compared against its stored array under its own budget, and passed.
+
+| Block | γ | moved / pinned | up | down |
+| --- | --- | --- | --- | --- |
+| `rest` | 1 | 0 / 1841 | 0 | 0 |
+| `rest_plus_eps` | 1 + 1e-12 | 1156 / 2051 | 0 | 1156 |
+| `near_rest` | 1.05 | 1130 / 2051 | 1130 | 0 |
+| `boosted_mild` | 2 | 1028 / 2051 | 1028 | 0 |
+| `boosted_strong` | 10 | 840 / 2051 | 839 | 1 |
+
+| Case | moved / pinned | max abs shift | rest |
+| --- | --- | --- | --- |
+| `spectra.photon.eta` | 560 / 1435 | 6209.45 | 0 |
+| `spectra.photon.eta_prime` | 552 / 1435 | 2502.46 | 0 |
+| `spectra.photon.omega` | 633 / 1435 | 481699 | 0 |
+| `spectra.photon.phi` | 551 / 1435 | 3435.51 | 0 |
+| `spectra.photon.charged_kaon` | 631 / 1435 | 483975 | 0 |
+| `spectra.photon.long_kaon` | 631 / 1435 | 659277 | 0 |
+| `spectra.photon.short_kaon` | 596 / 1435 | 587910 | 0 |
+
+Magnitudes, in the two regimes the sign splits over:
+
+- `rest_plus_eps`: the shipped value is a **median 9,768x** and up to
+  **360,507x** too high, and every one of its 1,156 positions falls.
+- The three boosted blocks rise, by a **median 3.34e-02 at γ = 1.05,
+  2.19e-03 at γ = 2 and 7.09e-05 at γ = 10**, and by up to 98.7%.
+- Public limit, off the corpus grid: at a parent one part in 1e12 above
+  rest, all seven channels now agree with their own rest-frame spectrum
+  to better than 1% over `E_γ` from `m/20` to `3m/10` (worst 8.5e-3, eta
+  at `m/20`). The follow-up measured 6,500x to 33,000x before.
+
+**Unchanged:** every other corpus case, including all four
+`mediator_spectra.*.photon.*` — the tabulated seven are not on their
+composition path, which `pytest test/parity` asserts case by case rather
+than this task inferring. `git diff --stat -- test/parity/data` is empty.
+
+`../PLAN.md`'s `version_bump: minor` is unchanged and correct: published
+numbers move, no public name, signature, return shape or documented unit
+does.
+
+## Verification
+
+Built in the worktree, and confirmed to be what was measured:
+
+```sh
+uv pip install --python .venv/bin/python -e . \
+    --config-setting build-args="--features test-probes"
+python -c "import hazma._core; print(hazma._core.__file__)"
+  → .../parity-pinned-defect-repair-36ba90/hazma/_core.abi3.so
+```
+
+```text
+cargo test --manifest-path rust/Cargo.toml --no-default-features \
+    --features test-probes          → test result: ok. 263 passed; 0 failed
+pytest test/parity -q               → 687 passed, 1 skipped
+pytest test/test_core_boost.py -q   → 51 passed
+pytest test/test_core_photon_tables.py -q → 190 passed, 1 skipped
+pytest -q                           → 2286 passed, 15 skipped, 1 warning,
+                                       37 subtests passed
+scripts/agents/preflight.sh --paths … --md …
+                                    → RESULT: PASS, all eleven rows
+```
+
+All 15 skips are pre-existing and none is A1's: 11 "known to be broken"
+form-factor tests, the charged kaon's absent monochromatic line, and the
+parity corpus's declared-budget skip (`numpy 2.5.1 → 2.5.3`,
+`scipy 1.18.0 → 1.18.1`, a macOS point release). A bare `pytest -q`
+reports 24 instead, because `python -m pytest` leaves `.venv/bin` off
+`PATH` and `test/agents/test_lint_delta.py` skips its nine subprocess
+tests when it cannot find `ruff` and `isort`.
+
+What the new and changed tests cover:
+
+- **The two hand-computable cases**, at their correct values, in both
+  languages: `boost::tests::a_clamped_window_covers_the_tables_final_row`
+  and `a_window_inside_one_cell_is_the_window`;
+  `TestWindowCoverage`'s three tests, each also asserting the port equals
+  `integrate_reference`.
+- **The physics invariant** (`../rules.md` rule 4):
+  `boost::tests::the_boost_conserves_the_tabulated_yield` — the boosted
+  spectrum integrated over the lab energy returns the table's own
+  integral, at three boosts. Owes nothing to the Cython or to the corpus.
+- **The public acceptance test** the follow-up proposed:
+  `test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum`,
+  over all seven channels at four energies each.
+- **The declaration**, through `test_entry_point_matches_corpus` on 28
+  blocks: the relation's prediction at the declared positions, the stored
+  value at every other position of the same array, and the staleness rule
+  that fails a declaration whose repair is reverted.
+- **The reduction order**, unchanged: `TestTrapezoidSummation` still
+  compares against the live `np.trapezoid`, now over the inclusive slice.
+
+**Test validity (stash-proof).** The kernel half of `rust/src/boost.rs`
+was replaced with `git show HEAD:rust/src/boost.rs`'s, keeping the new
+tests, and the tree rebuilt. Every layer turned red:
+
+```text
+cargo test … boost::   → 4 failed  (both coverage tests, the yield
+                          invariant, the tightened flat-table budget)
+pytest test/test_core_boost.py test/test_core_photon_tables.py \
+       test/parity -q  → 56 failed, 872 passed, 2 skipped
+```
+
+grouped as 28 `test_entry_point_matches_corpus` blocks (7 cases x 4
+declared blocks — the declaration is not stale), 7
+`test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum`, 7
+`test_the_tabulated_port_is_the_fused_reference`, 5
+`test_the_interior_sum_is_numpys_trapezoid`, 3 `TestWindowCoverage`, and
+5 more `TestBoostIntegrateLinearInterp` sensitivity checks. The kernel was
+then restored and `cmp`-verified byte-identical before rebuilding.
+
+**Nothing deferred.**
+
+## Open Questions
+
+- **Do B1's and B2's positions overlap A1's on `eta_prime` and `phi`?**
+  Still open, and now sharper: A1 declares `MOVED` over all four non-rest
+  blocks of both cases, so Tasks 5 and 6 cannot simply add keys — every
+  array B1 or B2 moves is already declared under A1, which `../rules.md`
+  rule 7 forbids leaving as an overlap. The two must collapse into one
+  composite declaration per array, or B1/B2 must be shown to move only
+  positions A1 leaves alone, which `MOVED` makes impossible to express as
+  a second key. This is the one structural consequence this task hands
+  forward.
+- **Should the `rest` blocks stay undeclared once B1 and B2 land?** B1
+  never reaches `eta_prime[rest]` and B2 reaches neither of phi's rest
+  blocks (Task 3), and A1 reaches no `rest` block at all, so all seven
+  `rest` blocks should still be compared against the stored array
+  afterwards. Worth re-checking rather than assuming when Tasks 5 and 6
+  measure.
+
+## Plan Impact
+
+**Impact Level:** Update `PLAN.md`.
+
+`PLAN.md`'s "Numerical impact" bullet for the boost integral asserted the
+shift was "systematic and one-signed (they are currently always slightly
+low)" — the follow-up's reading, which describes only the away-from-
+threshold regime. Task 4's Task Details block already carried the
+correction Task 2 measured; the summary bullet did not, and is now
+patched to the measured figures. No task ordering, gate or interface
+changed, and no ADR is needed: ADR-0001's mechanism absorbed a
+capture-backed `Reference` relation without amendment.
+
+## Stale-state sweep
+
+### Identifier sweep
+
+`rg -n --hidden '<id>' projects/ docs/ README.md
+hazma/ test/ rust/ .claude/ .codex/ CHANGELOG.md | cut -d: -f1 | sort |
+uniq -c`, run after the last prose edit. This note names each removed
+identifier once or twice in order to report it, so its own hits are
+listed and excluded.
+
+| Identifier | Hits outside this note | Disposition |
+| --- | --- | --- |
+| `TestDroppedInteriorCell` | 1 — `projects/cython-to-rust/.../task-3.4-interp-boost.md` | EDITED — renamed everywhere live; the survivor is the frozen project, which Task 11 owns |
+| `the_last_interior_cell_is_dropped` | 0 | DELETED |
+| `MIN_THRESHOLD_DIVERGENCE` | 0 | DELETED |
+| `test_the_boost_integral_still_diverges_near_threshold` | 0 | DELETED |
+| `TestWindowCoverage` | 5 — `test/test_core_boost.py` (3), the follow-up (2) | KEPT — definition, two cross-references, two repointed follow-up entries |
+| `oracle_reference` | 9 — `deltas.py` (3), `test/parity/README.md` (2), `../task-notes/README.md` (4) | KEPT — the new module and everything that names it |
+| `MAX_THRESHOLD_MISS` / `THRESHOLD_FRACTIONS` | 2 / 3 — `test/test_core_photon_tables.py` | KEPT — definition plus uses |
+| `A1_CASES` | 2 — `deltas.py`, the count command in `../references/defect-blast-radius.md` | KEPT |
+| `a_clamped_window_covers_the_tables_final_row`, `a_window_inside_one_cell_is_the_window`, `the_boost_conserves_the_tabulated_yield` | 1 each — `rust/src/boost.rs` | KEPT — definition only |
+
+### Line-number citation sweep
+
+```text
+$ python scripts/agents/check_doc_citations.py <the 7 docs this task touched>
+docs scanned: 7
+in-repo citations checked: 0
+external citations skipped: 2
+  hazma/_utils/boost.pyx (2)
+out-of-range or ambiguous: NONE
+```
+
+The two skipped are the follow-up's citations of the deleted Cython, kept
+deliberately as the historical record of where the defect lived.
+
+### Forward-looking phrase sweep
+
+```text
+$ rg -n '(Task [0-9]+ will|will be added|still pending|today: ?stub|In Progress)' \
+    task-4-boost-window.md test/parity/{oracle_reference,deltas}.py \
+    rust/src/boost.rs test/test_core_{boost,photon_tables}.py
+(no matches)
+```
+
+### Count sweep
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| `test_parity.EXPECTED_DECLARED_ARRAYS = 98` | `python -c "…; print(len(deltas.DECLARED_DELTAS))"` | 98 | OK |
+| "56 for A1" (`../task-notes/README.md`, this note) | `python -c "…; print(sum(1 for d in deltas.DECLARED_DELTAS.values() if d.repair=='A1'))"` | 56 | OK |
+| "0 of its 1841 `rest` positions" (`../references/defect-blast-radius.md`) | the command printed beside it there | 1841 | OK — was 1750, re-derived and corrected |
+| "10,045 pinned positions" | the per-block table's column sum, `1841 + 4 x 2051` | 10045 | OK |
+| "4,154 move" | `impact.py` over the two builds; equals Task 2's independent total | 4154 | OK |
+| "70 arrays" in the A1 capture | `python -c "print(len(np.load('test/parity/oracles/data/A1.npz').files))"` | 70 | OK — 7 cases x 5 blocks x 2 suffixes |
+| `git diff --stat -- test/parity/data` empty (rule 1) | that command | 0 lines | OK |
+
+### Numerical-impact statement
+
+the grid is the parity corpus itself,
+all 41 cases and 179,695 pinned values, evaluated live and compared
+against the stored arrays by `pytest test/parity -q` (687 passed, 1
+skipped). Public values moved: 4,154 of the 10,045 belonging to the seven
+tabulated photon cases, in the four non-`rest` blocks of each, down in
+`rest_plus_eps` and up in the three boosted blocks. No other case moved —
+every one of them is still compared against its stored array under its
+own budget and passed. Magnitudes are in `## Numerical impact` above and
+in `CHANGELOG.md`'s `[Unreleased]` entry.
+
+### Exit Criteria → what satisfies it
+
+| Criterion | Satisfied by |
+| --- | --- |
+| Declared deltas on all seven A1 cases and no other array | `deltas.DECLARED_DELTAS`'s 56 `A1` keys; `test_parity.EXPECTED_DECLARED_ARRAYS = 98`; `test_entry_point_matches_corpus` green on all 41 cases |
+| Reproduces Task 2's oracle within the existing budget | `cmp_a1.py` — 0 of 10,045 positions differ from the capture; the relation carries `TABULATED_RTOL` |
+| The measured sign matches the Task 4 gate | the per-block table in `## Numerical impact`: 1156 down, 2997 of 2998 up, `rest` 0 |
+| Every other corpus case unchanged | `pytest test/parity -q` → 687 passed, 1 skipped |
+| A physics invariant | `boost::tests::the_boost_conserves_the_tabulated_yield`, plus `test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum` over seven channels |
+| `git diff --stat -- test/parity/data` empty | that command, 0 lines |
+
+### Task-note self-consistency
+
+`**Status:** Complete` matches the
+Tasks-table cell in `../task-notes/README.md`. Every file named in §Files
+Changed appears in `git diff origin/master --stat` (14 files, two of them
+new), and every symbol cited in §Findings and §Decisions —
+`boost_integrate_linear_interp`, `oracle_reference.captured`,
+`cases.build_cases`, `deltas.DECLARED_DELTAS`, `DELTA_MODELS`,
+`Reference`, `tolerances.TABULATED_RTOL`, `TestWindowCoverage`,
+`a_flat_table_boosts_to_the_log_of_the_window` — resolves in the tree.
+
+## Handoff to Next Task
+
+**Tasks 5 (B1) and 6 (B2) are unblocked and have a new constraint.**
+
+- Read this note's first Open Question before anything else. A1 declares
+  `MOVED` on all four non-rest blocks of `spectra.photon.eta_prime` and
+  `spectra.photon.phi`, both suffixes — the eight arrays B1 and B2 land
+  on are already declared. `../rules.md` rule 7 requires one composite
+  declaration per shared array, not a second key; `deltas.DECLARED_DELTAS`
+  maps one key to one `Delta`, so a second key is not expressible anyway.
+  The composite's relation is the capture *plus* the closed-form term
+  (`test/parity/oracles/data/A1.npz` carries the boost repair alone,
+  since the Cython twin it was captured from has B1's and B2's defects).
+- `test/parity/oracle_reference.py` is the reader for A2, A3 and A4 as
+  well: `oracle_reference.captured("A2")` needs nothing new, and resolves
+  its own case list from the oracle manifest.
+- `EXPECTED_DECLARED_ARRAYS` is 98. Re-derive it with
+  `python -c "import sys; sys.path.insert(0,'test/parity'); import deltas;
+  print(len(deltas.DECLARED_DELTAS))"` rather than adding to it by hand.
+- The measurement recipe held: the defective build reproduced the stored
+  corpus bit for bit on all 10,045 A1 positions, so live-vs-stored and
+  before-vs-after agreed here. That is this platform, not a general fact —
+  keep capturing twice.
+- Tasks 7 (A2), 8 (A3) and 10 (A4) are the other three `Reference`
+  declarations and now have a worked precedent end to end.

--- a/rust/src/boost.rs
+++ b/rust/src/boost.rs
@@ -214,24 +214,21 @@ pub fn boost_delta_function(e0: f64, e: f64, m: f64, beta: f64) -> f64 {
 ///
 /// # Faithfulness notes
 ///
-/// Four details are reproduced rather than repaired, per
-/// `projects/cython-to-rust/rules.md` rule 1 — the corpus pins what the
-/// Cython returns, and a repair is a separate declared change. The first
-/// two are the same off-by-one read from opposite sides and are a real
-/// defect, tracked in
-/// `docs/followups/todo/boost-integral-drops-last-interior-cell.md`:
+/// The window coverage below **departs** from the shipped Cython, which
+/// mis-covered it from both sides: its trapezoid ran over an exclusive
+/// `x[ilow..ihigh]` while the upper partial-cell term started at
+/// `x[ihigh]`, leaving `[x[ihigh - 1], x[ihigh]]` covered by nothing —
+/// and where both bounds fell inside one cell the two partial-cell terms
+/// overlapped instead, over-counting by `cell width / window width`,
+/// which diverges as `β → 0`. That is roster entry `A1` of
+/// `projects/parity-pinned-defect-repair`, and the values it moves are
+/// declared in `test/parity/deltas.py` against the corpus arrays that
+/// pinned them.
 ///
-/// * the trapezoid runs over `x[ilow..ihigh]`, an **exclusive** upper
-///   bound, while the upper partial-cell term starts at `x[ihigh]` — so
-///   `[x[ihigh - 1], x[ihigh]]` is covered by *nothing*. When `ub` is
-///   clamped, `ihigh` is the last index and the upper term is skipped
-///   too, so the table's final row contributes to no term at all;
-/// * when both bounds fall inside one cell, `ihigh = ilow - 1` and the
-///   two partial-cell terms **overlap** instead, covering about two whole
-///   cells rather than the sliver between the bounds. The over-count is
-///   `cell width / window width`, which diverges as `β → 0` — which is
-///   why all seven tabulated photon spectra blow up near threshold
-///   rather than converging to their rest-frame values;
+/// Two details are still reproduced rather than repaired, per
+/// `projects/cython-to-rust/rules.md` rule 1 — the corpus pins what the
+/// Cython returns, and a repair is a separate declared change:
+///
 /// * cell membership is decided with a **1e-6 absolute** tolerance on
 ///   energies that span six decades, so "the bound sits on a node" means
 ///   something different at 0.005 MeV than at 1000 MeV;
@@ -344,31 +341,49 @@ pub fn boost_integrate_linear_interp(
         }
     });
 
-    if ilow < ihigh {
-        integral += trapezoid(&x[ilow..ihigh], ilow, &yy);
-    }
-
-    // Partial cell at the lower bound: integrate the linear interpolant
-    // of `y/x` across `[lb, x[ilow]]`.
-    if ilow > 0 && (x[ilow] - lb).abs() > 1e-6 {
+    if ilow > ihigh {
+        // Both bounds land inside the one cell `[x[ihigh], x[ilow]]`, so
+        // `ihigh == ilow - 1`. Neither partial-cell term below may run
+        // here: they would cover `[lb, x[ilow]]` and `[x[ihigh], ub]`,
+        // which overlap. What the window is worth is one linear
+        // interpolant integrated across `[lb, ub]`.
         let x2 = x[ilow];
-        let x1 = x[ilow - 1];
-        let m = (yy(ilow) - yy(ilow - 1)) / (x2 - x1);
-        // Fused: `y1 - m * x1`, then `0.5 * m * (x2 + lb) + b`, then the
-        // accumulation itself — three `fmsub`/`fmadd` in the Cython.
-        let b = (-m).mul_add(x1, yy(ilow - 1));
-        let inner = (0.5 * m).mul_add(x2 + lb, b);
-        integral = (x2 - lb).mul_add(inner, integral);
-    }
-
-    // Partial cell at the upper bound, same shape anchored on `x[ihigh]`.
-    if ihigh < npts - 1 && (ub - x[ihigh]).abs() > 1e-6 {
-        let x2 = x[ihigh + 1];
         let x1 = x[ihigh];
-        let m = (yy(ihigh + 1) - yy(ihigh)) / (x2 - x1);
+        let m = (yy(ilow) - yy(ihigh)) / (x2 - x1);
         let b = (-m).mul_add(x1, yy(ihigh));
-        let inner = (0.5 * m).mul_add(ub + x1, b);
-        integral = (ub - x1).mul_add(inner, integral);
+        let inner = (0.5 * m).mul_add(ub + lb, b);
+        integral = (ub - lb).mul_add(inner, integral);
+    } else {
+        // Inclusive at the top: the cell ending at `x[ihigh]` belongs to
+        // the interior sum, and the upper partial cell below picks up at
+        // `x[ihigh]`, so the two meet without overlapping and without a
+        // gap between them.
+        if ilow < ihigh {
+            integral += trapezoid(&x[ilow..=ihigh], ilow, &yy);
+        }
+
+        // Partial cell at the lower bound: integrate the linear interpolant
+        // of `y/x` across `[lb, x[ilow]]`.
+        if ilow > 0 && (x[ilow] - lb).abs() > 1e-6 {
+            let x2 = x[ilow];
+            let x1 = x[ilow - 1];
+            let m = (yy(ilow) - yy(ilow - 1)) / (x2 - x1);
+            // Fused: `y1 - m * x1`, then `0.5 * m * (x2 + lb) + b`, then the
+            // accumulation itself — three `fmsub`/`fmadd` in the Cython.
+            let b = (-m).mul_add(x1, yy(ilow - 1));
+            let inner = (0.5 * m).mul_add(x2 + lb, b);
+            integral = (x2 - lb).mul_add(inner, integral);
+        }
+
+        // Partial cell at the upper bound, same shape anchored on `x[ihigh]`.
+        if ihigh < npts - 1 && (ub - x[ihigh]).abs() > 1e-6 {
+            let x2 = x[ihigh + 1];
+            let x1 = x[ihigh];
+            let m = (yy(ihigh + 1) - yy(ihigh)) / (x2 - x1);
+            let b = (-m).mul_add(x1, yy(ihigh));
+            let inner = (0.5 * m).mul_add(ub + x1, b);
+            integral = (ub - x1).mul_add(inner, integral);
+        }
     }
 
     Ok(integral / (2.0 * gamma * beta))
@@ -531,13 +546,12 @@ mod tests {
     /// A flat rest-frame spectrum `y = c` boosts to `c ln(ub/lb)/(2γβ)`
     /// when the window sits inside the table.
     ///
-    /// The tolerance is set by the dropped interior cell, not by the
-    /// quadrature: at cell width `h` the missing cell is `h·c/ub` out of
-    /// `c·ln(ub/lb)`, which at `h = 1e-3` here is 2.6e-5 of the answer,
-    /// while the trapezoidal error on `c/x` over the same cells is
-    /// `~1e-10`. See [`the_last_interior_cell_is_dropped`] for the pin on
-    /// the drop itself; this test only has to stay loose enough to let it
-    /// through.
+    /// The tolerance is the trapezoidal rule's own, and nothing else is in
+    /// the way: the window sits strictly inside the table, so neither the
+    /// clamp nor the below-table tail runs. The composite error on `c/x`
+    /// is `(h²/12)(f′(ub) − f′(lb))`, which at `h = 1e-3` is 9.6e-10
+    /// absolute — 5.1e-10 of the answer, and positive, because the rule
+    /// over-estimates a convex integrand. 1e-9 is twice that.
     #[test]
     fn a_flat_table_boosts_to_the_log_of_the_window() {
         let x: Vec<f64> = (0..40_001).map(|i| 1.0 + f64::from(i) * 1e-3).collect();
@@ -549,35 +563,123 @@ mod tests {
         let want = 2.0 * (ub / lb).ln() / (2.0 * gamma * beta);
         let got = boost_integrate_linear_interp(energy, beta, &x, &y).unwrap();
         assert!(
-            (got - want).abs() < 1e-4 * want,
+            (got - want).abs() < 1e-9 * want,
             "boosted flat spectrum {got} vs {want}"
         );
     }
 
-    /// The interior sum stops one cell short of `ihigh`, so the cell
-    /// `[x[ihigh - 1], x[ihigh]]` is covered by nothing.
+    /// A clamped window covers the table's final row.
     ///
-    /// Reproduced, not repaired — `projects/cython-to-rust/rules.md`
-    /// rule 1, and
-    /// `docs/followups/todo/boost-integral-drops-last-interior-cell.md`.
-    /// The numbers are hand-computable: with `y = x` the integrand `y/x`
-    /// is 1, `beta = 0.6` gives `gamma = 1.25`, and `E = 2.2` gives
-    /// `lb = 1.1` and `ub = 4.4`, clamped to `xmax = 4`. The Cython then
-    /// covers `[1.1, 2]` (lower partial cell) and `[2, 3]` (the interior
-    /// sum) and nothing else, for `1.9 / (2γβ) = 1.9 / 1.5`. The true
-    /// integral over `[1.1, 4]` would be `2.9 / 1.5`.
+    /// Hand-computable: with `y = x` the integrand `y/x` is 1, so the
+    /// integral is the covered length. `beta = 0.6` gives `gamma = 1.25`,
+    /// and `E = 2.2` gives `lb = 1.1` and `ub = 4.4`, clamped to
+    /// `xmax = 4`. Covering `[1.1, 4]` is worth `2.9 / (2γβ) = 2.9 / 1.5`.
     ///
-    /// Checked against the live Cython through `__pyx_capi__` while that
-    /// extension still existed: it returned this same 1.2666666666666666
-    /// (Task 3.4 task note). The literal is what carries that measurement
-    /// now.
+    /// The shipped Cython answered `1.9 / 1.5` here — it covered `[1.1, 2]`
+    /// and `[2, 3]` and stopped, because its interior sum ran to an
+    /// exclusive `ihigh` and its upper partial-cell term was skipped
+    /// under the clamp. That is the `A1` repair; the corpus arrays which
+    /// pinned the old answer are declared in `test/parity/deltas.py`.
     #[test]
-    fn the_last_interior_cell_is_dropped() {
+    fn a_clamped_window_covers_the_tables_final_row() {
         let x = [1.0, 2.0, 3.0, 4.0];
         let y = x;
         let got = boost_integrate_linear_interp(2.2, 0.6, &x, &y).unwrap();
-        assert_eq!(got, 1.9 / 1.5);
-        assert_ne!(got, 2.9 / 1.5);
+        assert_eq!(got, 2.9 / 1.5);
+
+        // The sharpest form of the old drop: the final row used to reach
+        // no term at all, so corrupting it changed nothing.
+        let mut spoiled = y;
+        spoiled[3] = 1e6;
+        assert_ne!(
+            boost_integrate_linear_interp(2.2, 0.6, &x, &spoiled).unwrap(),
+            got
+        );
+    }
+
+    /// Both bounds inside one cell integrate that cell's interpolant over
+    /// the window, not two overlapping partial cells.
+    ///
+    /// Also hand-computable with `y = x`: `beta = 0.01` and `E = 3.5` put
+    /// `lb = 3.4652` and `ub = 3.5352` inside `[3, 4]`, and the window is
+    /// worth `ub - lb = 2 E γ β`, so the answer is `E` exactly.
+    ///
+    /// The shipped Cython ran both partial-cell terms here, covering
+    /// `[lb, x[ilow]]` and `[x[ihigh], ub]` — which overlap, and between
+    /// them span about two whole cells. It answered 53.497 against this
+    /// 3.5, a factor of 15.3, and the factor is `cell width / window
+    /// width`, so it grows without bound as the parent slows. That
+    /// divergence is why the seven tabulated photon spectra used to blow
+    /// up near threshold instead of converging to their rest-frame
+    /// values.
+    #[test]
+    fn a_window_inside_one_cell_is_the_window() {
+        let x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let y = x;
+        let got = boost_integrate_linear_interp(3.5, 0.01, &x, &y).unwrap();
+        assert!((got - 3.5).abs() < 1e-14 * 3.5, "{got} vs 3.5");
+    }
+
+    /// The boost conserves the yield: integrating the boosted spectrum
+    /// over the lab energy returns the rest-frame table's own integral.
+    ///
+    /// A boost redistributes photons in energy and creates none, so
+    /// `∫ dE dN/dE(E, β) = ∫ dx y(x)` for every `β`. Swapping the order of
+    /// the two integrals proves it: at fixed `x` the window admits `E`
+    /// over a range of length `2 β γ x`, which cancels the `1/(2γβ)`
+    /// prefactor and the `1/x` in the integrand exactly. This is the
+    /// physics invariant a corpus comparison cannot supply
+    /// (`projects/parity-pinned-defect-repair/rules.md` rule 4), and the
+    /// old window coverage failed it from both sides at once — losing a
+    /// cell out of every wide window, inventing whole cells out of every
+    /// narrow one.
+    ///
+    /// The table vanishes at `x[0]` so the below-table `1/E` tail term is
+    /// zero. That tail is an extrapolation below the tabulated support
+    /// rather than part of the table's yield, and it is still reproduced
+    /// from the Cython rather than repaired (see the function's
+    /// "Faithfulness notes"), so a table with a nonzero first row would be
+    /// testing that extrapolation instead of this identity.
+    ///
+    /// The 5e-5 budget is the outer trapezoid's own discretization error:
+    /// `dN/dE` has a kink wherever a bound crosses a table node, which a
+    /// composite rule resolves at `O(h)`.
+    #[test]
+    fn the_boost_conserves_the_tabulated_yield() {
+        // A smooth bump vanishing at both ends of the table.
+        let x: Vec<f64> = (0..201).map(|i| 1.0 + 0.05 * f64::from(i)).collect();
+        let y: Vec<f64> = x.iter().map(|xi| (xi - 1.0) * (11.0 - xi)).collect();
+        let rest = trapezoid_of(&x, &y);
+
+        for beta in [0.05_f64, 0.3, 0.9] {
+            let gamma = 1.0 / (1.0 - beta * beta).sqrt();
+            // Below `lo` the whole window sits under the table and above
+            // `hi` the whole window sits over it, so the support is inside.
+            let lo = x[0] / (gamma * (1.0 + beta));
+            let hi = x[x.len() - 1] / (gamma * (1.0 - beta));
+            let n = 400_000_usize;
+            let grid: Vec<f64> = (0..=n)
+                .map(|i| lo + (hi - lo) * i as f64 / n as f64)
+                .collect();
+            let boosted: Vec<f64> = grid
+                .iter()
+                .map(|&e| boost_integrate_linear_interp(e, beta, &x, &y).unwrap())
+                .collect();
+            let got = trapezoid_of(&grid, &boosted);
+            assert!(
+                (got - rest).abs() < 5e-5 * rest,
+                "beta = {beta}: the boosted yield is {got}, not {rest}"
+            );
+        }
+    }
+
+    /// A plain sequential trapezoid, for the yield invariant's outer
+    /// integral. Deliberately not [`trapezoid`], which reproduces NumPy's
+    /// pairwise reduction because the kernel's own inner sum must.
+    fn trapezoid_of(xs: &[f64], ys: &[f64]) -> f64 {
+        (0..xs.len() - 1)
+            .map(|i| (xs[i + 1] - xs[i]) * (ys[i + 1] + ys[i]) / 2.0)
+            .sum()
     }
 
     /// A `NaN` energy propagates instead of panicking.

--- a/test/parity/README.md
+++ b/test/parity/README.md
@@ -13,6 +13,7 @@ function's budget.
 | [`tolerances.py`](tolerances.py) | How far a replacement implementation may move each entry point, and why that far. |
 | [`stability.py`](stability.py) | Which pinned values are rounding residue rather than physics, and are therefore skipped. |
 | [`deltas.py`](deltas.py) | Which pinned arrays a repair has moved on purpose, and how the repaired value relates to the stored one. Also the models of repairs that have not landed yet. The stored arrays are never rewritten. |
+| [`oracle_reference.py`](oracle_reference.py) | Serves the [`oracles/`](oracles/README.md) captures as a `deltas.Reference`, so a Group A repair is graded against the Cython twin rather than against the stored array it corrects. |
 | [`reference.py`](reference.py) | Arbitrary-precision copies of the four cancellation-prone kernels. Used only to rebuild the mask. |
 | [`test_parity.py`](test_parity.py) | The gate — re-evaluates every entry point and compares against `data/`. |
 | [`test_delta_models.py`](test_delta_models.py) | Checks each `deltas.py` model against the stored arrays that pin the defect it describes. Evaluates no kernel. |
@@ -116,23 +117,26 @@ served kernel and belongs back in the count. If a swap changes a number,
 the fix is a declared tolerance in the parity suite plus an entry in the
 project's numerical record, never a regenerated array.
 
-Nine of the values in here are, separately, *wrong* — filed under
+Ten of the values in here are, separately, *wrong* — filed under
 `docs/followups/` and repaired by
 [`projects/parity-pinned-defect-repair`](../../projects/parity-pinned-defect-repair/PLAN.md).
 That does not make them regenerable either: the committed arrays are the
 record of what 2.1.0 shipped, and a repair is expressed as a declared
-delta against them, in [`deltas.py`](deltas.py) — two have been (the
-scalar decay spectrum's FSR normalization, roster entry B4, and the
-charged pion's doubled prompt neutrino line, B5), so the arrays of those
-two cases are compared against the relation each declares rather than
-against `stored`. Three more are *modelled* there without being
-declared — B1, B2 and B3, whose Cython twins are already gone — because
-a declaration on an array the tree has not moved yet would fail as
-stale; [`test_delta_models.py`](test_delta_models.py) checks those models
-against the stored arrays themselves. [`oracles/`](oracles/README.md)
+delta against them, in [`deltas.py`](deltas.py) — four have been (the
+scalar decay spectrum's FSR normalization, roster entry B4; the charged
+pion's doubled prompt neutrino line, B5; the two mediator thermal cross
+sections' unconverged quadrature, B6; and the boost integral's window
+coverage, A1, which reaches all seven tabulated photon spectra), so the
+arrays of those cases are compared against the relation each declares
+rather than against `stored`. Three more are *modelled* there without
+being declared — B1, B2 and B3, whose Cython twins are already gone —
+because a declaration on an array the tree has not moved yet would fail
+as stale; [`test_delta_models.py`](test_delta_models.py) checks those
+models against the stored arrays themselves. [`oracles/`](oracles/README.md)
 holds what the remaining positions *should* be, captured from the Cython
-twins before the port deleted them, and is the only other place in this
-directory where a corrected number lives.
+twins before the port deleted them; it is what A1 is graded against here,
+through [`oracle_reference.py`](oracle_reference.py), and is the only
+other place in this directory where a corrected number lives.
 
 ## What the corpus pins
 

--- a/test/parity/deltas.py
+++ b/test/parity/deltas.py
@@ -32,6 +32,14 @@ value, so nothing is recomputed and the prediction is limited by the
 transform's own arithmetic rather than by a quadrature. It is the
 strongest relation the spec offers and the one to reach for first.
 
+``Reference`` — the stored value is superseded outright by one a second
+implementation computes. For a defect that lost or doubled a term of a
+quadrature there is no term to add and no transform to apply, so the only
+statement available is what an implementation that does not carry the
+defect returns: `thermal_reference` integrates the same integrand with
+scipy's QUADPACK, and `oracle_reference` reads the arrays captured from
+the Cython twins before the port deleted them.
+
 Positions
 ---------
 A declaration covers exactly the positions its mechanism reaches
@@ -70,6 +78,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
+import oracle_reference
 import thermal_reference
 
 from hazma import parameters
@@ -222,7 +231,7 @@ class Delta:
         the prediction differs from the stored value. Undeclared
         positions are still compared against the stored value under the
         case's budget.
-    relation : Additive or Exact
+    relation : Additive, Exact or Reference
         How the repaired value relates to the stored one.
     measured : str
         The measurement behind the declaration, so the table is not a
@@ -673,12 +682,123 @@ _B6 = Delta(
     evidence="docs/followups/done/thermal-cross-section-quadrature-never-converges.md",
 )
 
+# ---------------------------------------------------------------------------
+# A1 -- the boost integral mis-covers its window at both ends
+# ---------------------------------------------------------------------------
+
+
+#: The seven tabulated photon cases `boost_integrate_linear_interp`
+#: reaches. Each contributes four keys below -- ``rest_plus_eps``,
+#: ``near_rest``, ``boosted_mild`` and ``boosted_strong``, both value
+#: suffixes. ``rest`` is deliberately absent from all seven: every one of
+#: these kernels short-circuits to its rest-frame spectrum at
+#: ``E - m < DBL_EPSILON``, so the integral never runs at ``beta = 0`` and
+#: those 1,841 pinned positions must still match the stored arrays.
+A1_CASES = (
+    "spectra.photon.eta",
+    "spectra.photon.eta_prime",
+    "spectra.photon.omega",
+    "spectra.photon.phi",
+    "spectra.photon.charged_kaon",
+    "spectra.photon.long_kaon",
+    "spectra.photon.short_kaon",
+)
+
+_A1 = Delta(
+    repair="A1",
+    positions=MOVED,
+    relation=Reference(
+        reference=oracle_reference.captured("A1"),
+        rtol=1e-12,
+        why="the reference is the same routine with the same window "
+        "coverage, compiled from the pre-port Cython, so the only thing "
+        "between it and the repaired kernel is the port's own arithmetic "
+        "-- which is what `tolerances.TABULATED_RTOL` already budgets for "
+        "these seven cases, and this is that number. Measured 0.0: the "
+        "repaired kernel reproduces the capture at all 10,045 pinned "
+        "positions bit for bit, as the unrepaired port reproduced the "
+        "corpus. Not tightened to zero, because the capture is one "
+        "platform's (`test_oracles.py` holds it against the corpus "
+        "manifest's) and a libm that moves the boost integral has to be "
+        "held exactly as tightly here as the undeclared positions are, "
+        "not tighter.",
+    ),
+    measured="4,154 of the 10,045 pinned positions move, in four of the "
+    "five blocks of each case and in none of the `rest` blocks. The sign "
+    "splits by block rather than by case: `rest_plus_eps` moves down at "
+    "all 1,156 of its positions, where the two partial-cell terms "
+    "overlapped and the shipped value is a median 9,768x and up to "
+    "360,507x too high; `near_rest`, `boosted_mild` and `boosted_strong` "
+    "move up at 2,997 of their 2,998, by up to 98.7%, where the dropped "
+    "interior cell left the value low. Per case: eta 560, eta_prime 552, "
+    "omega 633, phi 551, charged_kaon 631, long_kaon 631, short_kaon 596.",
+    evidence="projects/parity-pinned-defect-repair/task-notes/task-4-boost-window.md",
+)
+
+
 #: Every declared array. The two blocks of the same case that are absent --
 #: ``rest`` and ``rest_plus_eps`` -- must still match the stored arrays under
 #: the case's own budget, which is the "moved only what it intended" half of
 #: the B5 proof: at rest the kernel drops both prompt lines, and one epsilon
 #: above it no grid point's boost window is wide enough to straddle the line.
 DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
+    # A1.
+    ("spectra.photon.eta", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.eta", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.eta", "near_rest", "values"): _A1,
+    ("spectra.photon.eta", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.eta", "boosted_mild", "values"): _A1,
+    ("spectra.photon.eta", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.eta", "boosted_strong", "values"): _A1,
+    ("spectra.photon.eta", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.eta_prime", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.eta_prime", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.eta_prime", "near_rest", "values"): _A1,
+    ("spectra.photon.eta_prime", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.eta_prime", "boosted_mild", "values"): _A1,
+    ("spectra.photon.eta_prime", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.eta_prime", "boosted_strong", "values"): _A1,
+    ("spectra.photon.eta_prime", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.omega", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.omega", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.omega", "near_rest", "values"): _A1,
+    ("spectra.photon.omega", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.omega", "boosted_mild", "values"): _A1,
+    ("spectra.photon.omega", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.omega", "boosted_strong", "values"): _A1,
+    ("spectra.photon.omega", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.phi", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.phi", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.phi", "near_rest", "values"): _A1,
+    ("spectra.photon.phi", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.phi", "boosted_mild", "values"): _A1,
+    ("spectra.photon.phi", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.phi", "boosted_strong", "values"): _A1,
+    ("spectra.photon.phi", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.charged_kaon", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.charged_kaon", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.charged_kaon", "near_rest", "values"): _A1,
+    ("spectra.photon.charged_kaon", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.charged_kaon", "boosted_mild", "values"): _A1,
+    ("spectra.photon.charged_kaon", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.charged_kaon", "boosted_strong", "values"): _A1,
+    ("spectra.photon.charged_kaon", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.long_kaon", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.long_kaon", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.long_kaon", "near_rest", "values"): _A1,
+    ("spectra.photon.long_kaon", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.long_kaon", "boosted_mild", "values"): _A1,
+    ("spectra.photon.long_kaon", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.long_kaon", "boosted_strong", "values"): _A1,
+    ("spectra.photon.long_kaon", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.short_kaon", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.short_kaon", "rest_plus_eps", "scalar_values"): _A1,
+    ("spectra.photon.short_kaon", "near_rest", "values"): _A1,
+    ("spectra.photon.short_kaon", "near_rest", "scalar_values"): _A1,
+    ("spectra.photon.short_kaon", "boosted_mild", "values"): _A1,
+    ("spectra.photon.short_kaon", "boosted_mild", "scalar_values"): _A1,
+    ("spectra.photon.short_kaon", "boosted_strong", "values"): _A1,
+    ("spectra.photon.short_kaon", "boosted_strong", "scalar_values"): _A1,
     # B4. The ``mu_mu_only`` blocks of this case are deliberately absent:
     # they open no FSR channel and must still match the stored arrays bit
     # for bit. Within a declared array the same holds position by position:
@@ -881,6 +1001,7 @@ DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
 #: yet. A repair task moves its model into that table by adding the arrays
 #: it measured moving; see the module docstring.
 DELTA_MODELS: dict[str, Delta] = {
+    "A1": _A1,
     "B1": _B1,
     "B2": _B2,
     "B3": _B3,

--- a/test/parity/oracle_reference.py
+++ b/test/parity/oracle_reference.py
@@ -1,0 +1,122 @@
+"""The corrected-value captures under ``oracles/``, as a delta relation.
+
+``oracles/data/{A1,A2,A3,A4}.npz`` holds what each of the four Group A
+defects should have returned, evaluated from a *patched* copy of the
+Cython twin on the corpus's own grids before ``cython-to-rust`` deleted
+that twin. ``oracles/README.md`` is the capture's own account of itself
+and ``test_oracles.py`` is its gate; this module is the one line between
+those arrays and `deltas.DECLARED_DELTAS`.
+
+A Group A repair is therefore a `deltas.Reference`: the stored value is
+superseded rather than corrected, and what supersedes it was computed by
+an implementation that predates the port. That is the independent oracle
+`projects/parity-pinned-defect-repair/rules.md` rule 3 asks for, and it
+is why these repairs carry no closed-form model — each defect is a lost
+or doubled *term* of a quadrature, which no transform of the stored
+array can rebuild.
+
+A capture is keyed by corpus case, block label and array suffix, while a
+relation is handed only the entry point and the block. The entry point is
+what closes the gap: `_cases` maps it back to the case name through
+`cases.build_cases()`, so the case list stays derived from the corpus
+specification rather than transcribed beside it.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from functools import cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from cases import Block
+
+#: Where `oracles/capture.py` writes, and `oracles/README.md` documents.
+DATA_DIR = Path(__file__).resolve().parent / "oracles" / "data"
+
+
+@cache
+def _blocks(label: str) -> dict[tuple[str, str], dict[str, np.ndarray]]:
+    """One defect's capture, as ``(case, block label) -> {suffix: array}``.
+
+    Read through the oracle manifest rather than by rebuilding the npz
+    key, because that key carries the block's *index* and the manifest is
+    what maps an index back to a label.
+
+    The arrays come back read-only: they are shared by every comparison
+    that reads them and are the committed record of a measurement, not a
+    scratch buffer.
+    """
+    manifest = json.loads((DATA_DIR / "manifest.json").read_text())
+    captured: dict[tuple[str, str], dict[str, np.ndarray]] = {}
+    with np.load(DATA_DIR / f"{label}.npz") as data:
+        for case_name, case in manifest["defects"][label]["cases"].items():
+            for block in case["blocks"]:
+                arrays = {}
+                for suffix, entry in block["arrays"].items():
+                    array = data[entry["key"]]
+                    array.setflags(write=False)
+                    arrays[suffix] = array
+                captured[case_name, block["label"]] = arrays
+    return captured
+
+
+@cache
+def _cases(label: str) -> dict[tuple[str, str], str]:
+    """``(module, qualname) -> case name`` over the cases one capture covers.
+
+    Built by resolving the live entry points rather than by reading the
+    manifests' ``entry_point``, which records where each case was
+    *captured* from — the Cython modules the port has since deleted.
+    """
+    import cases as corpus  # noqa: PLC0415  (0.2s of model building, paid once)
+
+    built = corpus.build_cases()
+    out: dict[tuple[str, str], str] = {}
+    for case_name in sorted({case for case, _ in _blocks(label)}):
+        fn = built[case_name].resolve()
+        key = (fn.__module__, fn.__qualname__)
+        assert key not in out, f"{label}: {key} serves {out.get(key)} and {case_name}"
+        out[key] = case_name
+    return out
+
+
+def captured(label: str) -> Callable[..., dict[str, np.ndarray]]:
+    """A `deltas.Reference` callable serving one defect's whole capture.
+
+    Parameters
+    ----------
+    label : str
+        The roster label, from `deltas.REPAIRS`. Only the four Group A
+        defects have a capture.
+
+    Returns
+    -------
+    callable
+        ``(fn, block) -> {suffix: array}``. Unlike the other relations
+        this one reads ``fn`` — but only for its identity, never by
+        calling it, since a reference that ran the kernel it supersedes
+        would not be one.
+    """
+
+    def reference(fn: Callable[..., Any], block: Block) -> dict[str, np.ndarray]:
+        entry = (getattr(fn, "__module__", None), getattr(fn, "__qualname__", None))
+        try:
+            case_name = _cases(label)[entry]  # type: ignore[index]
+        except KeyError:
+            msg = f"the {label} capture covers no entry point {entry[0]}:{entry[1]}"
+            raise KeyError(msg) from None
+        try:
+            return _blocks(label)[case_name, block.label]
+        except KeyError:
+            msg = (
+                f"the {label} capture holds no {case_name}[{block.label}]; "
+                f"see test/parity/oracles/data/manifest.json"
+            )
+            raise KeyError(msg) from None
+
+    return reference

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -124,7 +124,7 @@ EXPECTED_PORTABILITY_ZEROS = 4
 #: same reason as the two above: the size of the set the gate compares
 #: against something other than the stored corpus is the number worth
 #: defending in a diff.
-EXPECTED_DECLARED_ARRAYS = 42
+EXPECTED_DECLARED_ARRAYS = 98
 
 
 def _drop_unpinnable(

--- a/test/parity/tolerances.py
+++ b/test/parity/tolerances.py
@@ -62,7 +62,9 @@ implementation does* rather than by what it computes:
 ``TABULATED`` (rtol 1e-12)
     Driven by `boost_integrate_linear_interp` over a shipped CSV table:
     `np.trapezoid` across interior cells, closed-form partial cells at
-    both edges, an analytic `1/E` tail below the table. A Rust rewrite
+    both edges, one closed form over the whole window when both bounds
+    land inside a single cell, and an analytic `1/E` tail below the
+    table. A Rust rewrite
     keeps the algorithm and changes the summation order, so the drift is
     accumulated rounding, not method error: the tables are 100 data rows
     (eta) or 500 (the other six), and 500 · 2^-52 is ~1.1e-13, so 1e-12

--- a/test/test_core_boost.py
+++ b/test/test_core_boost.py
@@ -72,8 +72,8 @@ Lifetime
 --------
 Nothing here reads the Cython any more, so nothing here has a deadline.
 :class:`TestFusedArithmetic` and :class:`TestTrapezoidSummation` pin the
-arithmetic, :class:`TestDroppedInteriorCell` pins the one defect this
-module knows the size of (53%, far above any rounding),
+arithmetic, :class:`TestWindowCoverage` pins the window coverage against
+the two hand-computable cases that 2.1.0 got wrong,
 :class:`TestBoostDeltaFunction` and
 :class:`TestBoostIntegrateLinearInterp` pin each branch by a closed form
 or a sensitivity check as well as against the reference, and
@@ -219,20 +219,27 @@ def integrate_reference(
         ihigh = int(np.flatnonzero(ub <= x)[0])
         if abs(float(x[ihigh]) - ub) > EDGE_ATOL:
             ihigh -= 1
-    if ilow < ihigh:
-        integral += float(np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh]))
-    if ilow > 0 and abs(float(x[ilow]) - lb) > EDGE_ATOL:
-        x2, x1 = float(x[ilow]), float(x[ilow - 1])
-        m = (float(yy[ilow]) - float(yy[ilow - 1])) / (x2 - x1)
-        b = mul_add(-m, x1, float(yy[ilow - 1]))
-        inner = mul_add(0.5 * m, x2 + lb, b)
-        integral = mul_add(x2 - lb, inner, integral)
-    if ihigh < npts - 1 and abs(ub - float(x[ihigh])) > EDGE_ATOL:
-        x2, x1 = float(x[ihigh + 1]), float(x[ihigh])
-        m = (float(yy[ihigh + 1]) - float(yy[ihigh])) / (x2 - x1)
+    if ilow > ihigh:
+        x2, x1 = float(x[ilow]), float(x[ihigh])
+        m = (float(yy[ilow]) - float(yy[ihigh])) / (x2 - x1)
         b = mul_add(-m, x1, float(yy[ihigh]))
-        inner = mul_add(0.5 * m, ub + x1, b)
-        integral = mul_add(ub - x1, inner, integral)
+        inner = mul_add(0.5 * m, ub + lb, b)
+        integral = mul_add(ub - lb, inner, integral)
+    else:
+        if ilow < ihigh:
+            integral += float(np.trapezoid(yy[ilow : ihigh + 1], x=x[ilow : ihigh + 1]))
+        if ilow > 0 and abs(float(x[ilow]) - lb) > EDGE_ATOL:
+            x2, x1 = float(x[ilow]), float(x[ilow - 1])
+            m = (float(yy[ilow]) - float(yy[ilow - 1])) / (x2 - x1)
+            b = mul_add(-m, x1, float(yy[ilow - 1]))
+            inner = mul_add(0.5 * m, x2 + lb, b)
+            integral = mul_add(x2 - lb, inner, integral)
+        if ihigh < npts - 1 and abs(ub - float(x[ihigh])) > EDGE_ATOL:
+            x2, x1 = float(x[ihigh + 1]), float(x[ihigh])
+            m = (float(yy[ihigh + 1]) - float(yy[ihigh])) / (x2 - x1)
+            b = mul_add(-m, x1, float(yy[ihigh]))
+            inner = mul_add(0.5 * m, ub + x1, b)
+            integral = mul_add(ub - x1, inner, integral)
     return integral / (2.0 * gamma * beta)
 
 
@@ -468,9 +475,10 @@ class TestBoostIntegrateLinearInterp:
         """`ub` past the table's top, but `lb` inside it.
 
         The clamp is what keeps this from returning zero, and the value
-        matches the reference. That the clamp *also* skips the upper
-        partial-cell term — and with it the table's last row — is pinned
-        separately in :class:`TestDroppedInteriorCell`.
+        matches the reference. That the clamp leaves the upper
+        partial-cell term unrun — so the interior sum has to reach the
+        table's last row on its own — is pinned separately in
+        :class:`TestWindowCoverage`.
         """
         energy, beta = 5.0, 0.6
         got = boost_integrate_linear_interp(energy, beta, FLAT_X, FLAT_Y)
@@ -609,49 +617,73 @@ class TestFusedArithmetic:
         ), f"unfused worst miss {worst:.3e} is smaller than recorded"
 
 
-class TestDroppedInteriorCell:
-    """The interior sum stops one cell short, and the port keeps it that way.
+class TestWindowCoverage:
+    """The window is covered once and covered whole, from both ends.
 
-    ``np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])`` has an exclusive
-    upper bound, so the cell ``[x[ihigh - 1], x[ihigh]]`` is covered by
-    neither the sum nor the upper partial-cell term. Reproduced rather
-    than repaired (``projects/cython-to-rust/rules.md`` rule 1); the
-    repair is tracked in
-    ``docs/followups/todo/boost-integral-drops-last-interior-cell.md``.
+    ``hazma`` 2.1.0 mis-covered it from both sides at once. Its interior
+    sum ran over ``np.trapezoid(yy[ilow:ihigh], x=x[ilow:ihigh])``, an
+    exclusive upper bound, while the upper partial-cell term started at
+    ``x[ihigh]`` — so ``[x[ihigh - 1], x[ihigh]]`` was covered by nothing;
+    and where both bounds landed inside one cell the two partial-cell
+    terms overlapped instead. That is roster entry ``A1`` of
+    ``projects/parity-pinned-defect-repair``, and the corpus arrays which
+    pinned the old values are declared in ``test/parity/deltas.py``.
+
+    Both cases are hand-computable with ``y = x``, which makes the
+    integrand ``y / x`` exactly 1 and the integral the covered length.
     """
 
     X = np.array([1.0, 2.0, 3.0, 4.0])
     Y = np.array([1.0, 2.0, 3.0, 4.0])  # y / x == 1, so integrals are lengths
 
-    def test_the_hand_computed_value_omits_one_cell(self) -> None:
+    WIDE_X = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    WIDE_Y = WIDE_X
+
+    def test_a_clamped_window_covers_the_whole_window(self) -> None:
         """``E = 2.2``, ``beta = 0.6``: ``lb = 1.1``, ``ub`` clamped to 4.
 
-        The kernel covers ``[1.1, 2]`` (lower partial cell) and ``[2, 3]``
-        (the interior sum) for ``1.9 / (2 gamma beta)``. Covering
-        ``[1.1, 4]`` as intended would give ``2.9`` -- a 53% difference,
-        far too large to be roundoff.
+        Covering ``[1.1, 4]`` is worth ``2.9 / (2 gamma beta) = 2.9 / 1.5``.
+        2.1.0 answered ``1.9 / 1.5`` — it covered ``[1.1, 2]`` and
+        ``[2, 3]`` and stopped.
         """
         got = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
-        assert got == pytest.approx(1.9 / 1.5, rel=1e-15)
-        assert got != pytest.approx(2.9 / 1.5, rel=1e-3)
+        assert got == pytest.approx(2.9 / 1.5, rel=1e-15)
         assert got == integrate_reference(2.2, 0.6, self.X, self.Y, mul_add=fma)
 
-    def test_a_clamped_window_never_reads_the_tables_last_row(self) -> None:
-        """The sharpest form of the drop.
+    def test_a_clamped_window_reads_the_tables_last_row(self) -> None:
+        """The sharpest form of what 2.1.0 dropped.
 
-        When the window reaches past the table, ``ihigh`` is the last
-        index, the upper partial-cell term is skipped, and the interior
-        sum stops one short -- so the final row contributes to nothing.
-        Replacing it with a value six orders larger leaves the answer
-        bit-identical, in the port and in the reference alike.
+        Under the clamp ``ihigh`` is the last index and the upper
+        partial-cell term does not run, so an exclusive interior sum left
+        the final row contributing to no term at all: replacing it with a
+        value six orders larger changed nothing. It changes the answer now,
+        in the port and in the reference alike.
         """
         spoiled = self.Y.copy()
         spoiled[-1] = 1e6
         base = boost_integrate_linear_interp(2.2, 0.6, self.X, self.Y)
-        assert boost_integrate_linear_interp(2.2, 0.6, self.X, spoiled) == base
+        assert boost_integrate_linear_interp(2.2, 0.6, self.X, spoiled) != base
         assert integrate_reference(
             2.2, 0.6, self.X, spoiled, mul_add=fma
-        ) == integrate_reference(2.2, 0.6, self.X, self.Y, mul_add=fma)
+        ) != integrate_reference(2.2, 0.6, self.X, self.Y, mul_add=fma)
+
+    def test_a_window_inside_one_cell_is_worth_the_window(self) -> None:
+        """``E = 3.5``, ``beta = 0.01``: both bounds inside ``[3, 4]``.
+
+        The window is ``ub - lb = 2 E gamma beta`` wide, so the answer is
+        ``E`` exactly. 2.1.0 ran both partial-cell terms here — covering
+        ``[lb, x[ilow]]`` and ``[x[ihigh], ub]``, which overlap — and
+        answered 53.4975, a factor of 15.3 too high. The factor is
+        ``cell width / window width``, so it grows without bound as the
+        parent slows; that is why the seven tabulated photon spectra used
+        to diverge near threshold instead of converging to their
+        rest-frame values.
+        """
+        got = boost_integrate_linear_interp(3.5, 0.01, self.WIDE_X, self.WIDE_Y)
+        assert got == pytest.approx(3.5, rel=1e-14)
+        assert got == integrate_reference(
+            3.5, 0.01, self.WIDE_X, self.WIDE_Y, mul_add=fma
+        )
 
 
 class TestTrapezoidSummation:
@@ -684,10 +716,12 @@ class TestTrapezoidSummation:
 
         got = boost_integrate_linear_interp(energy, beta, x, y)
         yy = y / x
-        # `ilow` is 1 (the node at `lb`), `ihigh` the node at `ub`; the
-        # Cython's slice stops one short of `ihigh`.
+        # `ilow` is 1 (the node at `lb`) and `ihigh` the node at `ub`, and
+        # the sum is inclusive of both.
         ihigh = x.size - 2
-        want = np.trapezoid(yy[1:ihigh], x=x[1:ihigh]) / (2.0 * gamma * beta)
+        want = np.trapezoid(yy[1 : ihigh + 1], x=x[1 : ihigh + 1]) / (
+            2.0 * gamma * beta
+        )
         assert got == want
 
     def test_a_sequential_sum_would_be_a_different_number(self) -> None:

--- a/test/test_core_photon_tables.py
+++ b/test/test_core_photon_tables.py
@@ -276,10 +276,18 @@ TAIL_RATIO_ON_HALVING = 2.0
 #: stop separating a correct weight from a halved one.
 MAX_LINE_TOLERANCE = 1e-3
 
-#: How far above its own rest-frame value the boost integral's
-#: over-count pushes a barely-moving parent -- a lower bound, since the
-#: measured factor is 6,500x to 33,000x.
-MIN_THRESHOLD_DIVERGENCE = 1e3
+#: How far a barely-moving parent's spectrum may sit from its own
+#: rest-frame value, relative. The worst of the seven channels over
+#: `THRESHOLD_FRACTIONS` is 8.5e-3, at ``eta`` and ``E = m/20``; 2e-2 is
+#: 2.3x that. hazma 2.1.0 missed this by 6,500x to 33,000x, so the bound
+#: separates converging from diverging by five and a half decades.
+MAX_THRESHOLD_MISS = 2e-2
+
+#: Where to check that convergence, as a fraction of the parent mass.
+#: ``m/10`` is the column
+#: ``docs/followups/todo/boost-integral-drops-last-interior-cell.md``
+#: tabulates the shipped divergence at; the others bracket it.
+THRESHOLD_FRACTIONS = (0.05, 0.1, 0.2, 0.3)
 
 
 class TestDispatchWiring:
@@ -631,22 +639,35 @@ class TestPhysics:
             assert np.all(values >= 0.0), f"{name} at E = {parent}"
             assert np.all(np.isfinite(values)), f"{name} at E = {parent}"
 
-    def test_the_boost_integral_still_diverges_near_threshold(self) -> None:
-        """The Task 3.4 defect, reproduced through a public entry point.
+    @pytest.mark.parametrize("name", NAMES)
+    def test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum(
+        self, name: str
+    ) -> None:
+        """The limit that says the boost window is covered correctly.
 
-        ``boost_integrate_linear_interp`` over-counts when both integration
-        bounds fall inside one table cell, by (cell width)/(window width) —
-        which diverges as ``β → 0``. So a barely-moving parent gives a
-        spectrum orders of magnitude *above* its own rest-frame value
-        instead of converging to it. Pinned here because this family is
-        where it is visible from outside:
+        A parent one part in 1e12 above rest is, physically, a parent at
+        rest: its boost opens a window 2.8e-06 wide in relative energy, so
+        the boosted spectrum must reproduce the rest-frame one. The two
+        are computed by entirely different code — at rest the kernel
+        short-circuits to ``np.interp`` on the table, one ulp above it the
+        boost integral takes over — so agreement here is a statement about
+        the integral rather than about the interpolation.
+
+        hazma 2.1.0 failed it by three to four orders of magnitude in the
+        other direction: its two partial-cell terms overlapped whenever
+        both bounds fell inside one cell, over-counting by
+        ``cell width / window width``, which diverges as the parent slows.
+        That is roster entry ``A1`` of
+        ``projects/parity-pinned-defect-repair``, and this is the
+        acceptance test
         ``docs/followups/todo/boost-integral-drops-last-interior-cell.md``
-        is blocked until after Phase 06 Task 6.4, and the corpus pins the
-        wrong values by design, so a swap that "fixed" it would fail its
-        own gate.
+        proposed for it.
         """
-        mass = MASS_ETA
-        dnde = core_photon.dnde_photon_eta
-        at_rest = dnde(100.0, mass)
-        barely_moving = dnde(100.0, mass * (1.0 + 1e-12))
-        assert barely_moving / at_rest > MIN_THRESHOLD_DIVERGENCE
+        dnde, _, mass, _ = SPECTRA[name]
+        for fraction in THRESHOLD_FRACTIONS:
+            energy = mass * fraction
+            at_rest = dnde(energy, mass)
+            barely_moving = dnde(energy, mass * (1.0 + 1e-12))
+            assert barely_moving == pytest.approx(
+                at_rest, rel=MAX_THRESHOLD_MISS
+            ), f"{name} at E = {energy}"


### PR DESCRIPTION
## Summary

- **Repairs `boost_integrate_linear_interp`'s window coverage**
  (`rust/src/boost.rs`), which was wrong from both ends. The interior
  trapezoid ran over an exclusive `x[ilow..ihigh]` while the upper
  partial-cell term began at `x[ihigh]`, so `[x[ihigh-1], x[ihigh]]` was
  covered by nothing — and under the clamp that applies when the window
  reaches past the table, the table's final row contributed to no term at
  all. Where **both** bounds fell inside a single cell the two
  partial-cell terms overlapped instead, over-counting by
  `cell width / window width`, which diverges as the parent slows. The
  interior sum is now inclusive of `x[ihigh]`, meeting the upper partial
  cell exactly, and the single-cell case integrates one linear
  interpolant across `[lb, ub]`.
- **The numbers move.** All seven tabulated photon spectra —
  `dnde_photon_{eta, eta_prime, omega, phi, charged_kaon, long_kaon,
  short_kaon}` — and every model spectrum summing them. **The sign splits
  by regime.** Near threshold the shipped values were far too high and now
  converge: at a parent one part in 1e12 above rest they returned
  **6,500x to 33,000x** their own rest-frame value at `E_γ = m/10`, and
  now agree with it to better than 1% over `E_γ` from `m/20` to `3m/10`.
  Away from threshold they were low by the dropped cell and now rise —
  over the 10,045 values the parity corpus pins, by a median **3.3% at
  γ = 1.05**, **0.22% at γ = 2** and **7.1e-5 at γ = 10**, and by up to
  98.7%. In total **4,154 of those 10,045 values move**: down at all
  1,156 `rest_plus_eps` positions and up at 2,997 of the 2,998 boosted
  ones. A parent *exactly* at rest is unaffected — all seven kernels
  short-circuit to the rest-frame spectrum before the integral, so it
  never runs at `β = 0`. The repaired values are the right ones;
  `CHANGELOG.md` carries the entry.
- **Declared, not regenerated.** The moved values are declared in
  `test/parity/deltas.py` against the corpus arrays that pinned them
  (ADR-0001); `test/parity/data/` is untouched. A new
  `test/parity/oracle_reference.py` serves the Group A captures as a
  `deltas.Reference`, so the repaired kernel is graded against the Cython
  twin captured before the port deleted it — **which it reproduces bit for
  bit at all 10,045 positions**. `EXPECTED_DECLARED_ARRAYS` goes 42 → 98.
- **Also corrects two claims this task disproved:** `PLAN.md` said the
  shift was "systematic and one-signed", and
  `references/defect-blast-radius.md` gave the `rest` block 1,750
  positions where it holds 1,841 (re-derived, with the command beside it).

## Project

`projects/parity-pinned-defect-repair/` — Task 4: Repair A1 — the boost
integral window.

See `projects/parity-pinned-defect-repair/task-notes/task-4-boost-window.md`
for implementation detail, decisions, the per-case measurement tables, and
verification.

## Test plan

- [x] Full suite, the gate CI runs:

  ```text
  $ pytest -q
  2286 passed, 15 skipped, 1 warning, 37 subtests passed in 27.10s
  ```

  All 15 skips are pre-existing: 11 "known to be broken" form-factor
  tests, the charged kaon's absent monochromatic line, and the parity
  corpus's declared-budget skip (`numpy 2.5.1 → 2.5.3`,
  `scipy 1.18.0 → 1.18.1`, a macOS point release).

- [x] The corpus gate, which is what proves the blast radius:

  ```text
  $ pytest test/parity -q
  687 passed, 1 skipped in 3.51s
  ```

  Every one of the 41 cases is re-evaluated and compared; only the 56
  declared arrays are held to the relation, and every other position of
  every case is still compared against its stored value under its own
  budget.

- [x] The kernel's own suite:

  ```text
  $ cargo test --manifest-path rust/Cargo.toml --no-default-features \
        --features test-probes
  test result: ok. 263 passed; 0 failed; 0 ignored
  ```

- [x] **Test validity (stash-proof).** The kernel half of
  `rust/src/boost.rs` was replaced with `git show HEAD:rust/src/boost.rs`'s,
  the new tests kept, and the tree rebuilt. Every layer turned red:

  ```text
  $ cargo test … boost::
  4 failed  (both coverage tests, the yield invariant, the tightened
             flat-table budget)

  $ pytest test/test_core_boost.py test/test_core_photon_tables.py test/parity -q
  56 failed, 872 passed, 2 skipped
  ```

  Grouped as 28 `test_entry_point_matches_corpus` blocks (7 cases x 4
  declared blocks — the declaration is not stale), 7
  `test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum`, 7
  `test_the_tabulated_port_is_the_fused_reference`, 5
  `test_the_interior_sum_is_numpys_trapezoid`, 3 `TestWindowCoverage`, and
  5 more sensitivity checks. The kernel was then restored and
  `cmp`-verified byte-identical before rebuilding.

- [x] Physics invariants that owe nothing to the Cython or the corpus:
  `boost::tests::the_boost_conserves_the_tabulated_yield` (the boosted
  spectrum integrated over the lab energy returns the table's own
  integral, at three boosts) and
  `test_a_barely_moving_parent_converges_to_its_rest_frame_spectrum`
  (all seven channels, four energies each).

- [x] `git diff --stat -- test/parity/data` — empty
  (`projects/parity-pinned-defect-repair/rules.md` rule 1).

- [x] Preflight gate:

  ```text
  $ scripts/agents/preflight.sh --paths "<6 .py files>" --md "<7 docs>"
  RESULT: PASS   (all eleven rows; version bump SKIPped — not a closing PR)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
