### PR TITLE
fix(spectra): move both phi photon lines to the photon energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,14 @@ user-facing change even when no signature did.
   be corrected by a constant factor. Pointwise on a 601-point grid over
   `1 ≤ E_γ ≤ 5 M_φ`, 331 of 601 values move at `E_φ = 1.5 M_φ` and 474 at
   `E_φ = 5 M_φ`, most of them up; a φ **exactly** at rest is unaffected,
-  because that branch adds no line. `hazma.spectra.dnde_photon` moves for
-  any final state containing a φ. `dnde_photon_omega`, whose two
-  `ω → Y γ` lines were always the photon's, does not move, and neither
-  do the five other tabulated photon spectra. Details:
+  because that branch adds no line. `hazma.spectra.dnde_photon` inherits
+  both halves: it moves for a final state whose φ is in flight, and not
+  at the production threshold `cme = Σm`, where the φ is at rest — so
+  `dnde_photon(E, 2 M_φ, ["phi", "phi"])` is bit-identical across this
+  change while `dnde_photon(E, 2.5 M_φ, ["phi", "phi"])` moves at 98 of
+  201 grid points. `dnde_photon_omega`, whose two `ω → Y γ` lines were
+  always the photon's, does not move, and neither do the five other
+  tabulated photon spectra. Details:
   `docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`.
 - **The η′'s two-photon line carried one photon per decay instead of
   two, and `dnde_photon_eta_prime` rises.** Five tabulated photon spectra
@@ -55,8 +59,9 @@ user-facing change even when no signature did.
   does not move at all; the continuum is unchanged. An η′ **exactly** at
   rest is unaffected, because that branch adds no line. Pointwise the
   rise runs from 7.7e-04 to a factor of two, the latter where the line
-  was the whole spectrum. `hazma.spectra.dnde_photon` moves for any final
-  state containing an η′. `dnde_photon_eta`, `dnde_photon_long_kaon` and
+  was the whole spectrum. `hazma.spectra.dnde_photon` moves for a final
+  state whose η′ is in flight, and not at the production threshold,
+  where the η′ is at rest. `dnde_photon_eta`, `dnde_photon_long_kaon` and
   `dnde_photon_short_kaon` — whose weights were already right — do not
   move, and neither do `dnde_photon_omega` or `dnde_photon_phi`, whose
   `X → Yγ` lines are correctly un-doubled. Details:
@@ -86,8 +91,9 @@ user-facing change even when no signature did.
   those 10,045 values move. A parent **exactly** at rest is unaffected:
   all seven kernels short-circuit to the rest-frame spectrum before the
   integral, so it never runs at `β = 0`. `hazma.spectra.dnde_photon` and
-  every model `total_spectrum` move for any final state containing one of
-  the seven. Details:
+  every model `total_spectrum` inherit that: they move for a final state
+  whose parent is in flight, and not at the production threshold, where
+  it is at rest. Details:
   `docs/followups/todo/boost-integral-drops-last-interior-cell.md`.
 - **The charged pion's prompt `π → e ν` neutrino line was counted twice.**
   `hazma.spectra.dnde_neutrino_charged_pion` summed two contributions that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ user-facing change even when no signature did.
 
 ### Changed
 
+- **Both φ photon lines sat at the daughter meson's energy instead of the
+  photon's, and `dnde_photon_phi` moves.** In the two-body decay
+  `X → Y γ` the photon carries `(M² − m²) / (2 M)` and the meson
+  `(M² + m²) / (2 M)`; the two sum to `M`. The φ kernel used the meson's
+  expression for both of its lines and then boosted the result as a
+  photon energy. In the φ rest frame `φ → ηγ` sat at 656.942 MeV where
+  362.519 belongs, a factor of 1.81, and `φ → η′γ` at 959.646 MeV where
+  59.815 belongs, a factor of 16.0 — the second putting 94% of the φ's
+  whole rest mass into a photon that carries 5.9% of it. Both now sit at
+  `(M_φ² − m²) / (2 M_φ)`. **This relocates a feature rather than
+  rescaling the spectrum: the yield is unchanged at
+  `BR(φ → ηγ) + BR(φ → η′γ) = 0.013092` photons per decay** — a boosted
+  δ-function integrates to its own weight wherever it sits — so a band
+  containing the old line and not the new one loses that yield outright,
+  a band containing neither does not move, and no downstream result can
+  be corrected by a constant factor. Pointwise on a 601-point grid over
+  `1 ≤ E_γ ≤ 5 M_φ`, 331 of 601 values move at `E_φ = 1.5 M_φ` and 474 at
+  `E_φ = 5 M_φ`, most of them up; a φ **exactly** at rest is unaffected,
+  because that branch adds no line. `hazma.spectra.dnde_photon` moves for
+  any final state containing a φ. `dnde_photon_omega`, whose two
+  `ω → Y γ` lines were always the photon's, does not move, and neither
+  do the five other tabulated photon spectra. Details:
+  `docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`.
 - **The η′'s two-photon line carried one photon per decay instead of
   two, and `dnde_photon_eta_prime` rises.** Five tabulated photon spectra
   add a monochromatic line on top of a CSV continuum, and for the four

--- a/docs/agents/lessons-examples.md
+++ b/docs/agents/lessons-examples.md
@@ -1305,3 +1305,37 @@ own decay length, so they never had the pathology the Rust kernels' fixed
 exposes the defect (0.765 relative error at the worst point). An oracle
 has to be built from the shape that actually breaks, and the way to know
 it is: revert the fix and watch the test go red.
+
+### composed-entry-point-inherits-the-branch-caveat
+
+PR #95 moved both φ photon line energies and measured the impact carefully:
+`dnde_photon_phi` moves at every parent energy above rest, and a φ **exactly**
+at rest does not, because `photon_tables::branch` returns `Branch::RestFrame`
+at `E − m < DBL_EPSILON` and that arm adds no line at all. The `CHANGELOG.md`
+entry stated both facts — and then said `hazma.spectra.dnde_photon` "moves for
+any final state containing a φ", which the first fact contradicts.
+
+Review supplied the counterexample: `dnde_photon(E, 2 m_phi, ["phi", "phi"])`
+puts both φs exactly at rest, so nothing the repair touched is reachable.
+Measured across a real revert-and-rebuild it is bit-identical, as is
+`["phi", "eta"]` at `cme = m_phi + m_eta`, while `["phi", "phi"]` at
+`cme = 2.5 m_phi` moves at 98 of 201 grid points.
+
+The same overstatement was already in the merged entries for the two sibling
+repairs — the η′ line weight and the boost-integral window — each one sentence
+after its own "a parent **exactly** at rest is unaffected". Both were fixed in
+the same sweep:
+
+```text
+$ rg -n --hidden 'any final state (containing|carrying)' \
+      projects/ docs/ hazma/ test/ .claude/ .codex/ README.md CHANGELOG.md
+CHANGELOG.md:39                     # the phi entry (this PR)
+CHANGELOG.md:89                     # the boost-window entry
+projects/.../task-notes/task-6-phi-lines.md:525
+projects/.../task-notes/README.md:291
+```
+
+The pattern to watch for: a paragraph that establishes a branch-scoped caveat
+about a kernel and then makes an unscoped claim about a function that composes
+it. Grep the impact paragraph for "any", and for each occurrence ask which
+branch of the underlying kernel that "any" reaches.

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -301,3 +301,10 @@ relevant `docs/agents/` checklist as a check, not here as a lesson.
   Enumerate the sites the fix touched, and for each confirm a test that fails
   when *only that site* is reverted — reverting all of them at once proves
   nothing about which one the test was watching (PR #91).
+- [composed-entry-point-inherits-the-branch-caveat] A kernel repair that spares
+  one branch spares every public entry point that composes it on that branch,
+  so an impact claim about the composed function is narrower than "any caller
+  reaching the kernel". State the caveat once and carry it into the same
+  paragraph's sentence about the consumer, and measure the composed function at
+  the configuration the spared branch corresponds to — for a spectrum kernel
+  with a rest-frame arm, that is the production threshold (PR #95).

--- a/docs/followups/README.md
+++ b/docs/followups/README.md
@@ -31,6 +31,7 @@ cp docs/followups/_template.md docs/followups/todo/<slug>.md
 | [the muon positron spectrum divides by its normalization](todo/positron-muon-spectrum-normalization-inverted.md) | 2026-08-11 | cython-to-rust Task 4.1 | cross-cutting |
 | [the η′ two-photon line carries one photon instead of two](todo/eta-prime-two-photon-line-missing-factor-two.md) | 2026-08-12 | cython-to-rust Task 4.2 | cross-cutting |
 | [the φ photon lines sit at the daughter meson's energy](todo/phi-photon-lines-use-the-daughter-meson-energy.md) | 2026-08-12 | cython-to-rust Task 4.2 | cross-cutting |
+| [the φ photon spectrum omits its direct `φ → π⁰γ` line](todo/phi-omits-its-direct-pi0-photon-line.md) | 2026-09-07 | parity-pinned-defect-repair Task 6 | cross-cutting |
 | [the muon photon spectrum's rest frame stops short of the endpoint](todo/photon-muon-rest-frame-endpoint-uses-the-wrong-power-of-r.md) | 2026-08-16 | cython-to-rust Task 4.3 | commit |
 | [the charged-pion photon spectrum returns zero in the forward cone](todo/charged-pion-photon-spectrum-misses-the-forward-cone.md) | 2026-08-17 | cython-to-rust Task 4.4 | cross-cutting |
 | [both rho photon spectra return the boost integrand at rest](todo/rho-rest-frame-branch-returns-the-integrand.md) | 2026-08-18 | cython-to-rust Task 4.5 | cross-cutting |

--- a/docs/followups/todo/phi-omits-its-direct-pi0-photon-line.md
+++ b/docs/followups/todo/phi-omits-its-direct-pi0-photon-line.md
@@ -1,0 +1,106 @@
+# The φ photon spectrum omits its direct `φ → π⁰γ` line
+
+- **Added:** 2026-09-07
+- **Source:** `projects/parity-pinned-defect-repair` Task 6 — the risk
+  bullet on
+  [`phi-photon-lines-use-the-daughter-meson-energy.md`](phi-photon-lines-use-the-daughter-meson-energy.md)
+  asked for this check before that repair landed, and the measurement
+  settled it
+  (`projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md`)
+- **Scope:** cross-cutting (a published spectrum is missing a feature and
+  a yield; the repair moves parity-pinned values)
+- **Status:** open
+- **Triggers / blockers:** none. It is a declared numerical change like
+  its siblings, and the declared-delta mechanism
+  (`projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`)
+  makes it independent of every other repair. It is **not** part of that
+  project's roster of ten, which `test/parity/deltas.py`'s `REPAIRS` holds
+  as a closed set, so adding it means adding a roster entry — either as a
+  new task in that project before it closes, or as its own change after.
+
+## Why
+
+Five tabulated photon spectra add one or more monochromatic lines on top
+of a CSV continuum, for decay modes whose photon is *direct* rather than
+a daughter's decay product. The ω does this for both of its modes:
+
+```rust
+rust/src/kernels/photon_tables.rs  OMEGA: lines = [
+    (OMEGA_TO_PI0_A_ENERGY, BR_OMEGA_TO_PI0_A),
+    (OMEGA_TO_ETA_A_ENERGY, BR_OMEGA_TO_ETA_A),
+]
+```
+
+The φ has three such modes — `φ → ηγ`, `φ → η′γ` and `φ → π⁰γ` — and
+carries lines for only the first two. `BR_PHI_TO_PI0_A = 1.32e-3` is
+defined at `rust/src/constants.rs:359` and read by nothing; the pre-port
+`constants.pxd` defined it and no `.pyx` read it either.
+
+**The CSV columns show the direct photon is genuinely absent rather than
+folded into the continuum.** Each `X → π⁰γ` mode contributes a `pi0_a`
+column holding the π⁰'s own decay photons. Normalized by the mode's own
+branching ratio, that column should integrate to `2 BR(π⁰ → γγ) = 1.976`
+— two photons per π⁰ — if it holds the daughter's photons and nothing
+else:
+
+| Parent | `pi0_a` integral | `BR(X → π⁰γ)` | ratio | has a line? |
+| --- | --- | --- | --- | --- |
+| φ | 0.0026115 | 1.32e-3 | 1.978 | no |
+| ω | 0.16275 | 8.34e-2 | 1.951 | yes |
+
+Both land on `2 BR(π⁰ → γγ)`; the ω's 1.3% shortfall is its table's
+low-energy truncation, and the φ's grid starts proportionally higher so
+it loses less. The ω's direct photon is therefore not in its column
+either — it comes from the line — and the φ, which has no line, is simply
+missing that photon. Measured with
+`numpy.trapezoid` over `hazma/spectra/_photon/data/{phi,omega}_photon.csv`.
+
+## What
+
+1. Add a third entry to `PHI`'s line list in
+   `rust/src/kernels/photon_tables.rs`:
+   `(photon_line_energy(pdg::MASS_PHI, pdg::MASS_PI0), pdg::BR_PHI_TO_PI0_A)`,
+   which puts it at 500.795 MeV in the φ rest frame.
+2. Declare the resulting corpus shift. Unlike B2 this **raises the
+   yield**, by `BR(φ → π⁰γ) = 1.32e-3` photons per decay at every boost,
+   so a magnitude check is meaningful here where B2 needed a position
+   check. It reaches the same `spectra.photon.phi` arrays as A1 and B2,
+   so the declaration extends the existing `A1+B2` composite rather than
+   standing beside it (`projects/parity-pinned-defect-repair/rules.md`
+   rule 7).
+3. `CHANGELOG.md` entry with the magnitude, and a `minor` bump at least
+   (`docs/versioning.md`).
+
+Before implementing, re-check whether the same omission reaches any other
+tabulated spectrum: the sweep behind the table above covered only the two
+parents with a `pi0_a` column, and the general question is whether every
+`X → Y γ` mode with a branching ratio in `rust/src/constants.rs` has a
+line in `photon_tables.rs`.
+
+## Entry points
+
+- `rust/src/kernels/photon_tables.rs` — `PHI`'s line list, and `OMEGA`'s
+  beside it as the worked example.
+- `rust/src/constants.rs:359` — `BR_PHI_TO_PI0_A`, currently unread.
+- `hazma/spectra/_photon/data/phi_photon.csv` — the `pi0_a` column that
+  establishes what the line would add rather than duplicate.
+- `test/test_core_photon_tables.py` — `SPECTRA["phi"]`'s line list, which
+  is the independent statement of which lines the kernel carries.
+- `test/parity/deltas.py` — `REPAIRS`, `DELTA_MODELS` and the `A1+B2`
+  declaration this would extend.
+
+## Risks / open questions
+
+- **The evidence is an integral, and an integral can hide a shape.** The
+  table above compares each `pi0_a` column's total against the π⁰'s two
+  decay photons and finds no room for a direct photon, but a monochromatic
+  line smeared into a tabulated column would move that total by exactly
+  the amount attributed to truncation. Comparing the two columns' *shapes*
+  — the φ's against the ω's, each normalized by its own branching ratio
+  and rescaled to the parent's mass — would settle it independently, and
+  is worth doing before the line is added rather than after.
+- **The same omission may reach other modes.** `rust/src/constants.rs`
+  defines branching ratios for several `X → Y γ` modes; only the ones with
+  a line in `photon_tables.rs` contribute their direct photon. That sweep
+  is item 3's "before implementing" note above and is the reason this is
+  filed as cross-cutting rather than as a one-line fix.

--- a/docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
+++ b/docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
@@ -8,7 +8,10 @@
   (`projects/cython-to-rust/task-notes/phase-04/task-4.2-photon-table-family.md`)
 - **Scope:** cross-cutting (a published spectrum has a feature in the
   wrong place; the repair is gated by the `cython-to-rust` corpus)
-- **Status:** open
+- **Status:** open — **repaired** 2026-09-07 as roster entry B2,
+  `projects/parity-pinned-defect-repair` Task 6. The file stays here
+  until that project's close (Task 12) moves all of its follow-ups to
+  `done/` in one sweep, so the inbound references are repointed once.
 - **Triggers / blockers:** **corpus re-pinning only** — no ordering
   constraint against `cython-to-rust` Phase 06 Task 6.4. Task 6.4 deletes
   the four surviving `.pyx`; this defect's twin,
@@ -51,9 +54,9 @@ hazma/spectra/_photon/_phi.pyx:114  res += BR_PHI_TO_ETAP_A * boost_delta_functi
 ```
 
 (Quoted from the pre-port sources, which Task 4.2 deleted in the same
-PR as the swap — `git show 665aed5:<path>` recovers them. The
-expressions themselves live on unchanged in
-`rust/src/kernels/photon_tables.rs`.)
+PR as the swap — `git show 665aed5:<path>` recovers them. The port
+carried the expressions over unchanged; the repair below is what
+replaced them.)
 
 The local's name — `eng_eta` — says what the expression computes. It is
 the η's energy, reused for the η′ without being renamed, and used for
@@ -98,12 +101,21 @@ placed correctly.
    sibling normalization defect, no downstream result can be corrected
    by a constant factor.
 
-The port's tests already encode the correct statement alongside the
-shipped one, so the repair mostly means flipping which is asserted:
-`the_phi_line_energies_are_the_daughter_mesons` in
+The port's tests already encoded the correct statement alongside the
+shipped one, so the repair was mostly a matter of flipping which is
+asserted. Both were renamed to state the repaired physics over all four
+`X → Y γ` lines rather than the φ's two against the ω's:
+`every_line_energy_is_the_photons_not_the_daughters` in
 `rust/src/kernels/photon_tables.rs`, and
-`TestPhysics::test_the_phi_lines_sit_at_the_daughter_mesons_energy` in
-`test/test_core_photon_tables.py`.
+`TestPhysics::test_every_line_sits_at_the_photons_energy_not_the_daughters`
+in `test/test_core_photon_tables.py`. Both constants now go through one
+`photon_line_energy(parent, daughter)`, so the `+` form has no site left
+to be written at.
+
+The corpus was not regenerated. `test/parity/deltas.py` declares the
+relocation as the composite `A1+B2` on the six `spectra.photon.phi`
+arrays both repairs move, and the two `rest_plus_eps` arrays keep A1's
+declaration alone.
 
 ## Entry points
 
@@ -111,7 +123,10 @@ shipped one, so the repair mostly means flipping which is asserted:
   `PHI_TO_ETAP_A_ENERGY`, and `OMEGA_TO_PI0_A_ENERGY` /
   `OMEGA_TO_ETA_A_ENERGY` beside them, which are the control.
 - `test/test_core_photon_tables.py` —
-  `TestPhysics::test_the_phi_lines_sit_at_the_daughter_mesons_energy`.
+  `TestPhysics::test_every_line_sits_at_the_photons_energy_not_the_daughters`
+  and `TestPhysics::test_each_line_sits_where_its_rest_frame_energy_declares`,
+  which recovers each line's rest-frame energy from the kernel's own
+  boosted output.
 - `test/parity/tolerances.py` — `spectra.photon.phi` is `TABULATED`
   (`rtol = 1e-12`), so nothing absorbs this quietly.
 - `hazma/spectra/_photon/data/phi_photon.csv` — the `eta_a` / `etap_a`
@@ -123,16 +138,25 @@ shipped one, so the repair mostly means flipping which is asserted:
 
 ## Risks / open questions
 
-- **The φ may also be missing a `φ → π⁰γ` line entirely, and this is not
-  established.** `constants.pxd` defines `BR_PHI_TO_PI0_A = 1.32e-3`, no
-  `.pyx` reads it, and the ω adds exactly the analogous line for its own
-  `π⁰γ` mode. The φ's `pi0_a` column integrates to 0.002612, against
-  `2 × BR(π⁰ → γγ) × BR(φ → π⁰γ) = 0.002609` for the π⁰'s decay photons
-  alone — suggestive of the direct photon being absent, but the two
-  agreeing to 0.1% is weaker evidence than it looks, since the tables are
-  truncated at low energy. **Check this properly before repairing the two
-  lines above**; if it holds, the same PR should add the missing line
-  rather than leaving a third declared change for later.
-- Sequencing against the corpus is the real cost, as with its siblings:
-  one declared regeneration after Phase 06 Task 6.4 covering all four
-  defects is cheaper than four.
+- **Resolved: the φ *is* missing a `φ → π⁰γ` line, and it is tracked
+  separately.** The check this bullet asked for was run in Task 6 and the
+  ω supplied the control the truncation argument needed. Normalizing each
+  `pi0_a` column by its own `BR(X → π⁰γ)` gives 1.978 for the φ and 1.951
+  for the ω, against `2 BR(π⁰ → γγ) = 1.976` — so both columns hold the
+  π⁰'s own two decay photons and nothing else, and the ω's separate
+  direct-photon line is where its direct photon comes from. The φ has no
+  such line, and `BR_PHI_TO_PI0_A` (now `rust/src/constants.rs:359`) is
+  still read by nothing.
+
+  It is **not** folded in here, contrary to what this bullet used to
+  instruct. That instruction was priced against regenerating the corpus
+  once for several changes; under the declared-delta mechanism
+  (`projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`)
+  the corpus is never regenerated and each repair declares its own delta,
+  so batching saves nothing. It is also a different defect: adding a line
+  changes the φ's yield, where B2 relocates it and leaves the yield
+  exactly where it was. Tracked as
+  [`phi-omits-its-direct-pi0-photon-line.md`](phi-omits-its-direct-pi0-photon-line.md).
+- Sequencing against the corpus was expected to be the real cost. It was
+  not: the declared-delta mechanism made each repair independent, and no
+  regeneration happened for any of them.

--- a/projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md
+++ b/projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md
@@ -46,6 +46,14 @@ value under the case's existing budget. Concretely:
   that prediction is open: a term added to the stored array, a
   closed-form transform of it, a value a second implementation computes,
   or one of those with a further repair's term composed on top.
+- The comparison is relative. A relation may declare an absolute floor
+  beside its relative budget, but only where its own arithmetic cannot
+  resolve the repaired value at every magnitude the array takes — a
+  composition that *relocates* a term subtracts it back out of the base,
+  and where the base is a captured array that cancellation destroys
+  whatever the term's last bit could not hold. The floor is one ulp of
+  the cancelled term, and a shape test caps it below what the case
+  already tolerates for a stored zero, so it cannot grow into a budget.
 - A declaration covers only the positions its mechanism moves: either an
   explicit tuple every entry of which the relation moves, or `MOVED`,
   resolved at comparison time against the array the relation predicts.
@@ -71,7 +79,10 @@ value under the case's existing budget. Concretely:
   the case budget at the declared positions, and costs one extra kernel
   evaluation per declared array in the gate. A closed-form transform of
   the stored array costs neither, which is why it is the relation to
-  reach for first.
+  reach for first. A relocation is the worst case: it cancels a term it
+  did not itself compute, so at positions where that term dominated the
+  result the prediction is exact only down to the term's last bit, and
+  those positions are gated by an absolute floor rather than relatively.
 - **Mitigation:** the relation's budget is measured and written beside
   it; the positions it loosens are exactly the ones the repair moved,
   and the mutation tests in `test_parity.py` keep it from loosening any

--- a/projects/parity-pinned-defect-repair/references/corpus-repinning.md
+++ b/projects/parity-pinned-defect-repair/references/corpus-repinning.md
@@ -62,6 +62,16 @@ strongest the physics supports:
 | `Reference(fn)` | only a second implementation can say what the value should be | all four Group A repairs, via a Task 2 capture; B6, via scipy |
 | `Composed(base, added)` | a second repair moves an array the first already declares | `A1+B1` on `spectra.photon.eta_prime` |
 
+Every relation is compared relatively, with no absolute floor. The one
+exception a repair may reach for is a `Composed` whose addend *relocates*
+a term: it subtracts the term back out of the base, and where the base is
+a captured array that cancellation destroys whatever the term's last bit
+could not hold, so the prediction reads exact zero where the kernel still
+returns the continuum. Such a relation declares an `atol` at one ulp of
+the cancelled term — `A1+B2` on `spectra.photon.phi` is the only one —
+and `test_a_declared_absolute_floor_stays_under_its_arrays_zero_floor`
+caps it below what the case already tolerates for a stored zero.
+
 `test/parity/deltas.py`'s module docstring is authoritative for the set —
 this table is the guidance, not the enumeration, and a repair that adds a
 relation adds it there. What does *not* change is the standard: name the

--- a/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
+++ b/projects/parity-pinned-defect-repair/references/defect-blast-radius.md
@@ -168,11 +168,24 @@ Blocks: all, every non-zero position — it is an overall factor.
 
 ### B1 — η′ line weight (1 case)
 
-`spectra.photon.eta_prime`. All blocks, at the line's image only.
+`spectra.photon.eta_prime`, at the line's image only. **Measured against
+the repaired kernel by Task 5:** 189 positions over six of the case's ten
+value arrays, all upward. Not "all blocks" — both `rest` arrays are
+untouched, because that branch adds no line at all, and so are the scalar
+probes of `rest_plus_eps` and `near_rest`, where the probe falls outside
+the line's boosted window. `../task-notes/task-5-eta-prime-line.md` has
+the per-array table.
 
 ### B2 — φ line energies (1 case)
 
-`spectra.photon.phi`. All blocks, at both lines' images only.
+`spectra.photon.phi`, at the four line images — two shipped, two
+repaired. **Measured against the repaired kernel by Task 6:** 305
+positions over six of the case's ten value arrays, 233 up and 72 down,
+which is what relocating a line rather than adding one looks like. Not
+"all blocks": both `rest` arrays take the no-line branch, and at
+`rest_plus_eps` the window is 2.8e-06 wide in relative energy, too narrow
+for any grid point to fall inside a shipped or a repaired line.
+`../task-notes/task-6-phi-lines.md` has the per-array table.
 
 ### B3 — rho rest-frame branch (2 cases)
 

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -268,8 +268,8 @@ against the 6,500x–33,000x the follow-up measured. The repaired kernel
 reproduces Task 2's Cython oracle **bit for bit** at all 10,045
 positions. Details: `task-4-boost-window.md`.
 
-**B1 — `dnde_photon_eta_prime`, and `dnde_photon` on any final state
-carrying an η′.** Measured before and after on the same worktree by
+**B1 — `dnde_photon_eta_prime`, and `dnde_photon` on a final state whose
+η′ is in flight.** Measured before and after on the same worktree by
 reverting the constant, rebuilding the editable install, and diffing the
 two captures. The spectrum rises at every parent energy above rest and is
 unchanged at `E = M_η′`, where the kernel takes its rest-frame arm and
@@ -288,16 +288,19 @@ integrals now all equal their declared weight to a ratio of
 1.0000000000. `spectra.photon.{eta,long_kaon,short_kaon,omega,phi}` are
 bit-identical across the rebuild. Details: `task-5-eta-prime-line.md`.
 
-**B2 — `dnde_photon_phi`, and `dnde_photon` on any final state carrying a
-φ.** Same before/after method. The spectrum moves at every parent energy
-above rest and is unchanged at `E = M_φ`: 1/601 grid points at
+**B2 — `dnde_photon_phi`, and `dnde_photon` on a final state whose φ is
+in flight.** Same before/after method. The spectrum moves at every parent
+energy above rest and is unchanged at `E = M_φ`: 1/601 grid points at
 `E = M(1+1e-6)`, 331/601 at `1.5 M` and 474/601 at `5 M`, **262 and 449
 of them up** — the sign splits, because a relocation vacates one window
 and fills another rather than adding to what is there. The n-body path
-moves with it (98/201 on `["phi", "phi"]`, 113/201 on `["phi", "eta"]`,
-0/201 on `["eta", "eta"]`). **The yield does not move**: the isolated
-line term integrates to 0.013092203 against the
-`BR(φ → ηγ) + BR(φ → η′γ) = 0.0130922` its weights declare, before and
+moves with it at `cme = 2.5 M_φ` (98/201 on `["phi", "phi"]`, 113/201 on
+`["phi", "eta"]`, 0/201 on `["eta", "eta"]`) and **not at the production
+threshold**, where the φ is at rest and the kernel takes the arm that adds
+no line: `["phi", "phi"]` at `cme = 2 M_φ` and `["phi", "eta"]` at
+`cme = M_φ + M_η` are both bit-identical across the rebuild. **The yield
+does not move**: the isolated line term integrates to 0.013092203 against
+the `BR(φ → ηγ) + BR(φ → η′γ) = 0.0130922` its weights declare, before and
 after, which is why the gate is a position assertion — a yield-only check
 passes on the unrepaired kernel, confirmed by running one. Inverting the
 boosted line term's outer edges recovers 59.8155 and 362.5189 MeV against

--- a/projects/parity-pinned-defect-repair/task-notes/README.md
+++ b/projects/parity-pinned-defect-repair/task-notes/README.md
@@ -27,7 +27,7 @@ section tracks live *status*.
 | 3 | Closed-form delta models (B1–B3) | 1 | **Complete** — models in `deltas.DELTA_MODELS`, keys land with the repairs | `task-3-closed-form-deltas.md` |
 | 4 | Repair A1 — boost integral window | 1, 2 | **Complete** | `task-4-boost-window.md` |
 | 5 | Repair B1 — η′ line weight | 3, 4 | **Complete** — declared as the composite `A1+B1` | `task-5-eta-prime-line.md` |
-| 6 | Repair B2 — φ line energies | 3, 4 | Not started | `task-6-phi-lines.md` |
+| 6 | Repair B2 — φ line energies | 3, 4 | **Complete** — declared as the composite `A1+B2` | `task-6-phi-lines.md` |
 | 7 | Repair A2 — muon photon endpoint | 1, 2 | Not started | `task-7-photon-muon-endpoint.md` |
 | 8 | Repair A3 — charged-pion forward cone | 7 | Not started | `task-8-charged-pion-cone.md` |
 | 9 | Repair B3 — rho rest-frame branch | 3, 8 | Not started | `task-9-rho-rest-frame.md` |
@@ -134,6 +134,23 @@ this project is time-critical.
   platform drift the case budget already absorbs (`numpy 2.5.1 → 2.5.3`,
   `scipy 1.18.0 → 1.18.1`, a macOS point release). Capture the blocks
   twice — defective build, then repaired build — and diff those.
+- **A repair that *relocates* a term cannot be declared exactly, and the
+  limit is representation rather than budget.** Task 6's composite
+  subtracts the shipped line back out of the A1 capture; where that line
+  dominated the value — a plateau of 3.107723e-05 over a continuum of
+  3.3e-21 — the capture never held the remainder, so the prediction reads
+  exact zero and no `rtol` describes the position. Additive repairs (B1,
+  B5) never hit this because they only add. Expect it for any later
+  repair that moves a feature rather than scaling one, and reach for a
+  declared absolute floor rather than a looser `rtol` (`../rules.md`
+  rule 2).
+- **`../references/defect-blast-radius.md`'s per-defect "all blocks" is a
+  graph reading, and both measurements so far came back narrower.** B1
+  moves 6 of 10 value arrays, B2 a *different* 6 of 10. The two `rest`
+  arrays never move (that branch adds no line) and `rest_plus_eps` opens
+  a window 2.8e-06 wide in relative energy, too narrow for a grid point
+  to fall inside any line, shipped or repaired. Both sections now carry
+  the measurement.
 - **A declared position at exactly 0.500000 is a second defect, not a
   rounding.** B5's factor-of-two positions are where the muon-decay
   continuum's own quadrature returns a hard zero: its integrand's support
@@ -228,8 +245,8 @@ this project is time-critical.
 
 ## Numerical impact so far
 
-**Five public values have moved: B4 in PR #87, B5 in Task 10a, B6 in
-Task 13, A1 in Task 4 and B1 in Task 5** (bullets below).
+**Six public values have moved: B4 in PR #87, B5 in Task 10a, B6 in
+Task 13, A1 in Task 4, B1 in Task 5 and B2 in Task 6** (bullets below).
 
 **A1 — all seven tabulated photon spectra.** Measured on the corpus's
 own grids (10,045 positions, 35 blocks) against a build carrying the
@@ -270,6 +287,26 @@ scalar probe of `rest_plus_eps` or `near_rest`. The four `X → γγ` line
 integrals now all equal their declared weight to a ratio of
 1.0000000000. `spectra.photon.{eta,long_kaon,short_kaon,omega,phi}` are
 bit-identical across the rebuild. Details: `task-5-eta-prime-line.md`.
+
+**B2 — `dnde_photon_phi`, and `dnde_photon` on any final state carrying a
+φ.** Same before/after method. The spectrum moves at every parent energy
+above rest and is unchanged at `E = M_φ`: 1/601 grid points at
+`E = M(1+1e-6)`, 331/601 at `1.5 M` and 474/601 at `5 M`, **262 and 449
+of them up** — the sign splits, because a relocation vacates one window
+and fills another rather than adding to what is there. The n-body path
+moves with it (98/201 on `["phi", "phi"]`, 113/201 on `["phi", "eta"]`,
+0/201 on `["eta", "eta"]`). **The yield does not move**: the isolated
+line term integrates to 0.013092203 against the
+`BR(φ → ηγ) + BR(φ → η′γ) = 0.0130922` its weights declare, before and
+after, which is why the gate is a position assertion — a yield-only check
+passes on the unrepaired kernel, confirmed by running one. Inverting the
+boosted line term's outer edges recovers 59.8155 and 362.5189 MeV against
+the declared 59.8150 and 362.5190, where the shipped energies were 959.65
+and 656.94. On the corpus: 305 positions over 6 of this case's 10 value
+arrays, 233 up and 72 down, none in either `rest` or either
+`rest_plus_eps` array. `spectra.photon.{eta,eta_prime,omega,charged_kaon,
+long_kaon,short_kaon}` are bit-identical across the rebuild. Details:
+`task-6-phi-lines.md`.
 
 **B6 — both mediator `thermal_cross_section`, and `relic_density`
 through them.** Measured on the two corpus cases' own grids (570
@@ -368,8 +405,8 @@ Reach: B1 six arrays / 189 positions, B2 six / 305, B3 four / 350.
 Tasks 4–10 each move a published spectrum by design, and each records the
 function, the grid and the max shift here in its own PR (`../rules.md`
 rule 10). Task 12 aggregates this section into the `CHANGELOG.md` entry —
-it does not reconstruct it. B4, B5, B6, A1 and B1 have each written their
-own `CHANGELOG.md` entry already, all but B4's under `[Unreleased]` because
+it does not reconstruct it. B4, B5, B6, A1, B1 and B2 have each written
+their own `CHANGELOG.md` entry already, all but B4's under `[Unreleased]` because
 2.2.0 is released; Task 12 renames that heading rather than re-deriving
 it, and
 `preflight.sh --closing` greps for `## [<new version>]`, so it must.
@@ -391,7 +428,24 @@ it, and
 - **A composite covers only the arrays *every* named repair moves**
   (Task 5): two of A1's eight `eta_prime` arrays keep A1's declaration
   alone, because B1 moves nothing at their scalar probe. Naming B1 there
-  would be a label wider than its mechanism.
+  would be a label wider than its mechanism. Task 6 is the second
+  instance and lands on a different set: both `rest_plus_eps` arrays keep
+  A1 alone, and `near_rest.scalar_values` — which B1 did not reach —
+  joins the composite.
+- **A relation may declare an absolute floor, and only a relocation needs
+  one** (Task 6). `atol` is a field on all four relations, defaulting to
+  `0.0`; the runner compares at `max(budget.atol, relation.atol)`, and
+  `test_a_declared_absolute_floor_stays_under_its_arrays_zero_floor` caps
+  every declared floor below `tolerances.zero_floor` of the array it
+  covers, with `EXPECTED_FLOORED_ARRAYS` counting them. `A1+B2` declares
+  1e-20, one ulp of the plateau it cancels. Amends ADR-0001 a second time.
+- **A defect found in a repair's own area is filed, not folded in**
+  (Task 6). The φ omits a direct `φ → π⁰γ` line, which the B2 follow-up
+  asked to be checked before repairing and instructed be fixed in the same
+  PR. It is filed as its own follow-up instead: that instruction was
+  priced against a corpus regeneration that ADR-0001 removed, adding a
+  line raises the yield where B2 relocates it, and `deltas.REPAIRS` is a
+  closed set of ten that a new defect cannot silently join.
 - **A relation's budget is the case's own where the port is bit-faithful**
   (Task 4): A1 carries `tolerances.TABULATED_RTOL` = 1e-12 against a
   measured 0.0, because the capture is one platform's and the declared
@@ -537,6 +591,30 @@ relations that were never built and neither that were), this file, and
 this task re-points keys rather than adding them. `test/parity/data/`
 untouched.
 
+### Task 6 (B2)
+
+`rust/src/kernels/photon_tables.rs` (a `photon_line_energy` const fn all
+four `X → Yγ` energies now go through, the two repaired constants and
+their doc comments, the module docstring, two renamed tests, two repaired
+bit patterns), `test/test_core_photon_tables.py` (`SPECTRA["phi"]`, the
+module docstring, the renamed `TestPhysics` test, and a new line-position
+test), `test/parity/deltas.py` (the `atol` field on all four relations,
+"Absolute floors", `_A1_B2`, six re-pointed keys),
+`test/parity/test_parity.py` (the runner honors a relation's floor,
+`EXPECTED_FLOORED_ARRAYS`, the cap test),
+`test/parity/test_delta_models.py` and `test/parity/README.md` (stale
+roll-calls of which models had landed — both already wrong for B1),
+`CHANGELOG.md`,
+`docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`,
+`docs/followups/todo/phi-omits-its-direct-pi0-photon-line.md` (new) with
+its `docs/followups/README.md` row,
+`../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`,
+`../references/corpus-repinning.md`,
+`../references/defect-blast-radius.md` (B1's and B2's measured reach),
+this file, and `task-6-phi-lines.md` (new). `EXPECTED_DECLARED_ARRAYS`
+stays 98 — this task re-points keys rather than adding them.
+`test/parity/data/` untouched.
+
 ### Task 13 (B6)
 
 `rust/src/kernels/vector_xs.rs`, `rust/src/kernels/scalar_xs.rs`
@@ -596,12 +674,13 @@ has no `hazma._core` test probes for the suite to import.
 ## Open Questions
 
 - **Do B1's and B2's declared arrays collapse into A1's?** Answered for
-  B1 (Task 5): they do, through a new `deltas.Composed` relation and the
-  label `A1+B1`, and they had to — A1 and B1 move 18 of the same
-  positions. Two of A1's eight `eta_prime` arrays keep A1's declaration
-  alone, because B1 reaches neither scalar probe. Task 6 repeats the
-  shape for `A1+B2` and re-derives which of φ's arrays B2 actually moves
-  rather than assuming six.
+  both. They do, through `deltas.Composed` and the labels `A1+B1`
+  (Task 5) and `A1+B2` (Task 6), and they had to: A1 and B1 share 18
+  positions on `eta_prime`, A1 and B2 share 90 of B2's 305 on `phi`. Each
+  composite leaves two of A1's eight arrays to A1 alone, but not the same
+  two — B1 spares the scalar probes of `rest_plus_eps` and `near_rest`,
+  B2 both `rest_plus_eps` arrays. Task 9 faces the same question for A3
+  and B3 on the two rho cases.
 - **Do A2's and A3's declared positions on the two rho cases actually
   overlap, or only appear to?** They are different mechanisms (an
   endpoint guard and a lost quadrature support) reaching the same arrays
@@ -619,14 +698,16 @@ has no `hazma._core` test probes for the suite to import.
   The sweep of the remaining `quad` call sites has not been done —
   [`neutrino-pion-continuum-loses-its-quadrature-support.md`](../../../docs/followups/todo/neutrino-pion-continuum-loses-its-quadrature-support.md)
   carries it as its own first question.
-- **Will Group B's relation budgets survive their repairs?** B1's did,
-  and then some: the composite measured 2.1e-16 against the repaired
-  kernel — one ulp — where the standalone model reserved 1e-11. It is
-  declared at the case's own 1e-12 rather than tightened to what it
-  measures, for A1's reason (the capture is one platform's). B2 and B3
-  still carry 1e-11 and 1e-9 unmeasured; Tasks 6 and 9 measure. A repair
-  needing a *wider* budget has found something Task 3 did not model
-  (`rules.md` rule 2).
+- **Will Group B's relation budgets survive their repairs?** B1's did
+  (2.1e-16 against the repaired kernel, one ulp, where the standalone
+  model reserved 1e-11) and B2's did relatively (2.9e-14 worst), but B2
+  needed something the question did not anticipate: an absolute floor,
+  because two positions have no meaningful relative budget at all. Both
+  are declared at the case's own 1e-12 rather than tightened to what they
+  measure, for A1's reason (the capture is one platform's). B3 still
+  carries 1e-9 unmeasured; Task 9 measures. A repair needing a *wider*
+  `rtol` has found something Task 3 did not model (`rules.md` rule 2) —
+  a floor is a different object and is capped by its own test.
 - **Should the Task 2 oracles stay committed after `cython-to-rust`
   closes?** They are the last evidence that a repaired value was ever
   checked against a non-Rust implementation. Anticipated ADR.
@@ -656,11 +737,11 @@ has no `hazma._core` test probes for the suite to import.
   the worked precedent for A2, A3 and A4 — they need no new machinery.
 - `test/parity/data/` is intact — `python test/parity/generate.py --check`
   verifies it in under a second with no build.
-- B4 (PR #87), B5 (Task 10a), B6 (Task 13), A1 (Task 4) and B1 (Task 5)
-  are the repairs that have changed a library value; every other corpus
-  array is still compared against its stored value.
+- B4 (PR #87), B5 (Task 10a), B6 (Task 13), A1 (Task 4), B1 (Task 5) and
+  B2 (Task 6) are the repairs that have changed a library value; every
+  other corpus array is still compared against its stored value.
   `test/parity/deltas.py` declares 98 arrays — 30 for B4, 6 for B5, 6 for
-  B6, 50 for A1 alone and 6 for the composite `A1+B1` — and
+  B6, 44 for A1 alone, 6 for `A1+B1` and 6 for `A1+B2` — and
   `test_parity.EXPECTED_DECLARED_ARRAYS` is the literal that makes a
   change to that number show up in a diff. Re-derive the split with
   `Counter(d.repair for d in deltas.DECLARED_DELTAS.values())`.
@@ -671,21 +752,27 @@ has no `hazma._core` test probes for the suite to import.
   repair (Findings). On this worktree Task 4's defective build
   reproduced the stored corpus bit for bit on all 10,045 A1 positions,
   so the two agreed; that is this platform, not a general fact.
-- B2 and B3 have finished, corpus-checked delta models in
-  `deltas.DELTA_MODELS`, and B3's arrays are still undeclared, so Task 9
-  adds keys and bumps `EXPECTED_DECLARED_ARRAYS` in the ordinary way.
-  **Task 6 cannot**: A1 already declares every array B2 moves, and one
-  key holds one `Delta`, so it composes as `A1+B2` the way Task 5 did for
-  B1 — `task-5-eta-prime-line.md` is the worked precedent, and the
-  position counts in `task-3-closed-form-deltas.md` are to be re-derived
-  against the repaired kernel rather than pasted. Task 5's held exactly;
-  that is one case, not a rule.
-- The delta layer now carries four relations. A new repair picks
-  `Additive` when the physics names the term, `Exact` when a closed form
-  transforms the stored array, `Reference` when only a second
-  implementation can say what the value should be, and `Composed` when a
-  second repair moves an array the first already declares; all four
-  answer `expected`, and the runner needs no change for any of them.
+- B3 is the last Group B model still undeclared, so Task 9 adds keys and
+  bumps `EXPECTED_DECLARED_ARRAYS` in the ordinary way — unless A3 has
+  already declared the rho arrays by then, in which case it composes.
+  Task 3's predicted reach has now held exactly twice (B1: 6 arrays, 189
+  positions; B2: 6 arrays, 305 positions, 233 up and 72 down), but B2's
+  six were not the six a reader would have guessed from B1's, so
+  re-derive *which* arrays as well as how many
+  (`../rules.md` rule 11).
+- A relation may now declare an absolute floor as well as an `rtol`
+  (Task 6). Reach for one only where the prediction cannot resolve the
+  repaired value at some magnitude the array takes — a relocation that
+  cancels a term it did not compute is the only case so far — and never
+  in place of an `rtol` a measurement says is too tight.
+- The delta layer carries four relations. A new repair picks `Additive`
+  when the physics names the term, `Exact` when a closed form transforms
+  the stored array, `Reference` when only a second implementation can say
+  what the value should be, and `Composed` when a second repair moves an
+  array the first already declares; all four answer `expected`, and a
+  fifth would need no runner change to be compared. The runner does read
+  one field beyond `expected` — a relation's optional `atol` — which
+  Task 6 added and only `A1+B2` sets.
 
 **Currently risky / unknown:**
 

--- a/projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md
+++ b/projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md
@@ -154,6 +154,16 @@ this repair and the A1 boost repair that already owns the same arrays.
 - **`SPECTRA["phi"]` in `test/test_core_photon_tables.py` moved with the
   kernel**, as `SPECTRA["eta_prime"]` did in Task 5: that table is the
   independent statement of which lines the kernel carries.
+- **The public-impact claim is scoped to a φ in flight** (review round 1).
+  The first draft said `dnde_photon` moves for "any final state containing
+  a φ", one sentence after recording that a φ at rest is untouched. At the
+  two-body production threshold every φ is at rest, so `branch` returns
+  `Branch::RestFrame`, that arm adds no line, and neither line energy is
+  reachable. The sweep found the identical overstatement in the merged
+  `CHANGELOG.md` entries for B1 and A1, each one sentence after its own
+  rest-frame caveat; all five occurrences are corrected and the class is
+  in `docs/agents/lessons.md` as
+  `[composed-entry-point-inherits-the-branch-caveat]`.
 
 ## Files Changed
 
@@ -211,11 +221,19 @@ spectrum.
 The n-body public path, `hazma.spectra.dnde_photon(E, cme, states)` on
 `np.geomspace(1, 2000, 201)` MeV at `cme = 2.5 M_φ`:
 
-| Final state | moved | relative shift | up / down |
-| --- | ---: | --- | ---: |
-| `["phi", "phi"]` | 98/201 | 6.57e-05 … 1.00 | 73 / 25 |
-| `["phi", "eta"]` | 113/201 | 2.81e-05 … 1.00 | 90 / 23 |
-| `["eta", "eta"]` | 0/201 | — | — |
+| Final state | `cme` | moved | relative shift | up / down |
+| --- | --- | ---: | --- | ---: |
+| `["phi", "phi"]` | `2.5 M_φ` | 98/201 | 6.57e-05 … 1.00 | 73 / 25 |
+| `["phi", "eta"]` | `2.5 M_φ` | 113/201 | 2.81e-05 … 1.00 | 90 / 23 |
+| `["eta", "eta"]` | `2.5 M_φ` | 0/201 | — | — |
+| `["phi", "phi"]` | `2 M_φ` | 0/201 | — | — |
+| `["phi", "eta"]` | `M_φ + M_η` | 0/201 | — | — |
+
+The last two rows are the two-body production thresholds, where every φ is
+produced at rest: `branch` returns `Branch::RestFrame` at
+`E − m < DBL_EPSILON`, that arm adds no line, and so neither repaired
+energy is reachable. A composed entry point is therefore narrower in reach
+than the kernel it calls, not equal to it.
 
 **Yield: relocated, not changed.** The line term isolated by subtracting
 the boosted continuum, integrated over its own window on a 2,000,001-point
@@ -522,10 +540,17 @@ $ git diff origin/master -- '*.py' '*.rs' \
 | φ `pi0_a` ratios 1.978 / 1.951 vs 1.976 | `numpy.trapezoid` over the two CSVs ÷ each `BR(X → π⁰γ)` | 0.0026115/1.32e-3 = 1.9784; 0.16275/8.34e-2 = 1.9514; `2 × 0.98823` = 1.97646 | OK |
 
 **Numerical-impact statement.** `hazma.spectra.dnde_photon_phi` and
-`hazma.spectra.dnde_photon` on any final state containing a φ move, by
-design; the grids, the per-block counts and the invariant yield are in
-`## Numerical impact` above. Six sibling photon spectra and the
-`["eta", "eta"]` n-body state are bit-identical across the rebuild
+`hazma.spectra.dnde_photon` on a final state whose φ is **in flight**
+move, by design; the grids, the per-block counts and the invariant yield
+are in `## Numerical impact` above. A φ at rest is not in the repair's
+reach at all — the kernel's `branch` guard takes the rest-frame arm at
+`E − m < DBL_EPSILON`, and that arm adds no line, so neither line energy
+can enter. Measured rather than argued: `["phi", "phi"]` at
+`cme = 2 M_φ` and `["phi", "eta"]` at `cme = M_φ + M_η`, the two-body
+production thresholds, are bit-identical across the rebuild, while
+`["phi", "phi"]` at `cme = 2.5 M_φ` moves at 98 of 201 grid points. Six
+sibling photon spectra and the `["eta", "eta"]` n-body state are
+bit-identical across the rebuild
 (`np.geomspace(1, 5 M, 601)` at four parent energies each, and
 `np.geomspace(1, 2000, 201)` at `cme = 2.5 M_φ`). The project's
 `version_bump: minor` is unchanged and still correct.

--- a/projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md
+++ b/projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md
@@ -1,0 +1,570 @@
+# Task 6: Repair B2 — the φ photon line energies
+
+**Date:** 2026-09-07
+**Project:** parity-pinned-defect-repair
+**Status:** Complete
+**Plan References:** `../PLAN.md` "Task 6", "Numerical impact"; `../rules.md`
+rules 1–7, 10, 11; `../references/corpus-repinning.md` (Relations, the
+shape tests); `../references/defect-blast-radius.md` (B2's row)
+**Related ADRs:** `../adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`
+(amended: a relation may declare an absolute floor)
+**Depends On:** Task 3 (the B2 model), Task 4 (A1, which declares the same
+arrays), Task 5 (the `Composed` relation)
+
+## Objective
+
+Put both φ photon lines at the photon's rest-frame energy rather than the
+daughter meson's, and declare the resulting corpus shift as a composite of
+this repair and the A1 boost repair that already owns the same arrays.
+
+## Exit Criteria
+
+- `PHI_TO_ETA_A_ENERGY` is 362.5189975276151 MeV and
+  `PHI_TO_ETAP_A_ENERGY` is 59.815040556235125 MeV, both from
+  `(M_φ² − m²) / (2 M_φ)`.
+- The gate is a **position** assertion, not a magnitude one: the total
+  yield is unchanged at 0.013092 photons per decay, so a yield-only check
+  passes on an unrepaired kernel.
+- A declared delta on `spectra.photon.phi` only. `spectra.photon.omega`,
+  whose two `ω → Yγ` lines were always the photon's, does not move.
+- The declaration composes with A1's rather than overlapping it
+  (`../rules.md` rule 7), and reverting the repair turns the gate red.
+- `git diff --stat -- test/parity/data` empty.
+
+## Inputs Reviewed
+
+- `../PLAN.md` — Goal, "Numerical impact", Task 6, "Orientation".
+- `../rules.md` — all eleven.
+- `task-notes/README.md` — Tasks table, Open Questions, Handoff.
+- `task-5-eta-prime-line.md` — the worked composite precedent, its Open
+  Questions (which answered "second composite, not a third part").
+- `../references/corpus-repinning.md` §Relations, §"How the runner uses
+  it"; `defect-blast-radius.md` (B2's row and the A1/B2 overlap).
+- `docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`,
+  including its unanswered `φ → π⁰γ` risk bullet.
+- `test/parity/deltas.py`, `test_parity.py`, `test_delta_models.py`,
+  `oracle_reference.py`, `tolerances.py`, `stability.py`.
+- `rust/src/kernels/photon_tables.rs`, `test/test_core_photon_tables.py`.
+
+## Findings
+
+- **Task 3's predicted reach held exactly, but not the predicted arrays.**
+  Six arrays and 305 positions, 233 up and 72 down — the model's own
+  numbers, re-derived against the repaired kernel (`../rules.md` rule 11).
+  The six are *not* the six B1 moved: B2 reaches `near_rest.scalar_values`
+  where B1 did not, and reaches neither `rest_plus_eps` array where B1
+  reached one. At `rest_plus_eps` the boost opens a window 2.8e-06 wide in
+  relative energy, too narrow for any grid point to fall inside a shipped
+  or a repaired line — a fact that holds for both, which is why that block
+  keeps A1's declaration alone.
+- **A1 and B2 genuinely overlap: 90 of B2's 305 positions.** Unevenly —
+  19 of `near_rest.values`, 0 of `near_rest.scalar_values`, 36 and 1 of
+  `boosted_mild.{values,scalar_values}`, 33 and 1 of `boosted_strong`.
+  Neither "provably disjoint" nor "one contains the other" was available,
+  so the composite is required rather than chosen.
+- **The sign splits, which is the signature of a relocation.** B1 moved
+  189 of 189 positions upward, because it added a second copy of a line.
+  B2 moves 233 up and 72 down: the shipped lines vacate their windows and
+  the repaired ones fill new ones. That is why the deliverable's gate had
+  to be positional — see the next finding.
+- **A yield-only gate would have passed on the unrepaired kernel, and this
+  was confirmed rather than reasoned about.** With the two constants
+  reverted and the extension rebuilt,
+  `test_each_line_carries_the_photon_count_its_weight_declares[phi]` still
+  passes: a boosted δ-function integrates to its own weight wherever it
+  sits. The new `test_each_line_sits_where_its_rest_frame_energy_declares`
+  is what fails, and only for the φ.
+- **The composite cannot be exact, and the reason is representation
+  rather than budget.** At two positions — `near_rest.values[195]` and
+  `boosted_mild.values[193]`, both inside the shipped `φ → ηγ` window and
+  outside both repaired ones — the prediction reads exactly 0.0 where the
+  kernel returns 3.331476e-21 and 3.143213e-22, which is the boosted
+  continuum (confirmed against `boost_integrate_linear_interp` directly).
+  The addend subtracts the shipped line back out of the A1 capture, and
+  the plateau there is 3.107723e-05, whose last bit is 6.8e-21 — larger
+  than the continuum underneath it, so the capture never held it and no
+  prediction built on the capture can return it. This is the layer's first
+  relation that *relocates* a term rather than adding one, and the only
+  kind that can hit this.
+- **The φ is indeed missing a direct `φ → π⁰γ` line**, which the
+  follow-up's risk bullet asked to be checked before this repair. The ω
+  supplied the control its truncation argument lacked: normalizing each
+  `pi0_a` column by its own `BR(X → π⁰γ)` gives 1.978 for the φ and 1.951
+  for the ω against `2 BR(π⁰ → γγ) = 1.976`, so both columns hold the π⁰'s
+  own decay photons and nothing else, and the ω's direct photon comes from
+  its line. `BR_PHI_TO_PI0_A` (`rust/src/constants.rs:359`) is read by
+  nothing. Filed rather than folded in — see Decisions.
+
+## Decisions and Implementation Notes
+
+- **A relation may declare an absolute floor, and `A1+B2` declares
+  1e-20.** `../rules.md` rule 2 forbids widening a budget when a repaired
+  value misses its relation, so the declaration had to change instead. The
+  honest statement is not relative: at a position whose predicted value is
+  exactly zero, no `rtol` describes anything. The floor is one ulp of the
+  plateau the composition cancels (6.8e-21, rounded to 1e-20). It sits
+  **11.6 decades under the smallest value these six arrays carry above it**
+  (3.849e-09) and 8.6 decades under the tightest `zero_floor` among them
+  (3.580e-12), so nothing but the two cancellation positions is inside it.
+  `atol` is a field on all four relations, defaulting to `0.0`, and
+  `_assert_declared_delta` compares at `max(budget.atol, relation.atol)`;
+  the staleness check keeps the case's own floor, because whether the
+  repair happened is a different question from how precisely it can be
+  predicted. ADR-0001 is amended accordingly.
+- **The floor is capped, not merely justified.**
+  `test_a_declared_absolute_floor_stays_under_its_arrays_zero_floor`
+  requires every declared `atol` to sit below `tolerances.zero_floor` of
+  the array it covers — what the corpus already tolerates where it stored
+  an exact zero — and counts them against `EXPECTED_FLOORED_ARRAYS = 6`.
+  Uncapped, the field would be a tunable that grows until the gate
+  passes: `docs/agents/lessons.md` `[exemption-wider-than-its-mechanism]`.
+- **Both φ energies and both ω energies now go through one
+  `const fn photon_line_energy(parent, daughter)`.** The defect was one
+  sign in an expression written out four times — the follow-up traces its
+  origin to exactly that — and one function leaves no site for the `+`
+  form to be written at. The ω constants are bit-identical through it,
+  which `every_folded_constant_is_the_shipped_immediate_or_its_declared_repair`
+  asserts against the immediates the shipped object code loads.
+- **`folded_constants_match_the_shipped_object_code` was renamed**, per
+  `docs/agents/lessons.md` `[test-name-claims-an-unmade-assertion]`: with
+  three of its sixteen constants now carrying a repaired value rather than
+  the shipped immediate, the old name claimed a check the test no longer
+  performs for all of them. It is
+  `every_folded_constant_is_the_shipped_immediate_or_its_declared_repair`,
+  and each repaired constant names the immediate it replaces beside it, so
+  the object code stays recoverable from the test.
+- **Both defect-pinning tests were rewritten to state the repaired physics
+  over all four `X → Yγ` lines**, the ω's held with the φ's rather than as
+  a control, since both mesons now run through the same function:
+  `the_phi_line_energies_are_the_daughter_mesons` →
+  `every_line_energy_is_the_photons_not_the_daughters`, and
+  `TestPhysics::test_the_phi_lines_sit_at_the_daughter_mesons_energy` →
+  `TestPhysics::test_every_line_sits_at_the_photons_energy_not_the_daughters`.
+  Both keep an explicit-value and a not-equal line against the shipped
+  energies, and both add `E_γ < M/2`, the bound no two-body photon can
+  exceed and which the shipped `φ → η′γ` energy broke by 88%.
+- **The missing `φ → π⁰γ` line is filed, not folded in.** The follow-up
+  instructed the opposite ("the same PR should add the missing line"), and
+  that instruction is superseded on its own terms: it was priced against
+  regenerating the corpus once for several changes, and under ADR-0001 the
+  corpus is never regenerated, so batching saves nothing. It is also a
+  different defect — adding a line raises the yield where B2 relocates it
+  — and it is not among the ten `deltas.REPAIRS` holds as a closed set.
+  The follow-up's bullet is rewritten to record the answer and the reason.
+- **`SPECTRA["phi"]` in `test/test_core_photon_tables.py` moved with the
+  kernel**, as `SPECTRA["eta_prime"]` did in Task 5: that table is the
+  independent statement of which lines the kernel carries.
+
+## Files Changed
+
+- `rust/src/kernels/photon_tables.rs` — the `photon_line_energy` const fn,
+  both φ energies and both ω energies routed through it, their doc
+  comments, the module docstring's folded-constants paragraph, the two
+  renamed tests and the two repaired bit patterns.
+- `test/test_core_photon_tables.py` — `SPECTRA["phi"]`'s two line
+  energies, the module docstring's defect section, the renamed
+  `TestPhysics` test, and the new
+  `test_each_line_sits_where_its_rest_frame_energy_declares`.
+- `test/parity/deltas.py` — the `atol` field on all four relations and its
+  "Absolute floors" section, the `_A1_B2` declaration, six re-pointed
+  `phi` keys, and the two line-energy helpers' docstrings.
+- `test/parity/test_parity.py` — the runner honors a relation's floor,
+  `EXPECTED_FLOORED_ARRAYS`, and the cap test.
+- `test/parity/test_delta_models.py` — the module docstring's roll-call of
+  which models have landed, and `MODEL_CASES`.
+- `test/parity/README.md` — the declared-repair roll-call (already stale
+  for B1) and the third carve-out.
+- `CHANGELOG.md` — the `[Unreleased] / Changed` entry, stating the
+  relocation and the unchanged yield.
+- `docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`
+  — status annotated as repaired, the renamed tests, and the `φ → π⁰γ`
+  risk bullet answered.
+- `docs/followups/todo/phi-omits-its-direct-pi0-photon-line.md`,
+  `docs/followups/README.md` — the new follow-up and its index row.
+- `projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md`
+  — the absolute-floor decision bullet and its consequence.
+- `../references/corpus-repinning.md` — the floor, under Relations.
+- `../references/defect-blast-radius.md` — B1's and B2's measured reach,
+  replacing "all blocks" in both.
+- `projects/parity-pinned-defect-repair/task-notes/README.md`,
+  `.../task-6-phi-lines.md` — bookkeeping.
+
+## Numerical impact
+
+**`hazma.spectra.dnde_photon_phi` moves at every parent energy above rest;
+six sibling spectra and the `E = M_φ` rest case do not.** Measured before
+and after on the same worktree, by reverting the two Rust constants,
+rebuilding the editable install, capturing, restoring (`grep`-verified)
+and rebuilding again.
+
+Grid: `np.geomspace(1.0, 5 M, 601)` MeV at four parent energies per
+spectrum.
+
+| Entry point | `E_parent` | moved | relative shift | up / down |
+| --- | --- | ---: | --- | ---: |
+| `dnde_photon_phi` | `M` | 0/601 | — | — |
+| `dnde_photon_phi` | `M (1 + 1e-6)` | 1/601 | 1.00 | 0 / 1 |
+| `dnde_photon_phi` | `1.5 M` | 331/601 | 5.26e-05 … 1.00 | 262 / 69 |
+| `dnde_photon_phi` | `5 M` | 474/601 | 1.12e-05 … 1.00 | 449 / 25 |
+| `dnde_photon_{eta,eta_prime,omega,charged_kaon,long_kaon,short_kaon}` | all four | 0/601 each | — | — |
+
+The n-body public path, `hazma.spectra.dnde_photon(E, cme, states)` on
+`np.geomspace(1, 2000, 201)` MeV at `cme = 2.5 M_φ`:
+
+| Final state | moved | relative shift | up / down |
+| --- | ---: | --- | ---: |
+| `["phi", "phi"]` | 98/201 | 6.57e-05 … 1.00 | 73 / 25 |
+| `["phi", "eta"]` | 113/201 | 2.81e-05 … 1.00 | 90 / 23 |
+| `["eta", "eta"]` | 0/201 | — | — |
+
+**Yield: relocated, not changed.** The line term isolated by subtracting
+the boosted continuum, integrated over its own window on a 2,000,001-point
+grid at `E_φ = 2 M_φ`, is **0.013092203** against the
+`BR(φ → ηγ) + BR(φ → η′γ) = 0.013092200` the two weights declare — the
+residual is the trapezoid across the plateau edges. That figure is
+invariant under the repair, because a boosted δ-function integrates to its
+own weight wherever it sits, which is precisely why the gate is
+positional. `PLAN.md`'s pre-repair "0.60% of the photon yield" reproduces
+against the rest-frame continuum: `0.013092 / 2.1616 = 0.606%` of the
+continuum, `0.602%` of the two together. Integrating the *lab-frame*
+spectrum on a fixed 601-point grid does move — by −6.6e-02 at
+`E_φ = M(1 + 1e-6)` — but that is the trapezoid failing to resolve a
+plateau whose width and height both change with its position, not a yield
+change; the window-independent statement above is the one to quote.
+
+**Physics invariant (`../rules.md` rule 4).** The line positions recovered
+from the kernel's own boosted output at `E_φ = 2 M_φ`, by inverting the
+outermost edges of the isolated line term:
+
+```text
+phi -> etap gamma   recovered  59.815510 MeV   declared  59.815041   rel 7.8e-06
+phi -> eta gamma    recovered 362.518896 MeV   declared 362.518998   rel 2.8e-07
+```
+
+Both inside the grid's own resolution (`cell / edge` is 6.3e-05 and
+7.5e-07). Against the shipped 959.646 and 656.942 MeV these are off by
+1504% and 81%, so the measurement separates the two hypotheses by five
+decades. `E_γ + E_daughter = M_φ` holds for both, and both now satisfy
+`E_γ < M_φ / 2 = 509.73` MeV, which the shipped `φ → η′γ` energy did not.
+
+**Corpus.** 6 arrays, 305 positions, all in `spectra.photon.phi`; the
+other six tabulated photon cases are bit-identical across the rebuild.
+
+| Block | Suffix | moved / size | relative shift | up / down | also moved by A1 |
+| --- | --- | ---: | --- | ---: | ---: |
+| `rest` | `values` | 0 / 255 | — | — | 0 |
+| `rest` | `scalar_values` | 0 / 8 | — | — | 0 |
+| `rest_plus_eps` | `values` | 0 / 285 | — | — | 0 |
+| `rest_plus_eps` | `scalar_values` | 0 / 8 | — | — | 0 |
+| `near_rest` | `values` | 57 / 285 | 1.29e-04 … 1.00e+00 | 23 / 34 | 19 |
+| `near_rest` | `scalar_values` | 1 / 8 | 1.00e+00 | 0 / 1 | 0 |
+| `boosted_mild` | `values` | 102 / 285 | 4.48e-05 … 1.00e+00 | 83 / 19 | 36 |
+| `boosted_mild` | `scalar_values` | 3 / 8 | 5.40e-05 … 2.35e-01 | 3 / 0 | 1 |
+| `boosted_strong` | `values` | 139 / 285 | 2.91e-06 … 1.00e+00 | 121 / 18 | 33 |
+| `boosted_strong` | `scalar_values` | 3 / 8 | 6.14e-04 … 1.47e-02 | 3 / 0 | 1 |
+
+The composite's residue against the repaired kernel, per array: 0.0 at
+`near_rest.scalar_values`, 1.2e-16 and 1.9e-16 at the two boosted scalar
+probes, 2.9e-14 worst at `boosted_strong.values`, and the two
+cancellation positions the 1e-20 floor covers.
+
+`git diff --stat -- test/parity/data` is empty (`../rules.md` rule 1).
+
+## Verification
+
+```text
+$ env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh \
+      --paths "test/parity/deltas.py test/parity/test_parity.py \
+               test/parity/test_delta_models.py \
+               test/test_core_photon_tables.py" \
+      --md "<the ten touched markdown files>"
+RESULT: PASS
+  black 4 files, isort 0 new (2 fixed), ruff 0 new (2 fixed),
+  cargo fmt/clippy/test, import hazma 2.2.0, markdownlint, forbidden
+  tokens none added, and
+  pytest  2293 passed, 16 skipped, 1 warning, 37 subtests passed in 26.80s
+
+$ .venv/bin/python -m pytest test/parity -q -n 0
+688 passed, 1 skipped in 6.41s
+
+$ .venv/bin/python -m pytest test/test_core_photon_tables.py -q -n 0
+196 passed, 2 skipped in 5.69s
+
+$ cargo test --manifest-path rust/Cargo.toml --no-default-features \
+      --features test-probes
+test result: ok. 263 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+The preflight `pytest` row is the full suite and is the run that gates the
+commit. It reads 16 skipped where a bare `.venv/bin/python -m pytest` reads
+25, because nine `test/agents/test_lint_delta.py` cases shell out to `ruff`
+and `isort` on `PATH`, which only preflight's invocation puts there. The
+count rose from Task 5's 2286/15 by the seven cases this task adds — six
+parametrizations of the new line-position test, the seventh skipping for
+the charged kaon, plus the floor-cap test. The remaining 15 standing skips
+are untouched, and the one warning is the pre-existing `SyntaxWarning` in
+`hazma/vector_mediator/_vector_mediator_fsr.py`.
+
+What the tests cover, by category:
+
+- **The repaired constants, in Rust:**
+  `photon_tables::tests::every_line_energy_is_the_photons_not_the_daughters`
+  (all four `X → Yγ` energies against `E_γ + E_Y = M`, `E_γ < E_Y` and
+  `E_γ < M/2`, plus the two φ values explicitly and `assert_ne!` against
+  the shipped pair), and
+  `every_folded_constant_is_the_shipped_immediate_or_its_declared_repair`
+  (the two repaired bit patterns, with the shipped immediates named).
+- **The physics invariant, in Python:**
+  `TestPhysics::test_each_line_sits_where_its_rest_frame_energy_declares`
+  recovers the smallest and largest rest-frame line energy from the
+  kernel's boosted output for all six line-bearing spectra, at a tolerance
+  derived from the grid cell;
+  `TestPhysics::test_every_line_sits_at_the_photons_energy_not_the_daughters`
+  holds the four `X → Yγ` energies against the identity and the numbers.
+- **The corpus gate:** `test_entry_point_matches_corpus` over all 41
+  cases, where the composite is exercised — six arrays against `A1+B2`,
+  four against `A1` alone, two `rest` arrays against the stored values
+  under the case's own budget.
+- **The declaration's shape:**
+  `test_every_declared_delta_addresses_a_real_stored_array`,
+  `test_every_delta_model_is_a_roster_repair_with_its_evidence` (which
+  already validated composite labels from Task 5),
+  `test_every_declaration_points_at_a_delta_model`,
+  `test_the_declared_arrays_are_counted` (98, unchanged — this task
+  re-points keys rather than adding them), and the new
+  `test_a_declared_absolute_floor_stays_under_its_arrays_zero_floor`.
+- **The model against the stored corpus:**
+  `test_delta_models.py::test_each_model_moves_what_it_says_it_moves[B2]`
+  and `test_the_phi_lines_are_stored_at_the_daughter_mesons_energy`, both
+  of which read the committed arrays and no kernel, so they keep saying
+  what the corpus pinned after the repair as before it.
+
+**Test validity (stash-proof).** Reverting both Rust constants to the `+`
+form and rebuilding the extension turns three parity cases red *with* the
+declaration in place — on the relation itself, not on the staleness rule,
+because the composite's prediction no longer matches the live value:
+
+```text
+FAILED test_entry_point_matches_corpus[spectra.photon.phi[near_rest]]
+FAILED test_entry_point_matches_corpus[spectra.photon.phi[boosted_mild]]
+FAILED test_entry_point_matches_corpus[spectra.photon.phi[boosted_strong]]
+3 failed, 2 passed, 618 deselected
+```
+
+`rest` and `rest_plus_eps` pass in both configurations, which is the
+"moved only what it intended" half. On the same reverted build:
+
+- `photon_tables::tests::every_line_energy_is_the_photons_not_the_daughters`
+  and `every_folded_constant_is_the_shipped_immediate_or_its_declared_repair`
+  fail, and every other test in the module passes;
+- `TestPhysics::test_each_line_sits_where_its_rest_frame_energy_declares[phi]`
+  fails and the other five parametrizations pass;
+- `test_each_line_carries_the_photon_count_its_weight_declares[phi]`
+  **passes** — the direct confirmation that a yield-only gate would not
+  have caught this;
+- `test_delta_models.py` passes in full (17 tests), because it reads the
+  committed corpus and no kernel.
+
+Nothing deferred.
+
+## Open Questions
+
+- **Will any later repair need an absolute floor?** The mechanism is
+  narrow: only a `Composed` whose addend relocates a term can hit it, and
+  of the four remaining repairs only B3 transforms rather than adds — as
+  an `Exact` on the stored array, which cancels nothing. So the expected
+  answer is no, and `EXPECTED_FLOORED_ARRAYS = 6` is what makes a second
+  one visible in a diff rather than absorbed.
+- **Should `DELTA_MODELS` keep the standalone `B2` entry now that `A1+B2`
+  holds the keys?** Kept, for the reason Task 5 gave for `B1`:
+  `test_delta_models.py` gates it against the stored corpus and
+  `EXPECTED_REACH["B2"]` is the re-derivable statement of what B2 alone
+  reaches. `DELTA_MODELS` now has nine entries for seven modelled defects;
+  Task 12 should say once that `A1`, `B1`, `B2`, `A1+B1` and `A1+B2` are
+  five entries for three repairs rather than leaving it to be inferred.
+- **Does the φ omit any *other* direct photon line, and do its siblings?**
+  The new follow-up asks it as its own first question — the sweep behind
+  the `pi0_a` table covered only the two parents with such a column, and
+  the general form is whether every `X → Yγ` branching ratio in
+  `rust/src/constants.rs` has a line in `photon_tables.rs`.
+- Inherited and still open: whether the Task 2 oracles stay committed
+  after `cython-to-rust` closes (`README.md` Open Questions).
+
+## Plan Impact
+
+**Impact Level:** ADR required (second amendment to ADR-0001).
+
+ADR-0001's Decision gains a bullet: the comparison is relative, and a
+relation may declare an absolute floor only where its own arithmetic
+cannot resolve the repaired value at every magnitude the array takes. The
+Consequences' Negative bullet gains the case that produces one — a
+relocation cancels a term it did not compute, so at positions where that
+term dominated, the prediction is exact only to the term's last bit.
+
+No task ordering, gate, interface or exit criterion changed. `PLAN.md`'s
+Task 6 block is unchanged and reproduces in full: both energies, the
+factor of 16, the 0.013092 relocated yield, the positional gate, and
+`spectra.photon.omega` not moving. The project's `version_bump: minor` is
+unchanged and still correct — a moved published spectrum with no name,
+signature, shape or unit change.
+
+## Stale-state sweep
+
+```text
+$ git status --short
+ M CHANGELOG.md
+ M docs/followups/README.md
+ A docs/followups/todo/phi-omits-its-direct-pi0-photon-line.md
+ M docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md
+ M projects/parity-pinned-defect-repair/adrs/ADR-0001-corpus-repairs-are-declared-deltas.md
+ M projects/parity-pinned-defect-repair/references/corpus-repinning.md
+ M projects/parity-pinned-defect-repair/references/defect-blast-radius.md
+ M projects/parity-pinned-defect-repair/task-notes/README.md
+ A projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md
+ M rust/src/kernels/photon_tables.rs
+ M test/parity/README.md
+ M test/parity/deltas.py
+ M test/parity/test_delta_models.py
+ M test/parity/test_parity.py
+ M test/test_core_photon_tables.py
+  Both new files are `git add -N`'d so the diff below walks them.
+
+$ git diff origin/master --stat --
+ CHANGELOG.md                                       |  23 +
+ docs/followups/README.md                           |   1 +
+ .../todo/phi-omits-its-direct-pi0-photon-line.md   | 106 ++++
+ ...i-photon-lines-use-the-daughter-meson-energy.md |  70 ++-
+ .../ADR-0001-corpus-repairs-are-declared-deltas.md |  13 +-
+ .../references/corpus-repinning.md                 |  10 +
+ .../references/defect-blast-radius.md              |  17 +-
+ .../task-notes/README.md                           | 165 ++++--
+ .../task-notes/task-6-phi-lines.md                 | 570 +++++++++++++++++++++
+ rust/src/kernels/photon_tables.rs                  | 169 +++---
+ test/parity/README.md                              |  26 +-
+ test/parity/deltas.py                              | 123 ++++-
+ test/parity/test_delta_models.py                   |  13 +-
+ test/parity/test_parity.py                         |  47 +-
+ test/test_core_photon_tables.py                    | 148 ++++--
+ 15 files changed, 1288 insertions(+), 213 deletions(-)
+```
+
+**Identifier sweep** —
+`rg -n --hidden '<id>' projects/ docs/ README.md hazma/ test/ rust/ .claude/ .codex/`
+for every name this task added, renamed or removed:
+
+| Identifier | Live hits outside this task's notes | Status |
+| --- | --- | --- |
+| `the_phi_line_energies_are_the_daughter_mesons` | none | DELETED (renamed) |
+| `test_the_phi_lines_sit_at_the_daughter_mesons_energy` | none | DELETED (renamed) |
+| `folded_constants_match_the_shipped_object_code` | `positron_muon.rs`, `photon_muon.rs`, `neutrino_muon.rs` — three other kernels' own same-named tests | KEPT (unrelated) |
+| `photon_line_energy` | `photon_tables.rs` ×6 (the fn, four constants, one doc link) | EDITED |
+| `every_line_energy_is_the_photons_not_the_daughters` | `photon_tables.rs` ×2, the φ follow-up ×1 | EDITED |
+| `every_folded_constant_is_the_shipped_immediate_or_its_declared_repair` | `photon_tables.rs` ×2 (the test and the module docstring) | EDITED |
+| `_A1_B2` / `"A1+B2"` | `deltas.py` ×9, project README ×1 | EDITED |
+| `EXPECTED_FLOORED_ARRAYS` | `test_parity.py` ×2, project README ×2 | EDITED |
+
+The one stale hit the sweep caught was `photon_tables.rs:128`, whose
+doc link still pointed at the pre-rename test name; fixed and re-run.
+`projects/cython-to-rust/` hits are closed records and are excluded.
+
+**Line-number citation sweep.**
+
+```text
+$ .venv/bin/python scripts/agents/check_doc_citations.py \
+      $(git diff origin/master --name-only -- '*.md')
+docs scanned: 10
+in-repo citations checked: 0
+external citations skipped: 6
+  hazma/spectra/_photon/_omega.pyx (2)
+  hazma/spectra/_photon/_phi.pyx (4)
+out-of-range or ambiguous: NONE
+```
+
+The six skips are the deleted `.pyx` quotations in the φ follow-up's
+"Why" section, recoverable with `git show 665aed5:<path>` as that section
+says. They are untouched by this task and were checked by eye — the
+lesson `[touched-doc-inherits-its-citations]` is about exactly this blind
+spot.
+
+**Forward-looking phrase sweep.**
+
+```text
+$ rg -n '(Task [0-9]+ will|will be added|still pending|today: ?stub)' \
+      projects/parity-pinned-defect-repair/ hazma/
+projects/parity-pinned-defect-repair/task-notes/task-4-boost-window.md:350
+projects/parity-pinned-defect-repair/task-notes/task-3-closed-form-deltas.md:384
+projects/parity-pinned-defect-repair/task-notes/task-10a-neutrino-pion-line.md:324
+```
+
+All three are the sweep command quoted inside a prior task's own sweep
+block, not a forward-looking claim. KEPT.
+
+**Scratch tokens.**
+
+```text
+$ git diff origin/master -- '*.py' '*.rs' \
+    | grep '^+.*\(TODO\|FIXME\|breakpoint()\|import pdb\|XXX\)'
+(no output)
+```
+
+**Count sweep.**
+
+| Claim location | Command | Actual | Status |
+| --- | --- | --- | --- |
+| `EXPECTED_DECLARED_ARRAYS = 98`, unchanged | `Counter(d.repair for d in deltas.DECLARED_DELTAS.values())` | `A1: 44, B4: 30, A1+B1: 6, A1+B2: 6, B5: 6, B6: 6` = 98 | OK |
+| `EXPECTED_FLOORED_ARRAYS = 6` | `sum(d.relation.atol > 0 for d in deltas.DECLARED_DELTAS.values())` | 6 | OK |
+| 305 positions over 6 arrays, 233 up / 72 down | before/after capture diff (Numerical impact table) | 57+1+102+3+139+3 = 305; 23+0+83+3+121+3 = 233 up | OK |
+| 90 of 305 also moved by A1 | same capture against `oracle_reference.captured("A1")` | 19+0+36+1+33+1 = 90 | OK |
+| `EXPECTED_REACH["B2"] = (6, 305)` unchanged | `pytest test/parity/test_delta_models.py -k B2` | passes; the model reads the stored corpus, which did not move | OK |
+| full suite 2293 passed, 16 skipped | `preflight.sh` pytest row | 2293 passed, 16 skipped, 37 subtests | OK |
+| `cargo test` 263 passed | `cargo test --no-default-features --features test-probes` | 263 passed | OK |
+| the 1e-20 floor's headroom (11.6 and 8.6 decades) | min live value above the floor / min `tolerances.zero_floor` over the six arrays | 3.849e-09 and 3.580e-12 | OK |
+| φ `pi0_a` ratios 1.978 / 1.951 vs 1.976 | `numpy.trapezoid` over the two CSVs ÷ each `BR(X → π⁰γ)` | 0.0026115/1.32e-3 = 1.9784; 0.16275/8.34e-2 = 1.9514; `2 × 0.98823` = 1.97646 | OK |
+
+**Numerical-impact statement.** `hazma.spectra.dnde_photon_phi` and
+`hazma.spectra.dnde_photon` on any final state containing a φ move, by
+design; the grids, the per-block counts and the invariant yield are in
+`## Numerical impact` above. Six sibling photon spectra and the
+`["eta", "eta"]` n-body state are bit-identical across the rebuild
+(`np.geomspace(1, 5 M, 601)` at four parent energies each, and
+`np.geomspace(1, 2000, 201)` at `cme = 2.5 M_φ`). The project's
+`version_bump: minor` is unchanged and still correct.
+
+**Exit Criteria → test mapping.**
+
+| Exit criterion | Satisfied by |
+| --- | --- |
+| Both constants at `(M_φ² − m²)/(2 M_φ)` | `photon_tables::tests::every_folded_constant_is_the_shipped_immediate_or_its_declared_repair` (bit patterns) and `every_line_energy_is_the_photons_not_the_daughters` (values and identity) |
+| The gate is positional, not a magnitude | `TestPhysics::test_each_line_sits_where_its_rest_frame_energy_declares`; confirmed necessary by `test_each_line_carries_the_photon_count_its_weight_declares[phi]` still passing on the reverted build |
+| Declared delta on `spectra.photon.phi` only; ω does not move | `test_entry_point_matches_corpus` over all 41 cases, plus the bit-identical rebuild of the other six tabulated spectra |
+| Composes rather than overlaps; a revert turns it red | `test_every_delta_model_is_a_roster_repair_with_its_evidence` (composite label ⇒ `Composed` with one addend per extra part) and the three-case red run under "Test validity" |
+| `git diff --stat -- test/parity/data` empty | the command, run above, prints nothing |
+
+**Task-note self-consistency.** `**Status:** Complete` matches the Tasks
+table cell in `README.md`; every file named in §Files Changed appears in
+the `--stat` above, and every symbol named in §Findings and §Decisions
+appears in the identifier sweep.
+
+## Handoff to Next Task
+
+**For Task 7 (A2 — the muon photon rest-frame endpoint), which is the
+next unblocked task:** nothing here constrains it. A2 is a `Reference`
+against a Task 2 capture on a single case, with no overlap to compose
+(`../rules.md` rule 7's carve-out, measured by Task 2), so
+`task-4-boost-window.md` remains the worked precedent rather than this
+note.
+
+Two things from this task are worth carrying anyway:
+
+- **Re-derive *which* arrays a model reaches, not only how many.** Task
+  3's counts held exactly for both B1 and B2, but B2's six arrays were
+  not B1's six — it reaches `near_rest.scalar_values` and neither
+  `rest_plus_eps` array. A count that matches is not evidence the reach
+  matches.
+- **A relation may declare an absolute floor, and only a relocation has
+  needed one.** If a later repair's prediction misses at a position whose
+  value is many decades below its neighbors, that is representation
+  rather than budget, and `deltas`'s "Absolute floors" section says what
+  to declare. It is not a route around `../rules.md` rule 2: the floor is
+  capped below the array's own zero floor and counted by
+  `EXPECTED_FLOORED_ARRAYS`.

--- a/rust/src/kernels/photon_tables.rs
+++ b/rust/src/kernels/photon_tables.rs
@@ -70,10 +70,12 @@
 //! Cython `DEF`s, so every combination the `.pyx` writes inline — `2·BR`,
 //! `M/2`, `(M² − m²)/(2M)` — is folded into a single immediate in the
 //! generated code. They are `const` here for the same reason, and
-//! [`tests::folded_constants_match_the_shipped_object_code`] pins each one
-//! against the immediate the disassembly loads — bar
-//! [`ETAP_TO_A_A_WEIGHT`], the one this port repairs, which is pinned
-//! against twice it.
+//! [`tests::every_folded_constant_is_the_shipped_immediate_or_its_declared_repair`]
+//! pins each one against the immediate the disassembly loads — bar the
+//! three the repairs move ([`ETAP_TO_A_A_WEIGHT`],
+//! [`PHI_TO_ETA_A_ENERGY`] and [`PHI_TO_ETAP_A_ENERGY`]), which are
+//! pinned against the repaired value with the shipped immediate named
+//! beside it.
 
 use std::sync::LazyLock;
 
@@ -112,31 +114,44 @@ const ETAP_TO_A_A_ENERGY: f64 = pdg::MASS_ETAP / 2.0;
 /// Photon energy from `K⁰ → γγ` in the kaon rest frame, MeV. Shared by
 /// the long and short kaons, which the Cython gives the same mass.
 const K0_TO_A_A_ENERGY: f64 = pdg::MASS_K0 / 2.0;
-/// Photon energy from `ω → π⁰γ` in the ω rest frame, MeV — the two-body
-/// value `(M_ω² − M_π0²) / (2 M_ω)`.
-const OMEGA_TO_PI0_A_ENERGY: f64 =
-    (pdg::MASS_OMEGA * pdg::MASS_OMEGA - pdg::MASS_PI0 * pdg::MASS_PI0) / (2.0 * pdg::MASS_OMEGA);
+/// Photon energy in the two-body decay `X → Y γ`, in X's rest frame, MeV.
+///
+/// `(M² − m²) / (2 M)`. Its counterpart `(M² + m²) / (2 M)` is the
+/// *daughter meson's* energy, and the two sum to `M`; writing the four
+/// line energies below through one function is what keeps the pair from
+/// being confusable, which is how the two φ lines came to be placed at
+/// the meson's energy in 2.1.0 (repair `B2`).
+///
+/// The operation order is the `.pyx` expressions' own, so the folded
+/// constants stay bit-identical to the shipped object code where the
+/// energy is unrepaired — see
+/// [`tests::every_folded_constant_is_the_shipped_immediate_or_its_declared_repair`].
+const fn photon_line_energy(parent: f64, daughter: f64) -> f64 {
+    (parent * parent - daughter * daughter) / (2.0 * parent)
+}
+
+/// Photon energy from `ω → π⁰γ` in the ω rest frame, MeV.
+const OMEGA_TO_PI0_A_ENERGY: f64 = photon_line_energy(pdg::MASS_OMEGA, pdg::MASS_PI0);
 /// Photon energy from `ω → ηγ` in the ω rest frame, MeV.
-const OMEGA_TO_ETA_A_ENERGY: f64 =
-    (pdg::MASS_OMEGA * pdg::MASS_OMEGA - pdg::MASS_ETA * pdg::MASS_ETA) / (2.0 * pdg::MASS_OMEGA);
-/// Rest-frame energy the Cython assigns the `φ → ηγ` line, MeV.
+const OMEGA_TO_ETA_A_ENERGY: f64 = photon_line_energy(pdg::MASS_OMEGA, pdg::MASS_ETA);
+/// Photon energy from `φ → ηγ` in the φ rest frame, MeV.
 ///
-/// `_phi.pyx:111` writes `(M_φ² + M_η²) / (2 M_φ)`, which is the *η's*
-/// energy in the two-body decay, not the photon's — the photon carries
-/// `(M_φ² − M_η²) / (2 M_φ)`. That is **656.94 MeV where 362.52 is
-/// right**, a factor of 1.81. The sign is reproduced rather than
-/// repaired, per `projects/cython-to-rust/rules.md` rule 1, and filed as
-/// `docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`.
-const PHI_TO_ETA_A_ENERGY: f64 =
-    (pdg::MASS_PHI * pdg::MASS_PHI + pdg::MASS_ETA * pdg::MASS_ETA) / (2.0 * pdg::MASS_PHI);
-/// Rest-frame energy the Cython assigns the `φ → η′γ` line, MeV.
+/// The `−` is this port's, not the Cython's: `_phi.pyx:111` wrote
+/// `(M_φ² + M_η²) / (2 M_φ)`, the *η's* energy in the two-body decay
+/// rather than the photon's, and fed it to the boost as a photon energy.
+/// So 2.1.0 shipped this line at **656.94 MeV where 362.52 belongs**, a
+/// factor of 1.81 and above the spectrum's own endpoint. The parity
+/// corpus still pins the misplaced line, and `test/parity/deltas.py`
+/// declares the relocation as repair `B2` rather than re-pinning the
+/// arrays. See [`tests::every_line_energy_is_the_photons_not_the_daughters`].
+const PHI_TO_ETA_A_ENERGY: f64 = photon_line_energy(pdg::MASS_PHI, pdg::MASS_ETA);
+/// Photon energy from `φ → η′γ` in the φ rest frame, MeV.
 ///
-/// The same sign error as [`PHI_TO_ETA_A_ENERGY`] and far worse here,
-/// because the η′ takes almost all of the φ's mass: **959.65 MeV where
-/// 59.82 is right**, a factor of 16.0, and 94% of the φ's own rest mass
-/// carried off by one photon.
-const PHI_TO_ETAP_A_ENERGY: f64 =
-    (pdg::MASS_PHI * pdg::MASS_PHI + pdg::MASS_ETAP * pdg::MASS_ETAP) / (2.0 * pdg::MASS_PHI);
+/// The same repair as [`PHI_TO_ETA_A_ENERGY`] and a far larger move,
+/// because the η′ takes almost all of the φ's mass: 2.1.0 shipped this
+/// line at **959.65 MeV where 59.82 belongs**, a factor of 16.0 and 94%
+/// of the φ's own rest mass carried off by one photon.
+const PHI_TO_ETAP_A_ENERGY: f64 = photon_line_energy(pdg::MASS_PHI, pdg::MASS_ETAP);
 
 // ===========================================================================
 // ---- Embedded tables ------------------------------------------------------
@@ -492,21 +507,25 @@ mod tests {
     }
 
     /// Every folded constant, against the immediate the shipped
-    /// `.cpython-312-darwin.so` loads at that site.
+    /// `.cpython-312-darwin.so` loads at that site — or, for the three a
+    /// repair has moved, against the value that replaces it.
     ///
-    /// Read out of `objdump -d` as the `movk` sequences that build each
-    /// one (little-endian halfwords, high halfword last). Rust's const
-    /// evaluator and clang's constant folder have to agree here to the
-    /// last bit: the parity budget for these entry points is 1e-12 and a
-    /// one-ulp shift in a line's energy moves the whole line.
+    /// The shipped immediates were read out of `objdump -d` as the `movk`
+    /// sequences that build each one (little-endian halfwords, high
+    /// halfword last). Rust's const evaluator and clang's constant folder
+    /// have to agree here to the last bit: the parity budget for these
+    /// entry points is 1e-12 and a one-ulp shift in a line's energy moves
+    /// the whole line. Each repaired constant names the immediate it
+    /// replaces beside it, so the object code stays recoverable from this
+    /// test and a silent revert to it still fails.
     #[test]
-    fn folded_constants_match_the_shipped_object_code() {
+    fn every_folded_constant_is_the_shipped_immediate_or_its_declared_repair() {
         assert_eq!(ETA_TO_A_A_WEIGHT.to_bits(), 0x3fe9_38ef_34d6_a162);
         assert_eq!(ETA_TO_A_A_ENERGY.to_bits(), 0x4071_1ee5_6041_8937);
-        // The one repaired weight: the shipped object code loads
-        // `0x3f97_9fa9_7e13_2b56` here and the two-photon line needs twice
-        // it (B1). Doubling only increments the exponent field, so the
-        // mantissa below is the shipped immediate's, digit for digit.
+        // B1: the shipped object code loads `0x3f97_9fa9_7e13_2b56` here
+        // and the two-photon line needs twice it. Doubling only increments
+        // the exponent field, so the mantissa below is the shipped
+        // immediate's, digit for digit.
         assert_eq!(ETAP_TO_A_A_WEIGHT.to_bits(), 0x3fa7_9fa9_7e13_2b56);
         assert_eq!(ETAP_TO_A_A_ENERGY.to_bits(), 0x407d_ee3d_70a3_d70a);
         assert_eq!(KL_TO_A_A_WEIGHT.to_bits(), 0x3f51_ec91_8e32_5d4a);
@@ -518,8 +537,13 @@ mod tests {
         assert_eq!(OMEGA_TO_ETA_A_ENERGY.to_bits(), 0x4068_f281_6f00_68dc);
         assert_eq!(pdg::BR_PHI_TO_ETA_A.to_bits(), 0x3f8a_af78_feef_5ec8);
         assert_eq!(pdg::BR_PHI_TO_ETAP_A.to_bits(), 0x3f10_4e2b_dcfd_9c78);
-        assert_eq!(PHI_TO_ETA_A_ENERGY.to_bits(), 0x4084_8789_3897_9d28);
-        assert_eq!(PHI_TO_ETAP_A_ENERGY.to_bits(), 0x408d_fd2a_ecc8_ec19);
+        // B2: the shipped object code loads the *daughter meson's* energy
+        // at both sites — `0x4084_8789_3897_9d28` (656.94 MeV) and
+        // `0x408d_fd2a_ecc8_ec19` (959.65 MeV). The photon's energy shares
+        // no bits with either, because the repair changes one sign in the
+        // numerator rather than scaling the result.
+        assert_eq!(PHI_TO_ETA_A_ENERGY.to_bits(), 0x4076_a84d_d059_fcfd);
+        assert_eq!(PHI_TO_ETAP_A_ENERGY.to_bits(), 0x404d_e853_3fba_f8c5);
     }
 
     /// All four `X → γγ` lines carry `2·BR`, the η′ included.
@@ -541,47 +565,44 @@ mod tests {
         assert_ne!(ETAP_TO_A_A_WEIGHT, pdg::BR_ETAP_TO_A_A);
     }
 
-    /// The φ's two line energies are the *daughter meson's*, not the
-    /// photon's, so both sit above where the photon can be.
+    /// All four `X → Y γ` lines sit at the photon's energy, below the
+    /// daughter meson's.
     ///
-    /// `(M_φ² + M_η²)/(2M_φ)` is `E_η`; the photon takes
-    /// `(M_φ² − M_η²)/(2M_φ)`, and the two sum to `M_φ`. So the η line
-    /// sits at 656.94 MeV instead of 362.52 (a factor of 1.81) and the
-    /// η′ line at 959.65 instead of 59.82 (a factor of 16.0) — the second
-    /// puts 94% of the φ's whole rest mass into one photon. Reproduced
-    /// per rule 1 and filed as
-    /// `docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md`.
+    /// `(M² − m²)/(2M)` is `E_γ` and `(M² + m²)/(2M)` is `E_Y`; the two
+    /// sum to `M`, which is what makes the distinction checkable rather
+    /// than a reading — a line energy that pairs with the *photon's* to
+    /// give the parent mass is the daughter's. The φ's two lines shipped
+    /// that way in 2.1.0 (`_phi.pyx:111,113`): 656.94 MeV instead of
+    /// 362.52 for `φ → ηγ`, a factor of 1.81, and 959.65 instead of 59.82
+    /// for `φ → η′γ`, a factor of 16.0 that put 94% of the φ's whole rest
+    /// mass into one photon. Repaired as roster entry B2 of
+    /// `projects/parity-pinned-defect-repair`; the corpus still pins the
+    /// misplaced lines and `test/parity/deltas.py` declares the shift.
     ///
-    /// The energy-conservation identity is what makes the diagnosis
-    /// checkable rather than a reading: `E_daughter + E_γ = M` holds
-    /// exactly for a two-body decay, so a line energy that pairs with the
-    /// *photon's* to give the parent mass is the daughter's.
+    /// The ω's two lines were always the photon's, and are held here with
+    /// the φ's rather than as a control, because the two mesons run
+    /// through the same [`photon_line_energy`] now.
     #[test]
-    fn the_phi_line_energies_are_the_daughter_mesons() {
-        for (line, mass) in [
-            (PHI_TO_ETA_A_ENERGY, pdg::MASS_ETA),
-            (PHI_TO_ETAP_A_ENERGY, pdg::MASS_ETAP),
+    fn every_line_energy_is_the_photons_not_the_daughters() {
+        for (line, parent, mass) in [
+            (PHI_TO_ETA_A_ENERGY, pdg::MASS_PHI, pdg::MASS_ETA),
+            (PHI_TO_ETAP_A_ENERGY, pdg::MASS_PHI, pdg::MASS_ETAP),
+            (OMEGA_TO_PI0_A_ENERGY, pdg::MASS_OMEGA, pdg::MASS_PI0),
+            (OMEGA_TO_ETA_A_ENERGY, pdg::MASS_OMEGA, pdg::MASS_ETA),
         ] {
-            let photon = (pdg::MASS_PHI * pdg::MASS_PHI - mass * mass) / (2.0 * pdg::MASS_PHI);
-            assert!((line + photon - pdg::MASS_PHI).abs() < 1e-12 * pdg::MASS_PHI);
-            assert!(line > photon);
-        }
-        assert!((PHI_TO_ETA_A_ENERGY - 656.942_002_472_385).abs() < 1e-9);
-        assert!((PHI_TO_ETAP_A_ENERGY - 959.645_959_443_764_8).abs() < 1e-9);
-
-        // The ω's, by contrast, *are* the photon's, so they pair with the
-        // daughter energy rather than being it. This is the control that
-        // makes the φ assertions a defect rather than a convention the
-        // whole family shares.
-        for (line, mass) in [
-            (OMEGA_TO_PI0_A_ENERGY, pdg::MASS_PI0),
-            (OMEGA_TO_ETA_A_ENERGY, pdg::MASS_ETA),
-        ] {
-            let daughter =
-                (pdg::MASS_OMEGA * pdg::MASS_OMEGA + mass * mass) / (2.0 * pdg::MASS_OMEGA);
-            assert!((line + daughter - pdg::MASS_OMEGA).abs() < 1e-12 * pdg::MASS_OMEGA);
+            let daughter = (parent * parent + mass * mass) / (2.0 * parent);
+            assert!((line + daughter - parent).abs() < 1e-12 * parent);
             assert!(line < daughter);
+            // No photon from a two-body decay carries more than half the
+            // parent's mass; both shipped φ energies did.
+            assert!(line < 0.5 * parent);
         }
+        // Stated as the energies as well as the form, so a revert to the
+        // shipped `+` fails on the number and not only on the identity.
+        assert!((PHI_TO_ETA_A_ENERGY - 362.518_997_527_615_1).abs() < 1e-9);
+        assert!((PHI_TO_ETAP_A_ENERGY - 59.815_040_556_235_125).abs() < 1e-9);
+        assert_ne!(PHI_TO_ETA_A_ENERGY, 656.942_002_472_385);
+        assert_ne!(PHI_TO_ETAP_A_ENERGY, 959.645_959_443_764_8);
     }
 
     /// Every table parses to a paired, non-empty, strictly ascending grid.

--- a/test/parity/README.md
+++ b/test/parity/README.md
@@ -122,17 +122,20 @@ Ten of the values in here are, separately, *wrong* — filed under
 [`projects/parity-pinned-defect-repair`](../../projects/parity-pinned-defect-repair/PLAN.md).
 That does not make them regenerable either: the committed arrays are the
 record of what 2.1.0 shipped, and a repair is expressed as a declared
-delta against them, in [`deltas.py`](deltas.py) — four have been (the
+delta against them, in [`deltas.py`](deltas.py) — six have been (the
 scalar decay spectrum's FSR normalization, roster entry B4; the charged
 pion's doubled prompt neutrino line, B5; the two mediator thermal cross
-sections' unconverged quadrature, B6; and the boost integral's window
-coverage, A1, which reaches all seven tabulated photon spectra), so the
+sections' unconverged quadrature, B6; the boost integral's window
+coverage, A1, which reaches all seven tabulated photon spectra; the η′
+two-photon line's weight, B1; and both φ line energies, B2), so the
 arrays of those cases are compared against the relation each declares
-rather than against `stored`. Three more are *modelled* there without
-being declared — B1, B2 and B3, whose Cython twins are already gone —
-because a declaration on an array the tree has not moved yet would fail
-as stale; [`test_delta_models.py`](test_delta_models.py) checks those
-models against the stored arrays themselves. [`oracles/`](oracles/README.md)
+rather than against `stored`. The last two moved arrays A1 had already
+declared, so each collapses into a composite — `A1+B1` and `A1+B2` — as
+the project's rule 7 requires. One more is *modelled* there without being
+declared — B3, whose Cython twin is already gone — because a declaration
+on an array the tree has not moved yet would fail as stale;
+[`test_delta_models.py`](test_delta_models.py) checks that model against
+the stored arrays themselves. [`oracles/`](oracles/README.md)
 holds what the remaining positions *should* be, captured from the Cython
 twins before the port deleted them; it is what A1 is graded against here,
 through [`oracle_reference.py`](oracle_reference.py), and is the only
@@ -191,7 +194,12 @@ Three carve-outs, all narrow and all declared:
   runner holds a declared array to that relation and every undeclared
   position to the stored value as before, and fails a declaration whose
   array no longer differs from the corpus, so a reverted repair cannot
-  hide behind it.
+  hide behind it. Six of those arrays — the `A1+B2` composite on
+  `spectra.photon.phi` — additionally carry an absolute floor, because
+  relocating a line cancels it back out of the captured array the
+  composite builds on and takes the continuum underneath with it; the
+  floor is one ulp of the cancelled plateau and is capped below the
+  array's own zero floor.
 
 The budget depends on which tree you are on. When the kernel digest, the
 toolchain and the numerics libraries all match what the manifest records,

--- a/test/parity/deltas.py
+++ b/test/parity/deltas.py
@@ -48,6 +48,20 @@ adds its own term on top. The `Delta` then names them all, as ``"A1+B1"``,
 and `repair_labels` is what splits a composite spelling back into the
 roster entries it is made of.
 
+Absolute floors
+---------------
+A prediction is compared to the repaired kernel relatively, with ``atol``
+at zero, because an absolute floor is scale-dependent and a spectrum runs
+over twenty decades (`tolerances`, "``atol`` is 0.0 everywhere"). One
+relation cannot hold to that. A `Composed` whose addend *relocates* a
+line subtracts the line back out of the base, and where the base is a
+captured array that subtraction annihilates whatever the cancelled term's
+last bit could not hold -- so the prediction is exactly zero at positions
+where the kernel still returns the continuum underneath, and no relative
+budget can describe it. Such a relation declares an ``atol`` at one ulp of
+the term it cancels, ``why`` says which term, and `test_parity` caps it
+below the array's own zero floor so it cannot grow into a budget.
+
 Positions
 ---------
 A declaration covers exactly the positions its mechanism reaches
@@ -134,12 +148,19 @@ class Additive:
         how; a term that is its own quadrature cannot be held to the
         case's bit-level budget.
     why : str
-        One-line justification of ``rtol``.
+        One-line justification of ``rtol``, and of ``atol`` where it is
+        set.
+    atol : float, optional
+        Absolute floor, added to ``rtol`` when the prediction is compared.
+        ``0.0`` everywhere the relation's arithmetic resolves the repaired
+        value at every magnitude it takes; see "Absolute floors" in the
+        module docstring for the one composition that cannot.
     """
 
     term: TermFn
     rtol: float
     why: str
+    atol: float = 0.0
 
     def expected(
         self,
@@ -168,12 +189,19 @@ class Exact:
         tighter than an `Additive` whose term is a quadrature; ``why``
         says which operations set it.
     why : str
-        One-line justification of ``rtol``.
+        One-line justification of ``rtol``, and of ``atol`` where it is
+        set.
+    atol : float, optional
+        Absolute floor, added to ``rtol`` when the prediction is compared.
+        ``0.0`` everywhere the relation's arithmetic resolves the repaired
+        value at every magnitude it takes; see "Absolute floors" in the
+        module docstring for the one composition that cannot.
     """
 
     transform: TransformFn
     rtol: float
     why: str
+    atol: float = 0.0
 
     def expected(
         self,
@@ -204,12 +232,19 @@ class Reference:
         Relative budget the relation holds to. Measured, and ``why`` says
         how.
     why : str
-        One-line justification of ``rtol``.
+        One-line justification of ``rtol``, and of ``atol`` where it is
+        set.
+    atol : float, optional
+        Absolute floor, added to ``rtol`` when the prediction is compared.
+        ``0.0`` everywhere the relation's arithmetic resolves the repaired
+        value at every magnitude it takes; see "Absolute floors" in the
+        module docstring for the one composition that cannot.
     """
 
     reference: TermFn
     rtol: float
     why: str
+    atol: float = 0.0
 
     def expected(
         self,
@@ -243,13 +278,22 @@ class Composed:
         Relative budget the composition holds to. Measured against the
         repaired kernel; ``why`` says what sets it.
     why : str
-        One-line justification of ``rtol``.
+        One-line justification of ``rtol``, and of ``atol`` where it is
+        set.
+    atol : float, optional
+        Absolute floor, added to ``rtol`` when the prediction is compared.
+        A composition whose addend *relocates* a term rather than adding
+        one subtracts it back out of the base, and where the base is a
+        captured array the subtraction annihilates whatever the cancelled
+        term's last bit could not hold; see "Absolute floors" in the
+        module docstring.
     """
 
     base: Additive | Exact | Reference
     added: tuple[Additive, ...]
     rtol: float
     why: str
+    atol: float = 0.0
 
     def expected(
         self,
@@ -340,9 +384,9 @@ def _photon_energy(parent: float, daughter: float) -> float:
     """Rest-frame photon energy in ``X -> Y gamma``, MeV.
 
     ``(M**2 - m**2) / (2 M)``, in the operation order
-    ``photon_tables::OMEGA_TO_PI0_A_ENERGY`` writes it. Its ``phi``
-    counterparts write ``+`` for the same quantity, which is B2 — see
-    `_daughter_energy`.
+    ``photon_tables::photon_line_energy`` writes it — for the phi's two
+    lines as well as the omega's, since B2. See `_daughter_energy` for
+    what the phi's shipped with.
     """
     return (parent * parent - daughter * daughter) / (2.0 * parent)
 
@@ -350,10 +394,11 @@ def _photon_energy(parent: float, daughter: float) -> float:
 def _daughter_energy(parent: float, daughter: float) -> float:
     """Rest-frame energy of the *daughter meson* in ``X -> Y gamma``, MeV.
 
-    ``(M**2 + m**2) / (2 M)``, in the operation order
-    ``photon_tables::PHI_TO_ETA_A_ENERGY`` writes it. That constant feeds
-    it to the boost as if it were the photon's energy, which is what B2
-    repairs; the two differ by ``m**2 / M``.
+    ``(M**2 + m**2) / (2 M)``, in the operation order the shipped
+    ``photon_tables::PHI_TO_ETA_A_ENERGY`` wrote it. That constant fed it
+    to the boost as if it were the photon's energy, which is what B2
+    repairs; the two differ by ``m**2 / M``. The model still needs it,
+    because the corpus is still pinned at the shipped energies.
     """
     return (parent * parent + daughter * daughter) / (2.0 * parent)
 
@@ -843,6 +888,49 @@ _A1_B1 = Delta(
 )
 
 
+# ---------------------------------------------------------------------------
+# A1 + B2 -- the six phi arrays both repairs move
+# ---------------------------------------------------------------------------
+
+
+_A1_B2 = Delta(
+    repair="A1+B2",
+    positions=MOVED,
+    relation=Composed(
+        base=_A1.relation,
+        added=(_B2.relation,),
+        rtol=1e-12,
+        atol=1e-20,
+        why="the base is the A1 capture and the addend is closed form, so "
+        "the relative budget is the case's own `tolerances.TABULATED_RTOL`, "
+        "for the reason A1 gives: the capture is one platform's, and a libm "
+        "that moves the boost integral must not fail here while the "
+        "undeclared positions of the same block still pass. Measured 2.9e-14 "
+        "worst over the six arrays. The floor is what relocation costs: the "
+        "addend subtracts the shipped line back out of the capture, and at "
+        "the two positions inside the shipped `phi -> eta gamma` window but "
+        "outside both repaired windows that cancellation takes the continuum "
+        "with it -- the plateau there is 3.107723e-05, whose last bit is "
+        "6.8e-21, and the continuum underneath it is 3.3e-21. So the "
+        "prediction reads exactly 0.0 where the kernel returns 3.3e-21 and "
+        "3.1e-22, and one ulp of the cancelled plateau is the tightest "
+        "statement available.",
+    ),
+    measured="B2 moves 305 positions over six of this case's ten value "
+    "arrays -- 57 and 1 of `near_rest.{values,scalar_values}`, 102 and 3 of "
+    "`boosted_mild.{values,scalar_values}`, 139 and 3 of "
+    "`boosted_strong.{values,scalar_values}` -- 233 of them up and 72 down, "
+    "which is what relocating a line rather than adding one looks like. 90 "
+    "of the 305 are positions A1 moves too, so the two compose rather than "
+    "declaring separately. The case's other four value arrays keep A1's "
+    "declaration alone: both `rest` arrays take the kernel's rest-frame arm, "
+    "which adds no line at all, and at `rest_plus_eps` the boost opens a "
+    "window 2.8e-06 wide in relative energy at beta = 1.414e-06, too narrow "
+    "for any grid point to fall inside a shipped or a repaired line.",
+    evidence="projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md",
+)
+
+
 #: Every declared array. The two blocks of the same case that are absent --
 #: ``rest`` and ``rest_plus_eps`` -- must still match the stored arrays under
 #: the case's own budget, which is the "moved only what it intended" half of
@@ -876,12 +964,12 @@ DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
     ("spectra.photon.omega", "boosted_strong", "scalar_values"): _A1,
     ("spectra.photon.phi", "rest_plus_eps", "values"): _A1,
     ("spectra.photon.phi", "rest_plus_eps", "scalar_values"): _A1,
-    ("spectra.photon.phi", "near_rest", "values"): _A1,
-    ("spectra.photon.phi", "near_rest", "scalar_values"): _A1,
-    ("spectra.photon.phi", "boosted_mild", "values"): _A1,
-    ("spectra.photon.phi", "boosted_mild", "scalar_values"): _A1,
-    ("spectra.photon.phi", "boosted_strong", "values"): _A1,
-    ("spectra.photon.phi", "boosted_strong", "scalar_values"): _A1,
+    ("spectra.photon.phi", "near_rest", "values"): _A1_B2,
+    ("spectra.photon.phi", "near_rest", "scalar_values"): _A1_B2,
+    ("spectra.photon.phi", "boosted_mild", "values"): _A1_B2,
+    ("spectra.photon.phi", "boosted_mild", "scalar_values"): _A1_B2,
+    ("spectra.photon.phi", "boosted_strong", "values"): _A1_B2,
+    ("spectra.photon.phi", "boosted_strong", "scalar_values"): _A1_B2,
     ("spectra.photon.charged_kaon", "rest_plus_eps", "values"): _A1,
     ("spectra.photon.charged_kaon", "rest_plus_eps", "scalar_values"): _A1,
     ("spectra.photon.charged_kaon", "near_rest", "values"): _A1,
@@ -1110,6 +1198,7 @@ DECLARED_DELTAS: dict[tuple[str, str, str], Delta] = {
 DELTA_MODELS: dict[str, Delta] = {
     "A1": _A1,
     "A1+B1": _A1_B1,
+    "A1+B2": _A1_B2,
     "B1": _B1,
     "B2": _B2,
     "B3": _B3,

--- a/test/parity/test_delta_models.py
+++ b/test/parity/test_delta_models.py
@@ -17,7 +17,7 @@ kernel; every comparison is against ``data/*.npz``, captured from Cython
 at kernel digest ``f5e6e269be47`` and never rewritten
 (``../rules.md`` rule 1). So these tests were falsifiable on the tree
 that carried all three defects, and they stay falsifiable as the repairs
-land one at a time: B1's has, and B2's and B3's have not.
+land one at a time: B1's and B2's have, and B3's has not.
 
 The three arguments
 -------------------
@@ -31,12 +31,12 @@ stored arrays, the eta reads ``2 BR`` and so do both neutral kaons — and
 the eta-prime reads ``1 BR``, which is the defect.
 
 **B2** — in ``X -> Y gamma`` the photon carries ``(M**2 - m**2) / (2 M)``
-and the meson ``(M**2 + m**2) / (2 M)``. The phi kernel boosts the
-second as if it were the first, which puts both lines *above* the
+and the meson ``(M**2 + m**2) / (2 M)``. The shipped phi kernel boosted
+the second as if it were the first, which put both lines *above* the
 spectrum's true endpoint, in a region where the boosted continuum is
 identically zero. The stored arrays have a two-tread staircase there
 whose treads are exactly the two plateau heights at the *shipped*
-energies — support the repaired kernel will not have, at energies the
+energies — support the repaired kernel does not have, at energies the
 corrected form does not produce.
 
 **B3** — the boost carries a ``1 / E'`` that belongs to its kernel, not
@@ -587,9 +587,10 @@ def test_a_two_body_decay_splits_the_parent_mass() -> None:
 #: than silently re-scoped (`../rules.md` rule 11).
 EXPECTED_REACH = {"B1": (6, 189), "B2": (6, 305), "B3": (4, 350)}
 
-#: Which corpus cases each unlanded model reaches, from the roster in
+#: Which corpus cases each model reaches, from the roster in
 #: ``references/defect-blast-radius.md``. A repair task turns these into
-#: `deltas.DECLARED_DELTAS` keys.
+#: `deltas.DECLARED_DELTAS` keys — B1's and B2's are now the composites
+#: ``A1+B1`` and ``A1+B2``, because A1 declares the same arrays.
 MODEL_CASES = {
     "B1": ("spectra.photon.eta_prime",),
     "B2": ("spectra.photon.phi",),

--- a/test/parity/test_parity.py
+++ b/test/parity/test_parity.py
@@ -126,6 +126,12 @@ EXPECTED_PORTABILITY_ZEROS = 4
 #: defending in a diff.
 EXPECTED_DECLARED_ARRAYS = 98
 
+#: How many of those hold to an absolute floor as well as a relative one
+#: (`deltas`, "Absolute floors"). Six: the `spectra.photon.phi` arrays the
+#: `A1+B2` composite covers, where relocating a line cancels it back out of
+#: the A1 capture.
+EXPECTED_FLOORED_ARRAYS = 6
+
 
 def _drop_unpinnable(
     live: np.ndarray,
@@ -229,11 +235,18 @@ def _assert_declared_delta(  # noqa: PLR0913 -- one argument per thing compared
         )
     selected = compare & declared
     relation = delta.relation
+    # The relation's own floor rather than the case's, where it declares
+    # one: a prediction that cancels a term far larger than the result
+    # cannot resolve below that term's last bit, and no relative budget
+    # describes a position whose predicted value is exactly zero
+    # (deltas.py, "Absolute floors"). The staleness check below keeps the
+    # case's floor, because whether the repair happened at all is a
+    # different question from how precisely it can be predicted.
     np.testing.assert_allclose(
         live[selected],
         predicted[selected],
         rtol=relation.rtol,
-        atol=budget.atol,
+        atol=max(budget.atol, relation.atol),
         equal_nan=True,
         err_msg=f"{where}: does not satisfy the {delta.repair} relation "
         f"({relation.why})",
@@ -632,6 +645,38 @@ def test_every_declaration_points_at_a_delta_model() -> None:
     models = set(map(id, deltas.DELTA_MODELS.values()))
     for key, delta in deltas.DECLARED_DELTAS.items():
         assert id(delta) in models, f"{key}: {delta.repair} is not a DELTA_MODELS entry"
+
+
+def test_a_declared_absolute_floor_stays_under_its_arrays_zero_floor(
+    stored_arrays: ArrayLoader,
+) -> None:
+    """A relation's ``atol`` may not grow into a budget.
+
+    Almost every relation holds at ``atol = 0.0``; the exception is a
+    composition that relocates a term and so cannot resolve below the
+    cancelled term's last bit (`deltas`, "Absolute floors"). The ceiling
+    is what the corpus already tolerates where it stored an exact zero —
+    `tolerances.zero_floor`, a fraction of the array's own median non-zero
+    magnitude — so a floor that crept up to absorb a real shift would
+    cross it and fail here rather than pass quietly.
+    """
+    declared = [
+        (key, delta)
+        for key, delta in deltas.DECLARED_DELTAS.items()
+        if delta.relation.atol > 0.0
+    ]
+    for (case_name, label, suffix), delta in declared:
+        blocks = {b["label"]: b for b in MANIFEST["cases"][case_name]["blocks"]}
+        pinned = stored_arrays(case_name)[blocks[label]["arrays"][suffix]["key"]]
+        ceiling = tolerances.zero_floor(pinned)
+        assert delta.relation.atol < ceiling, (
+            f"{case_name}[{label}].{suffix}: the {delta.repair} relation "
+            f"declares atol {delta.relation.atol:.1e}, at or above the "
+            f"{ceiling:.1e} this array tolerates for a stored zero"
+        )
+    # The mechanism is narrow, and stays narrow only if a new floor has to
+    # be counted rather than appearing among the other 90-odd arrays.
+    assert len(declared) == EXPECTED_FLOORED_ARRAYS
 
 
 def test_the_declared_arrays_are_counted() -> None:

--- a/test/test_core_photon_tables.py
+++ b/test/test_core_photon_tables.py
@@ -47,23 +47,22 @@ one fused multiply-add is reproduced here with a ``Fraction``-based ``fma``
 rather than approximated — so the comparison is bit-equality on every
 platform rather than on one.
 
-Two reproduced defects
-----------------------
-:class:`TestPhysics` asserts two things that are *wrong physics*, because the
-shipped Cython does them and ``projects/cython-to-rust/rules.md`` rule 1 says
-a port reproduces rather than repairs:
+Two repaired defects
+--------------------
+:class:`TestPhysics` asserts two things hazma 2.1.0 got wrong, both repaired
+under ``projects/parity-pinned-defect-repair``:
 
-* the η' two-photon line carries ``BR(η' -> a a)`` where its four siblings
-  carry ``2·BR`` — 0.02307 photons per decay instead of 0.04614
-  (``docs/followups/todo/eta-prime-two-photon-line-missing-factor-two.md``);
-* the φ's two lines are placed at the *daughter meson's* energy rather than
+* the η' two-photon line carried ``BR(η' -> a a)`` where its four siblings
+  carry ``2·BR`` — 0.02307 photons per decay instead of 0.04614 (roster
+  entry B1);
+* the φ's two lines were placed at the *daughter meson's* energy rather than
   the photon's — 656.94 MeV instead of 362.52 for ``φ -> η a``, and 959.65
-  instead of 59.82 for ``φ -> η' a``
-  (``docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md``).
+  instead of 59.82 for ``φ -> η' a`` (roster entry B2).
 
-Asserting the correct physics here would contradict the parity corpus, which
-pins the shipped values. When those follow-ups land, these two tests are the
-ones that change.
+The parity corpus still pins the shipped values, which is what the declared
+deltas in ``test/parity/deltas.py`` exist for; these two tests state the
+repaired physics instead, so a silent revert fails here rather than being
+absorbed.
 
 A note on notation: final states are written the way hazma's own data files
 write them, with ``a`` for a photon (``a_a``, ``pi0_a``, ``eta_a`` are
@@ -119,8 +118,8 @@ BR_PHI_TO_ETAP_A = 6.22e-5
 
 #: ``name -> (entry point, CSV, parent mass, [(line energy, line weight)])``.
 #: The line expressions are the ``.pyx`` ones character for character,
-#: except the eta-prime weight, which the port repairs (B1), and the two
-#: phi energies, which it still reproduces.
+#: except the eta-prime weight (B1) and the two phi energies (B2), which
+#: the repairs move.
 SPECTRA: dict[str, tuple[object, str, float, list[tuple[float, float]]]] = {
     "charged_kaon": (
         core_photon.dnde_photon_charged_kaon,
@@ -166,8 +165,8 @@ SPECTRA: dict[str, tuple[object, str, float, list[tuple[float, float]]]] = {
         "phi_photon.csv",
         MASS_PHI,
         [
-            ((MASS_PHI**2 + MASS_ETA**2) / (2 * MASS_PHI), BR_PHI_TO_ETA_A),
-            ((MASS_PHI**2 + MASS_ETAP**2) / (2 * MASS_PHI), BR_PHI_TO_ETAP_A),
+            ((MASS_PHI**2 - MASS_ETA**2) / (2 * MASS_PHI), BR_PHI_TO_ETA_A),
+            ((MASS_PHI**2 - MASS_ETAP**2) / (2 * MASS_PHI), BR_PHI_TO_ETAP_A),
         ],
     ),
 }
@@ -584,6 +583,63 @@ class TestPhysics:
         # above, or this test would pass on a halved weight.
         assert tolerance < MAX_LINE_TOLERANCE
 
+    @pytest.mark.parametrize("name", NAMES)
+    def test_each_line_sits_where_its_rest_frame_energy_declares(
+        self, name: str
+    ) -> None:
+        """The boosted line term's support recovers the rest-frame energies.
+
+        A rest-frame line at ``E₀`` boosts into a rectangle spanning
+        ``[gamma E₀ (1 - beta), gamma E₀ (1 + beta)]``, so the outermost
+        edges of the isolated line term are the smallest and the largest
+        ``E₀`` the spectrum carries, mapped through the boost. Inverting
+        the two edges recovers those energies from the kernel's own output
+        — a statement about *where* the lines are, which the weight test
+        above cannot make: relocating a line leaves every weight, and
+        therefore the whole yield, exactly where it was.
+
+        That is what makes this the gate on roster entry B2 of
+        ``projects/parity-pinned-defect-repair``. The shipped φ energies
+        were 656.94 and 959.65 MeV against the 362.52 and 59.82 asserted
+        here, so a revert misplaces both edges by 81% and 1504% of a
+        window — five decades outside the tolerance, which is derived from
+        the grid: an edge is resolved to the cell it falls in, so ``E₀``
+        comes back to within ``cell`` of the truth, and twice ``cell /
+        edge`` covers that with margin.
+        """
+        dnde, _, mass, lines = SPECTRA[name]
+        x, y = TABLES[name]
+        if not lines:
+            pytest.skip("the charged kaon has no monochromatic line")
+
+        parent = 2.0 * mass
+        beta = float(core_boost.boost_beta(parent, mass))
+        gamma = parent / mass
+        energies = [energy for energy, _ in lines]
+
+        lo = gamma * min(energies) * (1.0 - beta) * 0.5
+        hi = gamma * max(energies) * (1.0 + beta) * 1.5
+        grid = np.linspace(lo, hi, 2_000_001)
+        cell = (hi - lo) / (grid.size - 1)
+
+        line_term = np.asarray(dnde(grid, parent)) - np.asarray(
+            core_boost.boost_integrate_linear_interp(grid, beta, x, y)
+        )
+        # A floor well under the shortest plateau but far above the
+        # continuum residue, so the edges found are the line's own.
+        inside = np.flatnonzero(line_term > 1e-6 * line_term.max())
+        assert inside.size, name
+
+        for edge, factor, expected in (
+            (grid[inside[0]], 1.0 - beta, min(energies)),
+            (grid[inside[-1]], 1.0 + beta, max(energies)),
+        ):
+            recovered = edge / (gamma * factor)
+            assert recovered == pytest.approx(expected, rel=2.0 * cell / edge), (
+                f"{name}: a line edge at {edge} MeV inverts to a rest-frame "
+                f"{recovered} MeV, not the {expected} its energy declares"
+            )
+
     def test_every_two_photon_line_carries_twice_its_branching_ratio(self) -> None:
         """``X -> a a`` yields two photons, so its line weight is ``2·BR``.
 
@@ -605,32 +661,42 @@ class TestPhysics:
         # to the shipped weight fails on the number and not only the form.
         assert SPECTRA["eta_prime"][3][0][1] == pytest.approx(0.04614)
 
-    def test_the_phi_lines_sit_at_the_daughter_mesons_energy(self) -> None:
-        """A reproduced defect: ``+`` where the photon needs ``-``.
+    def test_every_line_sits_at_the_photons_energy_not_the_daughters(self) -> None:
+        """``X -> Y a`` puts the photon at ``(M² - m²)/(2M)``, below ``M/2``.
 
-        For ``φ -> X a`` the photon carries ``(M² - m²)/(2M)`` and the meson
-        ``(M² + m²)/(2M)``; the two sum to ``M``. ``_phi.pyx:111,113`` used
-        the second for the photon line. Reproduced per rules.md rule 1 and
-        tracked in
-        ``docs/followups/todo/phi-photon-lines-use-the-daughter-meson-energy.md``.
+        The meson carries ``(M² + m²)/(2M)`` and the two sum to ``M``, which
+        is what makes the distinction checkable rather than a reading.
+        ``_phi.pyx:111,113`` used the meson's expression for both φ lines,
+        putting them at 656.94 and 959.65 MeV where 362.52 and 59.82 belong
+        — the second above the φ's own half-mass, which no photon from a
+        two-body decay can exceed. Repaired as roster entry B2 of
+        ``projects/parity-pinned-defect-repair``; the corpus still pins the
+        misplaced lines and ``test/parity/deltas.py`` declares the shift.
+
+        Both mesons are held together because both are now correct; the ω's
+        lines were never misplaced.
         """
-        for line_energy, daughter_mass, correct in (
-            (SPECTRA["phi"][3][0][0], MASS_ETA, 362.5189975276151),
-            (SPECTRA["phi"][3][1][0], MASS_ETAP, 59.815040556235125),
+        for name, parent_mass, daughters, correct in (
+            (
+                "phi",
+                MASS_PHI,
+                (MASS_ETA, MASS_ETAP),
+                (362.5189975276151, 59.815040556235125),
+            ),
+            ("omega", MASS_OMEGA, (MASS_PI0, MASS_ETA), (379.6910146562748, 199.5783)),
         ):
-            photon = (MASS_PHI**2 - daughter_mass**2) / (2 * MASS_PHI)
-            assert photon == pytest.approx(correct)
-            assert line_energy + photon == pytest.approx(MASS_PHI)
-            assert line_energy > photon
-        # The ω's lines *are* the photon's, which is what makes the φ's a
-        # defect rather than a convention the family shares.
-        for line_energy, daughter_mass in (
-            (SPECTRA["omega"][3][0][0], MASS_PI0),
-            (SPECTRA["omega"][3][1][0], MASS_ETA),
-        ):
-            assert line_energy == pytest.approx(
-                (MASS_OMEGA**2 - daughter_mass**2) / (2 * MASS_OMEGA)
-            )
+            pairs = zip(daughters, correct, strict=True)
+            for index, (daughter_mass, expected) in enumerate(pairs):
+                line_energy = SPECTRA[name][3][index][0]
+                daughter = (parent_mass**2 + daughter_mass**2) / (2 * parent_mass)
+                assert line_energy == pytest.approx(expected), name
+                assert line_energy + daughter == pytest.approx(parent_mass), name
+                assert line_energy < daughter, name
+                assert line_energy < 0.5 * parent_mass, name
+        # Stated against the shipped energies too, so a revert to the `+`
+        # form fails on the number and not only on the identity.
+        assert SPECTRA["phi"][3][0][0] != pytest.approx(656.942002472385)
+        assert SPECTRA["phi"][3][1][0] != pytest.approx(959.6459594437648)
 
     @pytest.mark.parametrize("name", NAMES)
     def test_the_spectrum_is_non_negative_across_its_support(self, name: str) -> None:


### PR DESCRIPTION
## Summary

- **Both φ photon lines sat at the daughter meson's energy instead of the photon's, and `hazma.spectra.dnde_photon_phi` moves.** In `X → Y γ` the photon carries `(M² − m²)/(2M)` and the meson `(M² + m²)/(2M)`. The φ kernel used the meson's expression for both lines and boosted the result as a photon energy: `φ → ηγ` shipped at **656.942 MeV where 362.519 MeV is right** (a factor of 1.81) and `φ → η′γ` at **959.646 MeV where 59.815 MeV is right** (a factor of 16.0, putting 94% of the φ's rest mass into a photon that carries 5.9% of it). The repaired values are right; the shipped ones exceed `M_φ/2`, which no two-body photon can.
- **This relocates a feature rather than rescaling the spectrum. The yield does not change:** the isolated line term integrates to 0.013092203 against the `BR(φ → ηγ) + BR(φ → η′γ) = 0.0130922` its weights declare, before and after, because a boosted δ-function integrates to its own weight wherever it sits. So a band containing the old line and not the new one loses that yield outright, a band containing neither does not move, and no downstream result can be corrected by a constant factor. Pointwise on `np.geomspace(1, 5 M_φ, 601)` MeV: 0/601 values move at `E_φ = M_φ`, 1/601 at `M_φ(1+1e-6)`, 331/601 at `1.5 M_φ` and 474/601 at `5 M_φ`, 262 and 449 of the last two upward. `hazma.spectra.dnde_photon` inherits both halves: it moves for a final state whose φ is **in flight** — at `cme = 2.5 M_φ`, 98/201 on `["phi","phi"]` and 113/201 on `["phi","eta"]`, 0/201 on `["eta","eta"]` — and **not at a two-body production threshold**, where every φ is produced at rest and the repaired energies are unreachable: `["phi","phi"]` at `cme = 2 M_φ` and `["phi","eta"]` at `cme = M_φ + M_η` are bit-identical across the rebuild. The six other tabulated photon spectra — the ω included, whose lines were always the photon's — are bit-identical across the rebuild.
- **A yield-only gate passes on the unrepaired kernel, so the gate is positional.** `TestPhysics::test_each_line_sits_where_its_rest_frame_energy_declares` recovers each line's rest-frame energy from the kernel's own boosted output (59.8155 and 362.5189 MeV against the declared 59.8150 and 362.5190). Confirmed necessary rather than assumed: with the constants reverted and the extension rebuilt, the existing line-weight test still passes and only the new one fails.
- **All four `X → Y γ` line energies now go through one `photon_line_energy(parent, daughter)`**, so the sign that caused this has no site left to be written at. The ω's two constants are bit-identical through it, asserted against the immediates the shipped object code loads.
- **The parity corpus is not regenerated.** `test/parity/deltas.py` declares the shift as the composite `A1+B2` over the six `spectra.photon.phi` arrays both repairs move (305 positions, 233 up and 72 down, 90 of them also moved by A1); both `rest_plus_eps` arrays keep A1's declaration alone. This is the layer's first relation that *cancels* a term it did not compute, and at two positions that cancellation destroys a continuum sixteen decades under the plateau it subtracts. Relations now carry an optional absolute floor for that case — `A1+B2` declares 1e-20, one ulp of the cancelled plateau — capped below the array's own zero floor by a new test and counted by `EXPECTED_FLOORED_ARRAYS`, rather than the relative budget being widened. ADR-0001 is amended.
- **Filed, not folded in:** the follow-up asked whether the φ also omits a direct `φ → π⁰γ` line, and it does. Normalizing each `pi0_a` CSV column by its own `BR(X → π⁰γ)` gives 1.978 for the φ and 1.951 for the ω against `2 BR(π⁰ → γγ) = 1.976`, so both columns hold only the π⁰'s decay photons and the ω's direct photon comes from its line. That is a separate defect (it raises the yield where this one relocates it) and is tracked in `docs/followups/todo/phi-omits-its-direct-pi0-photon-line.md`.

`git diff --stat -- test/parity/data` is empty: the committed arrays are still the record of what 2.1.0 shipped.

## Project

`projects/parity-pinned-defect-repair/` — Task 6: Repair B2 — the φ photon line energies.

See `projects/parity-pinned-defect-repair/task-notes/task-6-phi-lines.md` for implementation detail, decisions, the full numerical-impact tables, and verification.

## Test plan

- [x] `scripts/agents/preflight.sh` — `RESULT: PASS` across all eleven rows.

```text
$ env PATH="$PWD/.venv/bin:$PATH" scripts/agents/preflight.sh \
      --paths "test/parity/deltas.py test/parity/test_parity.py \
               test/parity/test_delta_models.py \
               test/test_core_photon_tables.py" \
      --md "<the ten touched markdown files>"
PASS   black --check           4 files
PASS   isort --check-only      0 new, 2 fixed (0 pre-existing at 6a1058d82d25)
PASS   ruff check              0 new, 2 fixed (0 pre-existing at 6a1058d82d25)
PASS   cargo fmt --check       rust/
PASS   cargo clippy            rust/
PASS   cargo test              rust/
PASS   pytest                  2293 passed, 16 skipped, 1 warning, 37 subtests passed in 26.27s
PASS   import hazma            version 2.2.0
PASS   markdownlint            (10 files)
SKIP   version bump            not a closing PR (pass --closing)
PASS   forbidden tokens        none added
RESULT: PASS
```

- [x] The parity corpus and the photon-table kernel tests, run narrowly.

```text
$ .venv/bin/python -m pytest test/parity -q -n 0
688 passed, 1 skipped in 6.41s

$ .venv/bin/python -m pytest test/test_core_photon_tables.py -q -n 0
196 passed, 2 skipped in 5.69s

$ cargo test --manifest-path rust/Cargo.toml --no-default-features \
      --features test-probes
test result: ok. 263 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- [x] **Test validity (stash-proof).** Reverting both Rust constants to the `+` form and rebuilding the editable install turns three parity cases red *with* the declaration in place — on the relation itself, so the declaration cannot hide a revert:

```text
FAILED test_entry_point_matches_corpus[spectra.photon.phi[near_rest]]
FAILED test_entry_point_matches_corpus[spectra.photon.phi[boosted_mild]]
FAILED test_entry_point_matches_corpus[spectra.photon.phi[boosted_strong]]
3 failed, 2 passed, 618 deselected
```

  On that same reverted build, `every_line_energy_is_the_photons_not_the_daughters` and `every_folded_constant_is_the_shipped_immediate_or_its_declared_repair` fail in Rust, `TestPhysics::test_each_line_sits_where_its_rest_frame_energy_declares[phi]` fails in Python, and `test_each_line_carries_the_photon_count_its_weight_declares[phi]` **passes** — the direct confirmation that a yield-only gate would not have caught this. `spectra.photon.phi[rest]` and `[rest_plus_eps]` pass in both configurations, which is the "moved only what it intended" half.

- [x] Numerical impact measured before and after on the same worktree by reverting the constants, rebuilding, capturing, restoring and rebuilding again — not by comparing the live tree against the stored corpus, which would report platform drift as if it were the repair. Tables in the task note's `## Numerical impact`.

- [x] **Review round 1** — one blocking finding, accepted and fixed in `d4090926`. The impact claim said `dnde_photon` moves for "any final state containing a φ", one sentence after recording that a φ at rest is untouched; at a two-body production threshold every φ is at rest, so the two contradict. Measured across a revert and rebuild rather than argued:

```text
configuration                      moved/size  max |relative shift|
phi_rest                              0/201    unchanged (bit-identical)
nbody_phi_phi_threshold               0/201    unchanged (bit-identical)
nbody_phi_eta_threshold               0/201    unchanged (bit-identical)
nbody_phi_phi_in_flight              98/201    1.000e+00
```

  The stale-sibling sweep found the identical overstatement in the merged `CHANGELOG.md` entries for the η′ line weight (B1) and the boost-integral window (A1), each one sentence after its own rest-frame caveat; all five occurrences are scoped. The class is recorded as `[composed-entry-point-inherits-the-branch-caveat]` in `docs/agents/lessons.md` with its worked example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
