### PR TITLE
fix(spectra): double the eta-prime two-photon line weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ user-facing change even when no signature did.
 
 ### Changed
 
+- **The η′'s two-photon line carried one photon per decay instead of
+  two, and `dnde_photon_eta_prime` rises.** Five tabulated photon spectra
+  add a monochromatic line on top of a CSV continuum, and for the four
+  whose mode is `X → γγ` the line's weight is `2 BR`, because two photons
+  leave the decay. The η′ shipped a bare `BR`; the η, `K_L` and `K_S` did
+  not. The weight is now `2 BR(η′ → γγ)` like its three siblings.
+  **The yield rises by exactly `BR(η′ → γγ) = 0.02307` photons per decay,
+  at every boost** — a boosted δ-function integrates to its own weight —
+  which is 0.603% of the repaired total of 3.829 photons per decay
+  integrated over `1e-3 ≤ E_γ ≤ E_η′` at `E_η′ = 2 M_η′`. All of it lands
+  in the line, at `M_η′/2 = 478.89` MeV in the η′ rest frame and spread
+  across that energy's boosted window otherwise, so a band excluding it
+  does not move at all; the continuum is unchanged. An η′ **exactly** at
+  rest is unaffected, because that branch adds no line. Pointwise the
+  rise runs from 7.7e-04 to a factor of two, the latter where the line
+  was the whole spectrum. `hazma.spectra.dnde_photon` moves for any final
+  state containing an η′. `dnde_photon_eta`, `dnde_photon_long_kaon` and
+  `dnde_photon_short_kaon` — whose weights were already right — do not
+  move, and neither do `dnde_photon_omega` or `dnde_photon_phi`, whose
+  `X → Yγ` lines are correctly un-doubled. Details:
+  `docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md`.
 - **The boost integral mis-covered its window at both ends, and all seven
   tabulated photon spectra move.** `hazma.spectra.dnde_photon_eta`,
   `dnde_photon_eta_prime`, `dnde_photon_omega`, `dnde_photon_phi`,

--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -335,6 +335,24 @@ past-tense worked example and one canonical phase file given a dated
   PR's deletion had orphaned). Cite the full path, never the basename,
   whenever your own diff removes a file.
 
+- **A green `check_doc_citations.py` is not a green liveness check.** PR #94
+  annotated `docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md`
+  as repaired and corrected three of its claims, then ran the checker over all
+  six touched docs: `out-of-range or ambiguous: NONE`. It still shipped a
+  sentence saying `hazma/_utils/boost.pyx` "is still live" — a file
+  `cython-to-rust` Task 6.4 had deleted outright, leaving no `.pyx` anywhere in
+  the tree. The checker bounds-checks a citation only when it resolves the path
+  to a tracked file; with the file gone the citation is indistinguishable from
+  a `numpy/...` one, so it is counted under "external citations skipped" and
+  never checked. Verified with a two-line probe doc: both
+  `hazma/_utils/boost.pyx` and `hazma/_utils/boost.pyx:216` report EXTERNAL and
+  pass. `docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md`
+  carries the tool gap; the author-side rule is that a *liveness* claim needs
+  its own check. The class-wide sweep
+  (`rg -n --hidden 'still live|_utils/boost\.pyx' …`) found the identical
+  sentence in the φ follow-up, which is Task 6's premise, and would have been
+  read as fact by the next task (PR #94 — caught by review, not by the author).
+
 ### changed-vs-sees-only-commits
 
 - [changed-vs-sees-only-commits] A `--changed-vs <ref>` tool diffs

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -138,7 +138,11 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   every fact it cites into scope: run `check_doc_citations.py` over the docs you
   touched, pin historical evidence to a commit, cite full paths (never
   basenames) whenever your own diff removes a file, and remember that a ledger
-  entry about a bad citation is itself a citation (PR #42, #43, #65, #67, #74).
+  entry about a bad citation is itself a citation. A green checker is not
+  enough — a citation into a file the tree no longer has at all is reported as
+  EXTERNAL and skipped, so *also* grep the doc's cited paths for present-tense
+  liveness claims ("still live", "still supplies") and test each against the
+  tree (PR #42, #43, #65, #67, #74, #94).
 - [changed-vs-sees-only-commits] A `--changed-vs <ref>` tool diffs committed
   history, so on an uncommitted tree it scans zero files and prints a
   success-shaped line; before believing any gate, confirm it reported a non-zero

--- a/docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
+++ b/docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
@@ -8,7 +8,10 @@
   (`projects/cython-to-rust/task-notes/phase-04/task-4.2-photon-table-family.md`)
 - **Scope:** cross-cutting (a published number is wrong; the repair is
   gated by the `cython-to-rust` corpus)
-- **Status:** open
+- **Status:** open — **repaired** 2026-09-07 as roster entry B1,
+  `projects/parity-pinned-defect-repair` Task 5. The file stays here
+  until that project's close (Task 12) moves all of its follow-ups to
+  `done/` in one sweep, so the inbound references are repointed once.
 - **Triggers / blockers:** **corpus re-pinning only** — no ordering
   constraint against `cython-to-rust` Phase 06 Task 6.4. Task 6.4 deletes
   the four surviving `.pyx`; this defect's twin,
@@ -43,9 +46,10 @@ hazma/spectra/_photon/_eta_prime.pyx:107
 ```
 
 (Quoted from the pre-port sources, which Task 4.2 deleted in the same
-PR as the swap — `git show 665aed5:<path>` recovers them. The
-expressions themselves live on unchanged in
-`rust/src/kernels/photon_tables.rs`.)
+PR as the swap — `git show 665aed5:<path>` recovers them. The four
+expressions live on in `rust/src/kernels/photon_tables.rs`, where the
+η′'s is now the repaired `2.0 * pdg::BR_ETAP_TO_A_A` and the other three
+are unchanged.)
 
 The η′ has no factor of two. It is the code and not a reading of it: the
 shipped `_eta_prime.cpython-312-darwin.so` loads the immediate
@@ -85,18 +89,24 @@ that differs. (The φ's lines have a separate defect of their own; see
    the port has by then. This is a **declared numerical change**:
    `projects/cython-to-rust/rules.md` rule 3 and `docs/versioning.md`
    make a moved published spectrum a `minor` bump at least, and it needs
-   a `CHANGELOG.md` entry stating the 0.63%.
+   a `CHANGELOG.md` entry stating the magnitude. Quote the yield rather
+   than the 0.63% above: the repair adds exactly `BR = 0.02307` photons
+   per decay at every boost, while the percentage that is depends on the
+   integration window, and measures 0.603% of the repaired 3.8291 photons
+   per decay over `1e-3 <= E <= E_parent` at `E_parent = 2 M_η′`.
 3. Check the downstream consumers of `dnde_photon_eta_prime` — the η′
    final state in `hazma.theory`'s channel dicts and any limit that
    opens it — but note the shift is confined to one line, so anything
    integrating over a band that excludes `M_η′/2` in the parent's rest
    frame does not move at all.
 
-The port's tests already encode the correct statement alongside the
-shipped one, so the repair mostly means flipping which is asserted:
-`the_eta_prime_line_is_missing_its_factor_of_two` in
+The port's tests already encoded the correct statement alongside the
+shipped one, so the repair mostly meant flipping which is asserted. Both
+were renamed as well as re-pointed, and now hold the four `X -> gamma
+gamma` weights together:
+`every_two_photon_line_carries_twice_its_branching_ratio` in
 `rust/src/kernels/photon_tables.rs`, and
-`TestPhysics::test_the_eta_prime_line_carries_half_the_photons_it_should`
+`TestPhysics::test_every_two_photon_line_carries_twice_its_branching_ratio`
 in `test/test_core_photon_tables.py`.
 
 ## Entry points
@@ -124,6 +134,11 @@ in `test/test_core_photon_tables.py`.
   (checked). The two kaon tables carry no `a_a` column at all and say so
   in their header comments (`# missing: a_a`). The analytic line is the
   whole `X → γγ` contribution in every one of the four.
-- Sequencing against the corpus is the real cost, as with its siblings:
-  one declared regeneration after Phase 06 Task 6.4 covering all four
-  defects is cheaper than four.
+- Sequencing against the corpus was the real cost, and the "one declared
+  regeneration after Phase 06 Task 6.4" this line proposed was never an
+  available move — see
+  [`projects/parity-pinned-defect-repair/references/the-premise.md`](../../../projects/parity-pinned-defect-repair/references/the-premise.md).
+  What shipped instead is a declared delta against the arrays as they
+  stand: `test/parity/deltas.py` keys the six `spectra.photon.eta_prime`
+  arrays this repair moves to a composite of the A1 boost capture and
+  this line's second copy, and the corpus is not rewritten.

--- a/docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
+++ b/docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
@@ -22,7 +22,11 @@
   adds a second copy of a line term the stored spectrum already carries
   once, so the expected per-position delta is
   `BR_ETAP_TO_A_A · boost_delta_function(M_η′/2, …)` — computable from a
-  constant and from `hazma/_utils/boost.pyx`, which is still live.
+  constant and from `boost_delta_function`. This bullet named
+  `hazma/_utils/boost.pyx` as that function's home and called the file
+  live; `cython-to-rust` Task 6.4 has since deleted it, so the model
+  reads `hazma._core.boost` — a kernel this repair does not touch, and
+  one whose window arithmetic the model has to match bit for bit.
   So this repair is schedulable now, independently of the port's
   remaining phases. Sequenced in
   [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);

--- a/docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
+++ b/docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
@@ -18,7 +18,11 @@
   but the corrected values need no Cython oracle: both line energies are
   closed forms, `(M_φ² − m²)/(2 M_φ)`, so the expected delta is the two
   boosted line terms recomputed there minus the two the corpus stored,
-  and `hazma/_utils/boost.pyx` still supplies `boost_delta_function`.
+  built from `boost_delta_function`. This bullet named
+  `hazma/_utils/boost.pyx` as that function's home; `cython-to-rust`
+  Task 6.4 has since deleted it, so the model reads `hazma._core.boost` —
+  a kernel this repair does not touch, and one whose window arithmetic
+  the model has to match bit for bit.
   So this repair is schedulable now, independently of the port's
   remaining phases. Sequenced in
   [`projects/parity-pinned-defect-repair/PLAN.md`](../../../projects/parity-pinned-defect-repair/PLAN.md);

--- a/projects/parity-pinned-defect-repair/PLAN.md
+++ b/projects/parity-pinned-defect-repair/PLAN.md
@@ -561,6 +561,18 @@ population at execution time rather than trusting this paragraph, and
 sweep the behavior words as well as the task id
 (`[settling-a-deferral-has-two-sweeps]`).
 
+Also in scope, and a second class rather than a second copy: the
+**twin-liveness** claims. `references/defect-blast-radius.md`'s roster
+table annotates each Group A twin `(live)` and its lead-in says Group A
+"still has a live Cython twin and is on the clock for its oracle
+capture"; `references/corpus-repinning.md`'s Task 2 protocol says
+`test/test_core_boost.py` "already drives `hazma._utils.boost`". Task 2
+is complete and Task 6.4 left no `.pyx` in the tree, so all of that is
+now false in a live `references/` file. Sweep on the liveness claim
+(`still live`, `(live)`, `still supplies`) as well as on the task id —
+PR #94's review found the same sentence surviving in two follow-ups
+after the plan itself had been corrected.
+
 Also in scope: the "Risks" sections of the seven follow-ups, which still
 propose "one declared regeneration after Phase 06 Task 6.4". Those were
 deliberately left standing when the blocker bullets were rewritten, so

--- a/projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md
+++ b/projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md
@@ -38,11 +38,14 @@ value under the case's existing budget. Concretely:
 - The committed arrays and manifest are never rewritten.
 - A declaration names the repair (from a closed roster), the positions
   it covers, the relation, the measurement that justifies the
-  relation's own budget, and the file holding the evidence.
-- A relation answers one question — what the repaired array should be.
-  It may say so as a term added to the stored array or as a closed-form
-  transform of it; either way the runner compares against the array it
-  predicts.
+  relation's own budget, and the file holding the evidence. Where two
+  repairs move the same array it names both, joined by `+`, and one
+  relation covers them — never two overlapping declarations.
+- A relation answers one question — what the repaired array should be —
+  and the runner compares against the array it predicts. How it reaches
+  that prediction is open: a term added to the stored array, a
+  closed-form transform of it, a value a second implementation computes,
+  or one of those with a further repair's term composed on top.
 - A declaration covers only the positions its mechanism moves: either an
   explicit tuple every entry of which the relation moves, or `MOVED`,
   resolved at comparison time against the array the relation predicts.

--- a/projects/parity-pinned-defect-repair/references/corpus-repinning.md
+++ b/projects/parity-pinned-defect-repair/references/corpus-repinning.md
@@ -58,15 +58,19 @@ strongest the physics supports:
 | Relation | Use when | Example |
 | --- | --- | --- |
 | `Exact(f)` | the repaired array is a closed-form transform of the stored one | rho `rest`: repaired == stored × `E_γ` |
-| `Oracle(path)` | a Task 2 capture holds the corrected value | all four Group A repairs |
 | `Additive(term)` | the delta is a computable additive term | η′: `+ BR · boost_delta_function(M/2, …)` |
-| `Bounded(lo, hi, sign)` | only a magnitude and a sign are known | fallback; requires a written justification |
+| `Reference(fn)` | only a second implementation can say what the value should be | all four Group A repairs, via a Task 2 capture; B6, via scipy |
+| `Composed(base, added)` | a second repair moves an array the first already declares | `A1+B1` on `spectra.photon.eta_prime` |
 
-`Bounded` is the escape hatch and should be rare. A repair that can only
-say "it got bigger" has not been characterized, and
-`docs/agents/lessons.md` `[exemption-wider-than-its-mechanism]` is about
-exactly this: a carve-out written wider than the mechanism that earned it
-only ever loosens, so nothing turns red when it is wrong.
+`test/parity/deltas.py`'s module docstring is authoritative for the set —
+this table is the guidance, not the enumeration, and a repair that adds a
+relation adds it there. What does *not* change is the standard: name the
+mechanism, not a bound on it. A repair that can only say "it got bigger"
+has not been characterized, and `docs/agents/lessons.md`
+`[exemption-wider-than-its-mechanism]` is about exactly this — a carve-out
+written wider than the mechanism that earned it only ever loosens, so
+nothing turns red when it is wrong. No repair has needed such a fallback,
+and none should be added without one.
 
 ### How the runner uses it
 

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -26,7 +26,7 @@ section tracks live *status*.
 | 2 | Capture the corrected-value oracles | — | **Complete** | `task-2-cython-oracles.md` |
 | 3 | Closed-form delta models (B1–B3) | 1 | **Complete** — models in `deltas.DELTA_MODELS`, keys land with the repairs | `task-3-closed-form-deltas.md` |
 | 4 | Repair A1 — boost integral window | 1, 2 | **Complete** | `task-4-boost-window.md` |
-| 5 | Repair B1 — η′ line weight | 3, 4 | Not started | `task-5-eta-prime-line.md` |
+| 5 | Repair B1 — η′ line weight | 3, 4 | **Complete** — declared as the composite `A1+B1` | `task-5-eta-prime-line.md` |
 | 6 | Repair B2 — φ line energies | 3, 4 | Not started | `task-6-phi-lines.md` |
 | 7 | Repair A2 — muon photon endpoint | 1, 2 | Not started | `task-7-photon-muon-endpoint.md` |
 | 8 | Repair A3 — charged-pion forward cone | 7 | Not started | `task-8-charged-pion-cone.md` |
@@ -219,10 +219,17 @@ this project is time-critical.
   left them. Worth checking for the same shape on any defect inherited
   verbatim from a `.pyx`.
 
+- **A Group A capture carries every *other* defect its case had.**
+  `oracles/defects.py` patches exactly one `.pyx` per defect, so
+  `oracles/data/A1.npz` was taken from a restored Cython η′ that still
+  wrote a bare `BR`. That is what makes `A1 capture + B1 term` the
+  repaired value rather than a double-count, and the same holds for φ and
+  B2 (Task 5). A capture is a corrected value for *its* defect only.
+
 ## Numerical impact so far
 
-**Four public values have moved: B4 in PR #87, B5 in Task 10a, B6 in
-Task 13, and A1 in Task 4** (bullets below).
+**Five public values have moved: B4 in PR #87, B5 in Task 10a, B6 in
+Task 13, A1 in Task 4 and B1 in Task 5** (bullets below).
 
 **A1 — all seven tabulated photon spectra.** Measured on the corpus's
 own grids (10,045 positions, 35 blocks) against a build carrying the
@@ -243,6 +250,26 @@ rest-frame spectrum to better than 1% over `E_γ` from `m/20` to `3m/10`,
 against the 6,500x–33,000x the follow-up measured. The repaired kernel
 reproduces Task 2's Cython oracle **bit for bit** at all 10,045
 positions. Details: `task-4-boost-window.md`.
+
+**B1 — `dnde_photon_eta_prime`, and `dnde_photon` on any final state
+carrying an η′.** Measured before and after on the same worktree by
+reverting the constant, rebuilding the editable install, and diffing the
+two captures. The spectrum rises at every parent energy above rest and is
+unchanged at `E = M_η′`, where the kernel takes its rest-frame arm and
+adds no line: 7/601 grid points move at `E = 1.001 M`, 137/601 at
+`1.5 M`, 325/601 at `5 M`, all upward, by 7.7e-04 to 1.0 relative. The
+n-body path moves with it (36/201 on `["etap", "etap"]`, 45/201 on
+`["etap", "eta"]`, 0/201 on `["eta", "eta"]`). The yield rises by
+**exactly `BR_ETAP_TO_A_A` = 0.02307 photons per decay** at any boost —
+a boosted δ-function integrates to its own weight — which is 0.603% of
+the repaired 3.8291 over `1e-3 ≤ E ≤ E_parent` at `E_parent = 2 M`.
+`PLAN.md`'s pre-repair 0.63% was over a narrower total; quote the yield
+rather than the percentage. On the corpus: 189 positions over 6 of this
+case's 10 value arrays, none in either `rest` array and none at the
+scalar probe of `rest_plus_eps` or `near_rest`. The four `X → γγ` line
+integrals now all equal their declared weight to a ratio of
+1.0000000000. `spectra.photon.{eta,long_kaon,short_kaon,omega,phi}` are
+bit-identical across the rebuild. Details: `task-5-eta-prime-line.md`.
 
 **B6 — both mediator `thermal_cross_section`, and `relic_density`
 through them.** Measured on the two corpus cases' own grids (570
@@ -341,8 +368,8 @@ Reach: B1 six arrays / 189 positions, B2 six / 305, B3 four / 350.
 Tasks 4–10 each move a published spectrum by design, and each records the
 function, the grid and the max shift here in its own PR (`../rules.md`
 rule 10). Task 12 aggregates this section into the `CHANGELOG.md` entry —
-it does not reconstruct it. B4, B5 and B6 have each written their own
-`CHANGELOG.md` entry already, B5's and B6's under `[Unreleased]` because
+it does not reconstruct it. B4, B5, B6, A1 and B1 have each written their
+own `CHANGELOG.md` entry already, all but B4's under `[Unreleased]` because
 2.2.0 is released; Task 12 renames that heading rather than re-deriving
 it, and
 `preflight.sh --closing` greps for `## [<new version>]`, so it must.
@@ -354,6 +381,17 @@ it, and
   doubled term of a quadrature, which no transform of the stored array
   rebuilds. `test/parity/oracle_reference.py` is the single reader for
   all four.
+- **Two repairs on one array declare one `Composed` relation, labelled
+  `A1+B1`** (Task 5). `../rules.md` rule 7's first real case: A1 and B1
+  move 18 of the same positions on `spectra.photon.eta_prime`, so neither
+  disjointness nor a second key was available. `deltas.Composed` predicts
+  a base relation's array with each further repair's `Additive` term on
+  top, `deltas.repair_labels` splits the label back into roster entries,
+  and `REPAIRS` stays the closed set of ten. Amends ADR-0001.
+- **A composite covers only the arrays *every* named repair moves**
+  (Task 5): two of A1's eight `eta_prime` arrays keep A1's declaration
+  alone, because B1 moves nothing at their scalar probe. Naming B1 there
+  would be a label wider than its mechanism.
 - **A relation's budget is the case's own where the port is bit-faithful**
   (Task 4): A1 carries `tolerances.TABULATED_RTOL` = 1e-12 against a
   measured 0.0, because the capture is one platform's and the declared
@@ -482,6 +520,23 @@ relation, and the reader A2/A3/A4 reuse), `test/parity/deltas.py`,
 `../PLAN.md`, `../references/defect-blast-radius.md`, this file, and
 `task-4-boost-window.md` (new). `test/parity/data/` untouched.
 
+### Task 5 (B1)
+
+`rust/src/kernels/photon_tables.rs` (the doubled weight, its doc comment,
+the doubled folded-constant bit pattern, the renamed weight test),
+`test/test_core_photon_tables.py` (`SPECTRA["eta_prime"]`'s weight and the
+renamed `TestPhysics` test), `test/parity/deltas.py` (the `Composed`
+relation, `repair_labels`, `_A1_B1`, six re-pointed keys),
+`test/parity/test_parity.py` (composite labels in the model shape test),
+`CHANGELOG.md`,
+`docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md`,
+`../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`,
+`../references/corpus-repinning.md` (the Relations table, which named two
+relations that were never built and neither that were), this file, and
+`task-5-eta-prime-line.md` (new). `EXPECTED_DECLARED_ARRAYS` stays 98 —
+this task re-points keys rather than adding them. `test/parity/data/`
+untouched.
+
 ### Task 13 (B6)
 
 `rust/src/kernels/vector_xs.rs`, `rust/src/kernels/scalar_xs.rs`
@@ -540,14 +595,13 @@ has no `hazma._core` test probes for the suite to import.
 
 ## Open Questions
 
-- **Do B1's and B2's declared arrays collapse into A1's?** Answered in
-  part, and it is now the sharpest question in the project. A1 declares
-  `MOVED` on all four non-rest blocks of `spectra.photon.eta_prime` and
-  `spectra.photon.phi`, both suffixes, so every array B1 and B2 land on
-  already carries a declaration. `../rules.md` rule 7 forbids an overlap
-  and `DECLARED_DELTAS` maps one key to one `Delta`, so Tasks 5 and 6
-  build one composite relation per shared array rather than adding keys.
-  `task-4-boost-window.md`'s handoff has the mechanics.
+- **Do B1's and B2's declared arrays collapse into A1's?** Answered for
+  B1 (Task 5): they do, through a new `deltas.Composed` relation and the
+  label `A1+B1`, and they had to — A1 and B1 move 18 of the same
+  positions. Two of A1's eight `eta_prime` arrays keep A1's declaration
+  alone, because B1 reaches neither scalar probe. Task 6 repeats the
+  shape for `A1+B2` and re-derives which of φ's arrays B2 actually moves
+  rather than assuming six.
 - **Do A2's and A3's declared positions on the two rho cases actually
   overlap, or only appear to?** They are different mechanisms (an
   endpoint guard and a lost quadrature support) reaching the same arrays
@@ -565,12 +619,14 @@ has no `hazma._core` test probes for the suite to import.
   The sweep of the remaining `quad` call sites has not been done —
   [`neutrino-pion-continuum-loses-its-quadrature-support.md`](../../../docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md)
   carries it as its own first question.
-- **Will Group B's relation budgets survive their repairs?** B1 and B2
-  carry `rtol` 1e-11 and B3 1e-9, each derived from the case's own budget
-  rather than measured against a repaired kernel, which cannot exist yet.
-  Tasks 5, 6 and 9 measure the real figure and tighten; a repair needing
-  a *wider* one has found something Task 3 did not model (`rules.md`
-  rule 2).
+- **Will Group B's relation budgets survive their repairs?** B1's did,
+  and then some: the composite measured 2.1e-16 against the repaired
+  kernel — one ulp — where the standalone model reserved 1e-11. It is
+  declared at the case's own 1e-12 rather than tightened to what it
+  measures, for A1's reason (the capture is one platform's). B2 and B3
+  still carry 1e-11 and 1e-9 unmeasured; Tasks 6 and 9 measure. A repair
+  needing a *wider* budget has found something Task 3 did not model
+  (`rules.md` rule 2).
 - **Should the Task 2 oracles stay committed after `cython-to-rust`
   closes?** They are the last evidence that a repaired value was ever
   checked against a non-Rust implementation. Anticipated ADR.
@@ -600,12 +656,14 @@ has no `hazma._core` test probes for the suite to import.
   the worked precedent for A2, A3 and A4 — they need no new machinery.
 - `test/parity/data/` is intact — `python test/parity/generate.py --check`
   verifies it in under a second with no build.
-- B4 (PR #87), B5 (Task 10a), B6 (Task 13) and A1 (Task 4) are the
-  repairs that have changed a library value; every other corpus array is
-  still compared against its stored value. `test/parity/deltas.py`
-  declares 98 arrays — 30 for B4, 6 for B5, 6 for B6, 56 for A1 — and
+- B4 (PR #87), B5 (Task 10a), B6 (Task 13), A1 (Task 4) and B1 (Task 5)
+  are the repairs that have changed a library value; every other corpus
+  array is still compared against its stored value.
+  `test/parity/deltas.py` declares 98 arrays — 30 for B4, 6 for B5, 6 for
+  B6, 50 for A1 alone and 6 for the composite `A1+B1` — and
   `test_parity.EXPECTED_DECLARED_ARRAYS` is the literal that makes a
-  change to that number show up in a diff.
+  change to that number show up in a diff. Re-derive the split with
+  `Counter(d.repair for d in deltas.DECLARED_DELTAS.values())`.
 - The measurement recipe every remaining repair task needs: capture the
   corpus blocks from a build carrying the defect, restore the repair,
   rebuild, capture again, and diff *those* — not the live tree against
@@ -613,19 +671,21 @@ has no `hazma._core` test probes for the suite to import.
   repair (Findings). On this worktree Task 4's defective build
   reproduced the stored corpus bit for bit on all 10,045 A1 positions,
   so the two agreed; that is this platform, not a general fact.
-- B1, B2 and B3 have finished, corpus-checked delta models in
+- B2 and B3 have finished, corpus-checked delta models in
   `deltas.DELTA_MODELS`, and B3's arrays are still undeclared, so Task 9
   adds keys and bumps `EXPECTED_DECLARED_ARRAYS` in the ordinary way.
-  **Tasks 5 and 6 cannot**: A1 already declares every array B1 and B2
-  move, and one key holds one `Delta`, so those two compose with A1's
-  relation instead — `task-4-boost-window.md`'s handoff has the
-  mechanics, and the position counts in `task-3-closed-form-deltas.md`
-  are to be re-derived against the repaired kernel rather than pasted.
-- The delta layer now carries three relations. A new repair picks
+  **Task 6 cannot**: A1 already declares every array B2 moves, and one
+  key holds one `Delta`, so it composes as `A1+B2` the way Task 5 did for
+  B1 — `task-5-eta-prime-line.md` is the worked precedent, and the
+  position counts in `task-3-closed-form-deltas.md` are to be re-derived
+  against the repaired kernel rather than pasted. Task 5's held exactly;
+  that is one case, not a rule.
+- The delta layer now carries four relations. A new repair picks
   `Additive` when the physics names the term, `Exact` when a closed form
-  transforms the stored array, and `Reference` when only a second
-  implementation can say what the value should be; all three answer
-  `expected`, and the runner needs no change for any of them.
+  transforms the stored array, `Reference` when only a second
+  implementation can say what the value should be, and `Composed` when a
+  second repair moves an array the first already declares; all four
+  answer `expected`, and the runner needs no change for any of them.
 
 **Currently risky / unknown:**
 
@@ -633,9 +693,12 @@ has no `hazma._core` test probes for the suite to import.
   measured. Treat it as where to look, never as what you will find. B5 is
   the sharpest case so far: the table's coverage arithmetic said both
   `spectra.neutrino.*` cases were untouched, and one of them was not.
-- A repair's own follow-up can understate its magnitude by orders of
-  magnitude. B5's predicted 0.06% local shift measured at a factor of
-  two, because the follow-up sampled only the plateau. Re-derive every
-  figure before quoting it in a `CHANGELOG.md` entry.
+- A repair's own follow-up can misstate its magnitude in either
+  direction. B5's predicted 0.06% local shift measured at a factor of
+  two, because the follow-up sampled only the plateau; B1's predicted
+  0.63% measured at 0.603%, because a *percentage of a yield* depends on
+  the integration window while the absolute shift does not. Re-derive
+  every figure before quoting it in a `CHANGELOG.md` entry, and prefer
+  the window-independent statement where the physics offers one.
 - Every deadline in this plan depends on `cython-to-rust`'s pace, which
   this project does not control and must not assume.

--- a/projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md
+++ b/projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md
@@ -1,0 +1,507 @@
+# Task 5: Repair B1 — the η′ two-photon line weight
+
+**Date:** 2026-09-07
+**Project:** parity-pinned-defect-repair
+**Status:** Complete
+**Plan References:** `../PLAN.md` "Task 5", "Numerical impact"; `../rules.md`
+rules 1–7, 10, 11; `../references/corpus-repinning.md` (the shape tests);
+`../references/defect-blast-radius.md` (B1's row)
+**Related ADRs:** `../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`
+(amended: a declaration may name more than one repair)
+**Depends On:** Task 3 (the B1 model), Task 4 (A1, which declares the same
+arrays)
+
+## Objective
+
+Give the η′'s `η′ → γγ` line the factor of two its three `X → γγ`
+siblings carry, and declare the resulting corpus shift as a composite of
+this repair and the A1 boost repair that already owns the same arrays.
+
+## Exit Criteria
+
+- `ETAP_TO_A_A_WEIGHT` is `2 · BR(η′ → γγ)`, and the two tests that pinned
+  the shipped defect are renamed as well as re-pointed.
+- The line-term integral measures `2 · BR = 0.04614` photons per decay,
+  against the `0.02306998 ± 1.3e-08` the follow-up measured pre-repair.
+- A declared delta on `spectra.photon.eta_prime` only. `spectra.photon.eta`,
+  `spectra.photon.long_kaon` and `spectra.photon.short_kaon` — the three
+  siblings that were already right — do not move.
+- The declaration composes with A1's rather than overlapping it
+  (`../rules.md` rule 7), and reverting either repair turns the gate red.
+- `git diff --stat -- test/parity/data` empty.
+
+## Inputs Reviewed
+
+- `../PLAN.md` — Goal, "The premise this project corrects", "Numerical
+  impact", Task 5, Task 6, "Anticipated ADRs".
+- `../rules.md` — all eleven.
+- `task-notes/README.md` — Tasks table, Open Questions, Handoff.
+- `task-3-closed-form-deltas.md` Handoff (the B1 model and its predicted
+  keys), `task-4-boost-window.md` Open Questions + Handoff (the composite
+  constraint this task inherits).
+- `../references/corpus-repinning.md` §"Shape tests", `defect-blast-radius.md`
+  (B1's row and the A1/B1 overlap).
+- `docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md`.
+- `test/parity/deltas.py`, `test_parity.py`, `oracle_reference.py`,
+  `test_delta_models.py`, `oracles/{defects,entry_points}.py`.
+- `rust/src/kernels/photon_tables.rs`, `test/test_core_photon_tables.py`.
+
+## Findings
+
+- **The A1 capture for this case carries B1's defect, which is what makes
+  the composite well-defined.** `oracles/entry_points.py` resolves
+  `spectra.photon.eta_prime` to the restored Cython `_eta_prime.pyx`
+  (`_TABLES_RESTORED`, deleted at `0954e5a`), and `oracles/defects.py`
+  patches exactly one `.pyx` per defect — for A1 that is
+  `hazma/_utils/boost.pyx`. So `oracles/data/A1.npz` holds the boost
+  repair alone, over a kernel that still writes a bare `BR`. The repaired
+  value is therefore that capture plus a second copy of the line.
+- **A1's and B1's positions genuinely overlap; the composite is required,
+  not a convenience.** 18 of B1's 189 positions are ones A1 also moves,
+  distributed unevenly: all 9 of `rest_plus_eps.values`, 3 of
+  `near_rest.values`, 0 of `boosted_mild.scalar_values`, 3 of
+  `boosted_mild.values`, 1 of `boosted_strong.scalar_values` and 2 of
+  `boosted_strong.values`. Neither "provably disjoint" nor "one contains
+  the other" was available.
+- **Two of A1's eight `eta_prime` arrays keep A1's declaration alone.**
+  B1 moves nothing at the scalar probe of `rest_plus_eps` or `near_rest`
+  — the probe falls outside the line's boosted window at those two parent
+  energies — so declaring the composite there would name a repair the
+  array never saw (`../rules.md` rule 5).
+- **Task 3's predicted reach held exactly.** Six arrays, 189 positions,
+  the same six keys, re-derived against the repaired kernel rather than
+  inherited (`../rules.md` rule 11). `test_delta_models.EXPECTED_REACH`
+  needs no change: it measures the standalone B1 model against the stored
+  corpus, and neither moved.
+- **Every move is upward, and the `rest` block is untouched.** 189 of 189
+  positions rise, by 7.7e-04 to 1.0 relative. Both `rest` arrays are
+  unchanged, because the kernel short-circuits to its rest-frame spectrum
+  at `E − m < DBL_EPSILON` and that arm adds no line at all — the same
+  reason `rest` is absent from A1's declaration.
+- **The composite is one ulp from the repaired kernel, not bit-exact.**
+  The kernel folds a single `2·BR` weight into the boost's own fused
+  multiply-add; the prediction adds a second `BR` copy afterwards. That
+  association difference is the whole residue: 2.1e-16 worst.
+
+## Decisions and Implementation Notes
+
+- **A fourth relation, `Composed`, rather than a hand-summed callable.**
+  `deltas.Composed(base, added, rtol, why)` predicts the base relation's
+  array with each `Additive` addend's term on top. Writing the sum as a
+  bespoke `Reference` callable would have worked and been shorter, but it
+  would have hidden the second repair from everything that reads the
+  table — Task 12's aggregation included. Tasks 6 (A1+B2 on `phi`) and
+  possibly 8 (A3+B4 on the scalar decay case) need the same shape, so the
+  mechanism is built once here. The addends are typed `Additive` because
+  an addend has to leave room for what came before it, which `Exact` and
+  `Reference` do not.
+- **`Composed.expected` copies the base's dict before adding.** A
+  `Reference` base hands back `oracle_reference`'s `@cache`d arrays, which
+  are read-only and shared by every comparison that reads them; updating
+  in place would poison the capture for the rest of the run.
+- **`REPAIRS` stays the closed set of ten roster labels.** A composite
+  spells its label `"A1+B1"` and `deltas.repair_labels` splits it, so the
+  roster keeps exactly one meaning and the close still aggregates per
+  defect. `test_every_delta_model_is_a_roster_repair_with_its_evidence`
+  now checks each part against `REPAIRS`, rejects a repeated part, and —
+  the point of the change — requires a multi-part label to carry a
+  `Composed` with one addend per extra part. A composite spelling on a
+  plain relation would otherwise claim a repair the array never saw.
+- **The composite holds at `rtol = 1e-12`, the case's own
+  `tolerances.TABULATED_RTOL`, not at the 2.1e-16 measured.** Same reason
+  A1 gives for its own budget: the capture is one platform's, and a libm
+  that moves the boost integral must not fail at declared positions while
+  the undeclared positions of the same block still pass. It is not a
+  widening — 1e-12 is what these six arrays were already held to under
+  A1 alone.
+- **`SPECTRA["eta_prime"]` in `test/test_core_photon_tables.py` had to
+  move with the kernel.** `test_each_line_carries_the_photon_count_its_
+  weight_declares` measures the kernel's line term against that table's
+  declared weight, so the table is the independent statement of the
+  physics and not a mirror of the constant. Leaving it would have turned
+  that test red; changing it is what keeps the measurement a measurement.
+- **Both defect-pinning tests were renamed to state the repaired physics
+  over all four siblings**, per `docs/agents/lessons.md`
+  `[test-name-claims-an-unmade-assertion]`:
+  `the_eta_prime_line_is_missing_its_factor_of_two` →
+  `every_two_photon_line_carries_twice_its_branching_ratio`, and
+  `TestPhysics::test_the_eta_prime_line_carries_half_the_photons_it_should`
+  → `TestPhysics::test_every_two_photon_line_carries_twice_its_branching_ratio`.
+  Both now assert the η′ *with* its three siblings rather than against
+  them, and both keep an `assert_ne`/explicit-value line so a revert to
+  the shipped weight fails on the number.
+- **`folded_constants_match_the_shipped_object_code` keeps pinning the η′
+  weight, against twice the shipped immediate.** `0x3f97_9fa9_7e13_2b56`
+  → `0x3fa7_9fa9_7e13_2b56`: doubling only increments the exponent field,
+  so the mantissa is the shipped one digit for digit, and the test still
+  says where the constant came from.
+
+## Files Changed
+
+- `rust/src/kernels/photon_tables.rs` — `ETAP_TO_A_A_WEIGHT` is
+  `2.0 * pdg::BR_ETAP_TO_A_A`; its doc comment, the module docstring's
+  folded-constants paragraph, the folded-constant bit pattern, and the
+  renamed weight test.
+- `test/test_core_photon_tables.py` — `SPECTRA["eta_prime"]`'s line
+  weight, the table's comment, and the renamed `TestPhysics` test.
+- `test/parity/deltas.py` — the `Composed` relation, `repair_labels`, the
+  `_A1_B1` declaration, six re-pointed `eta_prime` keys, and the module
+  docstring's Relations section.
+- `test/parity/test_parity.py` — the model shape test now validates
+  composite labels.
+- `CHANGELOG.md` — the `[Unreleased] / Changed` entry for this repair,
+  stating the yield rather than a percentage of it.
+- `docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md` —
+  status annotated as repaired; the renamed tests, the surviving Rust
+  expression, and the magnitude to quote in `CHANGELOG.md` corrected.
+- `projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`
+  — the two Decision bullets this task made incomplete.
+- `../references/corpus-repinning.md` — the Relations table, which still
+  named two relations that were never built (`Oracle`, `Bounded`) and
+  neither of the two that were. It now points at `deltas.py`'s docstring
+  as the enumeration and keeps only the guidance, so it stops going stale
+  each time a relation is added.
+- `projects/parity-pinned-defect-repair/task-notes/README.md`,
+  `.../task-5-eta-prime-line.md` — bookkeeping.
+
+## Numerical impact
+
+**`hazma.spectra.dnde_photon_eta_prime` moves at every parent energy above
+rest; five sibling spectra and the `E = M_η′` rest case do not.** Measured
+before and after on the same worktree, by reverting the Rust constant,
+rebuilding the editable install, capturing, restoring (`cmp`-verified) and
+rebuilding again.
+
+Grid: `np.geomspace(1.0, 5 * M_η′, 601)` MeV at four parent energies.
+
+| Entry point | `E_parent` (MeV) | moved | relative shift | direction |
+| --- | --- | ---: | --- | --- |
+| `dnde_photon_eta_prime` | 957.78 (`= M`) | 0/601 | — | — |
+| `dnde_photon_eta_prime` | 958.73778 | 7/601 | 9.64e-01 … 1.00 | up |
+| `dnde_photon_eta_prime` | 1436.67 | 137/601 | 2.57e-03 … 1.00 | up |
+| `dnde_photon_eta_prime` | 4788.90 | 325/601 | 1.18e-03 … 1.00 | up |
+| `dnde_photon_{eta,long_kaon,short_kaon,omega,phi}` | all four | 0/601 each | — | — |
+
+The n-body public path, `hazma.spectra.dnde_photon(E, cme, states)` on
+`np.geomspace(1, 2000, 201)` MeV at `cme = 2.5 M_η′`:
+
+| Final state | moved | relative shift |
+| --- | ---: | --- |
+| `["etap", "etap"]` | 36/201 | 6.48e-03 … 1.00 |
+| `["etap", "eta"]` | 45/201 | 1.78e-03 … 1.00 |
+| `["eta", "eta"]` | 0/201 | — |
+
+**Yield.** `scipy.integrate.quad` over `1e-3 ≤ E ≤ E_parent` at
+`E_parent = 2 M_η′`: 3.80607171 → 3.82914171 photons per decay, a rise of
+**0.02307000 = `BR_ETAP_TO_A_A` exactly**, which is **0.603%** of the
+repaired total. `dnde_photon_eta` is unchanged at 3.30197000. The absolute
+rise is the invariant — a boosted δ-function integrates to its own weight
+at any boost — while the percentage depends on the integration window,
+which is why `PLAN.md`'s pre-repair 0.63% estimate does not reproduce.
+
+**Physics invariant (`../rules.md` rule 4).** The line term alone, isolated
+by subtracting the boosted continuum and integrated with QUADPACK over the
+line's window at `E_parent = 2 M`:
+
+```text
+eta         line integral = 0.78820000 +/- 8.8e-15   weight 0.78820000   ratio 1.0000000000
+eta_prime   line integral = 0.04614000 +/- 5.1e-16   weight 0.04614000   ratio 1.0000000000
+long_kaon   line integral = 0.00109400 +/- 8.4e-17   weight 0.00109400   ratio 1.0000000000
+short_kaon  line integral = 0.00000526 +/- 3.0e-17   weight 0.00000526   ratio 1.0000000000
+```
+
+`0.04614000` is the `2 · BR` the Exit Criteria name, against the
+`0.02306998 ± 1.3e-08` the follow-up measured pre-repair — a factor of
+2.0000009 on the follow-up's own figure, and 2 exactly on the constant.
+
+**Corpus.** 6 arrays, 189 positions, all in `spectra.photon.eta_prime`;
+the other six tabulated photon cases are bit-identical across the rebuild.
+
+| Block | Suffix | moved / size | relative shift | also moved by A1 |
+| --- | --- | ---: | --- | ---: |
+| `rest` | both | 0 / 285, 0 / 8 | — | 0 |
+| `rest_plus_eps` | `values` | 9 / 285 | 1.00 | 9 |
+| `rest_plus_eps` | `scalar_values` | 0 / 8 | — | — |
+| `near_rest` | `values` | 20 / 285 | 2.12e-02 … 1.00 | 3 |
+| `near_rest` | `scalar_values` | 0 / 8 | — | — |
+| `boosted_mild` | `values` | 57 / 285 | 1.47e-03 … 1.00 | 3 |
+| `boosted_mild` | `scalar_values` | 2 / 8 | 2.02e-03 … 7.89e-02 | 0 |
+| `boosted_strong` | `values` | 98 / 285 | 7.66e-04 … 1.00 | 2 |
+| `boosted_strong` | `scalar_values` | 3 / 8 | 7.66e-04 … 1.27e-02 | 1 |
+
+`git diff --stat -- test/parity/data` is empty (`../rules.md` rule 1).
+
+## Verification
+
+```text
+$ env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh \
+      --paths "test/parity/deltas.py test/parity/test_parity.py \
+               test/test_core_photon_tables.py" \
+      --md "<the four touched markdown files>"
+RESULT: PASS
+  black 3 files, isort 0 new (2 fixed), ruff 0 new (2 fixed),
+  cargo fmt/clippy/test, import hazma 2.2.0, markdownlint, forbidden
+  tokens none added, and
+  pytest  2286 passed, 15 skipped, 1 warning, 37 subtests passed in 25.30s
+
+$ .venv/bin/python -m pytest test/parity -q -n 0
+687 passed, 1 skipped in 6.39s
+
+$ .venv/bin/python -m pytest test/test_core_photon_tables.py -q -n 0
+190 passed, 1 skipped in 0.81s
+
+$ .venv/bin/python -m pytest test/parity/test_delta_models.py -q -n 0
+17 passed in 0.26s
+
+$ cargo test --manifest-path rust/Cargo.toml --no-default-features \
+      --features test-probes
+test result: ok. 263 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+The preflight `pytest` row is the full suite and is the run that gates the
+commit. It reads 15 skipped where a bare `.venv/bin/python -m pytest`
+reads 24, because nine `test/agents/test_lint_delta.py` cases shell out to
+`ruff` and `isort` on `PATH`, which only preflight's invocation puts
+there. The remaining 15 are the project's standing skips — 10 "known to
+be broken" form factors, 3 vector form factors, the charged kaon's absent
+monochromatic line, and `test_parity`'s provenance notice — none of them
+touched here. The one warning is the pre-existing `SyntaxWarning` in
+`hazma/vector_mediator/_vector_mediator_fsr.py`.
+
+What the tests cover, by category:
+
+- **The repaired constant, in Rust:** `photon_tables::tests::
+  every_two_photon_line_carries_twice_its_branching_ratio` (all four
+  `X → γγ` weights are `2·BR`, and the η′ is *not* the bare `BR`),
+  `folded_constants_match_the_shipped_object_code` (the doubled bit
+  pattern).
+- **The physics invariant, in Python:** `TestPhysics::
+  test_each_line_carries_the_photon_count_its_weight_declares` integrates
+  the isolated line term for all seven spectra against the weight the test
+  module declares, at a derived tolerance between 1e-5 and 1e-4;
+  `TestPhysics::test_every_two_photon_line_carries_twice_its_branching_ratio`
+  holds the four `X → γγ` weights together and pins the η′'s at 0.04614.
+- **The corpus gate:** `test_entry_point_matches_corpus` over all 41 cases,
+  which is where the composite declaration is exercised — six arrays
+  against `A1+B1`, two against `A1` alone, two `rest` arrays against the
+  stored values under the case's own budget.
+- **The declaration's shape:** `test_every_declared_delta_addresses_a_real_
+  stored_array`, `test_every_delta_model_is_a_roster_repair_with_its_
+  evidence` (extended here for composite labels),
+  `test_every_declaration_points_at_a_delta_model`,
+  `test_the_declared_arrays_are_counted` (98, unchanged — this task
+  re-points keys rather than adding them).
+- **The model against the stored corpus:** `test_delta_models.py::
+  test_each_model_moves_what_it_says_it_moves[B1]` and
+  `test_the_eta_prime_line_is_stored_at_one_branching_ratio_not_two`, both
+  of which read the committed arrays and no kernel, so they keep saying
+  what the corpus pinned after the repair as before it.
+
+**Test validity (stash-proof).** Reverting the one-line Rust change and
+rebuilding turns four parity cases red before the declaration is added —
+
+```text
+FAILED test_entry_point_matches_corpus[spectra.photon.eta_prime[rest_plus_eps]]
+FAILED test_entry_point_matches_corpus[spectra.photon.eta_prime[near_rest]]
+FAILED test_entry_point_matches_corpus[spectra.photon.eta_prime[boosted_mild]]
+FAILED test_entry_point_matches_corpus[spectra.photon.eta_prime[boosted_strong]]
+4 failed, 1 passed, 645 deselected
+```
+
+— and red again *with* the declaration in place, on the staleness rule
+(`../rules.md` rule 6): the composite's prediction still departs from the
+stored array, so the live value must too. Both directions were run on a
+rebuilt extension, not on `cargo test` alone. The `rest` block passes in
+every configuration, which is the "moved only what it intended" half.
+
+Nothing deferred.
+
+## Open Questions
+
+- **Should `DELTA_MODELS` keep the standalone `B1` entry now that
+  `A1+B1` holds the keys?** It is kept: `test_delta_models.py` gates it
+  against the stored corpus, `EXPECTED_REACH["B1"]` is the re-derivable
+  statement of what B1 alone reaches, and Task 12 aggregates per roster
+  entry. The cost is that `DELTA_MODELS` now has eight entries for seven
+  modelled defects, and a reader has to know that `A1`, `B1` and `A1+B1`
+  are not three independent repairs. Task 12 should say so once when it
+  aggregates rather than leaving it to be inferred.
+- **Does Task 6 need a second composite or can it extend this one?** A
+  second: `A1+B2` is a different case (`spectra.photon.phi`) and a
+  different addend, so it is another `Composed` beside this one, not a
+  third part of this label.
+- Inherited and still open: whether the Task 2 oracles stay committed
+  after `cython-to-rust` closes (`README.md` Open Questions).
+
+## Plan Impact
+
+**Impact Level:** ADR required (amendment to ADR-0001).
+
+Two of ADR-0001's Decision bullets became incomplete with this task and
+are patched in the same change:
+
+- "A declaration names the repair (from a closed roster)" — a composite
+  names more than one, which rule 7 requires wherever two repairs move the
+  same array. The bullet now says so and points at `repair_labels`.
+- "A relation … may say so as a term added to the stored array or as a
+  closed-form transform of it" — an enumeration that was already missing
+  `Reference` (added by Task 4) and would now also miss `Composed`. It is
+  restated as the invariant the relations share — a relation answers what
+  the repaired array should be, and the runner compares against what it
+  predicts — so it stops going stale each time one is added.
+
+No task ordering, gate, interface or exit criterion changed. `PLAN.md`'s
+Task 5 block is unchanged: its scope notes and its gate figure
+(`2 · BR = 0.04614` against `0.02306998 ± 1.3e-08`) both reproduce. The
+project's `version_bump: minor` is unchanged and still correct — a moved
+published spectrum with no name, signature, shape or unit change.
+
+## Stale-state sweep
+
+```text
+$ git status --short
+ M CHANGELOG.md
+ M docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md
+ M projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md
+ M projects/parity-pinned-defect-repair/references/corpus-repinning.md
+ M projects/parity-pinned-defect-repair/task-notes/README.md
+ A projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md
+ M rust/src/kernels/photon_tables.rs
+ M test/parity/deltas.py
+ M test/parity/test_parity.py
+ M test/test_core_photon_tables.py
+  The new note is `git add -N`'d so the diff below walks it.
+
+$ git diff origin/master --stat --
+ CHANGELOG.md                                       |  21 +
+ ...eta-prime-two-photon-line-missing-factor-two.md |  39 +-
+ .../ADR-0001-corpus-repairs-are-declared-deltas.md |  13 +-
+ .../references/corpus-repinning.md                 |  18 +-
+ .../task-notes/README.md                           | 139 ++++--
+ .../task-notes/task-5-eta-prime-line.md            | 492 +++++++++++++++
+ rust/src/kernels/photon_tables.rs                  |  53 ++-
+ test/parity/deltas.py                              | 131 +++++-
+ test/parity/test_parity.py                         |  21 +-
+ test/test_core_photon_tables.py                    |  38 +-
+ 10 files changed, 848 insertions(+), 117 deletions(-)
+
+$ .venv/bin/python scripts/agents/check_doc_citations.py <the six touched docs>
+docs scanned: 6
+in-repo citations checked: 0
+external citations skipped: 5
+out-of-range or ambiguous: NONE
+  The five skipped are the deleted `.pyx` this repair's history cites --
+  `constants.pxd`, `_eta.pyx`, `_eta_prime.pyx` and `_kaon.pyx` -- which
+  the checker cannot range-check because the port removed the files.
+  `docs/followups/todo/citation-checker-skips-deleted-inrepo-files.md`
+  already carries that gap.
+
+$ git diff --stat -- test/parity/data | wc -l
+0
+  `../rules.md` rule 1 holds: the committed corpus is untouched.
+
+$ git rev-parse --abbrev-ref HEAD && git rev-parse --show-toplevel
+claude/parity-pinned-defect-repair/task-5-eta-prime-line
+/Users/logan.morrison/dev/Hazma/.claude/worktrees/brave-curie-b1ca04
+
+$ grep -rn "the_eta_prime_line_is_missing_its_factor_of_two" . | grep -v '.git/'
+projects/parity-pinned-defect-repair/PLAN.md:345
+$ grep -rn "test_the_eta_prime_line_carries_half_the_photons_it_should" . \
+      | grep -v '.git/'
+projects/parity-pinned-defect-repair/PLAN.md:346
+  Both are PLAN.md's Task 5 scope note naming the pre-repair symbols as the
+  ones this task must rename. That instruction is still a true account of
+  the task, so the block is left as written; the follow-up's two copies
+  were re-pointed to the new names.
+
+$ grep -rnE "TODO|FIXME|breakpoint\(\)|import pdb" \
+      rust/src/kernels/photon_tables.rs test/parity/deltas.py \
+      test/parity/test_parity.py test/test_core_photon_tables.py
+  (no occurrences)
+  preflight's `forbidden tokens` row reports `none added` over the same
+  diff, which also covers stray `print(`.
+
+$ .venv/bin/python -c "import sys; sys.path.insert(0,'test/parity'); import deltas;
+    from collections import Counter;
+    print(len(deltas.DECLARED_DELTAS), Counter(d.repair for d in deltas.DECLARED_DELTAS.values()))"
+98 Counter({'A1': 50, 'B4': 30, 'A1+B1': 6, 'B5': 6, 'B6': 6})
+  Matches `test_parity.EXPECTED_DECLARED_ARRAYS`, which this task does not
+  change: A1 falls 56 -> 50 and those six move to `A1+B1`.
+  50 + 30 + 6 + 6 + 6 = 98.
+
+$ .venv/bin/python -m pytest test/parity/test_delta_models.py -q -n 0
+17 passed in 0.26s
+  `EXPECTED_REACH == {"B1": (6, 189), "B2": (6, 305), "B3": (4, 350)}` still
+  holds unedited: it measures the standalone models against the stored
+  corpus, and neither the models nor the corpus moved.
+
+$ .venv/bin/python -c "import hazma._core; print(hazma._core.__file__)"
+/Users/logan.morrison/dev/Hazma/.claude/worktrees/brave-curie-b1ca04/hazma/_core.abi3.so
+  Every Python-side number in this note was taken after the editable
+  reinstall, on this worktree's own extension.
+
+Bookkeeping consistency: this note's `**Status:**` is `Complete`; the
+Tasks-table cell in `task-notes/README.md` reads
+"**Complete** — declared as the composite `A1+B1`"; that file's
+"Numerical impact so far" opens "Five public values have moved" and
+carries the B1 bullet; "Files Changed" has a `### Task 5 (B1)` roll-up;
+two Open Questions (the A1/B1 collapse, the Group B budgets) are answered
+in place rather than left standing. No phase file and no
+`projects/README.md` row apply — this is a flat project and not its
+closing task.
+
+Numerical-impact statement: `dnde_photon_eta_prime` rises by exactly
+`BR_ETAP_TO_A_A` = 0.02307 photons per decay at every parent energy above
+rest (0.603% of the repaired 3.8291 at `E_parent = 2 M`), and is unchanged
+at `E_parent = M`. `dnde_photon` on an η′-bearing final state moves with
+it. No other public function moves: verified by the before/after diff over
+`dnde_photon_{eta,long_kaon,short_kaon,omega,phi}` at four parent energies
+and `dnde_photon(["eta", "eta"])`, all bit-identical across the rebuild.
+Recorded in `README.md`'s "Numerical impact so far" (`../rules.md`
+rule 10).
+```
+
+## Handoff to Next Task
+
+**Task 6 (B2, the φ line energies) is next and inherits a worked
+precedent for its hardest part.**
+
+- The composite mechanics are built: `deltas.Composed(base, added, rtol,
+  why)` and `deltas.repair_labels`. Task 6 adds `_A1_B2` in the same
+  shape — `base=_A1.relation`, `added=(_B2.relation,)` — keyed under
+  `"A1+B2"` in `DELTA_MODELS`, and re-points the `spectra.photon.phi`
+  keys B2 measurably moves. Nothing in the runner or the shape tests
+  needs changing again.
+- **Re-derive which of φ's eight A1 arrays B2 actually moves, then
+  re-point only those.** Task 3 predicted six; this task's η′ prediction
+  held exactly, but the two `rest_plus_eps`/`near_rest` scalar probes
+  were the arrays that turned out to be B1-free, and B2's relocation is a
+  different mechanism from B1's second copy. `EXPECTED_DECLARED_ARRAYS`
+  stays 98 if the count is six again.
+- The measurement recipe that produced every figure above: capture the
+  corpus blocks from the defective build, revert the one constant, rebuild
+  the **editable install** (not `cargo build`), capture, restore with a
+  `cmp` check, rebuild, and diff those two captures. `cargo test` alone
+  proves nothing about a Python-side number.
+- B2's gate is a *position* assertion, not a yield one — `PLAN.md` Task 6
+  says why, and this task's yield measurement is the counter-example that
+  makes the point concrete: B1 moved the yield by exactly its weight,
+  where B2 moves none of it.
+
+**Currently safe to assume:**
+
+- `test/parity/data/` is still intact and untouched by this project.
+- Four defects have now moved a library value: B4, B5, B6, A1 and B1.
+  `deltas.DECLARED_DELTAS` holds 98 arrays across five declarations, one
+  of which is composite.
+- `../rules.md` rule 7's first real test is answered: A1 and B1 overlap at
+  18 positions, and the composite is the mechanism that carries it.
+
+**Currently risky / unknown:**
+
+- The composite's budget is the case budget, not the 2.1e-16 this platform
+  measures. That is deliberate, but it means a repair that leaks a term
+  into a declared position below 1e-12 would not be caught there. The
+  undeclared positions of the same blocks still hold the line.
+- Task 9's B3 declaration is still an ordinary two-key addition; nothing
+  here changes that, and it should not be composed with anything.

--- a/projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md
+++ b/projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md
@@ -130,6 +130,19 @@ this repair and the A1 boost repair that already owns the same arrays.
   Both now assert the η′ *with* its three siblings rather than against
   them, and both keep an `assert_ne`/explicit-value line so a revert to
   the shipped weight fails on the number.
+- **Review round 1 (PR #94) caught two stale claims, both class-shaped.**
+  The follow-up this task annotated still said `hazma/_utils/boost.pyx`
+  "is still live" — Task 6.4 deleted it, and `PLAN.md`'s own Task 3
+  bullet already recorded the correction to `hazma._core.boost`; the
+  class sweep found the identical sentence in the φ follow-up, which is
+  Task 6's premise, and both are fixed. And this note's handoff said
+  "Four defects" while listing five; the same sweep found
+  `test_delta_models.py`'s module docstring asserting "all three defects
+  are still live", which this repair falsified for B1. A green
+  `check_doc_citations.py` did not catch the first class because a
+  citation into a deleted file is reported as EXTERNAL and skipped —
+  `docs/agents/lessons.md` `[touched-doc-inherits-its-citations]` now
+  says so.
 - **`folded_constants_match_the_shipped_object_code` keeps pinning the η′
   weight, against twice the shipped immediate.** `0x3f97_9fa9_7e13_2b56`
   → `0x3fa7_9fa9_7e13_2b56`: doubling only increments the exponent field,
@@ -491,7 +504,7 @@ precedent for its hardest part.**
 **Currently safe to assume:**
 
 - `test/parity/data/` is still intact and untouched by this project.
-- Four defects have now moved a library value: B4, B5, B6, A1 and B1.
+- Five defects have now moved a library value: B4, B5, B6, A1 and B1.
   `deltas.DECLARED_DELTAS` holds 98 arrays across five declarations, one
   of which is composite.
 - `../rules.md` rule 7's first real test is answered: A1 and B1 overlap at

--- a/rust/src/kernels/photon_tables.rs
+++ b/rust/src/kernels/photon_tables.rs
@@ -71,7 +71,9 @@
 //! `M/2`, `(M² − m²)/(2M)` — is folded into a single immediate in the
 //! generated code. They are `const` here for the same reason, and
 //! [`tests::folded_constants_match_the_shipped_object_code`] pins each one
-//! against the immediate the disassembly loads.
+//! against the immediate the disassembly loads — bar
+//! [`ETAP_TO_A_A_WEIGHT`], the one this port repairs, which is pinned
+//! against twice it.
 
 use std::sync::LazyLock;
 
@@ -88,14 +90,16 @@ use crate::interp;
 /// The factor of two is the Cython's: two photons per decay, so the line
 /// carries twice the branching ratio (`_eta.pyx:99`).
 const ETA_TO_A_A_WEIGHT: f64 = 2.0 * pdg::BR_ETA_TO_A_A;
-/// `BR(η′ → γγ)`. **No factor of two** — `_eta_prime.pyx:107` omits it
-/// where its four two-photon siblings have it, so the η′ spectrum carries
-/// 0.02307 photons per decay from this mode instead of 0.04614
-/// (measured by integrating the line term). Reproduced, not repaired
-/// (`projects/cython-to-rust/rules.md` rule 1); see
-/// [`tests::the_eta_prime_line_is_missing_its_factor_of_two`] and
-/// `docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md`.
-const ETAP_TO_A_A_WEIGHT: f64 = pdg::BR_ETAP_TO_A_A;
+/// `2·BR(η′ → γγ)`, the weight of the η′'s two-photon line.
+///
+/// The factor of two is this port's, not the Cython's: `_eta_prime.pyx:107`
+/// omitted it where its three `X → γγ` siblings above carry it, so 2.1.0
+/// shipped 0.02307 photons per decay from this mode instead of 0.04614.
+/// The parity corpus still pins the low value, and
+/// `test/parity/deltas.py` declares the resulting shift as repair `B1`
+/// rather than re-pinning the arrays. See
+/// [`tests::every_two_photon_line_carries_twice_its_branching_ratio`].
+const ETAP_TO_A_A_WEIGHT: f64 = 2.0 * pdg::BR_ETAP_TO_A_A;
 /// `2·BR(K_L → γγ)` (`_kaon.pyx:300`).
 const KL_TO_A_A_WEIGHT: f64 = 2.0 * pdg::BR_KL_TO_A_A;
 /// `2·BR(K_S → γγ)` (`_kaon.pyx:407`).
@@ -499,7 +503,11 @@ mod tests {
     fn folded_constants_match_the_shipped_object_code() {
         assert_eq!(ETA_TO_A_A_WEIGHT.to_bits(), 0x3fe9_38ef_34d6_a162);
         assert_eq!(ETA_TO_A_A_ENERGY.to_bits(), 0x4071_1ee5_6041_8937);
-        assert_eq!(ETAP_TO_A_A_WEIGHT.to_bits(), 0x3f97_9fa9_7e13_2b56);
+        // The one repaired weight: the shipped object code loads
+        // `0x3f97_9fa9_7e13_2b56` here and the two-photon line needs twice
+        // it (B1). Doubling only increments the exponent field, so the
+        // mantissa below is the shipped immediate's, digit for digit.
+        assert_eq!(ETAP_TO_A_A_WEIGHT.to_bits(), 0x3fa7_9fa9_7e13_2b56);
         assert_eq!(ETAP_TO_A_A_ENERGY.to_bits(), 0x407d_ee3d_70a3_d70a);
         assert_eq!(KL_TO_A_A_WEIGHT.to_bits(), 0x3f51_ec91_8e32_5d4a);
         assert_eq!(KS_TO_A_A_WEIGHT.to_bits(), 0x3ed6_0fe1_ca5f_e00f);
@@ -514,24 +522,23 @@ mod tests {
         assert_eq!(PHI_TO_ETAP_A_ENERGY.to_bits(), 0x408d_fd2a_ecc8_ec19);
     }
 
-    /// Four of the five two-photon lines carry `2·BR`; the η′ carries
-    /// `BR`.
+    /// All four `X → γγ` lines carry `2·BR`, the η′ included.
     ///
-    /// `hazma/spectra/_photon/_eta_prime.pyx:107` is the odd one out, and
-    /// the disassembled immediate confirms it is the code rather than a
-    /// reading of it — so the η′ spectrum is short one photon per `η′ →
-    /// γγ` decay. The ω and φ weights are *correctly* un-doubled: their
-    /// lines are `X → Yγ`, one photon each. Reproduced per rule 1 and
-    /// filed as
-    /// `docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md`;
-    /// this test is what makes a silent "cleanup" fail.
+    /// Two photons leave the decay, so the line's weight is twice the
+    /// branching ratio. The η′ was the one sibling that shipped without
+    /// the factor (`_eta_prime.pyx:107`, and the disassembled immediate
+    /// confirms it was the code rather than a reading of it), which left
+    /// its spectrum short one photon per `η′ → γγ` decay; this test is
+    /// what makes a silent revert to the shipped weight fail. The ω and φ
+    /// weights are *correctly* un-doubled and are deliberately absent:
+    /// their lines are `X → Yγ`, one photon each.
     #[test]
-    fn the_eta_prime_line_is_missing_its_factor_of_two() {
+    fn every_two_photon_line_carries_twice_its_branching_ratio() {
         assert_eq!(ETA_TO_A_A_WEIGHT, 2.0 * pdg::BR_ETA_TO_A_A);
         assert_eq!(KL_TO_A_A_WEIGHT, 2.0 * pdg::BR_KL_TO_A_A);
         assert_eq!(KS_TO_A_A_WEIGHT, 2.0 * pdg::BR_KS_TO_A_A);
-        assert_eq!(ETAP_TO_A_A_WEIGHT, pdg::BR_ETAP_TO_A_A);
-        assert_ne!(ETAP_TO_A_A_WEIGHT, 2.0 * pdg::BR_ETAP_TO_A_A);
+        assert_eq!(ETAP_TO_A_A_WEIGHT, 2.0 * pdg::BR_ETAP_TO_A_A);
+        assert_ne!(ETAP_TO_A_A_WEIGHT, pdg::BR_ETAP_TO_A_A);
     }
 
     /// The φ's two line energies are the *daughter meson's*, not the

--- a/test/parity/deltas.py
+++ b/test/parity/deltas.py
@@ -40,6 +40,14 @@ defect returns: `thermal_reference` integrates the same integrand with
 scipy's QUADPACK, and `oracle_reference` reads the arrays captured from
 the Cython twins before the port deleted them.
 
+``Composed`` — one relation for an array **more than one** repair moves.
+``rules.md`` rule 7 forbids leaving that as overlapping declarations, and
+one key holds one `Delta` in any case, so they collapse: a base relation
+predicts the array as the first repair leaves it, and each further repair
+adds its own term on top. The `Delta` then names them all, as ``"A1+B1"``,
+and `repair_labels` is what splits a composite spelling back into the
+roster entries it is made of.
+
 Positions
 ---------
 A declaration covers exactly the positions its mechanism reaches
@@ -62,11 +70,12 @@ declaration cannot outlive the repair it describes.
 
 Models without a declaration
 ----------------------------
-`DELTA_MODELS` holds one entry per roster repair whose delta has been
-modelled, `DECLARED_DELTAS` only the arrays a *landed* repair moves. The
-two differ while a model is established ahead of its repair: declaring an
-array the tree has not yet moved would fail the staleness rule above, so
-the model waits in `DELTA_MODELS` and the repair adds the keys.
+`DELTA_MODELS` holds one entry per modelled delta — a roster repair, or a
+composite of several — while `DECLARED_DELTAS` holds only the arrays a
+*landed* repair moves. The two differ while a model is established ahead
+of its repair: declaring an array the tree has not yet moved would fail
+the staleness rule above, so the model waits in `DELTA_MODELS` and the
+repair adds the keys.
 `test_delta_models.py` gates every entry either way.
 """
 
@@ -213,8 +222,66 @@ class Reference:
         return self.reference(fn, block)
 
 
+@dataclass(frozen=True)
+class Composed:
+    """``repaired == base``'s prediction with each ``added`` term on top.
+
+    What two repairs moving the same stored array declare instead of two
+    overlapping declarations (``rules.md`` rule 7): ``base`` predicts the
+    array as the first repair leaves it, and every repair after that
+    contributes the term it adds. The base may be any relation; the
+    addends are `Additive` because an addend has to leave room for what
+    came before it, which a relation that supersedes the array does not.
+
+    Parameters
+    ----------
+    base : Additive, Exact or Reference
+        Predicts the array with the first repair applied and no other.
+    added : tuple of Additive
+        One per further repair, in the order they landed.
+    rtol : float
+        Relative budget the composition holds to. Measured against the
+        repaired kernel; ``why`` says what sets it.
+    why : str
+        One-line justification of ``rtol``.
+    """
+
+    base: Additive | Exact | Reference
+    added: tuple[Additive, ...]
+    rtol: float
+    why: str
+
+    def expected(
+        self,
+        fn: Callable[..., Any],
+        block: Block,
+        stored: dict[str, np.ndarray],
+    ) -> dict[str, np.ndarray]:
+        """The repaired arrays this relation predicts, by suffix."""
+        # Copied, and every entry rebound rather than updated in place: a
+        # `Reference` base hands back `oracle_reference`'s cached arrays,
+        # which are read-only and shared by every comparison that reads
+        # them.
+        predicted = dict(self.base.expected(fn, block, stored))
+        for addend in self.added:
+            for suffix, term in addend.term(fn, block).items():
+                predicted[suffix] = predicted[suffix] + term
+        return predicted
+
+
 #: How a repaired value may relate to the stored one.
-Relation = Additive | Exact | Reference
+Relation = Additive | Exact | Reference | Composed
+
+
+def repair_labels(spelling: str) -> tuple[str, ...]:
+    """The roster entries one ``Delta.repair`` names, in declared order.
+
+    A composite declaration (`Composed`) names every repair that moved the
+    array, joined by ``+``; every other declaration names exactly one. The
+    close aggregates per roster entry, so it needs the parts rather than
+    the spelling.
+    """
+    return tuple(spelling.split("+"))
 
 
 @dataclass(frozen=True)
@@ -224,14 +291,16 @@ class Delta:
     Parameters
     ----------
     repair : str
-        Which roster entry moved it; drawn from `REPAIRS`.
+        Which roster entry moved it, drawn from `REPAIRS` — or, where two
+        repairs moved the same array and `Composed` collapsed them, every
+        one of them joined by ``+``. `repair_labels` splits it.
     positions : tuple of int or MOVED
         Which positions the relation covers: an explicit tuple, every
         entry of which the relation must move, or `MOVED` for wherever
         the prediction differs from the stored value. Undeclared
         positions are still compared against the stored value under the
         case's budget.
-    relation : Additive, Exact or Reference
+    relation : Additive, Exact, Reference or Composed
         How the repaired value relates to the stored one.
     measured : str
         The measurement behind the declaration, so the table is not a
@@ -736,6 +805,44 @@ _A1 = Delta(
 )
 
 
+# ---------------------------------------------------------------------------
+# A1 + B1 -- the six eta-prime arrays both repairs move
+# ---------------------------------------------------------------------------
+
+
+_A1_B1 = Delta(
+    repair="A1+B1",
+    positions=MOVED,
+    relation=Composed(
+        base=_A1.relation,
+        added=(_B1.relation,),
+        rtol=1e-12,
+        why="the base is the A1 capture and the addend is closed form, so "
+        "what separates the prediction from the repaired kernel is the "
+        "order the two line copies are summed in: the kernel folds one "
+        "`2 BR` weight into the boost's own fused multiply-add, the "
+        "prediction adds a second `BR` copy afterwards. Measured 2.1e-16 "
+        "worst over the six arrays, which is one ulp. Held at the case's "
+        "own `tolerances.TABULATED_RTOL` rather than tightened to that, "
+        "for the reason A1 gives: the capture is one platform's, and a "
+        "libm that moves the boost integral must not fail here while the "
+        "undeclared positions of the same block still pass.",
+    ),
+    measured="B1 moves 189 positions over six of this case's ten value "
+    "arrays -- 9 of `rest_plus_eps.values`, 20 of `near_rest.values`, 57 "
+    "and 2 of `boosted_mild.{values,scalar_values}`, 98 and 3 of "
+    "`boosted_strong.{values,scalar_values}` -- every one of them upward, "
+    "by 7.7e-04 to 1.0 relative. 18 of the 189 are positions A1 moves too, "
+    "which is why the two compose rather than declaring separately. The "
+    "case's other four value arrays keep A1's declaration alone: B1 moves "
+    "nothing in either `rest` array, where the kernel takes its rest-frame "
+    "arm and adds no line, and nothing at the scalar probe of "
+    "`rest_plus_eps` or `near_rest`, where the probe falls outside the "
+    "line's window.",
+    evidence="projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md",
+)
+
+
 #: Every declared array. The two blocks of the same case that are absent --
 #: ``rest`` and ``rest_plus_eps`` -- must still match the stored arrays under
 #: the case's own budget, which is the "moved only what it intended" half of
@@ -751,14 +858,14 @@ DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
     ("spectra.photon.eta", "boosted_mild", "scalar_values"): _A1,
     ("spectra.photon.eta", "boosted_strong", "values"): _A1,
     ("spectra.photon.eta", "boosted_strong", "scalar_values"): _A1,
-    ("spectra.photon.eta_prime", "rest_plus_eps", "values"): _A1,
+    ("spectra.photon.eta_prime", "rest_plus_eps", "values"): _A1_B1,
     ("spectra.photon.eta_prime", "rest_plus_eps", "scalar_values"): _A1,
-    ("spectra.photon.eta_prime", "near_rest", "values"): _A1,
+    ("spectra.photon.eta_prime", "near_rest", "values"): _A1_B1,
     ("spectra.photon.eta_prime", "near_rest", "scalar_values"): _A1,
-    ("spectra.photon.eta_prime", "boosted_mild", "values"): _A1,
-    ("spectra.photon.eta_prime", "boosted_mild", "scalar_values"): _A1,
-    ("spectra.photon.eta_prime", "boosted_strong", "values"): _A1,
-    ("spectra.photon.eta_prime", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.eta_prime", "boosted_mild", "values"): _A1_B1,
+    ("spectra.photon.eta_prime", "boosted_mild", "scalar_values"): _A1_B1,
+    ("spectra.photon.eta_prime", "boosted_strong", "values"): _A1_B1,
+    ("spectra.photon.eta_prime", "boosted_strong", "scalar_values"): _A1_B1,
     ("spectra.photon.omega", "rest_plus_eps", "values"): _A1,
     ("spectra.photon.omega", "rest_plus_eps", "scalar_values"): _A1,
     ("spectra.photon.omega", "near_rest", "values"): _A1,
@@ -1002,6 +1109,7 @@ DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
 #: it measured moving; see the module docstring.
 DELTA_MODELS: dict[str, Delta] = {
     "A1": _A1,
+    "A1+B1": _A1_B1,
     "B1": _B1,
     "B2": _B2,
     "B3": _B3,

--- a/test/parity/test_delta_models.py
+++ b/test/parity/test_delta_models.py
@@ -15,9 +15,9 @@ applies the **named defect** to it, and requires the result to be the
 number the corpus already stores. Nothing here evaluates a spectrum
 kernel; every comparison is against ``data/*.npz``, captured from Cython
 at kernel digest ``f5e6e269be47`` and never rewritten
-(``../rules.md`` rule 1). So these tests are falsifiable today, on a tree
-where all three defects are still live, and they stay falsifiable after
-the repairs land.
+(``../rules.md`` rule 1). So these tests were falsifiable on the tree
+that carried all three defects, and they stay falsifiable as the repairs
+land one at a time: B1's has, and B2's and B3's have not.
 
 The three arguments
 -------------------

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -591,17 +591,32 @@ def test_every_declared_delta_addresses_a_real_stored_array(
 def test_every_delta_model_is_a_roster_repair_with_its_evidence() -> None:
     """The label is from the closed roster and the evidence file exists.
 
-    The mechanism only aggregates at close time if every model names a
-    repair the roster knows, and only stays re-derivable if the
+    The mechanism only aggregates at close time if every model names
+    repairs the roster knows, and only stays re-derivable if the
     measurement behind it is written down somewhere that is checked in.
     Swept over `deltas.DELTA_MODELS` rather than over the declarations,
     so a model established ahead of its repair is held to the same terms
     while it waits for its keys.
+
+    A composite label names more than one roster entry, and then the
+    relation has to be the `deltas.Composed` that actually applies them
+    all: a spelling the relation does not back would claim a repair the
+    array never saw.
     """
     repo_root = Path(__file__).resolve().parents[2]
     for label, delta in deltas.DELTA_MODELS.items():
         assert delta.repair == label, f"{label}: keyed under {delta.repair!r}"
-        assert delta.repair in deltas.REPAIRS, f"{label}: repair {delta.repair!r}"
+        parts = deltas.repair_labels(label)
+        assert set(parts) <= deltas.REPAIRS, f"{label}: not all roster repairs"
+        assert len(set(parts)) == len(parts), f"{label}: names a repair twice"
+        if len(parts) > 1:
+            assert isinstance(
+                delta.relation, deltas.Composed
+            ), f"{label}: names {len(parts)} repairs without composing them"
+            assert len(delta.relation.added) == len(parts) - 1, (
+                f"{label}: composes {len(delta.relation.added) + 1} relations "
+                f"for {len(parts)} repairs"
+            )
         assert delta.measured.strip(), f"{label}: no measurement"
         assert delta.relation.why.strip(), f"{label}: relation budget has no reason"
         assert (repo_root / delta.evidence).is_file(), f"{label}: {delta.evidence}"

--- a/test/test_core_photon_tables.py
+++ b/test/test_core_photon_tables.py
@@ -119,7 +119,8 @@ BR_PHI_TO_ETAP_A = 6.22e-5
 
 #: ``name -> (entry point, CSV, parent mass, [(line energy, line weight)])``.
 #: The line expressions are the ``.pyx`` ones character for character,
-#: including the two the port reproduces rather than repairs.
+#: except the eta-prime weight, which the port repairs (B1), and the two
+#: phi energies, which it still reproduces.
 SPECTRA: dict[str, tuple[object, str, float, list[tuple[float, float]]]] = {
     "charged_kaon": (
         core_photon.dnde_photon_charged_kaon,
@@ -149,7 +150,7 @@ SPECTRA: dict[str, tuple[object, str, float, list[tuple[float, float]]]] = {
         core_photon.dnde_photon_eta_prime,
         "eta_prime_photon.csv",
         MASS_ETAP,
-        [(MASS_ETAP / 2.0, BR_ETAP_TO_A_A)],
+        [(MASS_ETAP / 2.0, 2.0 * BR_ETAP_TO_A_A)],
     ),
     "omega": (
         core_photon.dnde_photon_omega,
@@ -583,25 +584,26 @@ class TestPhysics:
         # above, or this test would pass on a halved weight.
         assert tolerance < MAX_LINE_TOLERANCE
 
-    def test_the_eta_prime_line_carries_half_the_photons_it_should(self) -> None:
-        """A reproduced defect: ``2·BR`` everywhere but the η'.
+    def test_every_two_photon_line_carries_twice_its_branching_ratio(self) -> None:
+        """``X -> a a`` yields two photons, so its line weight is ``2·BR``.
 
-        ``η' -> a a`` yields two photons, so the line's weight should be
-        ``2·BR(η' -> a a) = 0.04614``. ``_eta_prime.pyx:107`` wrote ``BR``,
-        which its four two-photon siblings did not, and the ω and φ weights
-        are correctly un-doubled because their modes ``X -> Y a`` yield one
-        photon each. Reproduced per rules.md rule 1 — the corpus pins the
-        low values — and tracked in
-        ``docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md``.
+        All four two-photon spectra, held together, because the η' was the
+        one that shipped without the factor: ``_eta_prime.pyx:107`` wrote a
+        bare ``BR``, giving 0.02307 photons per decay where the mode
+        delivers ``2·BR(η' -> a a) = 0.04614``. Repaired as roster entry B1
+        of ``projects/parity-pinned-defect-repair``; the corpus still pins
+        the low value and ``test/parity/deltas.py`` declares the shift.
+
+        The ω and φ are deliberately absent: their modes are ``X -> Y a``,
+        one photon each, so their un-doubled weights are correct.
         """
-        assert SPECTRA["eta_prime"][3] == [(MASS_ETAP / 2.0, BR_ETAP_TO_A_A)]
         assert SPECTRA["eta"][3] == [(MASS_ETA / 2.0, 2.0 * BR_ETA_TO_A_A)]
-        # And the shipped kernel really carries the halved count: the same
-        # isolate-the-line measurement as the test above, stated as the
-        # ratio it should have had.
-        lines = SPECTRA["eta_prime"][3]
-        assert lines[0][1] == pytest.approx(BR_ETAP_TO_A_A)
-        assert lines[0][1] == pytest.approx(0.5 * 2.0 * BR_ETAP_TO_A_A)
+        assert SPECTRA["long_kaon"][3] == [(MASS_K0 / 2.0, 2 * BR_KL_TO_A_A)]
+        assert SPECTRA["short_kaon"][3] == [(MASS_K0 / 2.0, 2 * BR_KS_TO_A_A)]
+        assert SPECTRA["eta_prime"][3] == [(MASS_ETAP / 2.0, 2.0 * BR_ETAP_TO_A_A)]
+        # Stated as the photon count as well as the expression, so a revert
+        # to the shipped weight fails on the number and not only the form.
+        assert SPECTRA["eta_prime"][3][0][1] == pytest.approx(0.04614)
 
     def test_the_phi_lines_sit_at_the_daughter_mesons_energy(self) -> None:
         """A reproduced defect: ``+`` where the photon needs ``-``.


### PR DESCRIPTION
## Summary

- **The η′'s `η′ → γγ` line carried one photon per decay instead of two.**
  Five tabulated photon spectra add a monochromatic line on top of a CSV
  continuum; for the four whose mode is `X → γγ` the weight is `2 BR`,
  because two photons leave the decay. The η′ shipped a bare `BR` where
  the η, `K_L` and `K_S` did not. `ETAP_TO_A_A_WEIGHT` is now
  `2 · BR(η′ → γγ)`, and the two tests that pinned the shipped defect are
  renamed to assert the repaired physics over all four siblings together.
- **A published spectrum moves, deliberately.** `dnde_photon_eta_prime`
  rises by **exactly `BR(η′ → γγ) = 0.02307` photons per decay at every
  boost** — a boosted δ-function integrates to its own weight — which is
  **0.603%** of the repaired total of 3.829 over `1e-3 ≤ E_γ ≤ E_η′` at
  `E_η′ = 2 M_η′`. The old value, 3.80607, was wrong; 3.82914 is right.
  All of the change lands in the line at `M_η′/2 = 478.89` MeV and its
  boosted images, so the continuum is unchanged and a band excluding the
  line does not move at all. Pointwise the rise runs from 7.7e-04 to a
  factor of two, the latter where the line was the whole spectrum. An η′
  **exactly** at rest is unaffected — that branch adds no line.
  `hazma.spectra.dnde_photon` moves for any final state carrying an η′
  (36/201 grid points on `["etap", "etap"]`, 45/201 on `["etap", "eta"]`,
  0/201 on `["eta", "eta"]`). `dnde_photon_{eta,long_kaon,short_kaon}` —
  already right — and `dnde_photon_{omega,phi}`, whose `X → Yγ` lines are
  correctly un-doubled, are bit-identical across a rebuild. Recorded in
  `CHANGELOG.md` under `[Unreleased]`.
- **The parity corpus is not rewritten.** A1 already declared every array
  this repair moves, and `rules.md` rule 7 forbids leaving that as an
  overlap, so the two collapse into one declaration: a new
  `deltas.Composed` relation predicts a base relation's array with each
  further repair's additive term on top, labelled `A1+B1`. It covers the
  six arrays both repairs move — 189 positions, all upward, 18 of them
  shared with A1 — and agrees with the repaired kernel to 2.1e-16, one
  ulp, while being held at the case's own `TABULATED_RTOL = 1e-12` for
  the reason A1 gives. Two of A1's eight η′ arrays keep A1's declaration
  alone, because this line reaches neither scalar probe.
  `EXPECTED_DECLARED_ARRAYS` stays 98 — keys re-pointed, not added, and
  `git diff --stat -- test/parity/data` is empty.
- **ADR-0001 amended.** Its Decision bullets now admit a declaration
  naming more than one repair, and the relation bullet is restated as the
  invariant the relations share rather than an enumeration that goes
  stale each time one is added. `references/corpus-repinning.md`'s
  Relations table, which still named two relations that were never built
  and neither of the two that were, points at `deltas.py` instead.

- **Review round 1 (`652a1418`) corrected two stale claims, each across its
  class.** The η′ follow-up this PR annotates said `hazma/_utils/boost.pyx`
  "is still live" while naming it as the home of `boost_delta_function`;
  Task 6.4 deleted it and no `.pyx` remains in the tree, so both it and the
  **φ follow-up**, which carried the identical sentence as Task 6's premise,
  now name `hazma._core.boost`. And the task note's handoff said "Four
  defects" while listing five, which the sweep also found in
  `test_delta_models.py`'s docstring as "all three defects are still live" —
  true when written, falsified for B1 by this PR. `check_doc_citations.py`
  passed over the touched docs and missed the first class, because a
  citation into a deleted file is reported as EXTERNAL and skipped;
  `[touched-doc-inherits-its-citations]` now says a liveness claim needs its
  own check. The same class survives in
  `references/defect-blast-radius.md`'s roster table, whose reconciliation
  is Task 11's job — its `PLAN.md` scope note now names the class and the
  terms to sweep on. No code path changed in this round.

## Project

`projects/parity-pinned-defect-repair/` — Task 5: Repair B1, the η′
two-photon line weight.

See `projects/parity-pinned-defect-repair/task-notes/task-5-eta-prime-line.md`
for implementation detail, decisions, and verification.

## Test plan

- [x] `scripts/agents/preflight.sh` — `RESULT: PASS` across all eleven
  rows, with the full suite as its pytest gate:

  ```text
  PASS   black --check           test/parity/deltas.py test/parity/test_parity.py test/test_core_photon_tables.py
  PASS   isort --check-only      0 new, 2 fixed (0 pre-existing at 46ec62926879)
  PASS   ruff check              0 new, 2 fixed (0 pre-existing at 46ec62926879)
  PASS   cargo fmt --check       rust/
  PASS   cargo clippy            rust/
  PASS   cargo test              rust/
  PASS   pytest                  2286 passed, 15 skipped, 1 warning, 37 subtests passed in 27.94s
  PASS   import hazma            version 2.2.0
  PASS   markdownlint            <the six touched markdown files>
  SKIP   version bump            not a closing PR (pass --closing)
  PASS   forbidden tokens        none added
  ```

- [x] The physics invariant — the line term alone, isolated by
  subtracting the boosted continuum and integrated with QUADPACK over the
  line's window at `E_parent = 2 M`. Every `X → γγ` line now delivers the
  photon count its weight declares:

  ```text
  eta         line integral = 0.78820000 +/- 8.8e-15   weight 0.78820000   ratio 1.0000000000
  eta_prime   line integral = 0.04614000 +/- 5.1e-16   weight 0.04614000   ratio 1.0000000000
  long_kaon   line integral = 0.00109400 +/- 8.4e-17   weight 0.00109400   ratio 1.0000000000
  short_kaon  line integral = 0.00000526 +/- 3.0e-17   weight 0.00000526   ratio 1.0000000000
  ```

  `0.04614000` against the `0.02306998 ± 1.3e-08` the follow-up measured
  pre-repair.

- [x] `cargo test --manifest-path rust/Cargo.toml --no-default-features
  --features test-probes` — `test result: ok. 263 passed; 0 failed; 0
  ignored`.

- [x] Test validity, both directions, on a rebuilt extension rather than
  `cargo test` alone. Reverting the one-line Rust change turns four
  parity cases red before the declaration is added
  (`spectra.photon.eta_prime[{rest_plus_eps,near_rest,boosted_mild,boosted_strong}]`,
  `4 failed, 1 passed, 645 deselected`), and red again *with* the
  declaration in place, on the staleness rule. The `rest` block passes in
  every configuration, which is the "moved only what it intended" half.

- [x] Numerical impact measured before/after on the same worktree — the
  Rust constant reverted, the editable install rebuilt, captured,
  restored with a `cmp` check, rebuilt — and the two captures diffed. Full
  tables in the task note's `## Numerical impact`.

- [x] Review round 1 re-gated: `RESULT: PASS` across all eleven rows,
  `pytest 2286 passed, 15 skipped, 1 warning, 37 subtests passed in 25.20s`
  — unchanged, as the round touched only prose and one module docstring
  (`git diff --name-only | grep -E '^(hazma|rust)/'` → empty). Pre- and
  post-fix `rg` sweeps for both classes are in the task note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
